### PR TITLE
[#12071] fix(jdbc-hologres): complete V3 type compatibility

### DIFF
--- a/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
@@ -173,6 +173,11 @@ public class HologresTypeConverter extends JdbcTypeConverter {
     } else if (type instanceof Types.VariantType) {
       throw new IllegalArgumentException(
           "Hologres JSON and JSONB do not preserve Gravitino Variant semantics; cannot convert Gravitino type variant");
+    } else if (type instanceof Types.GeometryType) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Hologres PostGIS geometry metadata does not preserve Gravitino Geometry CRS semantics; cannot convert Gravitino type %s",
+              type.simpleString()));
     } else if (type instanceof Types.ListType) {
       return fromGravitinoArrayType((ListType) type);
     } else if (type instanceof Types.ExternalType) {

--- a/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
@@ -167,6 +167,9 @@ public class HologresTypeConverter extends JdbcTypeConverter {
       return BPCHAR + "(" + ((Types.FixedCharType) type).length() + ")";
     } else if (type instanceof Types.BinaryType) {
       return BYTEA;
+    } else if (type instanceof Types.NullType) {
+      throw new IllegalArgumentException(
+          "Hologres table columns cannot represent Gravitino Unknown (NullType); cannot convert Gravitino type null");
     } else if (type instanceof Types.VariantType) {
       throw new IllegalArgumentException(
           "Hologres JSON and JSONB do not preserve Gravitino Variant semantics; cannot convert Gravitino type variant");

--- a/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
@@ -62,6 +62,8 @@ public class HologresTypeConverter extends JdbcTypeConverter {
   static final String BYTEA = "bytea";
   @VisibleForTesting static final String JDBC_ARRAY_PREFIX = "_";
   @VisibleForTesting static final String ARRAY_TOKEN = "[]";
+  @VisibleForTesting static final int MAX_TIMESTAMP_PRECISION = 6;
+  @VisibleForTesting static final int MAX_TIMESTAMPTZ_PRECISION = 3;
 
   @Override
   public Type toGravitino(JdbcTypeBean typeBean) {
@@ -90,11 +92,17 @@ public class HologresTypeConverter extends JdbcTypeConverter {
             .orElseGet(Types.TimeType::get);
       case TIMESTAMP:
         return Optional.ofNullable(typeBean.getDatetimePrecision())
-            .map(Types.TimestampType::withoutTimeZone)
+            .map(
+                precision ->
+                    Types.TimestampType.withoutTimeZone(
+                        Math.min(precision, MAX_TIMESTAMP_PRECISION)))
             .orElseGet(Types.TimestampType::withoutTimeZone);
       case TIMESTAMP_TZ:
         return Optional.ofNullable(typeBean.getDatetimePrecision())
-            .map(Types.TimestampType::withTimeZone)
+            .map(
+                precision ->
+                    Types.TimestampType.withTimeZone(
+                        Math.min(precision, MAX_TIMESTAMPTZ_PRECISION)))
             .orElseGet(Types.TimestampType::withTimeZone);
       case NUMERIC:
         return Types.DecimalType.of(typeBean.getColumnSize(), typeBean.getScale());
@@ -134,9 +142,17 @@ public class HologresTypeConverter extends JdbcTypeConverter {
     } else if (type instanceof Types.TimeType) {
       return type.simpleString();
     } else if (type instanceof Types.TimestampType) {
-      // Hologres does not support precision for TIMESTAMP/TIMESTAMPTZ (e.g. timestamptz(6)),
-      // so we always emit the base type without precision.
       Types.TimestampType timestampType = (Types.TimestampType) type;
+      int maxPrecision =
+          timestampType.hasTimeZone() ? MAX_TIMESTAMPTZ_PRECISION : MAX_TIMESTAMP_PRECISION;
+      if (timestampType.hasPrecisionSet() && timestampType.precision() > maxPrecision) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Hologres %s supports precision up to %d and cannot preserve Gravitino type %s",
+                timestampType.hasTimeZone() ? TIMESTAMP_TZ : TIMESTAMP,
+                maxPrecision,
+                type.simpleString()));
+      }
       return timestampType.hasTimeZone() ? TIMESTAMP_TZ : TIMESTAMP;
     } else if (type instanceof Types.DecimalType) {
       return NUMERIC

--- a/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
@@ -167,6 +167,9 @@ public class HologresTypeConverter extends JdbcTypeConverter {
       return BPCHAR + "(" + ((Types.FixedCharType) type).length() + ")";
     } else if (type instanceof Types.BinaryType) {
       return BYTEA;
+    } else if (type instanceof Types.VariantType) {
+      throw new IllegalArgumentException(
+          "Hologres JSON and JSONB do not preserve Gravitino Variant semantics; cannot convert Gravitino type variant");
     } else if (type instanceof Types.ListType) {
       return fromGravitinoArrayType((ListType) type);
     } else if (type instanceof Types.ExternalType) {

--- a/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/converter/HologresTypeConverter.java
@@ -178,6 +178,11 @@ public class HologresTypeConverter extends JdbcTypeConverter {
           String.format(
               "Hologres PostGIS geometry metadata does not preserve Gravitino Geometry CRS semantics; cannot convert Gravitino type %s",
               type.simpleString()));
+    } else if (type instanceof Types.GeographyType) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Hologres PostGIS geography metadata does not preserve Gravitino Geography CRS and edge-algorithm semantics; cannot convert Gravitino type %s",
+              type.simpleString()));
     } else if (type instanceof Types.ListType) {
       return fromGravitinoArrayType((ListType) type);
     } else if (type instanceof Types.ExternalType) {

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
@@ -331,6 +331,23 @@ public class TestHologresTypeConverter {
   }
 
   @Test
+  public void testRejectGeographyType() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> converter.fromGravitino(Types.GeographyType.of("EPSG:4326", "karney")));
+
+    Assertions.assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Hologres PostGIS geography metadata does not preserve Gravitino Geography CRS and edge-algorithm semantics"));
+
+    JdbcTypeConverter.JdbcTypeBean typeBean = new JdbcTypeConverter.JdbcTypeBean("geography");
+    Assertions.assertEquals(Types.ExternalType.of("geography"), converter.toGravitino(typeBean));
+  }
+
+  @Test
   public void testNullableArrayThrowsException() {
     Assertions.assertThrows(
         IllegalArgumentException.class,

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
@@ -280,6 +280,22 @@ public class TestHologresTypeConverter {
     // Test fromGravitino for external type
     String hologresType = converter.fromGravitino(Types.ExternalType.of("jsonb"));
     Assertions.assertEquals("jsonb", hologresType);
+
+    typeBean = new JdbcTypeConverter.JdbcTypeBean("jsonb");
+    gravitinoType = converter.toGravitino(typeBean);
+    Assertions.assertEquals(Types.ExternalType.of("jsonb"), gravitinoType);
+  }
+
+  @Test
+  public void testRejectVariantType() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> converter.fromGravitino(Types.VariantType.get()));
+
+    Assertions.assertTrue(
+        exception
+            .getMessage()
+            .contains("Hologres JSON and JSONB do not preserve Gravitino Variant semantics"));
   }
 
   @Test

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
@@ -299,6 +299,21 @@ public class TestHologresTypeConverter {
   }
 
   @Test
