### PR TITLE
[#12060] fix(hive): complete V3 type compatibility

### DIFF
--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
@@ -148,6 +148,9 @@ public class HiveDataTypeConverter implements DataTypeConverter<TypeInfo, String
       case GEOMETRY:
         throw new IllegalArgumentException(
             "Hive cannot preserve the Gravitino geometry type because it has no geometry type with CRS metadata.");
+      case GEOGRAPHY:
+        throw new IllegalArgumentException(
+            "Hive cannot preserve the Gravitino geography type because it has no geography type with CRS and edge-algorithm metadata.");
       default:
         throw new UnsupportedOperationException("Unsupported conversion to Hive type: " + type);
     }

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
@@ -31,6 +31,7 @@ import static org.apache.hadoop.hive.serde.serdeConstants.SMALLINT_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.STRING_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.TIMESTAMP_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.TINYINT_TYPE_NAME;
+import static org.apache.hadoop.hive.serde.serdeConstants.VOID_TYPE_NAME;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getCharTypeInfo;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getDecimalTypeInfo;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getListTypeInfo;
@@ -142,6 +143,8 @@ public class HiveDataTypeConverter implements DataTypeConverter<TypeInfo, String
       case VARIANT:
         throw new IllegalArgumentException(
             "Hive cannot preserve the Gravitino variant type because it has no equivalent type.");
+      case NULL:
+        return getPrimitiveTypeInfo(VOID_TYPE_NAME);
       default:
         throw new UnsupportedOperationException("Unsupported conversion to Hive type: " + type);
     }
@@ -182,6 +185,8 @@ public class HiveDataTypeConverter implements DataTypeConverter<TypeInfo, String
             return Types.IntervalYearType.get();
           case INTERVAL_DAY_TIME_TYPE_NAME:
             return Types.IntervalDayType.get();
+          case VOID_TYPE_NAME:
+            return Types.NullType.get();
           default:
             if (hiveTypeInfo instanceof CharTypeInfo) {
               return Types.FixedCharType.of(((CharTypeInfo) hiveTypeInfo).getLength());

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
@@ -145,6 +145,9 @@ public class HiveDataTypeConverter implements DataTypeConverter<TypeInfo, String
             "Hive cannot preserve the Gravitino variant type because it has no equivalent type.");
       case NULL:
         return getPrimitiveTypeInfo(VOID_TYPE_NAME);
+      case GEOMETRY:
+        throw new IllegalArgumentException(
+            "Hive cannot preserve the Gravitino geometry type because it has no geometry type with CRS metadata.");
       default:
         throw new UnsupportedOperationException("Unsupported conversion to Hive type: " + type);
     }

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
@@ -139,6 +139,9 @@ public class HiveDataTypeConverter implements DataTypeConverter<TypeInfo, String
             Arrays.stream(((Types.UnionType) type).types())
                 .map(this::fromGravitino)
                 .collect(Collectors.toList()));
+      case VARIANT:
+        throw new IllegalArgumentException(
+            "Hive cannot preserve the Gravitino variant type because it has no equivalent type.");
       default:
         throw new UnsupportedOperationException("Unsupported conversion to Hive type: " + type);
     }

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestHiveTableConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestHiveTableConverter.java
@@ -102,6 +102,27 @@ public class TestHiveTableConverter {
   }
 
   @Test
