### PR TITLE
[#12072] fix(jdbc-oceanbase): complete V3 type compatibility

### DIFF
--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
@@ -158,6 +158,9 @@ public class OceanBaseTypeConverter extends JdbcTypeConverter {
       return type.simpleString();
     } else if (type instanceof Types.BinaryType) {
       return type.simpleString();
+    } else if (type instanceof Types.VariantType) {
+      throw new IllegalArgumentException(
+          "OceanBase JSON cannot losslessly preserve the Gravitino variant type");
     } else if (type instanceof Types.ExternalType) {
       return ((Types.ExternalType) type).catalogString();
     }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
@@ -26,6 +26,8 @@ import org.apache.gravitino.rel.types.Types;
 /** Type converter for OceanBase. */
 public class OceanBaseTypeConverter extends JdbcTypeConverter {
 
+  private static final int MAX_TIMESTAMP_PRECISION = 6;
+
   static final String TINYINT = "tinyint";
   static final String TINYINT_UNSIGNED = "tinyint unsigned";
   static final String SMALLINT = "smallint";
@@ -137,6 +139,13 @@ public class OceanBaseTypeConverter extends JdbcTypeConverter {
       return type.simpleString();
     } else if (type instanceof Types.TimestampType) {
       Types.TimestampType timestampType = (Types.TimestampType) type;
+      if (timestampType.hasPrecisionSet() && timestampType.precision() > MAX_TIMESTAMP_PRECISION) {
+        throw new IllegalArgumentException(
+            String.format(
+                "OceanBase MySQL mode cannot preserve timestamp precision %d; "
+                    + "the maximum supported precision is %d",
+                timestampType.precision(), MAX_TIMESTAMP_PRECISION));
+      }
       String baseType = timestampType.hasTimeZone() ? TIMESTAMP : DATETIME;
       return timestampType.hasPrecisionSet()
           ? String.format("%s(%d)", baseType, timestampType.precision())

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
@@ -164,6 +164,9 @@ public class OceanBaseTypeConverter extends JdbcTypeConverter {
     } else if (type instanceof Types.VariantType) {
       throw new IllegalArgumentException(
           "OceanBase JSON cannot losslessly preserve the Gravitino variant type");
+    } else if (type instanceof Types.GeometryType) {
+      throw new IllegalArgumentException(
+          "OceanBase JDBC metadata cannot preserve Gravitino geometry CRS/SRID metadata");
     } else if (type instanceof Types.ExternalType) {
       return ((Types.ExternalType) type).catalogString();
     }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
@@ -167,6 +167,9 @@ public class OceanBaseTypeConverter extends JdbcTypeConverter {
     } else if (type instanceof Types.GeometryType) {
       throw new IllegalArgumentException(
           "OceanBase JDBC metadata cannot preserve Gravitino geometry CRS/SRID metadata");
+    } else if (type instanceof Types.GeographyType) {
+      throw new IllegalArgumentException(
+          "OceanBase has no geography column type that preserves CRS and edge algorithm metadata");
     } else if (type instanceof Types.ExternalType) {
       return ((Types.ExternalType) type).catalogString();
     }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
@@ -158,6 +158,9 @@ public class OceanBaseTypeConverter extends JdbcTypeConverter {
       return type.simpleString();
     } else if (type instanceof Types.BinaryType) {
       return type.simpleString();
+    } else if (type instanceof Types.NullType) {
+      throw new IllegalArgumentException(
+          "OceanBase has no column type that preserves the Gravitino unknown type");
     } else if (type instanceof Types.VariantType) {
       throw new IllegalArgumentException(
           "OceanBase JSON cannot losslessly preserve the Gravitino variant type");

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
@@ -99,8 +99,27 @@ public class TestOceanBaseTypeConverter {
         () -> OCEANBASE_TYPE_CONVERTER.fromGravitino(Types.UnparsedType.of(USER_DEFINED_TYPE)));
   }
 
+  @Test
+  public void testRejectNanosecondTimestampTypes() {
+    assertFromGravitinoRejected(
+        Types.TimestampType.withoutTimeZone(9),
+        "OceanBase MySQL mode cannot preserve timestamp precision 9; "
+            + "the maximum supported precision is 6");
+    assertFromGravitinoRejected(
+        Types.TimestampType.withTimeZone(9),
+        "OceanBase MySQL mode cannot preserve timestamp precision 9; "
+            + "the maximum supported precision is 6");
+  }
+
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {
     Assertions.assertEquals(jdbcTypeName, OCEANBASE_TYPE_CONVERTER.fromGravitino(gravitinoType));
+  }
+
+  private void assertFromGravitinoRejected(Type type, String expectedMessage) {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> OCEANBASE_TYPE_CONVERTER.fromGravitino(type));
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
   protected void checkJdbcTypeToGravitinoType(

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
@@ -111,6 +111,13 @@ public class TestOceanBaseTypeConverter {
             + "the maximum supported precision is 6");
   }
 
+  @Test
+  public void testRejectVariantType() {
+    assertFromGravitinoRejected(
+        Types.VariantType.get(),
+        "OceanBase JSON cannot losslessly preserve the Gravitino variant type");
+  }
+
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {
     Assertions.assertEquals(jdbcTypeName, OCEANBASE_TYPE_CONVERTER.fromGravitino(gravitinoType));
   }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
@@ -125,6 +125,14 @@ public class TestOceanBaseTypeConverter {
         "OceanBase has no column type that preserves the Gravitino unknown type");
   }
 
+  @Test
+  public void testRejectGeometryTypes() {
+    String expectedMessage =
+        "OceanBase JDBC metadata cannot preserve Gravitino geometry CRS/SRID metadata";
+    assertFromGravitinoRejected(Types.GeometryType.crs84(), expectedMessage);
+    assertFromGravitinoRejected(Types.GeometryType.of("EPSG:3857"), expectedMessage);
+  }
+
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {
     Assertions.assertEquals(jdbcTypeName, OCEANBASE_TYPE_CONVERTER.fromGravitino(gravitinoType));
   }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
@@ -118,6 +118,13 @@ public class TestOceanBaseTypeConverter {
         "OceanBase JSON cannot losslessly preserve the Gravitino variant type");
   }
 
+  @Test
+  public void testRejectUnknownType() {
+    assertFromGravitinoRejected(
+        Types.NullType.get(),
+        "OceanBase has no column type that preserves the Gravitino unknown type");
+  }
+
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {
     Assertions.assertEquals(jdbcTypeName, OCEANBASE_TYPE_CONVERTER.fromGravitino(gravitinoType));
   }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
@@ -133,6 +133,14 @@ public class TestOceanBaseTypeConverter {
     assertFromGravitinoRejected(Types.GeometryType.of("EPSG:3857"), expectedMessage);
   }
 
+  @Test
+  public void testRejectGeographyTypes() {
+    String expectedMessage =
+        "OceanBase has no geography column type that preserves CRS and edge algorithm metadata";
+    assertFromGravitinoRejected(Types.GeographyType.crs84(), expectedMessage);
+    assertFromGravitinoRejected(Types.GeographyType.of("EPSG:4326", "karney"), expectedMessage);
+  }
+
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {
     Assertions.assertEquals(jdbcTypeName, OCEANBASE_TYPE_CONVERTER.fromGravitino(gravitinoType));
   }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
@@ -2006,6 +2006,14 @@ public class CatalogOceanBaseIT extends BaseIT {
             + "the maximum supported precision is 6");
   }
 
