### PR TITLE
[#12065] fix(jdbc): validate type mappings before table DDL

### DIFF
--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableOperations.java
@@ -532,6 +532,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
       throws NoSuchTableException {
     LOG.info("Attempting to alter table {} from database {}", tableName, databaseName);
     try (Connection connection = getConnection(databaseName)) {
+      validateAlterTableTypes(connection, databaseName, tableName, changes);
       String sql = generateAlterTableSql(databaseName, tableName, changes);
       if (StringUtils.isEmpty(sql)) {
         LOG.info("No changes to alter table {} from database {}", tableName, databaseName);

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
@@ -212,6 +212,7 @@ public class OceanBaseTableOperations extends JdbcTableOperations {
       throws NoSuchTableException {
     LOG.info("Attempting to alter table {} from database {}", tableName, databaseName);
     try (Connection connection = getConnection(databaseName)) {
+      validateAlterTableTypes(connection, databaseName, tableName, changes);
       for (TableChange change : changes) {
         String sql = generateAlterTableSql(databaseName, tableName, change);
         if (StringUtils.isEmpty(sql)) {

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/converter/JdbcTypeConverter.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/converter/JdbcTypeConverter.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.catalog.jdbc.converter;
 
 import java.util.Objects;
 import org.apache.gravitino.connector.DataTypeConverter;
+import org.apache.gravitino.rel.types.Type;
 
 public abstract class JdbcTypeConverter
     implements DataTypeConverter<String, JdbcTypeConverter.JdbcTypeBean> {
@@ -29,6 +30,42 @@ public abstract class JdbcTypeConverter
   public static final String TIMESTAMP = "timestamp";
   public static final String VARCHAR = "varchar";
   public static final String TEXT = "text";
+
+  /**
+   * Creates a deterministic invalid-argument exception for an unsupported Gravitino-to-JDBC type
+   * mapping.
+   *
+   * @param connector JDBC connector name
+   * @param sourceType Gravitino source type
+   * @param constraint connector constraint that the source type violates
+   * @return invalid-argument exception containing the connector, source type, and constraint
+   */
+  public static IllegalArgumentException unsupportedTypeException(
+      String connector, Type sourceType, String constraint) {
+    return unsupportedTypeException(connector, sourceType.simpleString(), constraint);
+  }
+
+  /**
+   * Creates a deterministic invalid-argument exception for an unsupported JDBC-to-Gravitino type
+   * mapping.
+   *
+   * @param connector JDBC connector name
+   * @param sourceType JDBC source type
+   * @param constraint connector constraint that the source type violates
+   * @return invalid-argument exception containing the connector, source type, and constraint
+   */
+  public static IllegalArgumentException unsupportedTypeException(
+      String connector, JdbcTypeBean sourceType, String constraint) {
+    return unsupportedTypeException(connector, sourceType.toString(), constraint);
+  }
+
+  private static IllegalArgumentException unsupportedTypeException(
+      String connector, String sourceType, String constraint) {
+    return new IllegalArgumentException(
+        String.format(
+            "JDBC connector '%s' cannot map source type '%s': %s",
+            connector, sourceType, constraint));
+  }
 
   public static class JdbcTypeBean {
     /** Data type name. */

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -106,6 +106,94 @@ public abstract class JdbcTableOperations implements TableOperation {
     sqlBuilder.append("DEFAULT ").append(defaultValue).append(SPACE);
   }
 
+  /**
+   * Validates all create-table types before generating or executing DDL.
+   *
+   * <p>This method first invokes the configured type converter for every column so that static
+   * connector rules fail before any DDL. It then invokes {@link
+   * #validateCreateTableTypeCapabilities(Connection, String, String, JdbcColumn[])} for
+   * connection-dependent checks.
+   *
+   * @param connection live JDBC connection used for the create operation
+   * @param databaseName database that will contain the table
+   * @param tableName table to create
+   * @param columns columns requested for the table
+   * @throws SQLException if capability discovery through the JDBC connection fails
+   */
+  protected final void validateCreateTableTypes(
+      Connection connection, String databaseName, String tableName, JdbcColumn[] columns)
+      throws SQLException {
+    Arrays.stream(columns).forEach(column -> typeConverter.fromGravitino(column.dataType()));
+    validateCreateTableTypeCapabilities(connection, databaseName, tableName, columns);
+  }
+
+  /**
+   * Validates all alter-table types before generating or executing DDL.
+   *
+   * <p>This method first invokes the configured type converter for every type-bearing change so
+   * that the entire batch is checked before any DDL. It then invokes {@link
+   * #validateAlterTableTypeCapabilities(Connection, String, String, TableChange...)} for
+   * connection-dependent checks.
+   *
+   * @param connection live JDBC connection used for the alter operation
+   * @param databaseName database containing the table
+   * @param tableName table to alter
+   * @param changes requested table changes
+   * @throws SQLException if capability discovery through the JDBC connection fails
+   */
+  protected final void validateAlterTableTypes(
+      Connection connection, String databaseName, String tableName, TableChange... changes)
+      throws SQLException {
+    Arrays.stream(changes)
+        .forEach(
+            change -> {
+              if (change instanceof TableChange.AddColumn addColumn) {
+                typeConverter.fromGravitino(addColumn.getDataType());
+              } else if (change instanceof TableChange.UpdateColumnType updateColumnType) {
+                typeConverter.fromGravitino(updateColumnType.getNewDataType());
+              }
+            });
+    validateAlterTableTypeCapabilities(connection, databaseName, tableName, changes);
+  }
+
+  /**
+   * Validates connection-dependent create-table type capabilities.
+   *
+   * <p>The default implementation accepts all types. Connector implementations can override this
+   * hook to inspect the database version, installed extensions, or server mode.
+   *
+   * @param connection live JDBC connection used for the create operation
+   * @param databaseName database that will contain the table
+   * @param tableName table to create
+   * @param columns columns requested for the table
+   * @throws SQLException if capability discovery through the JDBC connection fails
+   */
+  protected void validateCreateTableTypeCapabilities(
+      Connection connection, String databaseName, String tableName, JdbcColumn[] columns)
+      throws SQLException {
+    // Nothing to validate by default.
+  }
+
+  /**
+   * Validates connection-dependent alter-table type capabilities.
+   *
+   * <p>The default implementation accepts all types. Connector implementations can override this
+   * hook to inspect the database version, installed extensions, or server mode. Every requested
+   * change is provided together so that an invalid later change is rejected before an earlier DDL
+   * statement executes.
+   *
+   * @param connection live JDBC connection used for the alter operation
+   * @param databaseName database containing the table
+   * @param tableName table to alter
+   * @param changes requested table changes
+   * @throws SQLException if capability discovery through the JDBC connection fails
+   */
+  protected void validateAlterTableTypeCapabilities(
+      Connection connection, String databaseName, String tableName, TableChange... changes)
+      throws SQLException {
+    // Nothing to validate by default.
+  }
+
   @Override
   public void create(
       String databaseName,
@@ -143,6 +231,7 @@ public abstract class JdbcTableOperations implements TableOperation {
       throws TableAlreadyExistsException {
     LOG.info("Attempting to create table {} in database {}", tableName, databaseName);
     try (Connection connection = getConnection(databaseName)) {
+      validateCreateTableTypes(connection, databaseName, tableName, columns);
       String sql =
           generateCreateTableSql(
               tableName,
@@ -354,6 +443,7 @@ public abstract class JdbcTableOperations implements TableOperation {
       throws NoSuchTableException {
     LOG.info("Attempting to alter table {} from database {}", tableName, databaseName);
     try (Connection connection = getConnection(databaseName)) {
+      validateAlterTableTypes(connection, databaseName, tableName, changes);
       String sql = generateAlterTableSql(databaseName, tableName, changes);
       if (StringUtils.isEmpty(sql)) {
         LOG.info("No changes to alter table {} from database {}", tableName, databaseName);

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/converter/TestJdbcTypeConverter.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/converter/TestJdbcTypeConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.converter;
+
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestJdbcTypeConverter {
+
+  @Test
+  public void testUnsupportedGravitinoTypeMessage() {
+    IllegalArgumentException exception =
+        JdbcTypeConverter.unsupportedTypeException(
+            "example", Types.TimestampType.withoutTimeZone(9), "maximum precision is 6");
+
+    Assertions.assertEquals(
+        "JDBC connector 'example' cannot map source type 'timestamp(9)': maximum precision is 6",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testUnsupportedJdbcTypeMessage() {
+    JdbcTypeConverter.JdbcTypeBean type = new JdbcTypeConverter.JdbcTypeBean("GEOMETRY");
+    type.setColumnSize(0);
+    type.setScale(0);
+
+    IllegalArgumentException exception =
+        JdbcTypeConverter.unsupportedTypeException(
+            "example", type, "SRID metadata cannot be preserved");
+
+    Assertions.assertEquals(
+        "JDBC connector 'example' cannot map source type "
+            + "'JdbcTypeBean{typeName='GEOMETRY', columnSize='0', scale='0', "
+            + "datetimePrecision='null'}': SRID metadata cannot be preserved",
+        exception.getMessage());
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
@@ -22,6 +22,9 @@ import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -37,6 +40,7 @@ import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.catalog.jdbc.converter.SqliteColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.SqliteExceptionConverter;
 import org.apache.gravitino.catalog.jdbc.converter.SqliteTypeConverter;
@@ -45,7 +49,11 @@ import org.apache.gravitino.connector.BaseColumn;
 import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.TableChange;
+import org.apache.gravitino.rel.expressions.distributions.Distribution;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.sorts.SortOrder;
+import org.apache.gravitino.rel.expressions.transforms.Transform;
+import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.rel.indexes.Indexes;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
@@ -245,6 +253,118 @@ public class TestJdbcTableOperations {
     Assertions.assertTrue(JDBC_TABLE_OPERATIONS.isMySQLDriverVersionSupported("org.sqlite.JDBC"));
   }
 
+  @Test
+  public void testCreateTypeValidationRunsBeforeBothCreateOverloads() {
+    assertCreateRejectedBeforeSql(false);
+    assertCreateRejectedBeforeSql(true);
+  }
+
+  @Test
+  public void testAlterTypeValidationRunsBeforeSqlGeneration() {
+    ValidatingSqliteTableOperations operations = createValidatingTableOperations();
+    TableChange[] changes = {
+      TableChange.updateColumnType(new String[] {"col"}, Types.VariantType.get()),
+      TableChange.addColumn(new String[] {"later_col"}, Types.StringType.get())
+    };
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> operations.alterTable(DATABASE_NAME, "validation_alter", changes));
+
+    Assertions.assertEquals(
+        ValidatingSqliteTableOperations.REJECTION_MESSAGE, exception.getMessage());
+    Assertions.assertTrue(operations.alterValidationCalled);
+    Assertions.assertEquals(changes.length, operations.validatedAlterChangeCount);
+    Assertions.assertFalse(operations.alterSqlGenerated);
+  }
+
+  @Test
+  public void testStaticConverterValidationRejectsWholeAlterBatchBeforeSqlGeneration() {
+    PreflightSqliteTableOperations operations = new PreflightSqliteTableOperations();
+    RejectingSqliteTypeConverter converter = new RejectingSqliteTypeConverter();
+    operations.initialize(
+        DATA_SOURCE,
+        EXCEPTION_CONVERTER,
+        converter,
+        COLUMN_DEFAULT_VALUE_CONVERTER,
+        Collections.emptyMap());
+    TableChange[] changes = {
+      TableChange.addColumn(new String[] {"valid_col"}, Types.StringType.get()),
+      TableChange.addColumn(new String[] {"invalid_col"}, Types.VariantType.get())
+    };
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> operations.alterTable(DATABASE_NAME, "preflight_alter", changes));
+
+    Assertions.assertEquals(
+        "JDBC connector 'sqlite-test' cannot map source type 'variant': unsupported test type",
+        exception.getMessage());
+    Assertions.assertEquals(
+        Arrays.asList(Type.Name.STRING, Type.Name.VARIANT), converter.validatedTypes);
+    Assertions.assertFalse(operations.alterSqlGenerated);
+  }
+
+  private static void assertCreateRejectedBeforeSql(boolean useSortOrderOverload) {
+    ValidatingSqliteTableOperations operations = createValidatingTableOperations();
+    String tableName =
+        useSortOrderOverload ? "validation_create_with_sort" : "validation_create_without_sort";
+    JdbcColumn[] columns = {
+      JdbcColumn.builder()
+          .withName("variant_col")
+          .withType(Types.VariantType.get())
+          .withNullable(true)
+          .build()
+    };
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              if (useSortOrderOverload) {
+                operations.create(
+                    DATABASE_NAME,
+                    tableName,
+                    columns,
+                    null,
+                    Collections.emptyMap(),
+                    new Transform[0],
+                    Distributions.NONE,
+                    Indexes.EMPTY_INDEXES,
+                    new SortOrder[0]);
+              } else {
+                operations.create(
+                    DATABASE_NAME,
+                    tableName,
+                    columns,
+                    null,
+                    Collections.emptyMap(),
+                    new Transform[0],
+                    Distributions.NONE,
+                    Indexes.EMPTY_INDEXES);
+              }
+            });
+
+    Assertions.assertEquals(
+        ValidatingSqliteTableOperations.REJECTION_MESSAGE, exception.getMessage());
+    Assertions.assertTrue(operations.createValidationCalled);
+    Assertions.assertFalse(operations.createSqlGenerated);
+    Assertions.assertFalse(operations.listTables(DATABASE_NAME).contains(tableName));
+  }
+
+  private static ValidatingSqliteTableOperations createValidatingTableOperations() {
+    ValidatingSqliteTableOperations operations = new ValidatingSqliteTableOperations();
+    operations.initialize(
+        DATA_SOURCE,
+        EXCEPTION_CONVERTER,
+        TYPE_CONVERTER,
+        COLUMN_DEFAULT_VALUE_CONVERTER,
+        Collections.emptyMap());
+    return operations;
+  }
+
   private static JdbcColumn[] generateRandomColumn(int minSize, int maxSize) {
     Random r = new Random();
     String prefixColName = "col_";
@@ -267,5 +387,85 @@ public class TestJdbcTableOperations {
         .skip(r.nextInt(values.size()))
         .findFirst()
         .orElseThrow(() -> new RuntimeException("No type found"));
+  }
+
+  private static class ValidatingSqliteTableOperations extends SqliteTableOperations {
+
+    private static final String REJECTION_MESSAGE = "test connector rejects variant";
+
+    private boolean createValidationCalled;
+    private boolean createSqlGenerated;
+    private boolean alterValidationCalled;
+    private boolean alterSqlGenerated;
+    private int validatedAlterChangeCount;
+
+    @Override
+    protected void validateCreateTableTypeCapabilities(
+        Connection connection, String databaseName, String tableName, JdbcColumn[] columns)
+        throws SQLException {
+      Assertions.assertFalse(connection.isClosed());
+      Assertions.assertNotNull(connection.getMetaData());
+      createValidationCalled = true;
+      throw new IllegalArgumentException(REJECTION_MESSAGE);
+    }
+
+    @Override
+    protected void validateAlterTableTypeCapabilities(
+        Connection connection, String databaseName, String tableName, TableChange... changes)
+        throws SQLException {
+      Assertions.assertFalse(connection.isClosed());
+      Assertions.assertNotNull(connection.getMetaData());
+      alterValidationCalled = true;
+      validatedAlterChangeCount = changes.length;
+      throw new IllegalArgumentException(REJECTION_MESSAGE);
+    }
+
+    @Override
+    protected String generateCreateTableSql(
+        String tableName,
+        JdbcColumn[] columns,
+        String comment,
+        Map<String, String> properties,
+        Transform[] partitioning,
+        Distribution distribution,
+        Index[] indexes) {
+      createSqlGenerated = true;
+      return super.generateCreateTableSql(
+          tableName, columns, comment, properties, partitioning, distribution, indexes);
+    }
+
+    @Override
+    protected String generateAlterTableSql(
+        String databaseName, String tableName, TableChange... changes) {
+      alterSqlGenerated = true;
+      return "ALTER TABLE " + tableName;
+    }
+  }
+
+  private static class PreflightSqliteTableOperations extends SqliteTableOperations {
+
+    private boolean alterSqlGenerated;
+
+    @Override
+    protected String generateAlterTableSql(
+        String databaseName, String tableName, TableChange... changes) {
+      alterSqlGenerated = true;
+      return "ALTER TABLE " + tableName;
+    }
+  }
+
+  private static class RejectingSqliteTypeConverter extends SqliteTypeConverter {
+
+    private final List<Type.Name> validatedTypes = new ArrayList<>();
+
+    @Override
+    public String fromGravitino(Type type) {
+      validatedTypes.add(type.name());
+      if (type instanceof Types.VariantType) {
+        throw JdbcTypeConverter.unsupportedTypeException(
+            "sqlite-test", type, "unsupported test type");
+      }
+      return super.fromGravitino(type);
+    }
   }
 }

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -937,6 +937,14 @@ The following types that Gravitino supports:
 
 The related java doc is [here](pathname:///docs/2.0.0-SNAPSHOT/api/java/org/apache/gravitino/rel/types/Type.html).
 
+##### JDBC type compatibility
+
+JDBC catalogs validate every type-bearing column in a create or alter request before sending table
+DDL to the database. Type support and constraints remain connector-specific; for example, a
+connector may reject a timestamp precision it cannot preserve or a spatial type whose CRS metadata
+would be lost. An incompatible mapping fails as an invalid argument before any statement in the
+request is executed. See the individual JDBC catalog documentation for supported mappings.
+
 ##### Null type
 
 The null type represents a column that holds only null values and whose concrete type is not yet


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add shared JDBC type-mapping preflight validation for complete create and alter requests.

The shared operation layer now validates every type-bearing column or change before generating or executing DDL, and exposes capability hooks for connector-specific checks. Custom ClickHouse and OceanBase operation paths are routed through the same contract.

### Why are the changes needed?

A later invalid column in a create or alter request must not leave earlier DDL partially applied. JDBC connectors need one shared boundary that converts or rejects the whole request before database mutation.

Fix: #12065

Related: #12056

### Does this PR introduce _any_ user-facing change?

Yes. Unsupported JDBC type mappings fail before DDL generation or execution, preserving the public invalid-argument and no-partial-mutation contract.

### How was this patch tested?

- Added focused `JdbcTypeConverter` validation coverage.
- Covered both create overloads.
- Covered whole-batch alter validation before SQL generation.
- Covered connector capability hooks.
- Updated `docs/manage-relational-metadata-using-gravitino.md`.
