### PR TITLE
[#12062] fix(paimon): complete V3 type compatibility

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
@@ -418,7 +418,7 @@ public class PaimonCatalogOperations
    * @param changes The changes to apply to the table.
    * @return The altered {@link GravitinoPaimonTable} instance.
    * @throws NoSuchTableException If the table with the provided identifier does not exist.
-   * @throws IllegalArgumentException This exception will not be thrown in this method.
+   * @throws IllegalArgumentException If a requested column type has no exact Paimon mapping.
    */
   @Override
   public GravitinoPaimonTable alterTable(NameIdentifier identifier, TableChange... changes)
@@ -667,7 +667,7 @@ public class PaimonCatalogOperations
    * @param changes The changes to apply to the table.
    * @return The altered {@link GravitinoPaimonTable} instance.
    * @throws NoSuchTableException If the table with the provided identifier does not exist.
-   * @throws IllegalArgumentException This exception will not be thrown in this method.
+   * @throws IllegalArgumentException If a requested column type has no exact Paimon mapping.
    */
   private GravitinoPaimonTable internalAlterTable(NameIdentifier identifier, TableChange... changes)
       throws NoSuchTableException, IllegalArgumentException {
@@ -678,6 +678,8 @@ public class PaimonCatalogOperations
       throw new NoSuchTableException(e, NO_SUCH_TABLE_EXCEPTION, paimonNameIdentifier);
     } catch (Catalog.ColumnNotExistException e) {
       throw new NoSuchColumnException(e, NO_SUCH_COLUMN_EXCEPTION, paimonNameIdentifier);
+    } catch (IllegalArgumentException e) {
+      throw e;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
@@ -254,6 +254,8 @@ public class TypeUtils {
           return DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH);
         case VARIANT:
           return DataTypes.VARIANT();
+        case NULL:
+          throw unsupportedType(type);
         case LIST:
           Types.ListType listType = (Types.ListType) type;
           DataType elementType = visit(listType.elementType());
@@ -309,6 +311,11 @@ public class TypeUtils {
       return timestampType.hasTimeZone()
           ? DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(precision)
           : DataTypes.TIMESTAMP(precision);
+    }
+
+    private static IllegalArgumentException unsupportedType(Type type) {
+      return new IllegalArgumentException(
+          String.format("Paimon does not support Gravitino %s data type.", type.simpleString()));
     }
   }
 }

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
@@ -45,6 +45,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 // Referred to org/apache/paimon/spark/SparkTypeUtils.java
 /** Utilities of {@link Type} to support type conversion. */