+  public void testRejectUnknownType() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> converter.fromGravitino(Types.NullType.get()));
+
+    Assertions.assertTrue(
+        exception
+            .getMessage()
+            .contains("Hologres table columns cannot represent Gravitino Unknown (NullType)"));
+
+    JdbcTypeConverter.JdbcTypeBean typeBean = new JdbcTypeConverter.JdbcTypeBean("unknown");
+    Assertions.assertEquals(Types.ExternalType.of("unknown"), converter.toGravitino(typeBean));
+  }
+
+  @Test
   public void testNullableArrayThrowsException() {
     Assertions.assertThrows(
         IllegalArgumentException.class,

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
@@ -145,13 +145,43 @@ public class TestHologresTypeConverter {
     hologresType = converter.fromGravitino(Types.TimestampType.withTimeZone());
     Assertions.assertEquals("timestamptz", hologresType);
 
-    // Test fromGravitino with timezone and precision - Hologres does not support precision
-    hologresType = converter.fromGravitino(Types.TimestampType.withTimeZone(6));
-    Assertions.assertEquals("timestamptz", hologresType);
-
-    // Test fromGravitino without timezone and precision - Hologres does not support precision
+    // Hologres stores timestamp without time zone with microsecond precision.
     hologresType = converter.fromGravitino(Types.TimestampType.withoutTimeZone(6));
     Assertions.assertEquals("timestamp", hologresType);
+
+    // Hologres stores timestamp with time zone with millisecond precision.
+    hologresType = converter.fromGravitino(Types.TimestampType.withTimeZone(3));
+    Assertions.assertEquals("timestamptz", hologresType);
+  }
+
+  @Test
+  public void testTimestampMetadataIsNormalizedToNativePrecision() {
+    JdbcTypeConverter.JdbcTypeBean typeBean =
+        new JdbcTypeConverter.JdbcTypeBean(HologresTypeConverter.TIMESTAMP);
+    typeBean.setDatetimePrecision(9);
+    Assertions.assertEquals(
+        Types.TimestampType.withoutTimeZone(HologresTypeConverter.MAX_TIMESTAMP_PRECISION),
+        converter.toGravitino(typeBean));
+
+    typeBean = new JdbcTypeConverter.JdbcTypeBean(HologresTypeConverter.TIMESTAMP_TZ);
+    typeBean.setDatetimePrecision(6);
+    Assertions.assertEquals(
+        Types.TimestampType.withTimeZone(HologresTypeConverter.MAX_TIMESTAMPTZ_PRECISION),
+        converter.toGravitino(typeBean));
+  }
+
+  @Test
+  public void testRejectNanosecondTimestampTypes() {
+    Type[] nanosecondTypes = {
+      Types.TimestampType.withoutTimeZone(9), Types.TimestampType.withTimeZone(9)
+    };
+
+    for (Type type : nanosecondTypes) {
+      IllegalArgumentException exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class, () -> converter.fromGravitino(type));
+      Assertions.assertTrue(exception.getMessage().contains("cannot preserve Gravitino type"));
+    }
   }
 
   @Test

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/converter/TestHologresTypeConverter.java
@@ -314,6 +314,23 @@ public class TestHologresTypeConverter {
   }
 
   @Test
+  public void testRejectGeometryType() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> converter.fromGravitino(Types.GeometryType.of("EPSG:3857")));
+
+    Assertions.assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Hologres PostGIS geometry metadata does not preserve Gravitino Geometry CRS semantics"));
+
+    JdbcTypeConverter.JdbcTypeBean typeBean = new JdbcTypeConverter.JdbcTypeBean("geometry");
+    Assertions.assertEquals(Types.ExternalType.of("geometry"), converter.toGravitino(typeBean));
+  }
+
+  @Test
   public void testNullableArrayThrowsException() {
     Assertions.assertThrows(
         IllegalArgumentException.class,

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
@@ -53,6 +53,7 @@ import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.expressions.transforms.Transforms;
 import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -948,5 +949,37 @@ public class CatalogHologresIT extends BaseIT {
     // Verify logical partition property
     Map<String, String> loadedProps = loadedTable.properties();
     Assertions.assertEquals("true", loadedProps.get("is_logical_partitioned_table"));
+  }
+
+  @Test
+  void testRejectNanosecondTimestampTypesWithoutSideEffects() {
+    assertCreateRejectedWithoutSideEffects(
+        "timestamp_ns",
+        Types.TimestampType.withoutTimeZone(9),
+        "Hologres timestamp supports precision up to 6");
+    assertCreateRejectedWithoutSideEffects(
+        "timestamptz_ns",
+        Types.TimestampType.withTimeZone(9),
+        "Hologres timestamptz supports precision up to 3");
+  }
+
+  private void assertCreateRejectedWithoutSideEffects(
+      String typeName, Type type, String expectedMessage) {
+    String rejectedTableName = GravitinoITUtils.genRandomName("rejected_" + typeName);
+    NameIdentifier tableIdentifier = NameIdentifier.of(schemaName, rejectedTableName);
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                tableCatalog.createTable(
+                    tableIdentifier,
+                    new Column[] {Column.of("unsupported_col", type)},
+                    null,
+                    ImmutableMap.of()));
+
+    Assertions.assertTrue(exception.getMessage().contains(expectedMessage));
+    Assertions.assertFalse(tableCatalog.tableExists(tableIdentifier));
   }
 }

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
@@ -971,6 +971,14 @@ public class CatalogHologresIT extends BaseIT {
         "Hologres JSON and JSONB do not preserve Gravitino Variant semantics");
   }
 
