### PR TITLE
[#12061] fix(aws-glue): complete V3 type compatibility

### DIFF
--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
@@ -28,6 +28,7 @@ import static org.apache.gravitino.rel.types.Types.ExternalType;
 import static org.apache.gravitino.rel.types.Types.FixedCharType;
 import static org.apache.gravitino.rel.types.Types.FixedType;
 import static org.apache.gravitino.rel.types.Types.FloatType;
+import static org.apache.gravitino.rel.types.Types.GeographyType;
 import static org.apache.gravitino.rel.types.Types.GeometryType;
 import static org.apache.gravitino.rel.types.Types.IntegerType;
 import static org.apache.gravitino.rel.types.Types.ListType;
@@ -628,6 +629,12 @@ final class GlueIcebergTableHelper {
   }
 
   private static org.apache.iceberg.types.Type toIcebergType(Type type, int[] nextId) {
+    if (type instanceof GeographyType) {
+      throw new IllegalArgumentException(
+          "Unsupported Gravitino type for Glue: geography. "
+              + "Glue Hive and Iceberg table paths do not preserve Geography CRS and edge "
+              + "algorithm semantics.");
+    }
     if (type instanceof GeometryType) {
       throw new IllegalArgumentException(
           "Unsupported Gravitino type for Glue: geometry. "

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
@@ -28,6 +28,7 @@ import static org.apache.gravitino.rel.types.Types.ExternalType;
 import static org.apache.gravitino.rel.types.Types.FixedCharType;
 import static org.apache.gravitino.rel.types.Types.FixedType;
 import static org.apache.gravitino.rel.types.Types.FloatType;
+import static org.apache.gravitino.rel.types.Types.GeometryType;
 import static org.apache.gravitino.rel.types.Types.IntegerType;
 import static org.apache.gravitino.rel.types.Types.ListType;
 import static org.apache.gravitino.rel.types.Types.LongType;
@@ -627,6 +628,11 @@ final class GlueIcebergTableHelper {
   }
 
   private static org.apache.iceberg.types.Type toIcebergType(Type type, int[] nextId) {
+    if (type instanceof GeometryType) {
+      throw new IllegalArgumentException(
+          "Unsupported Gravitino type for Glue: geometry. "
+              + "Glue Hive and Iceberg table paths do not preserve Geometry CRS semantics.");
+    }
     if (type instanceof NullType) {
       throw new IllegalArgumentException(
           "Unsupported Gravitino type for Glue: unknown. "

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
@@ -39,6 +39,7 @@ import static org.apache.gravitino.rel.types.Types.TimeType;
 import static org.apache.gravitino.rel.types.Types.TimestampType;
 import static org.apache.gravitino.rel.types.Types.UUIDType;
 import static org.apache.gravitino.rel.types.Types.VarCharType;
+import static org.apache.gravitino.rel.types.Types.VariantType;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -625,6 +626,11 @@ final class GlueIcebergTableHelper {
   }
 
   private static org.apache.iceberg.types.Type toIcebergType(Type type, int[] nextId) {
+    if (type instanceof VariantType) {
+      throw new IllegalArgumentException(
+          "Unsupported Gravitino type for Glue: variant. "
+              + "Glue Hive and Iceberg table paths do not define a Variant column type.");
+    }
     if (type instanceof ListType) {
       ListType listType = (ListType) type;
       org.apache.iceberg.types.Type elementType = toIcebergType(listType.elementType(), nextId);

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
@@ -32,6 +32,7 @@ import static org.apache.gravitino.rel.types.Types.IntegerType;
 import static org.apache.gravitino.rel.types.Types.ListType;
 import static org.apache.gravitino.rel.types.Types.LongType;
 import static org.apache.gravitino.rel.types.Types.MapType;
+import static org.apache.gravitino.rel.types.Types.NullType;
 import static org.apache.gravitino.rel.types.Types.ShortType;
 import static org.apache.gravitino.rel.types.Types.StringType;
 import static org.apache.gravitino.rel.types.Types.StructType;
@@ -626,6 +627,11 @@ final class GlueIcebergTableHelper {
   }
 
   private static org.apache.iceberg.types.Type toIcebergType(Type type, int[] nextId) {
+    if (type instanceof NullType) {
+      throw new IllegalArgumentException(
+          "Unsupported Gravitino type for Glue: unknown. "
+              + "Glue Hive and Iceberg table paths require a concrete column type.");
+    }
     if (type instanceof VariantType) {
       throw new IllegalArgumentException(
           "Unsupported Gravitino type for Glue: variant. "

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
@@ -184,6 +184,11 @@ public class GlueTypeConverter implements DataTypeConverter<String, String> {
 
   @Override
   public String fromGravitino(Type type) {
+    if (type instanceof Types.NullType) {
+      throw new IllegalArgumentException(
+          "Unsupported Gravitino type for Glue: unknown. "
+              + "Glue Hive and Iceberg table paths require a concrete column type.");
+    }
     if (type instanceof Types.VariantType) {
       throw new IllegalArgumentException(
           "Unsupported Gravitino type for Glue: variant. "

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
@@ -184,6 +184,12 @@ public class GlueTypeConverter implements DataTypeConverter<String, String> {
 
   @Override
   public String fromGravitino(Type type) {
+    if (type instanceof Types.GeographyType) {
+      throw new IllegalArgumentException(
+          "Unsupported Gravitino type for Glue: geography. "
+              + "Glue Hive and Iceberg table paths do not preserve Geography CRS and edge "
+              + "algorithm semantics.");
+    }
     if (type instanceof Types.GeometryType) {
       throw new IllegalArgumentException(
           "Unsupported Gravitino type for Glue: geometry. "

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
@@ -194,9 +194,15 @@ public class GlueTypeConverter implements DataTypeConverter<String, String> {
     if (type instanceof Types.StringType) return STRING;
     if (type instanceof Types.DateType) return DATE;
     if (type instanceof Types.TimestampType) {
+      Types.TimestampType tsType = (Types.TimestampType) type;
+      if (tsType.hasPrecisionSet() && tsType.precision() > 6) {
+        throw new IllegalArgumentException(
+            "Unsupported Gravitino type for Glue: "
+                + type.simpleString()
+                + ". Glue cannot safely preserve timestamp precision greater than 6.");
+      }
       // Glue/Hive timestamps are timezoneless; see:
       // https://cwiki.apache.org/confluence/display/hive/languagemanual+types
-      Types.TimestampType tsType = (Types.TimestampType) type;
       if (tsType.hasTimeZone()) {
         throw new IllegalArgumentException(
             "Unsupported Gravitino type for Glue: "

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
@@ -184,6 +184,11 @@ public class GlueTypeConverter implements DataTypeConverter<String, String> {
 
   @Override
   public String fromGravitino(Type type) {
+    if (type instanceof Types.VariantType) {
+      throw new IllegalArgumentException(
+          "Unsupported Gravitino type for Glue: variant. "
+              + "Glue Hive and Iceberg table paths do not define a Variant column type.");
+    }
     if (type instanceof Types.BooleanType) return BOOLEAN;
     if (type instanceof Types.ByteType) return TINYINT;
     if (type instanceof Types.ShortType) return SMALLINT;

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTypeConverter.java
@@ -184,6 +184,11 @@ public class GlueTypeConverter implements DataTypeConverter<String, String> {
 
   @Override
   public String fromGravitino(Type type) {
+    if (type instanceof Types.GeometryType) {
+      throw new IllegalArgumentException(
+          "Unsupported Gravitino type for Glue: geometry. "
+              + "Glue Hive and Iceberg table paths do not preserve Geometry CRS semantics.");
+    }
     if (type instanceof Types.NullType) {
       throw new IllegalArgumentException(
           "Unsupported Gravitino type for Glue: unknown. "

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
@@ -184,6 +184,33 @@ class TestGlueCatalogOperationsForIceberg {
     verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
   }
 
+  @Test
+  void testCreateTable_icebergRejectsVariantBeforeSdkCall() {
+    NameIdentifier ident = NameIdentifier.of("cat", "ns", DB, "variant");
+    GlueColumn[] cols = {
+      GlueColumn.builder()
+          .withName("payload")
+          .withType(Types.VariantType.get())
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                cols,
+                null,
+                Map.of(GlueConstants.TABLE_FORMAT, "iceberg", GlueConstants.LOCATION, LOCATION),
+                new Transform[0],
+                Distributions.NONE,
+                null,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
+  }
+
   // ---------------------------------------------------------------------------
   // alterTable Iceberg routing
   // ---------------------------------------------------------------------------

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
@@ -238,6 +238,33 @@ class TestGlueCatalogOperationsForIceberg {
     verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
   }
 
+  @Test
+  void testCreateTable_icebergRejectsGeometryBeforeSdkCall() {
+    NameIdentifier ident = NameIdentifier.of("cat", "ns", DB, "geometry");
+    GlueColumn[] cols = {
+      GlueColumn.builder()
+          .withName("shape")
+          .withType(Types.GeometryType.crs84())
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                cols,
+                null,
+                Map.of(GlueConstants.TABLE_FORMAT, "iceberg", GlueConstants.LOCATION, LOCATION),
+                new Transform[0],
+                Distributions.NONE,
+                null,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
+  }
+
   // ---------------------------------------------------------------------------
   // alterTable Iceberg routing
   // ---------------------------------------------------------------------------

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -154,6 +155,33 @@ class TestGlueCatalogOperationsForIceberg {
 
     verify(mockIcebergCatalog).buildTable(any(TableIdentifier.class), any(Schema.class));
     verify(mockBuilder).create();
+  }
+
+  @Test
+  void testCreateTable_icebergRejectsNanosecondTimestampBeforeSdkCall() {
+    NameIdentifier ident = NameIdentifier.of("cat", "ns", DB, "timestamp_ns");
+    GlueColumn[] cols = {
+      GlueColumn.builder()
+          .withName("event_time")
+          .withType(Types.TimestampType.withTimeZone(9))
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                cols,
+                null,
+                Map.of(GlueConstants.TABLE_FORMAT, "iceberg", GlueConstants.LOCATION, LOCATION),
+                new Transform[0],
+                Distributions.NONE,
+                null,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
   }
 
   // ---------------------------------------------------------------------------

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
@@ -265,6 +265,33 @@ class TestGlueCatalogOperationsForIceberg {
     verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
   }
 
+  @Test
+  void testCreateTable_icebergRejectsGeographyBeforeSdkCall() {
+    NameIdentifier ident = NameIdentifier.of("cat", "ns", DB, "geography");
+    GlueColumn[] cols = {
+      GlueColumn.builder()
+          .withName("region")
+          .withType(Types.GeographyType.crs84())
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                cols,
+                null,
+                Map.of(GlueConstants.TABLE_FORMAT, "iceberg", GlueConstants.LOCATION, LOCATION),
+                new Transform[0],
+                Distributions.NONE,
+                null,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
+  }
+
   // ---------------------------------------------------------------------------
   // alterTable Iceberg routing
   // ---------------------------------------------------------------------------

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogOperationsForIceberg.java
@@ -211,6 +211,33 @@ class TestGlueCatalogOperationsForIceberg {
     verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
   }
 
+  @Test
+  void testCreateTable_icebergRejectsUnknownBeforeSdkCall() {
+    NameIdentifier ident = NameIdentifier.of("cat", "ns", DB, "unknown");
+    GlueColumn[] cols = {
+      GlueColumn.builder()
+          .withName("unknown_value")
+          .withType(Types.NullType.get())
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                cols,
+                null,
+                Map.of(GlueConstants.TABLE_FORMAT, "iceberg", GlueConstants.LOCATION, LOCATION),
+                new Transform[0],
+                Distributions.NONE,
+                null,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockIcebergCatalog, never()).buildTable(any(TableIdentifier.class), any(Schema.class));
+  }
+
   // ---------------------------------------------------------------------------
   // alterTable Iceberg routing
   // ---------------------------------------------------------------------------

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
@@ -297,6 +297,33 @@ class TestGlueCatalogTableOperations {
   }
 
   @Test
+  void testCreateTableRejectsUnknownBeforeGlueCall() {
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "unknown");
+    Column[] columns = {
+      GlueColumn.builder()
+          .withName("unknown_value")
+          .withType(Types.NullType.get())
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                columns,
+                null,
+                Map.of(GlueConstants.FORMAT, "parquet"),
+                Transforms.EMPTY_TRANSFORM,
+                Distributions.NONE,
+                SortOrders.NONE,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockClient, never()).createTable(any(CreateTableRequest.class));
+  }
+
+  @Test
   void testCreateTableStorageDescriptorProperties() {
     NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "mytable");
     Map<String, String> props =

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
@@ -270,6 +270,33 @@ class TestGlueCatalogTableOperations {
   }
 
   @Test
+  void testCreateTableRejectsVariantBeforeGlueCall() {
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "variant");
+    Column[] columns = {
+      GlueColumn.builder()
+          .withName("payload")
+          .withType(Types.VariantType.get())
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                columns,
+                null,
+                Map.of(GlueConstants.FORMAT, "parquet"),
+                Transforms.EMPTY_TRANSFORM,
+                Distributions.NONE,
+                SortOrders.NONE,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockClient, never()).createTable(any(CreateTableRequest.class));
+  }
+
+  @Test
   void testCreateTableStorageDescriptorProperties() {
     NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "mytable");
     Map<String, String> props =

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
@@ -351,6 +351,33 @@ class TestGlueCatalogTableOperations {
   }
 
   @Test
+  void testCreateTableRejectsGeographyBeforeGlueCall() {
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "geography");
+    Column[] columns = {
+      GlueColumn.builder()
+          .withName("region")
+          .withType(Types.GeographyType.crs84())
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                columns,
+                null,
+                Map.of(GlueConstants.FORMAT, "parquet"),
+                Transforms.EMPTY_TRANSFORM,
+                Distributions.NONE,
+                SortOrders.NONE,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockClient, never()).createTable(any(CreateTableRequest.class));
+  }
+
+  @Test
   void testCreateTableStorageDescriptorProperties() {
     NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "mytable");
     Map<String, String> props =

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -239,6 +240,33 @@ class TestGlueCatalogTableOperations {
                 Distributions.NONE,
                 SortOrders.NONE,
                 new Index[] {mock(Index.class)}));
+  }
+
+  @Test
+  void testCreateTableRejectsNanosecondTimestampBeforeGlueCall() {
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "timestamp_ns");
+    Column[] columns = {
+      GlueColumn.builder()
+          .withName("event_time")
+          .withType(Types.TimestampType.withoutTimeZone(9))
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                columns,
+                null,
+                Map.of(GlueConstants.FORMAT, "parquet"),
+                Transforms.EMPTY_TRANSFORM,
+                Distributions.NONE,
+                SortOrders.NONE,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockClient, never()).createTable(any(CreateTableRequest.class));
   }
 
   @Test

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogTableOperations.java
@@ -324,6 +324,33 @@ class TestGlueCatalogTableOperations {
   }
 
   @Test
+  void testCreateTableRejectsGeometryBeforeGlueCall() {
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "geometry");
+    Column[] columns = {
+      GlueColumn.builder()
+          .withName("shape")
+          .withType(Types.GeometryType.crs84())
+          .withNullable(true)
+          .build()
+    };
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTable(
+                ident,
+                columns,
+                null,
+                Map.of(GlueConstants.FORMAT, "parquet"),
+                Transforms.EMPTY_TRANSFORM,
+                Distributions.NONE,
+                SortOrders.NONE,
+                Indexes.EMPTY_INDEXES));
+
+    verify(mockClient, never()).createTable(any(CreateTableRequest.class));
+  }
+
+  @Test
   void testCreateTableStorageDescriptorProperties() {
     NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "mydb", "mytable");
     Map<String, String> props =

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
@@ -262,6 +262,18 @@ class TestGlueTypeConverter {
         error.getMessage());
   }
 
+  @Test
+  void testFromGravitinoGeometryThrows() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CONVERTER.fromGravitino(Types.GeometryType.of("EPSG:3857")));
+    assertEquals(
+        "Unsupported Gravitino type for Glue: geometry. "
+            + "Glue Hive and Iceberg table paths do not preserve Geometry CRS semantics.",
+        error.getMessage());
+  }
+
   // -------------------------------------------------------------------------
   // helpers
   // -------------------------------------------------------------------------

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
@@ -241,6 +241,17 @@ class TestGlueTypeConverter {
   }
 
   @Test
+  void testFromGravitinoVariantThrows() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class, () -> CONVERTER.fromGravitino(Types.VariantType.get()));
+    assertEquals(
+        "Unsupported Gravitino type for Glue: variant. "
+            + "Glue Hive and Iceberg table paths do not define a Variant column type.",
+        error.getMessage());
+  }
+
+  @Test
   void testFromGravitinoUnsupportedTypeThrows() {
     assertThrows(
         IllegalArgumentException.class, () -> CONVERTER.fromGravitino(Types.NullType.get()));

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
@@ -220,6 +220,27 @@ class TestGlueTypeConverter {
   }
 
   @Test
+  void testFromGravitinoNanosecondTimestampThrows() {
+    IllegalArgumentException timestampError =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CONVERTER.fromGravitino(Types.TimestampType.withoutTimeZone(9)));
+    assertEquals(
+        "Unsupported Gravitino type for Glue: timestamp(9). "
+            + "Glue cannot safely preserve timestamp precision greater than 6.",
+        timestampError.getMessage());
+
+    IllegalArgumentException timestampTzError =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CONVERTER.fromGravitino(Types.TimestampType.withTimeZone(9)));
+    assertEquals(
+        "Unsupported Gravitino type for Glue: timestamp_tz(9). "
+            + "Glue cannot safely preserve timestamp precision greater than 6.",
+        timestampTzError.getMessage());
+  }
+
+  @Test
   void testFromGravitinoUnsupportedTypeThrows() {
     assertThrows(
         IllegalArgumentException.class, () -> CONVERTER.fromGravitino(Types.NullType.get()));

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
@@ -252,9 +252,14 @@ class TestGlueTypeConverter {
   }
 
   @Test
-  void testFromGravitinoUnsupportedTypeThrows() {
-    assertThrows(
-        IllegalArgumentException.class, () -> CONVERTER.fromGravitino(Types.NullType.get()));
+  void testFromGravitinoUnknownThrows() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class, () -> CONVERTER.fromGravitino(Types.NullType.get()));
+    assertEquals(
+        "Unsupported Gravitino type for Glue: unknown. "
+            + "Glue Hive and Iceberg table paths require a concrete column type.",
+        error.getMessage());
   }
 
   // -------------------------------------------------------------------------

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTypeConverter.java
@@ -274,6 +274,19 @@ class TestGlueTypeConverter {
         error.getMessage());
   }
 
+  @Test
+  void testFromGravitinoGeographyThrows() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CONVERTER.fromGravitino(Types.GeographyType.of("EPSG:4326", "SPHERICAL")));
+    assertEquals(
+        "Unsupported Gravitino type for Glue: geography. "
+            + "Glue Hive and Iceberg table paths do not preserve Geography CRS and edge "
+            + "algorithm semantics.",
+        error.getMessage());
+  }
+
   // -------------------------------------------------------------------------
   // helpers
   // -------------------------------------------------------------------------

--- a/docs/aws-glue-catalog.md
+++ b/docs/aws-glue-catalog.md
@@ -146,6 +146,7 @@ AWS Glue stores column types as strings and does not validate their downstream c
 | `variant`                            | Not supported      | Not supported         | Rejected before the Glue API is called because neither table path defines a Variant column type. |
 | `unknown`                            | Not supported      | Not supported         | Rejected before the Glue API is called because both table paths require a concrete column type. |
 | `geometry(crs)`                      | Not supported      | Not supported         | Rejected before the Glue API is called because neither table path preserves Geometry CRS semantics. |
+| `geography(crs, algorithm)`          | Not supported      | Not supported         | Rejected before the Glue API is called because neither table path preserves Geography CRS and edge-algorithm semantics. |
 
 ### Table Properties
 

--- a/docs/aws-glue-catalog.md
+++ b/docs/aws-glue-catalog.md
@@ -145,6 +145,7 @@ AWS Glue stores column types as strings and does not validate their downstream c
 | `timestamp(9)` / `timestamp_tz(9)`  | Not supported      | Not supported         | Rejected before the Glue API is called. Iceberg supports at most microsecond precision, and Hive-format Glue metadata does not safely preserve an explicit nanosecond precision. |
 | `variant`                            | Not supported      | Not supported         | Rejected before the Glue API is called because neither table path defines a Variant column type. |
 | `unknown`                            | Not supported      | Not supported         | Rejected before the Glue API is called because both table paths require a concrete column type. |
+| `geometry(crs)`                      | Not supported      | Not supported         | Rejected before the Glue API is called because neither table path preserves Geometry CRS semantics. |
 
 ### Table Properties
 

--- a/docs/aws-glue-catalog.md
+++ b/docs/aws-glue-catalog.md
@@ -143,6 +143,7 @@ AWS Glue stores column types as strings and does not validate their downstream c
 | Gravitino Data Type                  | Hive-format Tables | Iceberg-format Tables | Write Behavior |
 |--------------------------------------|--------------------|-----------------------|----------------|
 | `timestamp(9)` / `timestamp_tz(9)`  | Not supported      | Not supported         | Rejected before the Glue API is called. Iceberg supports at most microsecond precision, and Hive-format Glue metadata does not safely preserve an explicit nanosecond precision. |
+| `variant`                            | Not supported      | Not supported         | Rejected before the Glue API is called because neither table path defines a Variant column type. |
 
 ### Table Properties
 

--- a/docs/aws-glue-catalog.md
+++ b/docs/aws-glue-catalog.md
@@ -136,6 +136,14 @@ The following table lists the data types mapped from the Glue catalog to Graviti
 Data types not listed above map to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)**, which represents an unresolvable data type from the Glue catalog.
 :::
 
+#### V3 Type Write Compatibility
+
+AWS Glue stores column types as strings and does not validate their downstream compatibility. Gravitino therefore rejects V3 types that neither the Hive-format nor Iceberg-format table path can preserve safely.
+
+| Gravitino Data Type                  | Hive-format Tables | Iceberg-format Tables | Write Behavior |
+|--------------------------------------|--------------------|-----------------------|----------------|
+| `timestamp(9)` / `timestamp_tz(9)`  | Not supported      | Not supported         | Rejected before the Glue API is called. Iceberg supports at most microsecond precision, and Hive-format Glue metadata does not safely preserve an explicit nanosecond precision. |
+
 ### Table Properties
 
 The following table lists predefined properties for Glue tables. Additional key-value properties pass through to the underlying Glue database.

--- a/docs/aws-glue-catalog.md
+++ b/docs/aws-glue-catalog.md
@@ -144,6 +144,7 @@ AWS Glue stores column types as strings and does not validate their downstream c
 |--------------------------------------|--------------------|-----------------------|----------------|
 | `timestamp(9)` / `timestamp_tz(9)`  | Not supported      | Not supported         | Rejected before the Glue API is called. Iceberg supports at most microsecond precision, and Hive-format Glue metadata does not safely preserve an explicit nanosecond precision. |
 | `variant`                            | Not supported      | Not supported         | Rejected before the Glue API is called because neither table path defines a Variant column type. |
+| `unknown`                            | Not supported      | Not supported         | Rejected before the Glue API is called because both table paths require a concrete column type. |
 
 ### Table Properties
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Define and document AWS Glue compatibility for the five Gravitino V3-native type families.

Nanosecond timestamps, Variant, Unknown/Null, Geometry, and Geography are rejected across both Hive-format and Iceberg-format create paths before AWS Glue or Iceberg table mutation.

### Why are the changes needed?

Neither Glue path can preserve the complete semantics of these V3-native families through the connector's current schema conversion contract. Early rejection prevents opaque fallback and partial external metadata.

Fix: #12061

Related: #12056

### Does this PR introduce _any_ user-facing change?

Yes. Unsupported V3-native schemas now fail consistently before either backend is invoked.

### How was this patch tested?

- Added focused converter and routing coverage for both catalog formats.
- Verified no Glue `CreateTable` request is sent.
- Verified no Iceberg `buildTable` operation is invoked.
- Updated `docs/aws-glue-catalog.md`.