@@ -137,6 +138,11 @@ public class TypeUtils {
     @Override
     public Type visit(LocalZonedTimestampType localZonedTimestampType) {
       return Types.TimestampType.withTimeZone(localZonedTimestampType.getPrecision());
+    }
+
+    @Override
+    public Type visit(VariantType variantType) {
+      return Types.VariantType.get();
     }
 
     @Override
@@ -246,6 +252,8 @@ public class TypeUtils {
           return DataTypes.BINARY(fixedType.length());
         case BINARY:
           return DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH);
+        case VARIANT:
+          return DataTypes.VARIANT();
         case LIST:
           Types.ListType listType = (Types.ListType) type;
           DataType elementType = visit(listType.elementType());

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
@@ -234,14 +234,7 @@ public class TypeUtils {
               timeType.hasPrecisionSet() ? timeType.precision() : PRECISION_SECOND;
           return DataTypes.TIME(timeTypePrecision);
         case TIMESTAMP:
-          Types.TimestampType timestampType = (Types.TimestampType) type;
-          int timestampTypePrecision =
-              timestampType.hasPrecisionSet() ? timestampType.precision() : PRECISION_MICROSECOND;
-          if (timestampType.hasTimeZone()) {
-            return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(timestampTypePrecision);
-          } else {
-            return DataTypes.TIMESTAMP(timestampTypePrecision);
-          }
+          return toPaimonTimestampType((Types.TimestampType) type);
         case STRING:
           return DataTypes.STRING();
         case VARCHAR:
@@ -294,6 +287,20 @@ public class TypeUtils {
               String.format(
                   "Paimon does not support Gravitino %s data type.", type.simpleString()));
       }
+    }
+
+    private static DataType toPaimonTimestampType(Types.TimestampType timestampType) {
+      int precision =
+          timestampType.hasPrecisionSet() ? timestampType.precision() : PRECISION_MICROSECOND;
+      if (precision < TimestampType.MIN_PRECISION || precision > TimestampType.MAX_PRECISION) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Paimon supports Gravitino timestamp precision from %d to %d, but got: %d.",
+                TimestampType.MIN_PRECISION, TimestampType.MAX_PRECISION, precision));
+      }
+      return timestampType.hasTimeZone()
+          ? DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(precision)
+          : DataTypes.TIMESTAMP(precision);
     }
   }
 }

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
@@ -255,6 +255,7 @@ public class TypeUtils {
         case VARIANT:
           return DataTypes.VARIANT();
         case GEOMETRY:
+        case GEOGRAPHY:
         case NULL:
           throw unsupportedType(type);
         case LIST:

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TypeUtils.java
@@ -254,6 +254,7 @@ public class TypeUtils {
           return DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH);
         case VARIANT:
           return DataTypes.VARIANT();
+        case GEOMETRY:
         case NULL:
           throw unsupportedType(type);
         case LIST:

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
@@ -302,6 +302,11 @@ public class TestGravitinoPaimonTable {
   }
 
   @Test
+  void testGeometryTypeRejectedWithoutMutation() {
+    assertUnsupportedTypeRejectedWithoutMutation(Types.GeometryType.of("EPSG:3857"), "geometry");
+  }
+
+  @Test
   void testCreatePaimonPartitionedTable() {
     String paimonTableName = "test_paimon_partitioned_table";
     NameIdentifier tableIdentifier = NameIdentifier.of(paimonSchema.name(), paimonTableName);

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
@@ -212,6 +212,65 @@ public class TestGravitinoPaimonTable {
   }
 
   @Test
+  void testNanosecondTimestampRoundTrip() {
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(paimonSchema.name(), "test_nanosecond_timestamp");
+    Column[] columns =
+        new Column[] {
+          GravitinoPaimonColumn.builder()
+              .withName("timestamp_ns")
+              .withType(Types.TimestampType.withoutTimeZone(9))
+              .withNullable(true)
+              .build(),
+          GravitinoPaimonColumn.builder()
+              .withName("timestamp_tz_ns")
+              .withType(Types.TimestampType.withTimeZone(9))
+              .withNullable(true)
+              .build()
+        };
+
+    paimonCatalogOperations.createTable(
+        tableIdentifier,
+        columns,
+        PAIMON_COMMENT,
+        Collections.emptyMap(),
+        new Transform[0],
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    Table loadedTable = paimonCatalogOperations.loadTable(tableIdentifier);
+    Assertions.assertEquals(
+        Types.TimestampType.withoutTimeZone(9), loadedTable.columns()[0].dataType());
+    Assertions.assertEquals(
+        Types.TimestampType.withTimeZone(9), loadedTable.columns()[1].dataType());
+
+    NameIdentifier invalidTableIdentifier =
+        NameIdentifier.of(paimonSchema.name(), "test_picosecond_timestamp");
+    IllegalArgumentException exception =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class,
+            () ->
+                paimonCatalogOperations.createTable(
+                    invalidTableIdentifier,
+                    new Column[] {
+                      GravitinoPaimonColumn.builder()
+                          .withName("timestamp_ps")
+                          .withType(Types.TimestampType.withoutTimeZone(10))
+                          .withNullable(true)
+                          .build()
+                    },
+                    PAIMON_COMMENT,
+                    Collections.emptyMap(),
+                    new Transform[0],
+                    Distributions.NONE,
+                    new SortOrder[0]));
+    Assertions.assertEquals(
+        "Paimon supports Gravitino timestamp precision from 0 to 9, but got: 10.",
+        exception.getMessage());
+    Assertions.assertFalse(paimonCatalogOperations.tableExists(invalidTableIdentifier));
+  }
+
+  @Test
   void testCreatePaimonPartitionedTable() {
     String paimonTableName = "test_paimon_partitioned_table";
     NameIdentifier tableIdentifier = NameIdentifier.of(paimonSchema.name(), paimonTableName);

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
@@ -51,12 +51,14 @@ import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
 import org.apache.gravitino.rel.TableCatalog;
+import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.expressions.NamedReference;
 import org.apache.gravitino.rel.expressions.distributions.Distribution;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;
 import org.apache.gravitino.rel.expressions.sorts.SortOrder;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
+import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.types.DataField;
@@ -292,6 +294,11 @@ public class TestGravitinoPaimonTable {
     Table loadedTable = paimonCatalogOperations.loadTable(tableIdentifier);
     Assertions.assertEquals(Types.VariantType.get(), loadedTable.columns()[0].dataType());
     Assertions.assertTrue(loadedTable.columns()[0].nullable());
+  }
+
+  @Test
+  void testUnknownTypeRejectedWithoutMutation() {
+    assertUnsupportedTypeRejectedWithoutMutation(Types.NullType.get(), "unknown");
   }
 
   @Test
@@ -769,6 +776,66 @@ public class TestGravitinoPaimonTable {
         new VarCharType(Integer.MAX_VALUE).notNull(), paimonTableSchema.fields().get(2).type());
     Assertions.assertArrayEquals(
         primaryKeys.toArray(new String[0]), paimonTableSchema.primaryKeys().toArray(new String[0]));
+  }
+
+  private void assertUnsupportedTypeRejectedWithoutMutation(Type type, String tableNameSuffix) {
+    String expectedMessage =
+        String.format("Paimon does not support Gravitino %s data type.", type.simpleString());
+    NameIdentifier createIdentifier =
+        NameIdentifier.of(paimonSchema.name(), "test_rejected_create_" + tableNameSuffix);
+    Column unsupportedColumn =
+        GravitinoPaimonColumn.builder()
+            .withName("unsupported_col")
+            .withType(type)
+            .withNullable(true)
+            .build();
+
+    IllegalArgumentException createException =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class,
+            () ->
+                paimonCatalogOperations.createTable(
+                    createIdentifier,
+                    new Column[] {unsupportedColumn},
+                    PAIMON_COMMENT,
+                    Collections.emptyMap(),
+                    new Transform[0],
+                    Distributions.NONE,
+                    new SortOrder[0]));
+    Assertions.assertEquals(expectedMessage, createException.getMessage());
+    Assertions.assertFalse(paimonCatalogOperations.tableExists(createIdentifier));
+
+    NameIdentifier alterIdentifier =
+        NameIdentifier.of(paimonSchema.name(), "test_rejected_alter_" + tableNameSuffix);
+    paimonCatalogOperations.createTable(
+        alterIdentifier,
+        new Column[] {
+          GravitinoPaimonColumn.builder()
+              .withName("id")
+              .withType(Types.IntegerType.get())
+              .withNullable(true)
+              .build()
+        },
+        PAIMON_COMMENT,
+        Collections.emptyMap(),
+        new Transform[0],
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    IllegalArgumentException alterException =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class,
+            () ->
+                paimonCatalogOperations.alterTable(
+                    alterIdentifier,
+                    TableChange.setProperty("v3-mutation-marker", "must-not-exist"),
+                    TableChange.addColumn(new String[] {"unsupported_col"}, type, true)));
+    Assertions.assertEquals(expectedMessage, alterException.getMessage());
+
+    Table unmodifiedTable = paimonCatalogOperations.loadTable(alterIdentifier);
+    Assertions.assertFalse(unmodifiedTable.properties().containsKey("v3-mutation-marker"));
+    Assertions.assertEquals(1, unmodifiedTable.columns().length);
+    Assertions.assertEquals("id", unmodifiedTable.columns()[0].name());
   }
 
   private static String genRandomName() {

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
@@ -271,6 +271,30 @@ public class TestGravitinoPaimonTable {
   }
 
   @Test
+  void testVariantRoundTrip() {
+    NameIdentifier tableIdentifier = NameIdentifier.of(paimonSchema.name(), "test_variant");
+    Column variantColumn =
+        GravitinoPaimonColumn.builder()
+            .withName("variant_col")
+            .withType(Types.VariantType.get())
+            .withNullable(true)
+            .build();
+
+    paimonCatalogOperations.createTable(
+        tableIdentifier,
+        new Column[] {variantColumn},
+        PAIMON_COMMENT,
+        Collections.emptyMap(),
+        new Transform[0],
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    Table loadedTable = paimonCatalogOperations.loadTable(tableIdentifier);
+    Assertions.assertEquals(Types.VariantType.get(), loadedTable.columns()[0].dataType());
+    Assertions.assertTrue(loadedTable.columns()[0].nullable());
+  }
+
+  @Test
   void testCreatePaimonPartitionedTable() {
     String paimonTableName = "test_paimon_partitioned_table";
     NameIdentifier tableIdentifier = NameIdentifier.of(paimonSchema.name(), paimonTableName);

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestGravitinoPaimonTable.java
@@ -307,6 +307,12 @@ public class TestGravitinoPaimonTable {
   }
 
   @Test
+  void testGeographyTypeRejectedWithoutMutation() {
+    assertUnsupportedTypeRejectedWithoutMutation(
+        Types.GeographyType.of("EPSG:4326", "karney"), "geography");
+  }
+
+  @Test
   void testCreatePaimonPartitionedTable() {
     String paimonTableName = "test_paimon_partitioned_table";
     NameIdentifier tableIdentifier = NameIdentifier.of(paimonSchema.name(), paimonTableName);

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
@@ -144,6 +144,11 @@ public class TestTypeUtils {
   }
 
   @Test
+  void testGeometryType() {
+    checkRejectedType(Types.GeometryType.of("EPSG:3857"));
+  }
+
+  @Test
   void testToPaimonTypeNullability() {
     assertEquals(
         DataTypes.ARRAY(DataTypes.INT().notNull()),

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
@@ -113,6 +113,12 @@ public class TestTypeUtils {
   }
 
   @Test
+  void testVariantType() {
+    assertEquals(DataTypes.VARIANT(), toPaimonType(Types.VariantType.get()));
+    assertEquals(Types.VariantType.get(), fromPaimonType(DataTypes.VARIANT()));
+  }
+
+  @Test
   void testUnparsedType() {
     Arrays.asList(
             DataTypes.CHAR(CharType.MAX_LENGTH), DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH))

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
@@ -149,6 +149,11 @@ public class TestTypeUtils {
   }
 
   @Test
+  void testGeographyType() {
+    checkRejectedType(Types.GeographyType.of("EPSG:4326", "karney"));
+  }
+
+  @Test
   void testToPaimonTypeNullability() {
     assertEquals(
         DataTypes.ARRAY(DataTypes.INT().notNull()),

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
@@ -92,6 +92,27 @@ public class TestTypeUtils {
   }
 
   @Test
+  void testNanosecondTimestampType() {
+    Type timestamp = Types.TimestampType.withoutTimeZone(9);
+    Type timestampTz = Types.TimestampType.withTimeZone(9);
+
+    assertEquals(DataTypes.TIMESTAMP(9), toPaimonType(timestamp));
+    assertEquals(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9), toPaimonType(timestampTz));
+    assertEquals(timestamp, fromPaimonType(DataTypes.TIMESTAMP(9)));
+    assertEquals(timestampTz, fromPaimonType(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)));
+
+    Arrays.asList(Types.TimestampType.withoutTimeZone(10), Types.TimestampType.withTimeZone(10))
+        .forEach(
+            type -> {
+              IllegalArgumentException exception =
+                  assertThrowsExactly(IllegalArgumentException.class, () -> toPaimonType(type));
+              assertEquals(
+                  "Paimon supports Gravitino timestamp precision from 0 to 9, but got: 10.",
+                  exception.getMessage());
+            });
+  }
+
+  @Test
   void testUnparsedType() {
     Arrays.asList(
             DataTypes.CHAR(CharType.MAX_LENGTH), DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH))

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTypeUtils.java
@@ -127,16 +127,20 @@ public class TestTypeUtils {
 
   @Test
   void testUnsupportedType() {
-    // Test UnsupportedOperationException with IntervalYearType, IntervalDayType, FixedCharType,
-    // UUIDType, FixedType, UnionType, NullType for toPaimonType.
+    // Test UnsupportedOperationException with IntervalYearType, IntervalDayType, UUIDType,
+    // UnionType and UnparsedType for toPaimonType.
     Arrays.asList(
             Types.IntervalYearType.get(),
             Types.IntervalDayType.get(),
             Types.UUIDType.get(),
             Types.UnionType.of(Types.IntegerType.get()),
-            Types.NullType.get(),
             Types.UnparsedType.of("unparsed"))
         .forEach(this::checkUnsupportedType);
+  }
+
+  @Test
+  void testUnknownType() {
+    checkRejectedType(Types.NullType.get());
   }
 
   @Test
@@ -262,6 +266,14 @@ public class TestTypeUtils {
   private void checkUnsupportedType(Type type) {
     UnsupportedOperationException exception =
         assertThrowsExactly(UnsupportedOperationException.class, () -> toPaimonType(type));
+    assertEquals(
+        String.format("Paimon does not support Gravitino %s data type.", type.simpleString()),
+        exception.getMessage());
+  }
+
+  private void checkRejectedType(Type type) {
+    IllegalArgumentException exception =
+        assertThrowsExactly(IllegalArgumentException.class, () -> toPaimonType(type));
     assertEquals(
         String.format("Paimon does not support Gravitino %s data type.", type.simpleString()),
         exception.getMessage());

--- a/docs/lakehouse-paimon-catalog.md
+++ b/docs/lakehouse-paimon-catalog.md
@@ -204,6 +204,7 @@ Paimon Table primary key constraint should not be same with partition fields, th
 | `Fixed`           | `Binary`                     |
 | `Binary`          | `VarBinary`                  |
 | `Variant`         | `Variant`                    |
+| `Unknown` (`NullType`) | Rejected before mutation |
 
 Paimon 1.2 supports timestamp precision from 0 through 9. Gravitino `Timestamp(9)` and
 `Timestamp_tz(9)` therefore round-trip losslessly as Paimon `Timestamp(9)` and
@@ -212,6 +213,10 @@ created or altered.
 
 Gravitino `Variant` maps directly to Paimon's native `Variant` logical type. The connector does not
 coerce Variant values to JSON strings or binary values.
+
+Paimon has nullable types but no null-only logical column type equivalent to Gravitino `Unknown`.
+Creating, adding, or changing a column to `Unknown` therefore returns an
+`IllegalArgumentException` before Paimon table metadata is changed.
 
 :::info
 Gravitino doesn't support Paimon `MultisetType` type.

--- a/docs/lakehouse-paimon-catalog.md
+++ b/docs/lakehouse-paimon-catalog.md
@@ -199,10 +199,15 @@ Paimon Table primary key constraint should not be same with partition fields, th
 | `FixedChar`       | `Char`                       |
 | `Date`            | `Date`                       |
 | `Time(p)`         | `Time(p)`                    |
-| `Timestamp(p)`    | `LocalZonedTimestamp(p)`     |
-| `Timestamp_tz(p)` | `Timestamp(p)`               |
+| `Timestamp(p)`    | `Timestamp(p)`               |
+| `Timestamp_tz(p)` | `LocalZonedTimestamp(p)`     |
 | `Fixed`           | `Binary`                     |
 | `Binary`          | `VarBinary`                  |
+
+Paimon 1.2 supports timestamp precision from 0 through 9. Gravitino `Timestamp(9)` and
+`Timestamp_tz(9)` therefore round-trip losslessly as Paimon `Timestamp(9)` and
+`LocalZonedTimestamp(9)`, respectively. Higher precisions are rejected before table metadata is
+created or altered.
 
 :::info
 Gravitino doesn't support Paimon `MultisetType` type.

--- a/docs/lakehouse-paimon-catalog.md
+++ b/docs/lakehouse-paimon-catalog.md
@@ -205,6 +205,7 @@ Paimon Table primary key constraint should not be same with partition fields, th
 | `Binary`          | `VarBinary`                  |
 | `Variant`         | `Variant`                    |
 | `Unknown` (`NullType`) | Rejected before mutation |
+| `Geometry(crs)`   | Rejected before mutation     |
 
 Paimon 1.2 supports timestamp precision from 0 through 9. Gravitino `Timestamp(9)` and
 `Timestamp_tz(9)` therefore round-trip losslessly as Paimon `Timestamp(9)` and
@@ -217,6 +218,10 @@ coerce Variant values to JSON strings or binary values.
 Paimon has nullable types but no null-only logical column type equivalent to Gravitino `Unknown`.
 Creating, adding, or changing a column to `Unknown` therefore returns an
 `IllegalArgumentException` before Paimon table metadata is changed.
+
+Paimon has no spatial logical type or field-level CRS metadata. Mapping Gravitino `Geometry` to
+Paimon `VarBinary` would preserve WKB bytes but lose the planar geometry and CRS semantics, so the
+connector rejects it before mutation.
 
 :::info
 Gravitino doesn't support Paimon `MultisetType` type.

--- a/docs/lakehouse-paimon-catalog.md
+++ b/docs/lakehouse-paimon-catalog.md
@@ -203,11 +203,15 @@ Paimon Table primary key constraint should not be same with partition fields, th
 | `Timestamp_tz(p)` | `LocalZonedTimestamp(p)`     |
 | `Fixed`           | `Binary`                     |
 | `Binary`          | `VarBinary`                  |
+| `Variant`         | `Variant`                    |
 
 Paimon 1.2 supports timestamp precision from 0 through 9. Gravitino `Timestamp(9)` and
 `Timestamp_tz(9)` therefore round-trip losslessly as Paimon `Timestamp(9)` and
 `LocalZonedTimestamp(9)`, respectively. Higher precisions are rejected before table metadata is
 created or altered.
+
+Gravitino `Variant` maps directly to Paimon's native `Variant` logical type. The connector does not
+coerce Variant values to JSON strings or binary values.
 
 :::info
 Gravitino doesn't support Paimon `MultisetType` type.

--- a/docs/lakehouse-paimon-catalog.md
+++ b/docs/lakehouse-paimon-catalog.md
@@ -206,6 +206,7 @@ Paimon Table primary key constraint should not be same with partition fields, th
 | `Variant`         | `Variant`                    |
 | `Unknown` (`NullType`) | Rejected before mutation |
 | `Geometry(crs)`   | Rejected before mutation     |
+| `Geography(crs, algorithm)` | Rejected before mutation |
 
 Paimon 1.2 supports timestamp precision from 0 through 9. Gravitino `Timestamp(9)` and
 `Timestamp_tz(9)` therefore round-trip losslessly as Paimon `Timestamp(9)` and
@@ -222,6 +223,10 @@ Creating, adding, or changing a column to `Unknown` therefore returns an
 Paimon has no spatial logical type or field-level CRS metadata. Mapping Gravitino `Geometry` to
 Paimon `VarBinary` would preserve WKB bytes but lose the planar geometry and CRS semantics, so the
 connector rejects it before mutation.
+
+Paimon also has no spheroidal spatial type carrying both a CRS and an edge-interpolation algorithm.
+Mapping Gravitino `Geography` to `VarBinary` would discard that type metadata, so it is rejected
+before mutation as well.
 
 :::info
 Gravitino doesn't support Paimon `MultisetType` type.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Define and document Paimon compatibility for the five Gravitino V3-native type families.

| Type family | Outcome |
| --- | --- |
| Nanosecond timestamps | Round-trip exact precision-9 timestamps. |
| Variant | Round-trip through Paimon's native Variant type. |
| Unknown/Null | Reject before mutation. |
| Geometry | Reject because CRS metadata cannot be preserved. |
| Geography | Reject because CRS and edge-algorithm metadata cannot be preserved. |

### Why are the changes needed?

Paimon can represent two V3-native families faithfully, but the other families must not be silently narrowed or serialized opaquely.

Fix: #12062

Related: #12056

### Does this PR introduce _any_ user-facing change?

Yes. Precision-9 timestamps and Variant gain exact mappings; unsupported Unknown and spatial schemas fail before mutation.

### How was this patch tested?

- Added real filesystem catalog create/load round-trip coverage.
- Covered rejected create and mixed-alter no-side-effect behavior.
- Covered focused and full module paths.
- Updated `docs/lakehouse-paimon-catalog.md`.