+  @Test
+  void testRejectVariantWithoutCreatingTable() {
+    assertCreateRejectedWithoutSideEffect(
+        "variant",
+        Types.VariantType.get(),
+        "OceanBase JSON cannot losslessly preserve the Gravitino variant type");
+  }
+
   private void assertCreateRejectedWithoutSideEffect(
       String tablePrefix, Type type, String expectedMessage) {
     TableCatalog tableCatalog = catalog.asTableCatalog();

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
@@ -2032,6 +2032,16 @@ public class CatalogOceanBaseIT extends BaseIT {
         "geometry_epsg3857", Types.GeometryType.of("EPSG:3857"), expectedMessage);
   }
 
+  @Test
+  void testRejectGeographyWithoutCreatingTables() {
+    String expectedMessage =
+        "OceanBase has no geography column type that preserves CRS and edge algorithm metadata";
+    assertCreateRejectedWithoutSideEffect(
+        "geography_crs84", Types.GeographyType.crs84(), expectedMessage);
+    assertCreateRejectedWithoutSideEffect(
+        "geography_karney", Types.GeographyType.of("EPSG:4326", "karney"), expectedMessage);
+  }
+
   private void assertCreateRejectedWithoutSideEffect(
       String tablePrefix, Type type, String expectedMessage) {
     TableCatalog tableCatalog = catalog.asTableCatalog();

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
@@ -69,6 +69,7 @@ import org.apache.gravitino.rel.expressions.transforms.Transforms;
 import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.rel.indexes.Indexes;
 import org.apache.gravitino.rel.types.Decimal;
+import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.utils.RandomNameUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -1989,5 +1990,43 @@ public class CatalogOceanBaseIT extends BaseIT {
           Assertions.fail("Unexpected datetime column: " + column.name());
       }
     }
