### PR TITLE
[#12064] fix(lance): complete V3 type compatibility

### DIFF
--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -252,6 +252,10 @@ public class LanceTableOperations extends ManagedTableOperations {
     Preconditions.checkArgument(
         StringUtils.isNotBlank(location), "Table location must be specified");
 
+    // Validate every field before EXIST_OK or OVERWRITE can return, drop metadata, or purge a
+    // dataset. Conversion failures must never leave a partial mutation.
+    convertColumnsToArrowSchema(columns);
+
     // Extract creation mode from properties
     CreationMode mode =
         Optional.ofNullable(properties.get(LANCE_CREATION_MODE))

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -122,6 +122,36 @@ public class TestLanceTableOperations {
   }
 
   @Test
+  public void testVariantTypeIsRejectedBeforeOverwriteMutation() {
+    NameIdentifier ident = NameIdentifier.of("catalog", "schema", "table");
+    Column[] columns = {Column.of("payload", Types.VariantType.get(), "variant")};
+    Map<String, String> properties =
+        Map.of(
+            Table.PROPERTY_LOCATION,
+            tempDir.resolve("variant-overwrite").toString(),
+            LANCE_CREATION_MODE,
+            "OVERWRITE");
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                lanceTableOps.createTable(
+                    ident,
+                    columns,
+                    null,
+                    properties,
+                    new Transform[0],
+                    null,
+                    new SortOrder[0],
+                    new Index[0]));
+
+    Assertions.assertTrue(exception.getMessage().contains("exact native representation"));
+    verify(lanceTableOps, never()).purgeTable(ident);
+    verify(lanceTableOps, never()).dropTable(ident);
+  }
+
+  @Test
   public void testLoadDeclaredTableSchemaFromLocation() throws Exception {
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("declared-table").toString();

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -508,6 +508,39 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
   }
 
   @Test
+  public void testUnknownTypeRoundTrip() {
+    String phase2TableName = GravitinoITUtils.genRandomName("lance_unknown");
+    NameIdentifier identifier = NameIdentifier.of(schemaName, phase2TableName);
+    String location = tempDirectory + "/" + phase2TableName;
+    Column[] columns = {Column.of("unknown_value", Types.NullType.get(), "null-only value")};
+    Map<String, String> properties = createProperties();
+    properties.put(Table.PROPERTY_TABLE_FORMAT, LANCE_TABLE_FORMAT);
+    properties.put(Table.PROPERTY_LOCATION, location);
+
+    Table created =
+        catalog
+            .asTableCatalog()
+            .createTable(
+                identifier,
+                columns,
+                "unknown type round-trip",
+                properties,
+                Transforms.EMPTY_TRANSFORM,
+                null,
+                null);
+    Table loaded = catalog.asTableCatalog().loadTable(identifier);
+
+    Assertions.assertEquals(Types.NullType.get(), created.columns()[0].dataType());
+    Assertions.assertEquals(Types.NullType.get(), loaded.columns()[0].dataType());
+    Assertions.assertTrue(created.columns()[0].nullable());
+    try (Dataset dataset = Dataset.open().uri(location).build()) {
+      Field field = dataset.getSchema().getFields().get(0);
+      Assertions.assertEquals(ArrowType.Null.INSTANCE, field.getType());
+      Assertions.assertTrue(field.isNullable());
+    }
+  }
+
+  @Test
   void testLanceTableFormat() {
     String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
     Column[] columns = createColumns();

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -576,6 +576,42 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
   }
 
   @Test
+  public void testGeographyTypeRoundTrip() {
+    String phase2TableName = GravitinoITUtils.genRandomName("lance_geography");
+    NameIdentifier identifier = NameIdentifier.of(schemaName, phase2TableName);
+    String location = tempDirectory + "/" + phase2TableName;
+    Types.GeographyType geography = Types.GeographyType.of("EPSG:4326", "karney");
+    Column[] columns = {Column.of("shape", geography, "ellipsoidal WKB geography")};
+    Map<String, String> properties = createProperties();
+    properties.put(Table.PROPERTY_TABLE_FORMAT, LANCE_TABLE_FORMAT);
+    properties.put(Table.PROPERTY_LOCATION, location);
+
+    Table created =
+        catalog
+            .asTableCatalog()
+            .createTable(
+                identifier,
+                columns,
+                "geography type round-trip",
+                properties,
+                Transforms.EMPTY_TRANSFORM,
+                null,
+                null);
+    Table loaded = catalog.asTableCatalog().loadTable(identifier);
+
+    Assertions.assertEquals(geography, created.columns()[0].dataType());
+    Assertions.assertEquals(geography, loaded.columns()[0].dataType());
+    try (Dataset dataset = Dataset.open().uri(location).build()) {
+      Field field = dataset.getSchema().getFields().get(0);
+      Assertions.assertEquals(ArrowType.Binary.INSTANCE, field.getType());
+      Assertions.assertEquals("geoarrow.wkb", field.getMetadata().get("ARROW:extension:name"));
+      Assertions.assertEquals(
+          "{\"crs\":\"EPSG:4326\",\"edges\":\"karney\"}",
+          field.getMetadata().get("ARROW:extension:metadata"));
+    }
+  }
+
+  @Test
   void testLanceTableFormat() {
     String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
     Column[] columns = createColumns();

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -456,6 +456,58 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
   }
 
   @Test
+  public void testVariantOverwriteRejectedWithoutSideEffects() {
+    String phase2TableName = GravitinoITUtils.genRandomName("lance_variant_rejection");
+    NameIdentifier identifier = NameIdentifier.of(schemaName, phase2TableName);
+    String location = tempDirectory + "/" + phase2TableName;
+    Map<String, String> properties = createProperties();
+    properties.put(Table.PROPERTY_TABLE_FORMAT, LANCE_TABLE_FORMAT);
+    properties.put(Table.PROPERTY_LOCATION, location);
+    properties.put(Table.PROPERTY_EXTERNAL, "true");
+    Column[] originalColumns = {
+      Column.of("id", Types.IntegerType.get(), "original integer column")
+    };
+
+    catalog
+        .asTableCatalog()
+        .createTable(
+            identifier,
+            originalColumns,
+            "original table",
+            properties,
+            Transforms.EMPTY_TRANSFORM,
+            null,
+            null);
+
+    Map<String, String> overwriteProperties = Maps.newHashMap(properties);
+    overwriteProperties.put(LANCE_CREATION_MODE, "OVERWRITE");
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalog
+                    .asTableCatalog()
+                    .createTable(
+                        identifier,
+                        new Column[] {Column.of("payload", Types.VariantType.get(), "variant")},
+                        "invalid overwrite",
+                        overwriteProperties,
+                        Transforms.EMPTY_TRANSFORM,
+                        null,
+                        null));
+
+    Assertions.assertTrue(exception.getMessage().contains("exact native representation"));
+    Assertions.assertTrue(catalog.asTableCatalog().tableExists(identifier));
+    Assertions.assertEquals(
+        Types.IntegerType.get(),
+        catalog.asTableCatalog().loadTable(identifier).columns()[0].dataType());
+    try (Dataset dataset = Dataset.open().uri(location).build()) {
+      Assertions.assertEquals(
+          new ArrowType.Int(32, true), dataset.getSchema().getFields().get(0).getType());
+    }
+  }
+
+  @Test
   void testLanceTableFormat() {
     String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
     Column[] columns = createColumns();

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -541,6 +541,41 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
   }
 
   @Test