+  @Test
+  void testRejectUnknownWithoutSideEffects() {
+    assertCreateRejectedWithoutSideEffects(
+        "unknown",
+        Types.NullType.get(),
+        "Hologres table columns cannot represent Gravitino Unknown (NullType)");
+  }
+
   private void assertCreateRejectedWithoutSideEffects(
       String typeName, Type type, String expectedMessage) {
     String rejectedTableName = GravitinoITUtils.genRandomName("rejected_" + typeName);

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
@@ -987,6 +987,14 @@ public class CatalogHologresIT extends BaseIT {
         "Hologres PostGIS geometry metadata does not preserve Gravitino Geometry CRS semantics");
   }
 
+  @Test
+  void testRejectGeographyWithoutSideEffects() {
+    assertCreateRejectedWithoutSideEffects(
+        "geography",
+        Types.GeographyType.of("EPSG:4326", "karney"),
+        "Hologres PostGIS geography metadata does not preserve Gravitino Geography CRS and edge-algorithm semantics");
+  }
+
   private void assertCreateRejectedWithoutSideEffects(
       String typeName, Type type, String expectedMessage) {
     String rejectedTableName = GravitinoITUtils.genRandomName("rejected_" + typeName);

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
@@ -963,6 +963,14 @@ public class CatalogHologresIT extends BaseIT {
         "Hologres timestamptz supports precision up to 3");
   }
 