+  }
+
+  @Test
+  void testRejectNanosecondTimestampsWithoutCreatingTables() {
+    assertCreateRejectedWithoutSideEffect(
+        "timestamp_ns",
+        Types.TimestampType.withoutTimeZone(9),
+        "OceanBase MySQL mode cannot preserve timestamp precision 9; "
+            + "the maximum supported precision is 6");
+    assertCreateRejectedWithoutSideEffect(
+        "timestamptz_ns",
+        Types.TimestampType.withTimeZone(9),
+        "OceanBase MySQL mode cannot preserve timestamp precision 9; "
+            + "the maximum supported precision is 6");
+  }
+
+  private void assertCreateRejectedWithoutSideEffect(
+      String tablePrefix, Type type, String expectedMessage) {
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(schemaName, GravitinoITUtils.genRandomName(tablePrefix));
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                tableCatalog.createTable(
+                    tableIdentifier,
+                    new Column[] {Column.of("value", type)},
+                    "unsupported type",
+                    Collections.emptyMap()));
+
+    Assertions.assertTrue(
+        exception.getMessage().contains(expectedMessage),
+        String.format(
+            "Expected rejection to contain \"%s\", but was: %s",
+            expectedMessage, exception.getMessage()));
+    Assertions.assertFalse(tableCatalog.tableExists(tableIdentifier));
   }
 }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
@@ -2014,6 +2014,14 @@ public class CatalogOceanBaseIT extends BaseIT {
         "OceanBase JSON cannot losslessly preserve the Gravitino variant type");
   }
 
+  @Test
+  void testRejectUnknownWithoutCreatingTable() {
+    assertCreateRejectedWithoutSideEffect(
+        "unknown",
+        Types.NullType.get(),
+        "OceanBase has no column type that preserves the Gravitino unknown type");
+  }
+
   private void assertCreateRejectedWithoutSideEffect(
       String tablePrefix, Type type, String expectedMessage) {
     TableCatalog tableCatalog = catalog.asTableCatalog();

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
@@ -2022,6 +2022,16 @@ public class CatalogOceanBaseIT extends BaseIT {
         "OceanBase has no column type that preserves the Gravitino unknown type");
   }
 
+  @Test
+  void testRejectGeometryWithoutCreatingTables() {
+    String expectedMessage =
+        "OceanBase JDBC metadata cannot preserve Gravitino geometry CRS/SRID metadata";
+    assertCreateRejectedWithoutSideEffect(
+        "geometry_crs84", Types.GeometryType.crs84(), expectedMessage);
+    assertCreateRejectedWithoutSideEffect(
+        "geometry_epsg3857", Types.GeometryType.of("EPSG:3857"), expectedMessage);
+  }
+
   private void assertCreateRejectedWithoutSideEffect(
       String tablePrefix, Type type, String expectedMessage) {
     TableCatalog tableCatalog = catalog.asTableCatalog();

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
@@ -121,6 +121,13 @@ public class TestOceanBaseTableOperationsSqlGeneration {
         "OceanBase JDBC metadata cannot preserve Gravitino geometry CRS/SRID metadata");
   }
 
