### PR TITLE
[#12106] improvement(common): gate Kerberos login-module debug on sun.security.krb5.debug

### DIFF
--- a/common/src/main/java/org/apache/gravitino/auth/KerberosUtils.java
+++ b/common/src/main/java/org/apache/gravitino/auth/KerberosUtils.java
@@ -134,7 +134,11 @@ public class KerberosUtils {
       options.put("doNotPrompt", "true");
       options.put("refreshKrb5Config", "true");
       options.put("isInitiator", "true");
-      options.put("debug", "true");
+      // Enabling the login module's debug prints Kerberos details (principal, keytab path, etc.)
+      // to stdout on every login, which is noise/info-leak in normal client use. Gate it on the
+      // standard JDK Kerberos debug switch (-Dsun.security.krb5.debug=true) so it stays off by
+      // default but turns on when someone is already debugging Kerberos.
+      options.put("debug", String.valueOf(Boolean.getBoolean("sun.security.krb5.debug")));
 
       return new AppConfigurationEntry[] {
         new AppConfigurationEntry(


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `KerberosUtils.KerberosConfiguration`, replace the hardcoded `options.put("debug", "true")` with `options.put("debug", String.valueOf(Boolean.getBoolean("sun.security.krb5.debug")))`, so the `Krb5LoginModule` debug flag follows the standard JDK Kerberos debug switch instead of being always on.

### Why are the changes needed?

The login module printed Kerberos detail (principal, keytab path, etc.) to stdout on every login. The one production path using this class is `clients/client-java`'s `KerberosTokenProvider`, so a Kerberos-authenticating Java client emitted this output unconditionally — log noise and a minor information leak. Gating on `-Dsun.security.krb5.debug` keeps it off by default and turns it on only when Kerberos is already being debugged.

Fix: #12106

### Does this PR introduce _any_ user-facing change?

No API change. Behavior change: Kerberos login-module debug output is no longer printed unless `-Dsun.security.krb5.debug=true` is set. Existing Kerberos integration tests already set that property, so their debug output is unaffected.

### How was this patch tested?

Compile + spotless. No unit test is added: the change is a one-line default flip whose behavior (`Boolean.getBoolean`, off unless the standard krb5 debug property is set) is self-evident, and observing the internal JAAS option would require widening production visibility for no real regression coverage.