+  public void testGeometryTypeRoundTrip() {
+    String phase2TableName = GravitinoITUtils.genRandomName("lance_geometry");
+    NameIdentifier identifier = NameIdentifier.of(schemaName, phase2TableName);
+    String location = tempDirectory + "/" + phase2TableName;
+    Types.GeometryType geometry = Types.GeometryType.of("EPSG:3857");
+    Column[] columns = {Column.of("shape", geometry, "planar WKB geometry")};
+    Map<String, String> properties = createProperties();
+    properties.put(Table.PROPERTY_TABLE_FORMAT, LANCE_TABLE_FORMAT);
+    properties.put(Table.PROPERTY_LOCATION, location);
+
+    Table created =
+        catalog
+            .asTableCatalog()
+            .createTable(
+                identifier,
+                columns,
+                "geometry type round-trip",
+                properties,
+                Transforms.EMPTY_TRANSFORM,
+                null,
+                null);
+    Table loaded = catalog.asTableCatalog().loadTable(identifier);
+
+    Assertions.assertEquals(geometry, created.columns()[0].dataType());
+    Assertions.assertEquals(geometry, loaded.columns()[0].dataType());
+    try (Dataset dataset = Dataset.open().uri(location).build()) {
+      Field field = dataset.getSchema().getFields().get(0);
+      Assertions.assertEquals(ArrowType.Binary.INSTANCE, field.getType());
+      Assertions.assertEquals("geoarrow.wkb", field.getMetadata().get("ARROW:extension:name"));
+      Assertions.assertEquals(
+          "{\"crs\":\"EPSG:3857\"}", field.getMetadata().get("ARROW:extension:metadata"));
+    }
+  }
+
+  @Test
   void testLanceTableFormat() {
     String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
     Column[] columns = createColumns();

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -44,6 +44,7 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.commons.io.FileUtils;
@@ -411,6 +412,47 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
 
     Assertions.assertThrows(
         RuntimeException.class, () -> catalog.asTableCatalog().loadTable(newNameIdentifier));
+  }
+
+  @Test
+  public void testNanosecondTimestampTypeRoundTrip() {
+    String phase2TableName = GravitinoITUtils.genRandomName("lance_timestamp_ns");
+    NameIdentifier identifier = NameIdentifier.of(schemaName, phase2TableName);
+    String location = tempDirectory + "/" + phase2TableName;
+    Column[] columns = {
+      Column.of("timestamp_ns", Types.TimestampType.withoutTimeZone(9), "nanosecond timestamp"),
+      Column.of("timestamptz_ns", Types.TimestampType.withTimeZone(9), "nanosecond instant")
+    };
+    Map<String, String> properties = createProperties();
+    properties.put(Table.PROPERTY_TABLE_FORMAT, LANCE_TABLE_FORMAT);
+    properties.put(Table.PROPERTY_LOCATION, location);
+
+    Table created =
+        catalog
+            .asTableCatalog()
+            .createTable(
+                identifier,
+                columns,
+                "timestamp nanosecond round-trip",
+                properties,
+                Transforms.EMPTY_TRANSFORM,
+                null,
+                null);
+    Table loaded = catalog.asTableCatalog().loadTable(identifier);
+
+    Assertions.assertEquals(
+        Types.TimestampType.withoutTimeZone(9), created.columns()[0].dataType());
+    Assertions.assertEquals(Types.TimestampType.withTimeZone(9), created.columns()[1].dataType());
+    Assertions.assertEquals(Types.TimestampType.withoutTimeZone(9), loaded.columns()[0].dataType());
+    Assertions.assertEquals(Types.TimestampType.withTimeZone(9), loaded.columns()[1].dataType());
+
+    try (Dataset dataset = Dataset.open().uri(location).build()) {
+      List<Field> fields = dataset.getSchema().getFields();
+      Assertions.assertEquals(
+          new ArrowType.Timestamp(TimeUnit.NANOSECOND, null), fields.get(0).getType());
+      Assertions.assertEquals(
+          new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC"), fields.get(1).getType());
+    }
   }
 
   @Test

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -73,6 +73,7 @@ Lance uses Apache Arrow for table schemas. The following table shows type mappin
 | `Unknown` (`NullType`)           | `Null` (nullable columns only)          |
 | `Variant`                        | Rejected before mutation                |
 | `Geometry(crs)`                  | `geoarrow.wkb` with planar CRS metadata |
+| `Geography(crs, algorithm)`      | `geoarrow.wkb` with CRS and edge metadata |
 | `Fixed(n)`                       | `Fixed-Size Binary(n)`                  |
 | `Interval_year`                  | Not supported by Lance                  |
 | `Interval_day`                   | `Duration(Microsecond)`                 |
@@ -95,6 +96,10 @@ because it cannot contain a valid value.
 Gravitino `Geometry` uses WKB with planar edges and CRS type metadata. Lance preserves the same
 semantics as a GeoArrow 0.2 `geoarrow.wkb` extension field backed by Arrow `Binary`; both textual
 CRS identifiers and PROJJSON round-trip without losing the CRS.
+
+Gravitino `Geography` uses the same GeoArrow WKB storage and records its spherical or spheroidal
+edge algorithm in the GeoArrow `edges` metadata. All five Gravitino algorithms (`spherical`,
+`vincenty`, `thomas`, `andoyer`, and `karney`) round-trip with the CRS.
 
 ### External Types
 

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -76,6 +76,12 @@ Lance uses Apache Arrow for table schemas. The following table shows type mappin
 | `Interval_day`                   | `Duration(Microsecond)`                 |
 | `External(arrow_field_json_str)` | Any Arrow Field                         |
 
+`Timestamp(9)` and `Timestamp_tz(9)` round-trip losslessly through Lance as nanosecond Arrow
+timestamps. Gravitino `Timestamp_tz` has time-zone-aware instant semantics but does not carry a
+zone identifier, so the connector writes the canonical Arrow `UTC` identifier. Native Arrow
+timestamps with another zone identifier are preserved as `External` instead of silently rewriting
+that identifier.
+
 ### External Types
 
 For Arrow types not natively mapped in Gravitino, use the `External(arrow_field_json_str)` type, which accepts a JSON string representation of an Arrow `Field`.

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -70,7 +70,7 @@ Lance uses Apache Arrow for table schemas. The following table shows type mappin
 | `Timestamp_tz(3)`                | `TimestampType Millisecond withUtc`     |
 | `Timestamp_tz(9)`                | `TimestampType Nanosecond withUtc`      |
 | `Time`/`Time(9)`                 | `Time Nanosecond`                       |
-| `Null`                           | `Null`                                  |
+| `Unknown` (`NullType`)           | `Null` (nullable columns only)          |
 | `Variant`                        | Rejected before mutation                |
 | `Fixed(n)`                       | `Fixed-Size Binary(n)`                  |
 | `Interval_year`                  | Not supported by Lance                  |
@@ -86,6 +86,10 @@ that identifier.
 Lance 6.0 with Arrow 18 has no exact native representation for Gravitino `Variant`, so table
 creation rejects it before creating, replacing, or deleting table data. Arrow extension fields,
 including newer `arrow.parquet.variant` fields, remain lossless `External` types.
+
+Gravitino `Unknown` is a nullable, null-only placeholder whose concrete type may be assigned during
+schema evolution. It round-trips exactly as Arrow `Null`; a non-nullable Unknown column is rejected
+because it cannot contain a valid value.
 
 ### External Types
 

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -71,6 +71,7 @@ Lance uses Apache Arrow for table schemas. The following table shows type mappin
 | `Timestamp_tz(9)`                | `TimestampType Nanosecond withUtc`      |
 | `Time`/`Time(9)`                 | `Time Nanosecond`                       |
 | `Null`                           | `Null`                                  |
+| `Variant`                        | Rejected before mutation                |
 | `Fixed(n)`                       | `Fixed-Size Binary(n)`                  |
 | `Interval_year`                  | Not supported by Lance                  |
 | `Interval_day`                   | `Duration(Microsecond)`                 |
@@ -81,6 +82,10 @@ timestamps. Gravitino `Timestamp_tz` has time-zone-aware instant semantics but d
 zone identifier, so the connector writes the canonical Arrow `UTC` identifier. Native Arrow
 timestamps with another zone identifier are preserved as `External` instead of silently rewriting
 that identifier.
+
+Lance 6.0 with Arrow 18 has no exact native representation for Gravitino `Variant`, so table
+creation rejects it before creating, replacing, or deleting table data. Arrow extension fields,
+including newer `arrow.parquet.variant` fields, remain lossless `External` types.
 
 ### External Types
 

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -72,6 +72,7 @@ Lance uses Apache Arrow for table schemas. The following table shows type mappin
 | `Time`/`Time(9)`                 | `Time Nanosecond`                       |
 | `Unknown` (`NullType`)           | `Null` (nullable columns only)          |
 | `Variant`                        | Rejected before mutation                |
+| `Geometry(crs)`                  | `geoarrow.wkb` with planar CRS metadata |
 | `Fixed(n)`                       | `Fixed-Size Binary(n)`                  |
 | `Interval_year`                  | Not supported by Lance                  |
 | `Interval_day`                   | `Duration(Microsecond)`                 |
@@ -90,6 +91,10 @@ including newer `arrow.parquet.variant` fields, remain lossless `External` types
 Gravitino `Unknown` is a nullable, null-only placeholder whose concrete type may be assigned during
 schema evolution. It round-trips exactly as Arrow `Null`; a non-nullable Unknown column is rejected
 because it cannot contain a valid value.
+
+Gravitino `Geometry` uses WKB with planar edges and CRS type metadata. Lance preserves the same
+semantics as a GeoArrow 0.2 `geoarrow.wkb` extension field backed by Arrow `Binary`; both textual
+CRS identifiers and PROJJSON round-trip without losing the CRS.
 
 ### External Types
 

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
@@ -19,11 +19,16 @@
 
 package org.apache.gravitino.lance.common.ops.gravitino;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
@@ -45,6 +50,9 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
 
   public static final LanceDataTypeConverter CONVERTER = new LanceDataTypeConverter();
   private static final String ARROW_EXTENSION_NAME = "ARROW:extension:name";
+  private static final String ARROW_EXTENSION_METADATA = "ARROW:extension:metadata";
+  private static final String GEOARROW_WKB_EXTENSION_NAME = "geoarrow.wkb";
+  private static final Set<String> GEOARROW_METADATA_KEYS = Set.of("crs", "crs_type", "edges");
   private static final ObjectMapper mapper = new ObjectMapper();
 
   public Field toArrowField(String name, Type type, boolean nullable) {
@@ -137,6 +145,9 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
         Preconditions.checkArgument(nullable, "Lance Arrow Null columns must be nullable");
         return Field.nullable(name, ArrowType.Null.INSTANCE);
 
+      case GEOMETRY:
+        return toGeoArrowField(name, (Types.GeometryType) type, nullable);
+
       default:
         // non-complex type
         FieldType fieldType = new FieldType(nullable, fromGravitino(type), null);
@@ -204,6 +215,9 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
       case VARIANT:
         throw new IllegalArgumentException(
             "Lance 6.0 and Arrow 18 do not provide an exact native representation for Gravitino Variant");
+      case GEOMETRY:
+        throw new IllegalArgumentException(
+            "Gravitino Geometry requires GeoArrow field metadata; use toArrowField for Lance schemas");
       default:
         throw new UnsupportedOperationException("Unsupported Gravitino type: " + type.name());
     }
@@ -214,7 +228,7 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
     FieldType fieldType = arrowField.getFieldType();
     if (fieldType.getMetadata() != null
         && fieldType.getMetadata().containsKey(ARROW_EXTENSION_NAME)) {
-      return toExternalType(arrowField);
+      return toKnownExtensionType(arrowField).orElseGet(() -> toExternalType(arrowField));
     }
 
     switch (fieldType.getType().getTypeID()) {
@@ -332,6 +346,75 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
     }
 
     return toExternalType(arrowField);
+  }
+
+  private Field toGeoArrowField(String name, Types.GeometryType type, boolean nullable) {
+    ObjectNode extensionMetadata = mapper.createObjectNode();
+    putCrs(extensionMetadata, type.crs());
+    FieldType fieldType =
+        new FieldType(
+            nullable,
+            ArrowType.Binary.INSTANCE,
+            null,
+            Map.of(
+                ARROW_EXTENSION_NAME,
+                GEOARROW_WKB_EXTENSION_NAME,
+                ARROW_EXTENSION_METADATA,
+                extensionMetadata.toString()));
+    return new Field(name, fieldType, null);
+  }
+
+  private Optional<Type> toKnownExtensionType(Field arrowField) {
+    Map<String, String> metadata = arrowField.getFieldType().getMetadata();
+    if (!GEOARROW_WKB_EXTENSION_NAME.equals(metadata.get(ARROW_EXTENSION_NAME))
+        || !(arrowField.getType() instanceof ArrowType.Binary)) {
+      return Optional.empty();
+    }
+
+    String extensionMetadata = metadata.get(ARROW_EXTENSION_METADATA);
+    if (extensionMetadata == null) {
+      return Optional.empty();
+    }
+    try {
+      JsonNode metadataNode = mapper.readTree(extensionMetadata);
+      if (!metadataNode.isObject()
+          || !hasOnlyGeoArrowMetadataKeys(metadataNode)
+          || metadataNode.has("edges")) {
+        return Optional.empty();
+      }
+      String crs = readCrs(metadataNode.get("crs"));
+      return crs == null ? Optional.empty() : Optional.of(Types.GeometryType.of(crs));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  private boolean hasOnlyGeoArrowMetadataKeys(JsonNode metadataNode) {
+    return Lists.newArrayList(metadataNode.fieldNames()).stream()
+        .allMatch(GEOARROW_METADATA_KEYS::contains);
+  }
+
+  private void putCrs(ObjectNode metadataNode, String crs) {
+    try {
+      JsonNode parsedCrs = mapper.readTree(crs);
+      if (parsedCrs.isObject()) {
+        metadataNode.set("crs", parsedCrs);
+        return;
+      }
+    } catch (Exception ignored) {
+      // A CRS string is a valid GeoArrow fallback when it is not PROJJSON.
+    }
+    metadataNode.put("crs", crs);
+  }
+
+  private String readCrs(JsonNode crsNode) {
+    if (crsNode == null) {
+      return null;
+    }
+    if (crsNode.isTextual() && !crsNode.asText().isEmpty()) {
+      return crsNode.asText();
+    }
+    return crsNode.isObject() ? crsNode.toString() : null;
   }
 
   private Types.ExternalType toExternalType(Field arrowField) {

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
@@ -52,7 +52,7 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
   private static final String ARROW_EXTENSION_NAME = "ARROW:extension:name";
   private static final String ARROW_EXTENSION_METADATA = "ARROW:extension:metadata";
   private static final String GEOARROW_WKB_EXTENSION_NAME = "geoarrow.wkb";
-  private static final Set<String> GEOARROW_METADATA_KEYS = Set.of("crs", "crs_type", "edges");
+  private static final Set<String> GEOARROW_METADATA_KEYS = Set.of("crs", "edges");
   private static final ObjectMapper mapper = new ObjectMapper();
 
   public Field toArrowField(String name, Type type, boolean nullable) {
@@ -148,6 +148,9 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
       case GEOMETRY:
         return toGeoArrowField(name, (Types.GeometryType) type, nullable);
 
+      case GEOGRAPHY:
+        return toGeoArrowField(name, (Types.GeographyType) type, nullable);
+
       default:
         // non-complex type
         FieldType fieldType = new FieldType(nullable, fromGravitino(type), null);
@@ -218,6 +221,9 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
       case GEOMETRY:
         throw new IllegalArgumentException(
             "Gravitino Geometry requires GeoArrow field metadata; use toArrowField for Lance schemas");
+      case GEOGRAPHY:
+        throw new IllegalArgumentException(
+            "Gravitino Geography requires GeoArrow field metadata; use toArrowField for Lance schemas");
       default:
         throw new UnsupportedOperationException("Unsupported Gravitino type: " + type.name());
     }
@@ -349,8 +355,18 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
   }
 
   private Field toGeoArrowField(String name, Types.GeometryType type, boolean nullable) {
+    return toGeoArrowField(name, type.crs(), Optional.empty(), nullable);
+  }
+
+  private Field toGeoArrowField(String name, Types.GeographyType type, boolean nullable) {
+    return toGeoArrowField(name, type.crs(), Optional.of(type.algorithm()), nullable);
+  }
+
+  private Field toGeoArrowField(
+      String name, String crs, Optional<String> edgeAlgorithm, boolean nullable) {
     ObjectNode extensionMetadata = mapper.createObjectNode();
-    putCrs(extensionMetadata, type.crs());
+    putCrs(extensionMetadata, crs);
+    edgeAlgorithm.ifPresent(algorithm -> extensionMetadata.put("edges", algorithm));
     FieldType fieldType =
         new FieldType(
             nullable,
@@ -367,7 +383,11 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
   private Optional<Type> toKnownExtensionType(Field arrowField) {
     Map<String, String> metadata = arrowField.getFieldType().getMetadata();
     if (!GEOARROW_WKB_EXTENSION_NAME.equals(metadata.get(ARROW_EXTENSION_NAME))
-        || !(arrowField.getType() instanceof ArrowType.Binary)) {
+        || metadata.size() != 2
+        || !metadata.containsKey(ARROW_EXTENSION_METADATA)
+        || !(arrowField.getType() instanceof ArrowType.Binary)
+        || arrowField.getFieldType().getDictionary() != null
+        || !arrowField.getChildren().isEmpty()) {
       return Optional.empty();
     }
 
@@ -377,13 +397,21 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
     }
     try {
       JsonNode metadataNode = mapper.readTree(extensionMetadata);
-      if (!metadataNode.isObject()
-          || !hasOnlyGeoArrowMetadataKeys(metadataNode)
-          || metadataNode.has("edges")) {
+      if (!metadataNode.isObject() || !hasOnlyGeoArrowMetadataKeys(metadataNode)) {
         return Optional.empty();
       }
       String crs = readCrs(metadataNode.get("crs"));
-      return crs == null ? Optional.empty() : Optional.of(Types.GeometryType.of(crs));
+      if (crs == null) {
+        return Optional.empty();
+      }
+      JsonNode edgesNode = metadataNode.get("edges");
+      if (edgesNode == null) {
+        return Optional.of(Types.GeometryType.of(crs));
+      }
+      if (!edgesNode.isTextual()) {
+        return Optional.empty();
+      }
+      return Optional.of(Types.GeographyType.of(crs, edgesNode.asText()));
     } catch (Exception e) {
       return Optional.empty();
     }

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.rel.types.Types.FixedType;
 public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Field> {
 
   public static final LanceDataTypeConverter CONVERTER = new LanceDataTypeConverter();
+  private static final String ARROW_EXTENSION_NAME = "ARROW:extension:name";
   private static final ObjectMapper mapper = new ObjectMapper();
 
   public Field toArrowField(String name, Type type, boolean nullable) {
@@ -196,6 +197,9 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
       case FIXED:
         FixedType fixedType = (FixedType) type;
         return new ArrowType.FixedSizeBinary(fixedType.length());
+      case VARIANT:
+        throw new IllegalArgumentException(
+            "Lance 6.0 and Arrow 18 do not provide an exact native representation for Gravitino Variant");
       default:
         throw new UnsupportedOperationException("Unsupported Gravitino type: " + type.name());
     }
@@ -204,6 +208,11 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
   @Override
   public Type toGravitino(Field arrowField) {
     FieldType fieldType = arrowField.getFieldType();
+    if (fieldType.getMetadata() != null
+        && fieldType.getMetadata().containsKey(ARROW_EXTENSION_NAME)) {
+      return toExternalType(arrowField);
+    }
+
     switch (fieldType.getType().getTypeID()) {
       case Map:
         Field structField = arrowField.getChildren().get(0);
@@ -318,12 +327,14 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
         // fallthrough
     }
 
-    String typeString;
+    return toExternalType(arrowField);
+  }
+
+  private Types.ExternalType toExternalType(Field arrowField) {
     try {
-      typeString = mapper.writeValueAsString(arrowField);
+      return Types.ExternalType.of(mapper.writeValueAsString(arrowField));
     } catch (Exception e) {
       throw new RuntimeException("Failed to serialize Arrow field to string.", e);
     }
-    return Types.ExternalType.of(typeString);
   }
 }

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
@@ -133,6 +133,10 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
             field.isNullable());
         return field;
 
+      case NULL:
+        Preconditions.checkArgument(nullable, "Lance Arrow Null columns must be nullable");
+        return Field.nullable(name, ArrowType.Null.INSTANCE);
+
       default:
         // non-complex type
         FieldType fieldType = new FieldType(nullable, fromGravitino(type), null);

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/LanceDataTypeConverter.java
@@ -284,10 +284,13 @@ public class LanceDataTypeConverter implements DataTypeConverter<ArrowType, Fiel
               case MICROSECOND -> 6;
               case NANOSECOND -> 9;
             };
-        boolean hasTimeZone = timestampType.getTimezone() != null;
-        return hasTimeZone
-            ? Types.TimestampType.withTimeZone(precision)
-            : Types.TimestampType.withoutTimeZone(precision);
+        if (timestampType.getTimezone() == null) {
+          return Types.TimestampType.withoutTimeZone(precision);
+        }
+        if ("UTC".equals(timestampType.getTimezone())) {
+          return Types.TimestampType.withTimeZone(precision);
+        }
+        break;
       case Time:
         ArrowType.Time timeType = (ArrowType.Time) fieldType.getType();
         if (timeType.getUnit() == TimeUnit.NANOSECOND && timeType.getBitWidth() == 8 * 8) {

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
@@ -264,6 +264,21 @@ public class TestLanceDataTypeConverter {
   }
 
   @Test
+  public void testUnknownTypeRoundTripAndNullability() {
+    Field field = CONVERTER.toArrowField("unknown_value", Types.NullType.get(), true);
+
+    assertEquals(ArrowType.Null.INSTANCE, field.getType());
+    assertTrue(field.isNullable());
+    assertEquals(Types.NullType.get(), CONVERTER.toGravitino(field));
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CONVERTER.toArrowField("unknown_value", Types.NullType.get(), false));
+    assertTrue(exception.getMessage().contains("Null columns must be nullable"));
+  }
+
+  @Test
   public void testExternalTypeConversion() {
     String expectedColumnName = "col_name";
     boolean expectedNullable = true;

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
@@ -208,6 +208,36 @@ public class TestLanceDataTypeConverter {
   }
 
   @Test
+  public void testNanosecondTimestampRoundTrip() {
+    Types.TimestampType timestampNs = Types.TimestampType.withoutTimeZone(9);
+    Types.TimestampType timestampTzNs = Types.TimestampType.withTimeZone(9);
+
+    Field timestampField = CONVERTER.toArrowField("timestamp_ns", timestampNs, true);
+    Field timestampTzField = CONVERTER.toArrowField("timestamptz_ns", timestampTzNs, true);
+
+    assertEquals(
+        new ArrowType.Timestamp(TimeUnit.NANOSECOND, null),
+        timestampField.getFieldType().getType());
+    assertEquals(
+        new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC"),
+        timestampTzField.getFieldType().getType());
+    assertEquals(timestampNs, CONVERTER.toGravitino(timestampField));
+    assertEquals(timestampTzNs, CONVERTER.toGravitino(timestampTzField));
+  }
+
+  @Test
+  public void testNonUtcTimestampPreservesTimezoneAsExternalType() {
+    Field field =
+        Field.nullable(
+            "event_time", new ArrowType.Timestamp(TimeUnit.NANOSECOND, "America/Los_Angeles"));
+
+    Type converted = CONVERTER.toGravitino(field);
+
+    assertInstanceOf(Types.ExternalType.class, converted);
+    assertEquals(field, CONVERTER.toArrowField("event_time", converted, true));
+  }
+
+  @Test
   public void testExternalTypeConversion() {
     String expectedColumnName = "col_name";
     boolean expectedNullable = true;

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
@@ -305,6 +305,99 @@ public class TestLanceDataTypeConverter {
     assertEquals(geometry, CONVERTER.toGravitino(field));
   }
 
+  @ParameterizedTest
+  @CsvSource({"spherical", "vincenty", "thomas", "andoyer", "karney"})
+  public void testGeographyTypeRoundTripAsGeoArrowWkb(String edgeAlgorithm) {
+    Types.GeographyType geography = Types.GeographyType.of("EPSG:4326", edgeAlgorithm);
+
+    Field field = CONVERTER.toArrowField("shape", geography, true);
+
+    assertEquals(ArrowType.Binary.INSTANCE, field.getType());
+    assertEquals("geoarrow.wkb", field.getMetadata().get("ARROW:extension:name"));
+    assertEquals(
+        String.format("{\"crs\":\"EPSG:4326\",\"edges\":\"%s\"}", edgeAlgorithm),
+        field.getMetadata().get("ARROW:extension:metadata"));
+    assertEquals(geography, CONVERTER.toGravitino(field));
+  }
+
+  @Test
+  public void testUnsupportedGeoArrowEdgesRemainExternal() {
+    Field field =
+        new Field(
+            "shape",
+            new FieldType(
+                true,
+                ArrowType.Binary.INSTANCE,
+                null,
+                Map.of(
+                    "ARROW:extension:name",
+                    "geoarrow.wkb",
+                    "ARROW:extension:metadata",
+                    "{\"crs\":\"EPSG:4326\",\"edges\":\"rhumb\"}")),
+            null);
+
+    Type converted = CONVERTER.toGravitino(field);
+
+    assertInstanceOf(Types.ExternalType.class, converted);
+    assertEquals(field, CONVERTER.toArrowField("shape", converted, true));
+  }
+
+  @Test
+  public void testGeoArrowRepresentationMetadataRemainsExternal() {
+    Field field =
+        new Field(
+            "shape",
+            new FieldType(
+                true,
+                ArrowType.Binary.INSTANCE,
+                null,
+                Map.of(
+                    "ARROW:extension:name",
+                    "geoarrow.wkb",
+                    "ARROW:extension:metadata",
+                    "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\",\"edges\":\"karney\"}")),
+            null);
+
+    Type converted = CONVERTER.toGravitino(field);
+
+    assertInstanceOf(Types.ExternalType.class, converted);
+    assertEquals(field, CONVERTER.toArrowField("shape", converted, true));
+  }
+
+  @Test
+  public void testGeoArrowCustomFieldMetadataRemainsExternal() {
+    Field field =
+        new Field(
+            "shape",
+            new FieldType(
+                true,
+                ArrowType.Binary.INSTANCE,
+                null,
+                Map.of(
+                    "ARROW:extension:name",
+                    "geoarrow.wkb",
+                    "ARROW:extension:metadata",
+                    "{\"crs\":\"EPSG:4326\",\"edges\":\"karney\"}",
+                    "producer",
+                    "native-client")),
+            null);
+
+    Type converted = CONVERTER.toGravitino(field);
+
+    assertInstanceOf(Types.ExternalType.class, converted);
+    assertEquals(field, CONVERTER.toArrowField("shape", converted, true));
+  }
+
+  @Test
+  public void testGeographyRequiresFieldMetadata() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CONVERTER.fromGravitino(Types.GeographyType.crs84()));
+
+    assertTrue(exception.getMessage().contains("requires GeoArrow field metadata"));
+  }
+
   @Test
   public void testExternalTypeConversion() {
     String expectedColumnName = "col_name";

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
@@ -279,6 +279,33 @@ public class TestLanceDataTypeConverter {
   }
 
   @Test
+  public void testGeometryTypeRoundTripAsGeoArrowWkb() {
+    Types.GeometryType geometry = Types.GeometryType.of("EPSG:3857");
+
+    Field field = CONVERTER.toArrowField("shape", geometry, true);
+
+    assertEquals(ArrowType.Binary.INSTANCE, field.getType());
+    assertEquals("geoarrow.wkb", field.getMetadata().get("ARROW:extension:name"));
+    assertEquals("{\"crs\":\"EPSG:3857\"}", field.getMetadata().get("ARROW:extension:metadata"));
+    assertEquals(geometry, CONVERTER.toGravitino(field));
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> CONVERTER.fromGravitino(geometry));
+    assertTrue(exception.getMessage().contains("requires GeoArrow field metadata"));
+  }
+
+  @Test
+  public void testGeometryProjJsonCrsRoundTrip() {
+    String projJson = "{\"type\":\"ProjectedCRS\",\"name\":\"WGS 84 / Pseudo-Mercator\"}";
+    Types.GeometryType geometry = Types.GeometryType.of(projJson);
+
+    Field field = CONVERTER.toArrowField("shape", geometry, true);
+
+    assertEquals("{\"crs\":" + projJson + "}", field.getMetadata().get("ARROW:extension:metadata"));
+    assertEquals(geometry, CONVERTER.toGravitino(field));
+  }
+
+  @Test
   public void testExternalTypeConversion() {
     String expectedColumnName = "col_name";
     boolean expectedNullable = true;

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestLanceDataTypeConverter.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.arrow.vector.complex.MapVector;
@@ -235,6 +237,30 @@ public class TestLanceDataTypeConverter {
 
     assertInstanceOf(Types.ExternalType.class, converted);
     assertEquals(field, CONVERTER.toArrowField("event_time", converted, true));
+  }
+
+  @Test
+  public void testVariantTypeIsRejectedAndArrowExtensionsRemainExternal() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> CONVERTER.fromGravitino(Types.VariantType.get()));
+    assertTrue(exception.getMessage().contains("exact native representation"));
+
+    Field nativeVariant =
+        new Field(
+            "payload",
+            new FieldType(
+                true,
+                ArrowType.Struct.INSTANCE,
+                null,
+                Map.of("ARROW:extension:name", "arrow.parquet.variant")),
+            List.of(
+                Field.notNullable("metadata", ArrowType.Binary.INSTANCE),
+                Field.nullable("value", ArrowType.Binary.INSTANCE)));
+    Type converted = CONVERTER.toGravitino(nativeVariant);
+
+    assertInstanceOf(Types.ExternalType.class, converted);
+    assertEquals(nativeVariant, CONVERTER.toArrowField("payload", converted, true));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Define and document Lance compatibility for the five Gravitino V3-native type families.

| Type family | Outcome |
| --- | --- |
| Nanosecond timestamps | Round-trip exact precision-9 timestamps. |
| Variant | Reject before dataset mutation. |
| Unknown/Null | Round-trip nullable Unknown through Arrow Null; reject unsupported non-null use. |
| Geometry | Round-trip through GeoArrow WKB while preserving CRS. |
| Geography | Round-trip through GeoArrow WKB while preserving CRS and edge-algorithm metadata. |

### Why are the changes needed?

Lance and Arrow provide exact representations for four families. Variant has no lossless target and must fail without overwriting the existing dataset.

Fix: #12064

Related: #12056

### Does this PR introduce _any_ user-facing change?

Yes. Timestamp, nullable Unknown, Geometry, and Geography gain exact mappings, while Variant fails before mutation.

### How was this patch tested?

- Added native Lance schema round-trip coverage.
- Verified rejected Variant overwrite leaves the original dataset and metadata intact.
- Covered the Lance-specific module suites and native integration paths.
- Updated `docs/lakehouse-generic-lance-table.md`.
