### PR TITLE
[#12123] fix(catalog): shut down MySQL AbandonedConnectionCleanupThread and broaden ThreadLocal cleanup to prevent Metaspace leak

### DIFF
--- a/catalogs/catalog-common/build.gradle.kts
+++ b/catalogs/catalog-common/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  // Used only by TestClassLoaderResourceCleanerUtils to verify the MySQL
+  // AbandonedConnectionCleanupThread is shut down during ClassLoader cleanup.
+  testImplementation(libs.mysql.driver)
 
   testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/utils/ClassLoaderResourceCleanerUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/utils/ClassLoaderResourceCleanerUtils.java
@@ -31,9 +31,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Utility class to clean up resources related to a specific class loader to prevent memory leaks.
- * Gravitino will create a new class loader for each catalog and release it when there exist any
- * changes to the catalog. So, it's important to clean up resources related to the class loader to
- * prevent memory leaks.
+ * Gravitino uses isolated class loaders for catalog implementations, and these class loaders must
+ * be properly cleaned up when no longer needed to prevent Metaspace leaks.
  */
 public class ClassLoaderResourceCleanerUtils {
 
@@ -42,7 +41,13 @@ public class ClassLoaderResourceCleanerUtils {
   private ClassLoaderResourceCleanerUtils() {}
 
   /**
-   * Close all resources related to the given class loader to prevent memory leaks.
+   * Close all resources related to the given class loader to prevent memory leaks. This includes
+   * stopping threads, clearing ThreadLocals, shutting down MySQL's
+   * AbandonedConnectionCleanupThread, and releasing various logging and cloud SDK resources.
+   *
+   * <p><b>Warning:</b> This method performs destructive cleanup that affects all code sharing the
+   * ClassLoader. It must only be called when the ClassLoader is about to be destroyed and no
+   * catalog is still using it, i.e. from a catalog's {@code close()} path.
    *
    * @param classLoader the classloader to be closed
    */
@@ -57,12 +62,9 @@ public class ClassLoaderResourceCleanerUtils {
     executeAndCatch(
         ClassLoaderResourceCleanerUtils::closeStatsDataClearerInFileSystem, classLoader);
 
-    // Stop all threads with the current class loader and clear their threadLocal variables for
-    // jetty threads that are loaded by the current class loader.
-    // For example, thread local `threadData` in FileSystem#StatisticsDataCleaner is created
-    // within jetty thread with the current class loader. However, there are clear by
-    // `catalog.close` in ForkJoinPool in CaffeineCache, in this case, the thread local variable
-    // will not be cleared, so we need to clear them manually here.
+    // Stop threads that run under the target class loader and clear ThreadLocals that reference it.
+    // Such ThreadLocals can sit on any thread (Jetty webserver, Caffeine ForkJoinPool,
+    // catalog-cleaner) and keep the ClassLoader from being collected.
     executeAndCatch(
         ClassLoaderResourceCleanerUtils::stopThreadsAndClearThreadLocalVariables, classLoader);
 
@@ -77,6 +79,10 @@ public class ClassLoaderResourceCleanerUtils {
     executeAndCatch(ClassLoaderResourceCleanerUtils::closeResourceInAzure, classLoader);
 
     executeAndCatch(ClassLoaderResourceCleanerUtils::clearShutdownHooks, classLoader);
+
+    executeAndCatch(
+        ClassLoaderResourceCleanerUtils::shutdownMySQLAbandonedConnectionCleanupThread,
+        classLoader);
   }
 
   /**
@@ -146,7 +152,7 @@ public class ClassLoaderResourceCleanerUtils {
     for (Thread thread : threads) {
       // First clear thread local variables
       clearThreadLocalMap(thread, classLoader);
-      // Close all threads that are using the FilesetCatalogOperations class loader
+      // Stop all threads that are using the target class loader
       if (runningWithClassLoader(thread, classLoader)) {
         LOG.debug("Interrupting thread: {}", thread.getName());
         thread.setContextClassLoader(null);
@@ -178,8 +184,25 @@ public class ClassLoaderResourceCleanerUtils {
     return threads;
   }
 
-  private static void clearThreadLocalMap(Thread thread, ClassLoader targetClassLoader) {
-    if (thread == null || !thread.getName().startsWith("Gravitino-webserver-")) {
+  @VisibleForTesting
+  static void clearThreadLocalMap(Thread thread, ClassLoader targetClassLoader) {
+    if (thread == null) {
+      return;
+    }
+
+    // Sweep every application thread, not only the Gravitino-webserver-* ones: a ThreadLocal
+    // pointing at the target ClassLoader can live on any thread, such as a Caffeine ForkJoinPool
+    // worker, a catalog-cleaner thread, or a Hadoop daemon. The check below clears only entries
+    // whose value was loaded by the target ClassLoader, so ThreadLocals owned by other
+    // ClassLoaders are left alone.
+    //
+    // Skip threads whose immediate group is the JVM "system" group (Reference Handler, Finalizer,
+    // Signal Dispatcher, and the like): they hold no catalog ClassLoader references, and reflecting
+    // into their ThreadLocals is best avoided. This checks the immediate group only, so threads in
+    // a sub-group of system (such as InnocuousThreadGroup for common-pool workers) are still swept.
+    // That is intended: ForkJoinPool threads can hold catalog ThreadLocals.
+    ThreadGroup group = thread.getThreadGroup();
+    if (group != null && "system".equals(group.getName())) {
       return;
     }
 
@@ -256,7 +279,7 @@ public class ClassLoaderResourceCleanerUtils {
       LOG.debug("HTrace is not used, skipping release of HTrace LogFactory...");
     }
 
-    // Release the LogFactory for the FilesetCatalogOperations class loader
+    // Release the LogFactory for the target class loader
     Class<?> logFactoryClass =
         Class.forName("org.apache.commons.logging.LogFactory", true, currentClassLoader);
     MethodUtils.invokeStaticMethod(logFactoryClass, "release", currentClassLoader);
@@ -353,6 +376,36 @@ public class ClassLoaderResourceCleanerUtils {
   @VisibleForTesting
   static boolean isOwnedByClassLoader(Class<?> clazz, ClassLoader classLoader) {
     return classLoader != null && clazz.getClassLoader() == classLoader;
+  }
+
+  /**
+   * Shutdown MySQL's AbandonedConnectionCleanupThread to prevent it from holding a reference to the
+   * ClassLoader. Unlike simple thread interruption, {@code uncheckedShutdown()} cleans up the
+   * tracked connections map, releasing references to classes loaded by the target ClassLoader.
+   *
+   * @param classLoader the classloader where the MySQL driver is loaded
+   */
+  @VisibleForTesting
+  static void shutdownMySQLAbandonedConnectionCleanupThread(ClassLoader classLoader)
+      throws Exception {
+    // Load with initialize=false: when this class is owned by the target ClassLoader the MySQL
+    // driver has already been used, so the class is initialized and its cleanup thread started.
+    Class<?> clazz =
+        Class.forName("com.mysql.cj.jdbc.AbandonedConnectionCleanupThread", false, classLoader);
+    // uncheckedShutdown() is a JVM-global static that stops the single cleanup thread tied to this
+    // driver class. If the driver was resolved from a parent or shared ClassLoader (for example a
+    // MySQL entity store loaded on the app ClassLoader), stopping it here would break
+    // abandoned-connection cleanup for the whole JVM. Only act when the target ClassLoader owns the
+    // class, the same guard the other cleanup steps in this class use.
+    if (!isOwnedByClassLoader(clazz, classLoader)) {
+      LOG.debug(
+          "AbandonedConnectionCleanupThread is owned by {}, not the target classloader {}; skipping shutdown",
+          clazz.getClassLoader(),
+          classLoader);
+      return;
+    }
+    MethodUtils.invokeStaticMethod(clazz, "uncheckedShutdown");
+    LOG.info("AbandonedConnectionCleanupThread has been shutdown.");
   }
 
   @FunctionalInterface

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/utils/ClassLoaderResourceCleanerUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/utils/ClassLoaderResourceCleanerUtils.java
@@ -33,6 +33,13 @@ import org.slf4j.LoggerFactory;
  * Utility class to clean up resources related to a specific class loader to prevent memory leaks.
  * Gravitino uses isolated class loaders for catalog implementations, and these class loaders must
  * be properly cleaned up when no longer needed to prevent Metaspace leaks.
+ *
+ * <p>Several steps here are per-vendor special cases (AWS, GCP, Azure, commons-logging, MySQL).
+ * Three things hold for all of them, and for any added later: guard with {@link
+ * #isOwnedByClassLoader} so a library resolved from a parent or shared ClassLoader is left alone;
+ * prefer the library's own shutdown API over interrupting its thread; and run the step before
+ * {@link #stopThreadsAndClearThreadLocalVariables}, which interrupts any thread whose context
+ * ClassLoader is the target and would otherwise get there first.
  */
 public class ClassLoaderResourceCleanerUtils {
 
@@ -58,9 +65,30 @@ public class ClassLoaderResourceCleanerUtils {
       return;
     }
 
+    runCleanupSteps(classLoader);
+  }
+
+  /**
+   * The cleanup sequence itself, without the test-environment guard above. Split out so a test can
+   * drive the whole sequence: unit tests run with {@code GRAVITINO_TEST} set, which would otherwise
+   * make {@link #closeClassLoaderResource} return before doing anything. The order of the steps
+   * matters, see the class javadoc.
+   *
+   * @param classLoader the classloader to be closed
+   */
+  @VisibleForTesting
+  static void runCleanupSteps(ClassLoader classLoader) {
     // Clear statics threads in FileSystem and close all FileSystem instances.
     executeAndCatch(
         ClassLoaderResourceCleanerUtils::closeStatsDataClearerInFileSystem, classLoader);
+
+    // Ahead of the generic thread sweep below: the MySQL driver sets its cleanup thread's context
+    // ClassLoader to the loader that defined the driver, so the sweep would match that thread and
+    // interrupt it. Interrupting it lands in referenceQueue.remove() rather than the driver's own
+    // shutdown path, so let the driver stop the thread itself first.
+    executeAndCatch(
+        ClassLoaderResourceCleanerUtils::shutdownMySQLAbandonedConnectionCleanupThread,
+        classLoader);
 
     // Stop threads that run under the target class loader and clear ThreadLocals that reference it.
     // Such ThreadLocals can sit on any thread (Jetty webserver, Caffeine ForkJoinPool,
@@ -79,10 +107,6 @@ public class ClassLoaderResourceCleanerUtils {
     executeAndCatch(ClassLoaderResourceCleanerUtils::closeResourceInAzure, classLoader);
 
     executeAndCatch(ClassLoaderResourceCleanerUtils::clearShutdownHooks, classLoader);
-
-    executeAndCatch(
-        ClassLoaderResourceCleanerUtils::shutdownMySQLAbandonedConnectionCleanupThread,
-        classLoader);
   }
 
   /**
@@ -192,15 +216,21 @@ public class ClassLoaderResourceCleanerUtils {
 
     // Sweep every application thread, not only the Gravitino-webserver-* ones: a ThreadLocal
     // pointing at the target ClassLoader can live on any thread, such as a Caffeine ForkJoinPool
-    // worker, a catalog-cleaner thread, or a Hadoop daemon. The check below clears only entries
-    // whose value was loaded by the target ClassLoader, so ThreadLocals owned by other
-    // ClassLoaders are left alone.
+    // worker, a catalog-cleaner thread, or a Hadoop daemon.
+    //
+    // What bounds this is the value check below, not the set of threads: an entry is cleared only
+    // when its value's class was loaded by the target ClassLoader, so ThreadLocals belonging to
+    // other ClassLoaders are left alone even on a thread shared JVM-wide. What remains is that a
+    // value belonging to the catalog being dropped may be nulled while that thread is still using
+    // it. Work in flight against a catalog that is going away fails either way; an allowlist of
+    // thread names would not change that, and would reintroduce the silent miss this sweep was
+    // widened to fix.
     //
     // Skip threads whose immediate group is the JVM "system" group (Reference Handler, Finalizer,
     // Signal Dispatcher, and the like): they hold no catalog ClassLoader references, and reflecting
     // into their ThreadLocals is best avoided. This checks the immediate group only, so threads in
-    // a sub-group of system (such as InnocuousThreadGroup for common-pool workers) are still swept.
-    // That is intended: ForkJoinPool threads can hold catalog ThreadLocals.
+    // a sub-group of system (such as InnocuousThreadGroup for common-pool workers) are still swept,
+    // because those can hold catalog ThreadLocals.
     ThreadGroup group = thread.getThreadGroup();
     if (group != null && "system".equals(group.getName())) {
       return;

--- a/catalogs/catalog-common/src/test/java/org/apache/gravitino/utils/TestClassLoaderResourceCleanerUtils.java
+++ b/catalogs/catalog-common/src/test/java/org/apache/gravitino/utils/TestClassLoaderResourceCleanerUtils.java
@@ -25,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
@@ -222,6 +224,84 @@ class TestClassLoaderResourceCleanerUtils {
     systemThread.join();
 
     assertNotNull(cleared[0], "system-group thread ThreadLocals must be left untouched");
+  }
+
+  /**
+   * End-to-end proof that broadening the sweep lets a dropped catalog's ClassLoader be collected. A
+   * long-lived worker thread that is not a {@code Gravitino-webserver-*} thread holds a ThreadLocal
+   * whose value was loaded by the target ClassLoader, which is exactly what pins the ClassLoader
+   * after a catalog is dropped. After {@code clearThreadLocalMap} runs and the test drops its own
+   * references, a WeakReference to the ClassLoader must clear once GC runs. The webserver-only
+   * filter used before would skip this thread and the ClassLoader would stay reachable.
+   */
+  @Test
+  @SuppressWarnings("ThreadLocalUsage") // a per-thread ThreadLocal is the leak this test reproduces
+  void testClearThreadLocalMapLetsDroppedClassLoaderBeCollected() throws Exception {
+    URL classesUrl = LeakyValue.class.getProtectionDomain().getCodeSource().getLocation();
+    ClassLoader platform = ClassLoader.getSystemClassLoader().getParent();
+
+    WeakReference<ClassLoader> ref;
+    // Blocks the worker after it sets the ThreadLocal so the thread stays alive; a thread that
+    // exits would null its own threadLocals in Thread.exit() and hide the leak.
+    CountDownLatch release = new CountDownLatch(1);
+    Thread worker;
+    try {
+      URLClassLoader child = new URLClassLoader(new URL[] {classesUrl}, platform);
+      Object childOwnedValue =
+          Class.forName(LeakyValue.class.getName(), true, child)
+              .getDeclaredConstructor()
+              .newInstance();
+      ref = new WeakReference<>(child);
+
+      CountDownLatch valueSet = new CountDownLatch(1);
+      Object[] valueHolder = {childOwnedValue};
+      worker =
+          new Thread(
+              () -> {
+                ThreadLocal<Object> tl = new ThreadLocal<>();
+                tl.set(valueHolder[0]);
+                valueSet.countDown();
+                try {
+                  release.await();
+                } catch (InterruptedException ignored) {
+                  // test teardown
+                }
+              },
+              "clp-reclaim-probe");
+      worker.setDaemon(true);
+      worker.start();
+      valueSet.await();
+
+      assertFalse(worker.getName().startsWith("Gravitino-webserver-"));
+      ClassLoaderResourceCleanerUtils.clearThreadLocalMap(worker, child);
+
+      // Drop every strong reference the test holds; the only thing that could still pin `child` is
+      // the worker's ThreadLocal, which the sweep just cleared.
+      child.close();
+      child = null;
+      childOwnedValue = null;
+      valueHolder[0] = null;
+    } finally {
+      // nothing yet; worker is released after the assertion
+    }
+
+    assertTrue(
+        awaitCollected(ref),
+        "dropped ClassLoader must be collectable once its ThreadLocal is swept");
+    release.countDown();
+    worker.join(1000);
+  }
+
+  private static boolean awaitCollected(WeakReference<?> ref) throws InterruptedException {
+    for (int i = 0; i < 20; i++) {
+      if (ref.get() == null) {
+        return true;
+      }
+      System.gc();
+      Runtime.getRuntime().runFinalization();
+      Thread.sleep(50);
+    }
+    return ref.get() == null;
   }
 
   private static URL mysqlConnectorJarUrl() {

--- a/catalogs/catalog-common/src/test/java/org/apache/gravitino/utils/TestClassLoaderResourceCleanerUtils.java
+++ b/catalogs/catalog-common/src/test/java/org/apache/gravitino/utils/TestClassLoaderResourceCleanerUtils.java
@@ -29,6 +29,7 @@ import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
@@ -244,13 +245,16 @@ class TestClassLoaderResourceCleanerUtils {
     // Blocks the worker after it sets the ThreadLocal so the thread stays alive; a thread that
     // exits would null its own threadLocals in Thread.exit() and hide the leak.
     CountDownLatch release = new CountDownLatch(1);
-    Thread worker;
+    Thread worker = null;
     try {
       URLClassLoader child = new URLClassLoader(new URL[] {classesUrl}, platform);
       Object childOwnedValue =
           Class.forName(LeakyValue.class.getName(), true, child)
               .getDeclaredConstructor()
               .newInstance();
+      // Guard the test's premise: the value must be loaded by `child`, otherwise the sweep's
+      // value-ClassLoader check never matches and the reclamation below would prove nothing.
+      assertSame(child, childOwnedValue.getClass().getClassLoader());
       ref = new WeakReference<>(child);
 
       CountDownLatch valueSet = new CountDownLatch(1);
@@ -270,9 +274,8 @@ class TestClassLoaderResourceCleanerUtils {
               "clp-reclaim-probe");
       worker.setDaemon(true);
       worker.start();
-      valueSet.await();
+      assertTrue(valueSet.await(10, TimeUnit.SECONDS), "worker should set its ThreadLocal");
 
-      assertFalse(worker.getName().startsWith("Gravitino-webserver-"));
       ClassLoaderResourceCleanerUtils.clearThreadLocalMap(worker, child);
 
       // Drop every strong reference the test holds; the only thing that could still pin `child` is
@@ -281,15 +284,18 @@ class TestClassLoaderResourceCleanerUtils {
       child = null;
       childOwnedValue = null;
       valueHolder[0] = null;
-    } finally {
-      // nothing yet; worker is released after the assertion
-    }
 
-    assertTrue(
-        awaitCollected(ref),
-        "dropped ClassLoader must be collectable once its ThreadLocal is swept");
-    release.countDown();
-    worker.join(1000);
+      // Assert before releasing the worker: once it returns, Thread.exit() nulls its threadLocals
+      // and would let `child` be collected even if the sweep did nothing.
+      assertTrue(
+          awaitCollected(ref),
+          "dropped ClassLoader must be collectable once its ThreadLocal is swept");
+    } finally {
+      release.countDown();
+      if (worker != null) {
+        worker.join(1000);
+      }
+    }
   }
 
   private static boolean awaitCollected(WeakReference<?> ref) throws InterruptedException {
@@ -298,7 +304,6 @@ class TestClassLoaderResourceCleanerUtils {
         return true;
       }
       System.gc();
-      Runtime.getRuntime().runFinalization();
       Thread.sleep(50);
     }
     return ref.get() == null;

--- a/catalogs/catalog-common/src/test/java/org/apache/gravitino/utils/TestClassLoaderResourceCleanerUtils.java
+++ b/catalogs/catalog-common/src/test/java/org/apache/gravitino/utils/TestClassLoaderResourceCleanerUtils.java
@@ -20,17 +20,24 @@
 package org.apache.gravitino.utils;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 class TestClassLoaderResourceCleanerUtils {
 
+  /** A trivial payload whose only purpose is to be loaded by a child ClassLoader in tests. */
+  public static class LeakyValue {}
+
   /**
-   * When a class is loaded by exactly the target classloader, isOwnedByClassLoader must return true
-   * — the guard should allow static-state cleanup to proceed.
+   * When a class is loaded by exactly the target classloader, isOwnedByClassLoader must return
+   * true: the guard should allow static-state cleanup to proceed.
    */
   @Test
   void testIsOwnedByClassLoaderReturnsTrueForOwningLoader() {
@@ -42,8 +49,8 @@ class TestClassLoaderResourceCleanerUtils {
 
   /**
    * When a class was resolved via parent delegation (i.e. the actual loader is the parent, not the
-   * child), isOwnedByClassLoader must return false — the guard should skip cleanup to avoid
-   * mutating shared JVM-global static state.
+   * child), isOwnedByClassLoader must return false: the guard should skip cleanup to avoid mutating
+   * shared JVM-global static state.
    */
   @Test
   void testIsOwnedByClassLoaderReturnsFalseForParentDelegatedClass() throws Exception {
@@ -59,7 +66,7 @@ class TestClassLoaderResourceCleanerUtils {
 
   /**
    * Bootstrap-loaded classes (whose getClassLoader() returns null) are never "owned" by a named
-   * classloader — the guard must return false for them too.
+   * classloader, so the guard must return false for them too.
    */
   @Test
   void testIsOwnedByClassLoaderReturnsFalseForBootstrapLoadedClass() {
@@ -67,5 +74,207 @@ class TestClassLoaderResourceCleanerUtils {
     assertFalse(
         ClassLoaderResourceCleanerUtils.isOwnedByClassLoader(
             String.class, ClassLoader.getSystemClassLoader()));
+  }
+
+  /**
+   * Loading MySQL's {@code AbandonedConnectionCleanupThread} starts a daemon thread {@code
+   * mysql-cj-abandoned-connection-cleanup} whose contextClassLoader is the loader that loaded it.
+   * That reference pins the ClassLoader and leaks Metaspace after a catalog is dropped. {@code
+   * shutdownMySQLAbandonedConnectionCleanupThread} must terminate that thread when the class is
+   * owned by the target loader.
+   */
+  @Test
+  void testShutdownMySQLAbandonedConnectionCleanupThreadStopsThread() throws Exception {
+    URL mysqlJar = mysqlConnectorJarUrl();
+    Assumptions.assumeTrue(mysqlJar != null, "mysql-connector jar is not on the test classpath");
+
+    // Parent is the platform loader so `child` loads its OWN copy of the class (no delegation to
+    // the app loader): the cleanup thread's contextClassLoader is `child` and the ownership guard
+    // passes. Load AbandonedConnectionCleanupThread directly rather than the Driver so the thread
+    // starts without registering a child-loaded Driver into the JVM-global DriverManager. That
+    // registration would pin `child` after this test and leak it, which is the leak this utility
+    // exists to prevent.
+    ClassLoader platform = ClassLoader.getSystemClassLoader().getParent();
+    try (URLClassLoader child = new URLClassLoader(new URL[] {mysqlJar}, platform)) {
+      Class.forName("com.mysql.cj.jdbc.AbandonedConnectionCleanupThread", true, child);
+      assertNotNull(
+          findCleanupThreadBoundTo(child),
+          "loading AbandonedConnectionCleanupThread should start the cleanup thread bound to child");
+
+      ClassLoaderResourceCleanerUtils.shutdownMySQLAbandonedConnectionCleanupThread(child);
+
+      assertTrue(
+          waitForCleanupThreadGone(child),
+          "cleanup thread bound to the child loader should be gone after uncheckedShutdown");
+    }
+  }
+
+  /**
+   * When the MySQL class resolves to a parent/shared ClassLoader (the driver sits on a shared
+   * classpath while the catalog being closed has its own child loader), {@code
+   * shutdownMySQLAbandonedConnectionCleanupThread} must skip the JVM-global {@code
+   * uncheckedShutdown()} so closing one catalog does not stop a cleanup thread owned by another
+   * loader.
+   */
+  @Test
+  void testShutdownMySQLAbandonedConnectionCleanupThreadSkipsParentOwnedClass() throws Exception {
+    URL mysqlJar = mysqlConnectorJarUrl();
+    Assumptions.assumeTrue(mysqlJar != null, "mysql-connector jar is not on the test classpath");
+
+    ClassLoader platform = ClassLoader.getSystemClassLoader().getParent();
+    // `owner` holds the class; `child` delegates to it, mirroring a driver on a shared parent CL.
+    try (URLClassLoader owner = new URLClassLoader(new URL[] {mysqlJar}, platform);
+        URLClassLoader child = new URLClassLoader(new URL[0], owner)) {
+      Class.forName("com.mysql.cj.jdbc.AbandonedConnectionCleanupThread", true, owner);
+      assertNotNull(
+          findCleanupThreadBoundTo(owner), "cleanup thread should be bound to the owner loader");
+
+      // classLoader=child, but the class resolves to `owner` via delegation, so the guard skips.
+      ClassLoaderResourceCleanerUtils.shutdownMySQLAbandonedConnectionCleanupThread(child);
+      // When uncheckedShutdown() does run it kills the thread within ~100ms (see the positive
+      // test's poll). Wait past that window and confirm the owner's thread is still alive, which
+      // shows the guard skipped it rather than just not having stopped it yet. Without the guard,
+      // 1s is long enough for the shutdown to take effect and this assertion fails.
+      assertTrue(
+          cleanupThreadStaysAliveFor(owner, 1000),
+          "cleanup thread owned by the parent loader must survive a child-scoped cleanup");
+
+      // An owner-scoped cleanup does run (guard passes), so nothing lingers past this test.
+      ClassLoaderResourceCleanerUtils.shutdownMySQLAbandonedConnectionCleanupThread(owner);
+      assertTrue(
+          waitForCleanupThreadGone(owner), "owner-scoped cleanup should stop the thread it owns");
+    }
+  }
+
+  /**
+   * The broadened {@code clearThreadLocalMap} must clear a ThreadLocal whose value is owned by the
+   * target ClassLoader even on a non-{@code Gravitino-webserver-*} thread (the pre-#10093 code only
+   * touched webserver threads). A ThreadLocal holding a value from a different ClassLoader must be
+   * left untouched, which is the {@code isOwnedByClassLoader}-style guard inside the sweep.
+   */
+  @Test
+  @SuppressWarnings("ThreadLocalUsage") // local ThreadLocals are required to test per-thread sweep
+  void testClearThreadLocalMapClearsOnlyTargetClassLoaderValues() throws Exception {
+    URL classesUrl = LeakyValue.class.getProtectionDomain().getCodeSource().getLocation();
+    ClassLoader platform = ClassLoader.getSystemClassLoader().getParent();
+    ThreadLocal<Object> targetOwned = new ThreadLocal<>();
+    ThreadLocal<Object> foreign = new ThreadLocal<>();
+    // `child` is the cleanup target; `sibling` is an unrelated loader. Both load their own copy of
+    // LeakyValue, so both values have a non-null ClassLoader. This exercises the real
+    // discrimination (value CL == target vs a different non-null CL), not just the null-CL case.
+    try (URLClassLoader child = new URLClassLoader(new URL[] {classesUrl}, platform);
+        URLClassLoader sibling = new URLClassLoader(new URL[] {classesUrl}, platform)) {
+      Object childOwnedValue =
+          Class.forName(LeakyValue.class.getName(), true, child)
+              .getDeclaredConstructor()
+              .newInstance();
+      assertSame(child, childOwnedValue.getClass().getClassLoader());
+      Object siblingOwnedValue =
+          Class.forName(LeakyValue.class.getName(), true, sibling)
+              .getDeclaredConstructor()
+              .newInstance();
+      assertSame(sibling, siblingOwnedValue.getClass().getClassLoader());
+
+      // This test runs on the JUnit "main"/worker thread, deliberately NOT a webserver thread, so
+      // it also proves the broadened scope.
+      assertFalse(Thread.currentThread().getName().startsWith("Gravitino-webserver-"));
+
+      targetOwned.set(childOwnedValue);
+      foreign.set(siblingOwnedValue);
+
+      ClassLoaderResourceCleanerUtils.clearThreadLocalMap(Thread.currentThread(), child);
+
+      assertNull(targetOwned.get(), "ThreadLocal owned by the target ClassLoader must be cleared");
+      assertSame(
+          siblingOwnedValue,
+          foreign.get(),
+          "ThreadLocal owned by a different non-null ClassLoader must be kept");
+    } finally {
+      targetOwned.remove();
+      foreign.remove();
+    }
+  }
+
+  /**
+   * JVM-internal threads live in the {@code system} thread group; the sweep must skip them entirely
+   * rather than reflect into their ThreadLocals.
+   */
+  @Test
+  @SuppressWarnings("ThreadLocalUsage") // local ThreadLocal is required to test per-thread sweep
+  void testClearThreadLocalMapSkipsSystemThreadGroup() throws Exception {
+    ClassLoader loader = ClassLoaderResourceCleanerUtils.class.getClassLoader();
+    ThreadGroup systemGroup = systemThreadGroup();
+    assertNotNull(systemGroup, "expected to locate the system thread group");
+
+    Object[] cleared = new Object[1];
+    Thread systemThread =
+        new Thread(
+            systemGroup,
+            () -> {
+              ThreadLocal<Object> tl = new ThreadLocal<>();
+              tl.set(new LeakyValue());
+              // Sweeping a system-group thread must be a no-op: the value stays set.
+              ClassLoaderResourceCleanerUtils.clearThreadLocalMap(Thread.currentThread(), loader);
+              cleared[0] = tl.get();
+            },
+            "clp-system-group-probe");
+    systemThread.start();
+    systemThread.join();
+
+    assertNotNull(cleared[0], "system-group thread ThreadLocals must be left untouched");
+  }
+
+  private static URL mysqlConnectorJarUrl() {
+    // The driver class is on the test classpath (declared as testImplementation). Resolve its
+    // code-source URL so a child URLClassLoader can load an isolated copy of the driver.
+    try {
+      Class<?> driver = Class.forName("com.mysql.cj.jdbc.Driver");
+      return driver.getProtectionDomain().getCodeSource().getLocation();
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private static Thread findCleanupThreadBoundTo(ClassLoader loader) {
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      if (t.getName().contains("abandoned-connection-cleanup")
+          && t.getContextClassLoader() == loader) {
+        return t;
+      }
+    }
+    return null;
+  }
+
+  private static boolean waitForCleanupThreadGone(ClassLoader loader) throws InterruptedException {
+    for (int i = 0; i < 50; i++) {
+      if (findCleanupThreadBoundTo(loader) == null) {
+        return true;
+      }
+      Thread.sleep(100);
+    }
+    return findCleanupThreadBoundTo(loader) == null;
+  }
+
+  private static boolean cleanupThreadStaysAliveFor(ClassLoader loader, long millis)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + millis;
+    while (System.currentTimeMillis() < deadline) {
+      if (findCleanupThreadBoundTo(loader) == null) {
+        return false;
+      }
+      Thread.sleep(50);
+    }
+    return findCleanupThreadBoundTo(loader) != null;
+  }
+
+  private static ThreadGroup systemThreadGroup() {
+    ThreadGroup group = Thread.currentThread().getThreadGroup();
+    while (group != null) {
+      if ("system".equals(group.getName())) {
+        return group;
+      }
+      group = group.getParent();
+    }
+    return null;
   }
 }

--- a/catalogs/catalog-common/src/test/java/org/apache/gravitino/utils/TestClassLoaderResourceCleanerUtils.java
+++ b/catalogs/catalog-common/src/test/java/org/apache/gravitino/utils/TestClassLoaderResourceCleanerUtils.java
@@ -298,6 +298,83 @@ class TestClassLoaderResourceCleanerUtils {
     }
   }
 
+  /**
+   * The property the issue is actually about: stopping the cleanup thread has to make the dropped
+   * ClassLoader collectable, not merely make the thread go away. The control case matters, because
+   * a bare WeakReference plus System.gc() assertion is unreliable enough that a green result
+   * without one proves little.
+   */
+  @Test
+  void testShutdownMySQLAbandonedConnectionCleanupThreadLetsDroppedClassLoaderBeCollected()
+      throws Exception {
+    URL mysqlJar = mysqlConnectorJarUrl();
+    Assumptions.assumeTrue(mysqlJar != null, "mysql-connector jar is not on the test classpath");
+    ClassLoader platform = ClassLoader.getSystemClassLoader().getParent();
+
+    // Control: the same shape of child loader, never asked for the driver. If this one were not
+    // collectable either, the assertions below would be measuring the probe, not the leak.
+    URLClassLoader control = new URLClassLoader(new URL[] {mysqlJar}, platform);
+    WeakReference<ClassLoader> controlRef = new WeakReference<>(control);
+    control.close();
+    control = null;
+    assertTrue(
+        awaitCollected(controlRef),
+        "a child loader that never loaded the driver must be collectable");
+
+    URLClassLoader child = new URLClassLoader(new URL[] {mysqlJar}, platform);
+    Class.forName("com.mysql.cj.jdbc.AbandonedConnectionCleanupThread", true, child);
+    assertNotNull(findCleanupThreadBoundTo(child), "the cleanup thread should be running");
+    WeakReference<ClassLoader> ref = new WeakReference<>(child);
+    child.close();
+    child = null;
+
+    // The leak: the running cleanup thread pins the loader through its context ClassLoader.
+    assertFalse(
+        awaitCollected(ref), "a live cleanup thread must keep the dropped loader reachable");
+
+    // Still reachable, so the test can get the loader back to run the fix on it.
+    ClassLoader leaked = ref.get();
+    assertNotNull(leaked, "loader should still be reachable while its cleanup thread runs");
+    ClassLoaderResourceCleanerUtils.shutdownMySQLAbandonedConnectionCleanupThread(leaked);
+    assertTrue(
+        waitForCleanupThreadGone(leaked), "cleanup thread should be gone after the shutdown");
+    leaked = null;
+
+    assertTrue(
+        awaitCollected(ref), "loader must be collectable once its cleanup thread is stopped");
+  }
+
+  /**
+   * Drives the whole cleanup sequence rather than one step. Every other case here calls a single
+   * step directly, so nothing covers the sequence, which is where step ordering lives. This asserts
+   * the sequence's outcome; it cannot by itself distinguish one order from another, since a later
+   * step can cover for an earlier one.
+   *
+   * <p>Goes through {@code runCleanupSteps} rather than {@code closeClassLoaderResource}: the
+   * latter returns immediately when {@code GRAVITINO_TEST} is set, which the build sets for every
+   * test task.
+   */
+  @Test
+  void testRunCleanupStepsStopsTheDriverThreadAndFreesTheClassLoader() throws Exception {
+    URL mysqlJar = mysqlConnectorJarUrl();
+    Assumptions.assumeTrue(mysqlJar != null, "mysql-connector jar is not on the test classpath");
+    ClassLoader platform = ClassLoader.getSystemClassLoader().getParent();
+
+    URLClassLoader child = new URLClassLoader(new URL[] {mysqlJar}, platform);
+    Class.forName("com.mysql.cj.jdbc.AbandonedConnectionCleanupThread", true, child);
+    assertNotNull(findCleanupThreadBoundTo(child), "the cleanup thread should be running");
+    WeakReference<ClassLoader> ref = new WeakReference<>(child);
+
+    ClassLoaderResourceCleanerUtils.runCleanupSteps(child);
+
+    assertTrue(
+        waitForCleanupThreadGone(child),
+        "the sequence should leave no cleanup thread on the loader");
+    child.close();
+    child = null;
+    assertTrue(awaitCollected(ref), "loader must be collectable after the full cleanup sequence");
+  }
+
   private static boolean awaitCollected(WeakReference<?> ref) throws InterruptedException {
     for (int i = 0; i < 20; i++) {
       if (ref.get() == null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two additions to `ClassLoaderResourceCleanerUtils.closeClassLoaderResource`:

- Shut down MySQL's `AbandonedConnectionCleanupThread` via `uncheckedShutdown()`, which also clears the tracked-connection map so the driver's ClassLoader can be collected. The call is guarded by `isOwnedByClassLoader`, matching the other cleanup steps in this class, so it never stops a cleanup thread owned by a parent or shared ClassLoader (for example a MySQL entity store loaded on the app ClassLoader, whose driver class delegates up to the app loader).
- Broaden the ThreadLocal sweep from `Gravitino-webserver-*` threads to all application threads, skipping only the JVM `system` thread group. Only entries whose value was loaded by the target ClassLoader are cleared, so ThreadLocals owned by other ClassLoaders are left alone.

### Why are the changes needed?

After a MySQL-backed catalog is dropped, its isolated ClassLoader stays reachable through the `mysql-cj-abandoned-connection-cleanup` thread's context ClassLoader and through ThreadLocals on non-webserver threads (Caffeine ForkJoinPool, catalog-cleaner, Hadoop daemons). `closeClassLoaderResource` releases neither today, so the ClassLoader leaks on every reload and Metaspace grows until `OutOfMemoryError: Metaspace`.

Fix: #12123

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `TestClassLoaderResourceCleanerUtils` cases (`mysql-connector-j` added as a test-only dependency):

- `testShutdownMySQLAbandonedConnectionCleanupThreadStopsThread`: loading `AbandonedConnectionCleanupThread` in a child `URLClassLoader` starts the cleanup thread bound to that loader; after `shutdownMySQLAbandonedConnectionCleanupThread` the thread is gone. It loads the cleanup-thread class directly rather than the driver, so the test does not register a driver into the JVM-global `DriverManager`.
- `testShutdownMySQLAbandonedConnectionCleanupThreadSkipsParentOwnedClass`: when the class resolves to a parent loader, a child-scoped cleanup leaves the parent's thread alive; an owner-scoped cleanup stops it.
- `testClearThreadLocalMapClearsOnlyTargetClassLoaderValues`: on a non-webserver thread, a ThreadLocal whose value is loaded by the target ClassLoader is cleared, while one loaded by a different (non-null) ClassLoader is kept.
- `testClearThreadLocalMapSkipsSystemThreadGroup`: a ThreadLocal on a `system`-group thread is left untouched.

Ran `./gradlew :catalogs:catalog-common:test --tests "org.apache.gravitino.utils.TestClassLoaderResourceCleanerUtils"`: 7/7 green.