+  @Test
+  public void testRejectGeographyBeforeSqlGeneration() {
+    assertCreateTableRejected(
+        Types.GeographyType.crs84(),
+        "OceanBase has no geography column type that preserves CRS and edge algorithm metadata");
+  }
+
   private void assertCreateTableRejected(Type type, String expectedMessage) {
     TestableOceanBaseTableOperations ops = new TestableOceanBaseTableOperations();
     JdbcColumn column =

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
@@ -27,6 +27,7 @@ import org.apache.gravitino.rel.expressions.distributions.Distributions;
 import org.apache.gravitino.rel.expressions.literals.Literals;
 import org.apache.gravitino.rel.expressions.transforms.Transforms;
 import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -88,5 +89,26 @@ public class TestOceanBaseTableOperationsSqlGeneration {
     Assertions.assertTrue(
         sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
         "Should contain DEFAULT value but was: " + sql);
+  }
+
+  @Test
+  public void testRejectNanosecondTimestampsBeforeSqlGeneration() {
+    assertCreateTableRejected(Types.TimestampType.withoutTimeZone(9));
+    assertCreateTableRejected(Types.TimestampType.withTimeZone(9));
+  }
+
+  private void assertCreateTableRejected(Type type) {
+    TestableOceanBaseTableOperations ops = new TestableOceanBaseTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder().withName("col1").withType(type).withNullable(true).build();
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> ops.createTableSql("test_table", new JdbcColumn[] {column}));
+    Assertions.assertEquals(
+        "OceanBase MySQL mode cannot preserve timestamp precision 9; "
+            + "the maximum supported precision is 6",
+        exception.getMessage());
   }
 }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
@@ -107,6 +107,13 @@ public class TestOceanBaseTableOperationsSqlGeneration {
         "OceanBase JSON cannot losslessly preserve the Gravitino variant type");
   }
 
+  @Test
+  public void testRejectUnknownBeforeSqlGeneration() {
+    assertCreateTableRejected(
+        Types.NullType.get(),
+        "OceanBase has no column type that preserves the Gravitino unknown type");
+  }
+
   private void assertCreateTableRejected(Type type, String expectedMessage) {
     TestableOceanBaseTableOperations ops = new TestableOceanBaseTableOperations();
     JdbcColumn column =

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
@@ -114,6 +114,13 @@ public class TestOceanBaseTableOperationsSqlGeneration {
         "OceanBase has no column type that preserves the Gravitino unknown type");
   }
 