+  public void testRejectGeographyBeforeBuildingHiveTable() {
+    Column[] columns = {Column.of("region", Types.GeographyType.crs84(), "Spheroidal geography")};
+    HiveTable hiveTable =
+        HiveTable.builder()
+            .withName("places")
+            .withDatabaseName("db")
+            .withColumns(columns)
+            .withProperties(new HashMap<>())
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("tester").withCreateTime(Instant.now()).build())
+            .build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> HiveTableConverter.toHiveTable(hiveTable));
+    assertEquals(
+        "Hive cannot preserve the Gravitino geography type because it has no geography type with CRS and edge-algorithm metadata.",
+        exception.getMessage());
+  }
+
+  @Test
   public void testGetColumnsWithNoDuplicates() {
     // Create a table with columns and partition keys that don't overlap
     Table table = new Table();

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestHiveTableConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestHiveTableConverter.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.catalog.hive.HiveConstants.TABLE_TYPE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -39,6 +40,27 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.jupiter.api.Test;
 
 public class TestHiveTableConverter {
+
+  @Test
+  public void testRejectVariantBeforeBuildingHiveTable() {
+    Column[] columns = {Column.of("payload", Types.VariantType.get(), "Semi-structured payload")};
+    HiveTable hiveTable =
+        HiveTable.builder()
+            .withName("events")
+            .withDatabaseName("db")
+            .withColumns(columns)
+            .withProperties(new HashMap<>())
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("tester").withCreateTime(Instant.now()).build())
+            .build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> HiveTableConverter.toHiveTable(hiveTable));
+    assertEquals(
+        "Hive cannot preserve the Gravitino variant type because it has no equivalent type.",
+        exception.getMessage());
+  }
 
   @Test
   public void testGetColumnsWithNoDuplicates() {

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestHiveTableConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestHiveTableConverter.java
@@ -63,6 +63,24 @@ public class TestHiveTableConverter {
   }
 
   @Test
+  public void testConvertUnknownColumnToHiveVoid() {
+    Column[] columns = {Column.of("future_value", Types.NullType.get(), "Unknown value")};
+    HiveTable hiveTable =
+        HiveTable.builder()
+            .withName("events")
+            .withDatabaseName("db")
+            .withColumns(columns)
+            .withProperties(new HashMap<>())
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("tester").withCreateTime(Instant.now()).build())
+            .build();
+
+    Table convertedTable = HiveTableConverter.toHiveTable(hiveTable);
+    assertEquals("void", convertedTable.getSd().getCols().get(0).getType());
+    assertEquals(Types.NullType.get(), HiveTableConverter.getColumns(convertedTable)[0].dataType());
+  }
+
+  @Test
   public void testGetColumnsWithNoDuplicates() {
     // Create a table with columns and partition keys that don't overlap
     Table table = new Table();

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestHiveTableConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestHiveTableConverter.java
@@ -81,6 +81,27 @@ public class TestHiveTableConverter {
   }
 
   @Test
+  public void testRejectGeometryBeforeBuildingHiveTable() {
+    Column[] columns = {Column.of("shape", Types.GeometryType.crs84(), "Planar geometry")};
+    HiveTable hiveTable =
+        HiveTable.builder()
+            .withName("places")
+            .withDatabaseName("db")
+            .withColumns(columns)
+            .withProperties(new HashMap<>())
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("tester").withCreateTime(Instant.now()).build())
+            .build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> HiveTableConverter.toHiveTable(hiveTable));
+    assertEquals(
+        "Hive cannot preserve the Gravitino geometry type because it has no geometry type with CRS metadata.",
+        exception.getMessage());
+  }
+
+  @Test
   public void testGetColumnsWithNoDuplicates() {
     // Create a table with columns and partition keys that don't overlap
     Table table = new Table();

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
@@ -103,6 +103,17 @@ public class TestTypeConverter {
         exception.getMessage());
   }
 
+  @Test
+  public void testVariantThrowsException() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> HiveDataTypeConverter.CONVERTER.fromGravitino(Types.VariantType.get()));
+    Assertions.assertEquals(
+        "Hive cannot preserve the Gravitino variant type because it has no equivalent type.",
+        exception.getMessage());
+  }
+
   private void testConverter(String typeName) {
     TypeInfo hiveType = getTypeInfoFromTypeString(typeName);
     TypeInfo convertedType = CONVERTER.fromGravitino(CONVERTER.toGravitino(hiveType.getTypeName()));

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
@@ -32,6 +32,7 @@ import static org.apache.hadoop.hive.serde.serdeConstants.SMALLINT_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.STRING_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.TIMESTAMP_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.TINYINT_TYPE_NAME;
+import static org.apache.hadoop.hive.serde.serdeConstants.VOID_TYPE_NAME;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getCharTypeInfo;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getDecimalTypeInfo;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getListTypeInfo;
@@ -65,6 +66,7 @@ public class TestTypeConverter {
     testConverter(DATE_TYPE_NAME);
     testConverter(TIMESTAMP_TYPE_NAME);
     testConverter(BINARY_TYPE_NAME);
+    testConverter(VOID_TYPE_NAME);
     testConverter(INTERVAL_YEAR_MONTH_TYPE_NAME);
     testConverter(INTERVAL_DAY_TIME_TYPE_NAME);
     testConverter(getVarcharTypeInfo(10).getTypeName());
@@ -112,6 +114,15 @@ public class TestTypeConverter {
     Assertions.assertEquals(
         "Hive cannot preserve the Gravitino variant type because it has no equivalent type.",
         exception.getMessage());
+  }
+
+  @Test
+  public void testUnknownMapsToHiveVoid() {
+    Assertions.assertEquals(
+        getPrimitiveTypeInfo(VOID_TYPE_NAME),
+        HiveDataTypeConverter.CONVERTER.fromGravitino(Types.NullType.get()));
+    Assertions.assertEquals(
+        Types.NullType.get(), HiveDataTypeConverter.CONVERTER.toGravitino(VOID_TYPE_NAME));
   }
 
   private void testConverter(String typeName) {

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
@@ -125,6 +125,17 @@ public class TestTypeConverter {
         Types.NullType.get(), HiveDataTypeConverter.CONVERTER.toGravitino(VOID_TYPE_NAME));
   }
 
+  @Test
+  public void testGeometryThrowsException() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> HiveDataTypeConverter.CONVERTER.fromGravitino(Types.GeometryType.crs84()));
+    Assertions.assertEquals(
+        "Hive cannot preserve the Gravitino geometry type because it has no geometry type with CRS metadata.",
+        exception.getMessage());
+  }
+
   private void testConverter(String typeName) {
     TypeInfo hiveType = getTypeInfoFromTypeString(typeName);
     TypeInfo convertedType = CONVERTER.fromGravitino(CONVERTER.toGravitino(hiveType.getTypeName()));

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
@@ -136,6 +136,17 @@ public class TestTypeConverter {
         exception.getMessage());
   }
 