+  @Test
+  void testRejectVariantWithoutSideEffects() {
+    assertCreateRejectedWithoutSideEffects(
+        "variant",
+        Types.VariantType.get(),
+        "Hologres JSON and JSONB do not preserve Gravitino Variant semantics");
+  }
+
   private void assertCreateRejectedWithoutSideEffects(
       String typeName, Type type, String expectedMessage) {
     String rejectedTableName = GravitinoITUtils.genRandomName("rejected_" + typeName);

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/integration/test/CatalogHologresIT.java
@@ -979,6 +979,14 @@ public class CatalogHologresIT extends BaseIT {
         "Hologres table columns cannot represent Gravitino Unknown (NullType)");
   }
 
+  @Test
+  void testRejectGeometryWithoutSideEffects() {
+    assertCreateRejectedWithoutSideEffects(
+        "geometry",
+        Types.GeometryType.of("EPSG:3857"),
+        "Hologres PostGIS geometry metadata does not preserve Gravitino Geometry CRS semantics");
+  }
+
   private void assertCreateRejectedWithoutSideEffects(
       String typeName, Type type, String expectedMessage) {
     String rejectedTableName = GravitinoITUtils.genRandomName("rejected_" + typeName);

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
@@ -865,6 +865,30 @@ public class TestHologresTableOperations {
     assertTrue(sql.contains("NULL DEFAULT val * 2"));
   }
 
+  @Test
+  void testCreateTableRejectsNanosecondTimestampTypesBeforeSqlGeneration() {
+    Types.TimestampType[] nanosecondTypes = {
+      Types.TimestampType.withoutTimeZone(9), Types.TimestampType.withTimeZone(9)
+    };
+
+    for (Types.TimestampType type : nanosecondTypes) {
+      JdbcColumn column = JdbcColumn.builder().withName("nanosecond_col").withType(type).build();
+      IllegalArgumentException exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  ops.createTableSql(
+                      "test_table",
+                      new JdbcColumn[] {column},
+                      null,
+                      Collections.emptyMap(),
+                      Transforms.EMPTY_TRANSFORM,
+                      Distributions.NONE,
+                      Indexes.EMPTY_INDEXES));
+      assertTrue(exception.getMessage().contains("cannot preserve Gravitino type"));
+    }
+  }
+
   // ==================== generateAlterTableSql tests ====================
 
   @Test

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
@@ -912,6 +912,29 @@ public class TestHologresTableOperations {
             .contains("Hologres JSON and JSONB do not preserve Gravitino Variant semantics"));
   }
 
+  @Test
+  void testCreateTableRejectsUnknownBeforeSqlGeneration() {
+    JdbcColumn column =
+        JdbcColumn.builder().withName("unknown_col").withType(Types.NullType.get()).build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                ops.createTableSql(
+                    "test_table",
+                    new JdbcColumn[] {column},
+                    null,
+                    Collections.emptyMap(),
+                    Transforms.EMPTY_TRANSFORM,
+                    Distributions.NONE,
+                    Indexes.EMPTY_INDEXES));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Hologres table columns cannot represent Gravitino Unknown (NullType)"));
+  }
+
   // ==================== generateAlterTableSql tests ====================
 
   @Test

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
@@ -935,6 +935,33 @@ public class TestHologresTableOperations {
             .contains("Hologres table columns cannot represent Gravitino Unknown (NullType)"));
   }
 