+  @Test
+  public void testRejectGeometryBeforeSqlGeneration() {
+    assertCreateTableRejected(
+        Types.GeometryType.crs84(),
+        "OceanBase JDBC metadata cannot preserve Gravitino geometry CRS/SRID metadata");
+  }
+
   private void assertCreateTableRejected(Type type, String expectedMessage) {
     TestableOceanBaseTableOperations ops = new TestableOceanBaseTableOperations();
     JdbcColumn column =

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
@@ -93,11 +93,21 @@ public class TestOceanBaseTableOperationsSqlGeneration {
 
   @Test
   public void testRejectNanosecondTimestampsBeforeSqlGeneration() {
-    assertCreateTableRejected(Types.TimestampType.withoutTimeZone(9));
-    assertCreateTableRejected(Types.TimestampType.withTimeZone(9));
+    String expectedMessage =
+        "OceanBase MySQL mode cannot preserve timestamp precision 9; "
+            + "the maximum supported precision is 6";
+    assertCreateTableRejected(Types.TimestampType.withoutTimeZone(9), expectedMessage);
+    assertCreateTableRejected(Types.TimestampType.withTimeZone(9), expectedMessage);
   }
 
-  private void assertCreateTableRejected(Type type) {
+  @Test
+  public void testRejectVariantBeforeSqlGeneration() {
+    assertCreateTableRejected(
+        Types.VariantType.get(),
+        "OceanBase JSON cannot losslessly preserve the Gravitino variant type");
+  }
+
+  private void assertCreateTableRejected(Type type, String expectedMessage) {
     TestableOceanBaseTableOperations ops = new TestableOceanBaseTableOperations();
     JdbcColumn column =
         JdbcColumn.builder().withName("col1").withType(type).withNullable(true).build();
@@ -106,9 +116,6 @@ public class TestOceanBaseTableOperationsSqlGeneration {
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> ops.createTableSql("test_table", new JdbcColumn[] {column}));
-    Assertions.assertEquals(
-        "OceanBase MySQL mode cannot preserve timestamp precision 9; "
-            + "the maximum supported precision is 6",
-        exception.getMessage());
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 }

--- a/docs/jdbc-oceanbase-catalog.md
+++ b/docs/jdbc-oceanbase-catalog.md
@@ -153,6 +153,7 @@ DDL. The pinned OceanBase 4.2.1 test environment uses MySQL compatibility mode.
 |-----------------------------------------|------------------------------------------------------------------------------------------------------|
 | `Timestamp(9)`, `Timestamp_tz(9)`       | Rejected because MySQL-mode `DATETIME` and `TIMESTAMP` preserve at most microsecond precision (0–6). |
 | `Variant`                               | Rejected because OceanBase `JSON` cannot losslessly preserve the complete Gravitino variant domain. |
+| `Unknown` (`NullType`)                  | Rejected because OceanBase has no corresponding column type.                                        |
 
 :::info
 OceanBase doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.

--- a/docs/jdbc-oceanbase-catalog.md
+++ b/docs/jdbc-oceanbase-catalog.md
@@ -152,6 +152,7 @@ DDL. The pinned OceanBase 4.2.1 test environment uses MySQL compatibility mode.
 | Gravitino type family                   | OceanBase behavior                                                                                   |
 |-----------------------------------------|------------------------------------------------------------------------------------------------------|
 | `Timestamp(9)`, `Timestamp_tz(9)`       | Rejected because MySQL-mode `DATETIME` and `TIMESTAMP` preserve at most microsecond precision (0–6). |
+| `Variant`                               | Rejected because OceanBase `JSON` cannot losslessly preserve the complete Gravitino variant domain. |
 
 :::info
 OceanBase doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.

--- a/docs/jdbc-oceanbase-catalog.md
+++ b/docs/jdbc-oceanbase-catalog.md
@@ -155,6 +155,7 @@ DDL. The pinned OceanBase 4.2.1 test environment uses MySQL compatibility mode.
 | `Variant`                               | Rejected because OceanBase `JSON` cannot losslessly preserve the complete Gravitino variant domain. |
 | `Unknown` (`NullType`)                  | Rejected because OceanBase has no corresponding column type.                                        |
 | `Geometry(crs)`                         | Rejected because the connector cannot currently reload OceanBase spatial subtype and SRID metadata. |
+| `Geography(crs, algorithm)`             | Rejected because OceanBase has no type preserving geography edge semantics.                         |
 
 :::info
 OceanBase doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.

--- a/docs/jdbc-oceanbase-catalog.md
+++ b/docs/jdbc-oceanbase-catalog.md
@@ -154,6 +154,7 @@ DDL. The pinned OceanBase 4.2.1 test environment uses MySQL compatibility mode.
 | `Timestamp(9)`, `Timestamp_tz(9)`       | Rejected because MySQL-mode `DATETIME` and `TIMESTAMP` preserve at most microsecond precision (0–6). |
 | `Variant`                               | Rejected because OceanBase `JSON` cannot losslessly preserve the complete Gravitino variant domain. |
 | `Unknown` (`NullType`)                  | Rejected because OceanBase has no corresponding column type.                                        |
+| `Geometry(crs)`                         | Rejected because the connector cannot currently reload OceanBase spatial subtype and SRID metadata. |
 
 :::info
 OceanBase doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.

--- a/docs/jdbc-oceanbase-catalog.md
+++ b/docs/jdbc-oceanbase-catalog.md
@@ -144,6 +144,15 @@ Refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metada
 | `FixedChar`         | `FixedChar`         |
 | `Binary`            | `Binary`            |
 
+#### Iceberg V3 type interoperability
+
+The OceanBase catalog either preserves an Iceberg V3 type exactly or rejects it before executing
+DDL. The pinned OceanBase 4.2.1 test environment uses MySQL compatibility mode.
+
+| Gravitino type family                   | OceanBase behavior                                                                                   |
+|-----------------------------------------|------------------------------------------------------------------------------------------------------|
+| `Timestamp(9)`, `Timestamp_tz(9)`       | Rejected because MySQL-mode `DATETIME` and `TIMESTAMP` preserve at most microsecond precision (0–6). |
+
 :::info
 OceanBase doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.
 Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.6.0-incubating.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Define and document OceanBase compatibility for the five Gravitino V3-native type families.

Nanosecond timestamps, Variant, Unknown/Null, Geometry, and Geography are rejected before DDL because the connector cannot currently reconstruct their complete identity and parameters.

### Why are the changes needed?

Potential native database representations are not lossless through the connector's current metadata path. Early rejection avoids silent coercion and partial table creation.

Fix: #12072

Related: #12056

Shared JDBC preflight: #12065

Shared JDBC preflight PR: #12081

### Does this PR introduce _any_ user-facing change?

Yes. Unsupported V3-native schemas now fail deterministically before DDL.

### How was this patch tested?

- Added converter and SQL-generation coverage.
- Covered Docker rejected-create and no-table behavior.
- Covered module and formatting checks.
- Updated `docs/jdbc-oceanbase-catalog.md`.