+  @Test
+  public void testGeographyThrowsException() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> HiveDataTypeConverter.CONVERTER.fromGravitino(Types.GeographyType.crs84()));
+    Assertions.assertEquals(
+        "Hive cannot preserve the Gravitino geography type because it has no geography type with CRS and edge-algorithm metadata.",
+        exception.getMessage());
+  }
+
   private void testConverter(String typeName) {
     TypeInfo hiveType = getTypeInfoFromTypeString(typeName);
     TypeInfo convertedType = CONVERTER.fromGravitino(CONVERTER.toGravitino(hiveType.getTypeName()));

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -171,6 +171,7 @@ types return an invalid-argument response before Hive Metastore metadata is chan
 | Gravitino type | Hive outcome | Reason |
 |----------------|--------------|--------|
 | `variant` | Rejected | Hive has no equivalent type that preserves arbitrary semi-structured values. |
+| `unknown` | Converted to `void` | Both types accept only null values and round-trip without changing semantics. |
 
 ### Table Properties
 

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -163,6 +163,15 @@ The following table lists the data types mapped from the Hive catalog to Graviti
 2. Since version 1.0.0, using the `struct` data type with field comments will throw an error, as it does not work for Hive tables (see [HIVE-26593](https://issues.apache.org/jira/browse/HIVE-26593)).
 :::
 
+#### Iceberg V3 type interoperability
+
+Hive types are accepted only when their Gravitino semantics can be preserved. Unsupported V3
+types return an invalid-argument response before Hive Metastore metadata is changed.
+
+| Gravitino type | Hive outcome | Reason |
+|----------------|--------------|--------|
+| `variant` | Rejected | Hive has no equivalent type that preserves arbitrary semi-structured values. |
+
 ### Table Properties
 
 Table properties supply or set metadata for the underlying Hive tables.

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -172,6 +172,7 @@ types return an invalid-argument response before Hive Metastore metadata is chan
 |----------------|--------------|--------|
 | `variant` | Rejected | Hive has no equivalent type that preserves arbitrary semi-structured values. |
 | `unknown` | Converted to `void` | Both types accept only null values and round-trip without changing semantics. |
+| `geometry` | Rejected | Hive has no geometry type that preserves coordinate-reference-system metadata. |
 
 ### Table Properties
 

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -173,6 +173,7 @@ types return an invalid-argument response before Hive Metastore metadata is chan
 | `variant` | Rejected | Hive has no equivalent type that preserves arbitrary semi-structured values. |
 | `unknown` | Converted to `void` | Both types accept only null values and round-trip without changing semantics. |
 | `geometry` | Rejected | Hive has no geometry type that preserves coordinate-reference-system metadata. |
+| `geography` | Rejected | Hive has no geography type that preserves CRS and edge-interpolation semantics. |
 
 ### Table Properties
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Complete and document the non-timestamp Hive compatibility work discovered during the V3 type effort.

| Type family | Outcome |
| --- | --- |
| Nanosecond timestamps | Intentionally unchanged and tracked separately in #12073. |
| Variant | Reject before Hive table construction. |
| Unknown/Null | Round-trip exactly through Hive `void`. |
| Geometry | Reject because CRS metadata cannot be preserved. |
| Geography | Reject because CRS and edge-algorithm metadata cannot be preserved. |

This PR contains no timestamp implementation or timestamp-history revert.

### Why are the changes needed?

Hive has an exact representation for Unknown/Null but not for the other completed V3-native families. The connector must preserve the exact mapping where possible and reject the rest before HMS metadata mutation.

Fix: #12060

Related: #12056

Follow-up: #12073

### Does this PR introduce _any_ user-facing change?

Yes. Unknown/Null columns round-trip through Hive `void`, while Variant and spatial columns fail explicitly. Existing timestamp behavior remains unchanged.

### How was this patch tested?

- Added focused `HiveDataTypeConverter` and `HiveTableConverter` coverage.
- Retained the existing timestamp tests unchanged.
- Verified the final diff contains no timestamp change.
- Updated `docs/apache-hive-catalog.md`.