+  @Test
+  void testCreateTableRejectsGeometryBeforeSqlGeneration() {
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("geometry_col")
+            .withType(Types.GeometryType.of("EPSG:3857"))
+            .build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                ops.createTableSql(
+                    "test_table",
+                    new JdbcColumn[] {column},
+                    null,
+                    Collections.emptyMap(),
+                    Transforms.EMPTY_TRANSFORM,
+                    Distributions.NONE,
+                    Indexes.EMPTY_INDEXES));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Hologres PostGIS geometry metadata does not preserve Gravitino Geometry CRS semantics"));
+  }
+
   // ==================== generateAlterTableSql tests ====================
 
   @Test

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
@@ -889,6 +889,29 @@ public class TestHologresTableOperations {
     }
   }
 
+  @Test
+  void testCreateTableRejectsVariantBeforeSqlGeneration() {
+    JdbcColumn column =
+        JdbcColumn.builder().withName("variant_col").withType(Types.VariantType.get()).build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                ops.createTableSql(
+                    "test_table",
+                    new JdbcColumn[] {column},
+                    null,
+                    Collections.emptyMap(),
+                    Transforms.EMPTY_TRANSFORM,
+                    Distributions.NONE,
+                    Indexes.EMPTY_INDEXES));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Hologres JSON and JSONB do not preserve Gravitino Variant semantics"));
+  }
+
   // ==================== generateAlterTableSql tests ====================
 
   @Test

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
@@ -962,6 +962,33 @@ public class TestHologresTableOperations {
                 "Hologres PostGIS geometry metadata does not preserve Gravitino Geometry CRS semantics"));
   }
 
+  @Test
+  void testCreateTableRejectsGeographyBeforeSqlGeneration() {
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("geography_col")
+            .withType(Types.GeographyType.of("EPSG:4326", "karney"))
+            .build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                ops.createTableSql(
+                    "test_table",
+                    new JdbcColumn[] {column},
+                    null,
+                    Collections.emptyMap(),
+                    Transforms.EMPTY_TRANSFORM,
+                    Distributions.NONE,
+                    Indexes.EMPTY_INDEXES));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Hologres PostGIS geography metadata does not preserve Gravitino Geography CRS and edge-algorithm semantics"));
+  }
+
   // ==================== generateAlterTableSql tests ====================
 
   @Test

--- a/docs/jdbc-hologres-catalog.md
+++ b/docs/jdbc-hologres-catalog.md
@@ -148,6 +148,7 @@ Hologres-specific table properties are set via the `WITH` clause during CREATE T
 |-------------------------------------|----------------------------------------------------------------------------------------------------------|
 | `Timestamp(9)` / `Timestamp_tz(9)` | Rejected before DDL. Hologres stores these types with microsecond and millisecond precision, respectively. |
 | `Variant`                           | Rejected before DDL. Native `json` and `jsonb` load as `External` and do not preserve Variant semantics. |
+| `Unknown`                           | Rejected before DDL because Hologres table columns cannot represent a null-only logical type.             |
 
 :::info
 - Hologres stores `TIMESTAMP` values with microsecond precision and `TIMESTAMPTZ` values with millisecond precision. JDBC metadata is normalized to precision 6 and 3, respectively, and the type converter emits the base type without a precision suffix.

--- a/docs/jdbc-hologres-catalog.md
+++ b/docs/jdbc-hologres-catalog.md
@@ -147,6 +147,7 @@ Hologres-specific table properties are set via the `WITH` clause during CREATE T
 | Gravitino Type                      | Hologres outcome                                                                                         |
 |-------------------------------------|----------------------------------------------------------------------------------------------------------|
 | `Timestamp(9)` / `Timestamp_tz(9)` | Rejected before DDL. Hologres stores these types with microsecond and millisecond precision, respectively. |
+| `Variant`                           | Rejected before DDL. Native `json` and `jsonb` load as `External` and do not preserve Variant semantics. |
 
 :::info
 - Hologres stores `TIMESTAMP` values with microsecond precision and `TIMESTAMPTZ` values with millisecond precision. JDBC metadata is normalized to precision 6 and 3, respectively, and the type converter emits the base type without a precision suffix.

--- a/docs/jdbc-hologres-catalog.md
+++ b/docs/jdbc-hologres-catalog.md
@@ -150,6 +150,7 @@ Hologres-specific table properties are set via the `WITH` clause during CREATE T
 | `Variant`                           | Rejected before DDL. Native `json` and `jsonb` load as `External` and do not preserve Variant semantics. |
 | `Unknown`                           | Rejected before DDL because Hologres table columns cannot represent a null-only logical type.             |
 | `Geometry`                          | Rejected before DDL. Native PostGIS `geometry` loads as `External`; exact CRS metadata is not translated. |
+| `Geography`                         | Rejected before DDL. Native PostGIS `geography` loads as `External`; exact CRS and edge-algorithm metadata are not translated. |
 
 :::info
 - Hologres stores `TIMESTAMP` values with microsecond precision and `TIMESTAMPTZ` values with millisecond precision. JDBC metadata is normalized to precision 6 and 3, respectively, and the type converter emits the base type without a precision suffix.

--- a/docs/jdbc-hologres-catalog.md
+++ b/docs/jdbc-hologres-catalog.md
@@ -133,8 +133,8 @@ Hologres-specific table properties are set via the `WITH` clause during CREATE T
 | `Binary`                    | `bytea`                    |                                                    |
 | `Date`                      | `date`                     |                                                    |
 | `Time`                      | `time`                     | With optional precision                            |
-| `Timestamp`                 | `timestamp`                | Always emitted without precision suffix             |
-| `Timestamp_tz`              | `timestamptz`              | Always emitted without precision suffix             |
+| `Timestamp`                 | `timestamp`                | Microsecond precision; emitted without a precision suffix |
+| `Timestamp_tz`              | `timestamptz`              | Millisecond precision; emitted without a precision suffix |
 | `List(IntegerType, false)`  | `int4[]` (`_int4`)         | Array types via `_` prefix                          |
 | `List(LongType, false)`     | `int8[]` (`_int8`)         |                                                    |
 | `List(FloatType, false)`    | `float4[]` (`_float4`)     |                                                    |
@@ -142,8 +142,14 @@ Hologres-specific table properties are set via the `WITH` clause during CREATE T
 | `List(BooleanType, false)`  | `bool[]` (`_bool`)         |                                                    |
 | `List(StringType, false)`   | `text[]` (`_text`)         |                                                    |
 
+#### V3 Type Compatibility
+
+| Gravitino Type                      | Hologres outcome                                                                                         |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `Timestamp(9)` / `Timestamp_tz(9)` | Rejected before DDL. Hologres stores these types with microsecond and millisecond precision, respectively. |
+
 :::info
-- Hologres does not support precision syntax for `TIMESTAMP`/`TIMESTAMPTZ` (e.g., `timestamptz(6)` is invalid), so the type converter always emits the base type without precision.
+- Hologres stores `TIMESTAMP` values with microsecond precision and `TIMESTAMPTZ` values with millisecond precision. JDBC metadata is normalized to precision 6 and 3, respectively, and the type converter emits the base type without a precision suffix.
 - Array element types must be non-nullable (Hologres limitation). Multidimensional arrays are not supported.
 - Types like `json`, `jsonb`, `uuid`, `inet`, `money`, `roaringbitmap` are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** with the original type name preserved.
 :::

--- a/docs/jdbc-hologres-catalog.md
+++ b/docs/jdbc-hologres-catalog.md
@@ -149,6 +149,7 @@ Hologres-specific table properties are set via the `WITH` clause during CREATE T
 | `Timestamp(9)` / `Timestamp_tz(9)` | Rejected before DDL. Hologres stores these types with microsecond and millisecond precision, respectively. |
 | `Variant`                           | Rejected before DDL. Native `json` and `jsonb` load as `External` and do not preserve Variant semantics. |
 | `Unknown`                           | Rejected before DDL because Hologres table columns cannot represent a null-only logical type.             |
+| `Geometry`                          | Rejected before DDL. Native PostGIS `geometry` loads as `External`; exact CRS metadata is not translated. |
 
 :::info
 - Hologres stores `TIMESTAMP` values with microsecond precision and `TIMESTAMPTZ` values with millisecond precision. JDBC metadata is normalized to precision 6 and 3, respectively, and the type converter emits the base type without a precision suffix.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Define and document Hologres compatibility for the five Gravitino V3-native type families.

Nanosecond timestamps, Variant, Unknown/Null, Geometry, and Geography are rejected before DDL because the connector cannot currently preserve their complete Gravitino semantics.

### Why are the changes needed?

Conditional database capabilities are not sufficient without a version- and metadata-aware round-trip contract. Early rejection prevents lossy writes and partial table creation.

Fix: #12071

Related: #12056

Shared JDBC preflight: #12065

Shared JDBC preflight PR: #12081

### Does this PR introduce _any_ user-facing change?

Yes. Unsupported V3-native schemas now fail deterministically before DDL.

### How was this patch tested?

- Added converter, operation, and no-side-effect coverage.
- Covered the local module test paths.
- Documented credential-gated cloud integration verification.
- Updated `docs/jdbc-hologres-catalog.md`.
