### PR TITLE
[Cherry-pick to branch-1.3] [#12097] improvement(core): Validate names before normalizing in CapabilityHelpers (#12098)

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
@@ -252,9 +252,8 @@ public class CapabilityHelpers {
   }
 
   private static String[] applyCapabilities(String[] fieldName, Capability capabilities) {
-    String[] sensitiveOnColumnName = applyCaseSensitiveOnColumnName(fieldName, capabilities);
-    applyNameSpecification(Capability.Scope.COLUMN, sensitiveOnColumnName[0], capabilities);
-    return sensitiveOnColumnName;
+    applyNameSpecification(Capability.Scope.COLUMN, fieldName[0], capabilities);
+    return applyCaseSensitiveOnColumnName(fieldName, capabilities);
   }
 
   private static Transform applyCapabilities(Transform transform, Capability capabilities) {
@@ -343,38 +342,42 @@ public class CapabilityHelpers {
 
   private static FilesetChange applyCapabilities(
       FilesetChange.RenameFileset renameFileset, Capability capabilities) {
+    applyNameSpecification(Capability.Scope.FILESET, renameFileset.getNewName(), capabilities);
     String newName =
         applyCaseSensitiveOnName(
             Capability.Scope.FILESET, renameFileset.getNewName(), capabilities);
-    applyNameSpecification(Capability.Scope.FILESET, newName, capabilities);
     return FilesetChange.rename(newName);
   }
 
   private static ViewChange applyCapabilities(
       ViewChange.RenameView renameView, Capability capabilities) {
+    applyNameSpecification(Capability.Scope.VIEW, renameView.getNewName(), capabilities);
     String newName =
         applyCaseSensitiveOnName(Capability.Scope.VIEW, renameView.getNewName(), capabilities);
-    applyNameSpecification(Capability.Scope.VIEW, newName, capabilities);
     return ViewChange.rename(newName);
   }
 
   private static TableChange applyCapabilities(
       TableChange.RenameTable renameTable, Capability capabilities) {
+    applyNameSpecification(Capability.Scope.TABLE, renameTable.getNewName(), capabilities);
     String newName =
         applyCaseSensitiveOnName(Capability.Scope.TABLE, renameTable.getNewName(), capabilities);
     String newSchemaName =
         renameTable
             .getNewSchemaName()
-            .map(s -> applyCaseSensitiveOnName(Capability.Scope.SCHEMA, s, capabilities))
+            .map(
+                s -> {
+                  applyNameSpecification(Capability.Scope.SCHEMA, s, capabilities);
+                  return applyCaseSensitiveOnName(Capability.Scope.SCHEMA, s, capabilities);
+                })
             .orElse(null);
-    applyNameSpecification(Capability.Scope.TABLE, newName, capabilities);
     return TableChange.rename(newName, newSchemaName);
   }
 
   private static TableChange applyCapabilities(
       TableChange.ColumnChange change, Capability capabilities) {
+    applyNameSpecification(Capability.Scope.COLUMN, change.fieldName()[0], capabilities);
     String[] fieldName = applyCaseSensitiveOnColumnName(change.fieldName(), capabilities);
-    applyNameSpecification(Capability.Scope.COLUMN, fieldName[0], capabilities);
 
     if (change instanceof TableChange.AddColumn) {
       return applyCapabilities((TableChange.AddColumn) change, capabilities);
@@ -404,10 +407,10 @@ public class CapabilityHelpers {
           (TableChange.UpdateColumnPosition) change;
       if (updateColumnPosition.getPosition() instanceof TableChange.After) {
         TableChange.After afterPosition = (TableChange.After) updateColumnPosition.getPosition();
+        applyNameSpecification(Capability.Scope.COLUMN, afterPosition.getColumn(), capabilities);
         String afterFieldName =
             applyCaseSensitiveOnName(
                 Capability.Scope.COLUMN, afterPosition.getColumn(), capabilities);
-        applyNameSpecification(Capability.Scope.COLUMN, afterFieldName, capabilities);
         return TableChange.updateColumnPosition(
             fieldName, TableChange.ColumnPosition.after(afterFieldName));
       }
@@ -498,9 +501,8 @@ public class CapabilityHelpers {
 
   private static String applyCapabilitiesOnName(
       Capability.Scope scope, String name, Capability capabilities) {
-    String standardizeName = applyCaseSensitiveOnName(scope, name, capabilities);
-    applyNameSpecification(scope, standardizeName, capabilities);
-    return standardizeName;
+    applyNameSpecification(scope, name, capabilities);
+    return applyCaseSensitiveOnName(scope, name, capabilities);
   }
 
   public static String applyCaseSensitiveOnName(

--- a/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
@@ -173,9 +173,7 @@ public class CapabilityHelpers {
 
   public static Partition applyCaseSensitive(Partition partition, Capability capabilities) {
     String newName =
-        capabilities.caseSensitiveOnName(Capability.Scope.PARTITION).supported()
-            ? partition.name()
-            : partition.name().toLowerCase();
+        applyCaseSensitiveOnName(Capability.Scope.PARTITION, partition.name(), capabilities);
     if (partition instanceof IdentityPartition) {
       IdentityPartition identityPartition = (IdentityPartition) partition;
       return Partitions.identity(
@@ -507,16 +505,28 @@ public class CapabilityHelpers {
 
   public static String applyCaseSensitiveOnName(
       Capability.Scope scope, String name, Capability capabilities) {
-    return capabilities.caseSensitiveOnName(scope).supported() ? name : name.toLowerCase();
+    if (name == null) {
+      return null;
+    }
+    String normalizedName = capabilities.normalizeName(scope, name);
+    if (normalizedName == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Capability.normalizeName(%s, %s) must not return null for a non-null name",
+              scope, name));
+    }
+    return normalizedName;
   }
 
   private static String[] applyCaseSensitiveOnColumnName(String[] name, Capability capabilities) {
-    if (!capabilities.caseSensitiveOnName(Capability.Scope.COLUMN).supported()) {
-      String[] standardizeColumnName = Arrays.copyOf(name, name.length);
-      standardizeColumnName[0] = name[0].toLowerCase();
-      return standardizeColumnName;
+    String normalizedFirstName =
+        applyCaseSensitiveOnName(Capability.Scope.COLUMN, name[0], capabilities);
+    if (normalizedFirstName.equals(name[0])) {
+      return name;
     }
-    return name;
+    String[] standardizeColumnName = Arrays.copyOf(name, name.length);
+    standardizeColumnName[0] = normalizedFirstName;
+    return standardizeColumnName;
   }
 
   private static void applyColumnNotNull(Column column, Capability capabilities) {

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetNormalizeDispatcher.java
@@ -24,7 +24,6 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
 import java.io.IOException;
 import java.util.Map;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -36,6 +35,10 @@ import org.apache.gravitino.file.FileInfo;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.file.FilesetChange;
 
+/**
+ * Note on list operations: names returned by list methods (e.g. {@link #listFilesets(Namespace)})
+ * are assumed to already be in their canonical, legal form and are not re-normalized here.
+ */
 public class FilesetNormalizeDispatcher implements FilesetDispatcher {
   private final CatalogManager catalogManager;
   private final FilesetDispatcher dispatcher;
@@ -50,8 +53,7 @@ public class FilesetNormalizeDispatcher implements FilesetDispatcher {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    NameIdentifier[] identifiers = dispatcher.listFilesets(caseSensitiveNs);
-    return normalizeCaseSensitive(identifiers);
+    return dispatcher.listFilesets(caseSensitiveNs);
   }
 
   @Override
@@ -124,14 +126,5 @@ public class FilesetNormalizeDispatcher implements FilesetDispatcher {
   private NameIdentifier normalizeCaseSensitive(NameIdentifier filesetIdent) {
     Capability capabilities = getCapability(filesetIdent, catalogManager);
     return applyCaseSensitive(filesetIdent, Capability.Scope.FILESET, capabilities);
-  }
-
-  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] filesetIdents) {
-    if (ArrayUtils.isEmpty(filesetIdents)) {
-      return filesetIdents;
-    }
-
-    Capability capabilities = getCapability(filesetIdents[0], catalogManager);
-    return applyCaseSensitive(filesetIdents, Capability.Scope.FILESET, capabilities);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/FunctionNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FunctionNormalizeDispatcher.java
@@ -22,7 +22,6 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
 import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -37,6 +36,10 @@ import org.apache.gravitino.function.FunctionType;
 /**
  * {@code FunctionNormalizeDispatcher} normalizes function identifiers and namespaces by applying
  * case-sensitivity and other naming capabilities before delegating to the underlying dispatcher.
+ *
+ * <p>Note on list operations: names returned by list methods (e.g. {@link
+ * #listFunctions(Namespace)}) are assumed to already be in their canonical, legal form and are not
+ * re-normalized here.
  */
 public class FunctionNormalizeDispatcher implements FunctionDispatcher {
   private final CatalogManager catalogManager;
@@ -50,8 +53,7 @@ public class FunctionNormalizeDispatcher implements FunctionDispatcher {
   @Override
   public NameIdentifier[] listFunctions(Namespace namespace) throws NoSuchSchemaException {
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    NameIdentifier[] identifiers = dispatcher.listFunctions(caseSensitiveNs);
-    return normalizeCaseSensitive(identifiers);
+    return dispatcher.listFunctions(caseSensitiveNs);
   }
 
   @Override
@@ -100,15 +102,6 @@ public class FunctionNormalizeDispatcher implements FunctionDispatcher {
   private NameIdentifier normalizeCaseSensitive(NameIdentifier functionIdent) {
     Capability capabilities = getCapability(functionIdent, catalogManager);
     return applyCaseSensitive(functionIdent, Capability.Scope.FUNCTION, capabilities);
-  }
-
-  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] functionIdents) {
-    if (ArrayUtils.isEmpty(functionIdents)) {
-      return functionIdents;
-    }
-
-    Capability capabilities = getCapability(functionIdents[0], catalogManager);
-    return applyCaseSensitive(functionIdents, Capability.Scope.FUNCTION, capabilities);
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier functionIdent) {

--- a/core/src/main/java/org/apache/gravitino/catalog/ModelNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ModelNormalizeDispatcher.java
@@ -23,7 +23,6 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
 import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
 import java.util.Map;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -38,6 +37,10 @@ import org.apache.gravitino.model.ModelChange;
 import org.apache.gravitino.model.ModelVersion;
 import org.apache.gravitino.model.ModelVersionChange;
 
+/**
+ * Note on list operations: names returned by list methods (e.g. {@link #listModels(Namespace)}) are
+ * assumed to already be in their canonical, legal form and are not re-normalized here.
+ */
 public class ModelNormalizeDispatcher implements ModelDispatcher {
   private final CatalogManager catalogManager;
   private final ModelDispatcher dispatcher;
@@ -52,8 +55,7 @@ public class ModelNormalizeDispatcher implements ModelDispatcher {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    NameIdentifier[] identifiers = dispatcher.listModels(caseSensitiveNs);
-    return normalizeCaseSensitive(identifiers);
+    return dispatcher.listModels(caseSensitiveNs);
   }
 
   @Override
@@ -179,15 +181,6 @@ public class ModelNormalizeDispatcher implements ModelDispatcher {
   private NameIdentifier normalizeCaseSensitive(NameIdentifier ident) {
     Capability capabilities = getCapability(ident, catalogManager);
     return applyCaseSensitive(ident, Capability.Scope.MODEL, capabilities);
-  }
-
-  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] idents) {
-    if (ArrayUtils.isEmpty(idents)) {
-      return idents;
-    }
-
-    Capability capabilities = getCapability(idents[0], catalogManager);
-    return applyCaseSensitive(idents, Capability.Scope.MODEL, capabilities);
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier ident) {

--- a/core/src/main/java/org/apache/gravitino/catalog/PartitionNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PartitionNormalizeDispatcher.java
@@ -22,13 +22,17 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitiveOnName;
 import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
-import java.util.Arrays;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchPartitionException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.rel.partitions.Partition;
 
+/**
+ * Note on list operations: names returned by list methods (e.g. {@link
+ * #listPartitionNames(NameIdentifier)}, {@link #listPartitions(NameIdentifier)}) are assumed to
+ * already be in their canonical, legal form and are not re-normalized here.
+ */
 public class PartitionNormalizeDispatcher implements PartitionDispatcher {
   private final CatalogManager catalogManager;
   private final PartitionDispatcher dispatcher;
@@ -42,23 +46,15 @@ public class PartitionNormalizeDispatcher implements PartitionDispatcher {
   @Override
   public String[] listPartitionNames(NameIdentifier tableIdent) {
     Capability capabilities = getCapability(tableIdent, catalogManager);
-    String[] partitionNames =
-        dispatcher.listPartitionNames(
-            applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities));
-    return Arrays.stream(partitionNames)
-        .map(
-            partitionName ->
-                applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, capabilities))
-        .toArray(String[]::new);
+    return dispatcher.listPartitionNames(
+        applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities));
   }
 
   @Override
   public Partition[] listPartitions(NameIdentifier tableIdent) {
     Capability capabilities = getCapability(tableIdent, catalogManager);
-    Partition[] partitions =
-        dispatcher.listPartitions(
-            CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities));
-    return applyCaseSensitive(partitions, capabilities);
+    return dispatcher.listPartitions(
+        CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities));
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaNormalizeDispatcher.java
@@ -23,7 +23,6 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
 import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
 import java.util.Map;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
@@ -34,6 +33,10 @@ import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
 
+/**
+ * Note on list operations: names returned by list methods (e.g. {@link #listSchemas(Namespace)})
+ * are assumed to already be in their canonical, legal form and are not re-normalized here.
+ */
 public class SchemaNormalizeDispatcher implements SchemaDispatcher {
   private final CatalogManager catalogManager;
   private final SchemaDispatcher dispatcher;
@@ -57,10 +60,7 @@ public class SchemaNormalizeDispatcher implements SchemaDispatcher {
               NameIdentifier.of(namespace.levels())));
     }
 
-    NameIdentifier[] identifiers = dispatcher.listSchemas(namespace);
-    // The constraints of the name spec may be more strict than underlying catalog,
-    // and for compatibility reasons, we only apply case-sensitive capabilities here.
-    return normalizeCaseSensitive(identifiers);
+    return dispatcher.listSchemas(namespace);
   }
 
   @Override
@@ -109,14 +109,5 @@ public class SchemaNormalizeDispatcher implements SchemaDispatcher {
   private NameIdentifier normalizeCaseSensitive(NameIdentifier schemaIdent) {
     Capability capabilities = getCapability(schemaIdent, catalogManager);
     return applyCaseSensitive(schemaIdent, Capability.Scope.SCHEMA, capabilities);
-  }
-
-  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] schemaIdents) {
-    if (ArrayUtils.isEmpty(schemaIdents)) {
-      return schemaIdents;
-    }
-
-    Capability capabilities = getCapability(schemaIdents[0], catalogManager);
-    return applyCaseSensitive(schemaIdents, Capability.Scope.SCHEMA, capabilities);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/TableNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableNormalizeDispatcher.java
@@ -23,7 +23,6 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
 import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
 import java.util.Map;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -38,6 +37,10 @@ import org.apache.gravitino.rel.expressions.sorts.SortOrder;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
 
+/**
+ * Note on list operations: names returned by list methods (e.g. {@link #listTables(Namespace)}) are
+ * assumed to already be in their canonical, legal form and are not re-normalized here.
+ */
 public class TableNormalizeDispatcher implements TableDispatcher {
   private final CatalogManager catalogManager;
   private final TableDispatcher dispatcher;
@@ -52,8 +55,7 @@ public class TableNormalizeDispatcher implements TableDispatcher {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    NameIdentifier[] identifiers = dispatcher.listTables(caseSensitiveNs);
-    return normalizeCaseSensitive(identifiers);
+    return dispatcher.listTables(caseSensitiveNs);
   }
 
   @Override
@@ -121,15 +123,6 @@ public class TableNormalizeDispatcher implements TableDispatcher {
   private NameIdentifier normalizeCaseSensitive(NameIdentifier tableIdent) {
     Capability capability = getCapability(tableIdent, catalogManager);
     return applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capability);
-  }
-
-  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] tableIdents) {
-    if (ArrayUtils.isEmpty(tableIdents)) {
-      return tableIdents;
-    }
-
-    Capability capabilities = getCapability(tableIdents[0], catalogManager);
-    return applyCaseSensitive(tableIdents, Capability.Scope.TABLE, capabilities);
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier tableIdent) {

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicNormalizeDispatcher.java
@@ -23,7 +23,6 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
 import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
 import java.util.Map;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -34,6 +33,10 @@ import org.apache.gravitino.messaging.DataLayout;
 import org.apache.gravitino.messaging.Topic;
 import org.apache.gravitino.messaging.TopicChange;
 
+/**
+ * Note on list operations: names returned by list methods (e.g. {@link #listTopics(Namespace)}) are
+ * assumed to already be in their canonical, legal form and are not re-normalized here.
+ */
 public class TopicNormalizeDispatcher implements TopicDispatcher {
   private final CatalogManager catalogManager;
   private final TopicDispatcher dispatcher;
@@ -48,8 +51,7 @@ public class TopicNormalizeDispatcher implements TopicDispatcher {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    NameIdentifier[] identifiers = dispatcher.listTopics(caseSensitiveNs);
-    return normalizeCaseSensitive(identifiers);
+    return dispatcher.listTopics(caseSensitiveNs);
   }
 
   @Override
@@ -96,15 +98,6 @@ public class TopicNormalizeDispatcher implements TopicDispatcher {
   private NameIdentifier normalizeCaseSensitive(NameIdentifier topicIdent) {
     Capability capabilities = getCapability(topicIdent, catalogManager);
     return applyCaseSensitive(topicIdent, Capability.Scope.TOPIC, capabilities);
-  }
-
-  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] topicIdents) {
-    if (ArrayUtils.isEmpty(topicIdents)) {
-      return topicIdents;
-    }
-
-    Capability capabilities = getCapability(topicIdents[0], catalogManager);
-    return applyCaseSensitive(topicIdents, Capability.Scope.TOPIC, capabilities);
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier topicIdent) {

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewNormalizeDispatcher.java
@@ -24,7 +24,6 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -36,6 +35,10 @@ import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewChange;
 
+/**
+ * Note on list operations: names returned by list methods (e.g. {@link #listViews(Namespace)}) are
+ * assumed to already be in their canonical, legal form and are not re-normalized here.
+ */
 public class ViewNormalizeDispatcher implements ViewDispatcher {
 
   private final CatalogManager catalogManager;
@@ -51,8 +54,7 @@ public class ViewNormalizeDispatcher implements ViewDispatcher {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    NameIdentifier[] identifiers = dispatcher.listViews(caseSensitiveNs);
-    return normalizeCaseSensitive(identifiers);
+    return dispatcher.listViews(caseSensitiveNs);
   }
 
   @Override
@@ -106,14 +108,6 @@ public class ViewNormalizeDispatcher implements ViewDispatcher {
   private NameIdentifier normalizeCaseSensitive(NameIdentifier ident) {
     Capability capabilities = getCapability(ident, catalogManager);
     return applyCaseSensitive(ident, Capability.Scope.VIEW, capabilities);
-  }
-
-  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] idents) {
-    if (ArrayUtils.isEmpty(idents)) {
-      return idents;
-    }
-    Capability capabilities = getCapability(idents[0], catalogManager);
-    return applyCaseSensitive(idents, Capability.Scope.VIEW, capabilities);
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier ident) {

--- a/core/src/main/java/org/apache/gravitino/connector/capability/Capability.java
+++ b/core/src/main/java/org/apache/gravitino/connector/capability/Capability.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.connector.capability;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Locale;
 import java.util.Set;
 import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.annotation.Evolving;
@@ -71,6 +72,25 @@ public interface Capability {
    */
   default CapabilityResult caseSensitiveOnName(Scope scope) {
     return DEFAULT.caseSensitiveOnName(scope);
+  }
+
+  /**
+   * Normalizes the given name to the catalog's canonical form before it is used to call the
+   * underlying catalog operation and persisted as the Gravitino entity name. This is invoked
+   * instead of the simple lowercase folding implied by {@link #caseSensitiveOnName(Scope)} whenever
+   * a catalog needs custom folding logic (for example, a catalog whose native folding direction is
+   * uppercase, or one that supports a case-sensitive quoted form alongside a case-insensitive
+   * unquoted form).
+   *
+   * @param scope The scope of the capability.
+   * @param name The name to normalize.
+   * @return The normalized, canonical name.
+   */
+  default String normalizeName(Scope scope, String name) {
+    if (name == null) {
+      return null;
+    }
+    return caseSensitiveOnName(scope).supported() ? name : name.toLowerCase(Locale.ROOT);
   }
 
   /**

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCapabilityHelpers.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCapabilityHelpers.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import java.util.Locale;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
+import org.apache.gravitino.rel.expressions.literals.Literal;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.partitions.IdentityPartition;
+import org.apache.gravitino.rel.partitions.Partition;
+import org.apache.gravitino.rel.partitions.Partitions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestCapabilityHelpers {
+
+  private static final Capability UPPERCASE_CAPABILITY =
+      new Capability() {
+        @Override
+        public CapabilityResult caseSensitiveOnName(Scope scope) {
+          return CapabilityResult.unsupported("not case sensitive");
+        }
+
+        @Override
+        public String normalizeName(Scope scope, String name) {
+          return name.toUpperCase(Locale.ROOT);
+        }
+      };
+
+  private static final Capability NULL_NORMALIZING_CAPABILITY =
+      new Capability() {
+        @Override
+        public String normalizeName(Scope scope, String name) {
+          return null;
+        }
+      };
+
+  @Test
+  void testApplyCaseSensitiveOnNameHonorsCustomNormalizeName() {
+    String normalized =
+        CapabilityHelpers.applyCaseSensitiveOnName(
+            Capability.Scope.TABLE, "myTable", UPPERCASE_CAPABILITY);
+    Assertions.assertEquals("MYTABLE", normalized);
+  }
+
+  @Test
+  void testApplyCaseSensitivePartitionHonorsCustomNormalizeName() {
+    IdentityPartition partition =
+        Partitions.identity(
+            "myPartition",
+            new String[][] {{"col1"}},
+            new Literal<?>[] {Literals.stringLiteral("val1")},
+            null);
+
+    Partition result = CapabilityHelpers.applyCaseSensitive(partition, UPPERCASE_CAPABILITY);
+    Assertions.assertEquals("MYPARTITION", result.name());
+  }
+
+  @Test
+  void testApplyCaseSensitiveOnNameRejectsNullNormalizeNameResult() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CapabilityHelpers.applyCaseSensitiveOnName(
+                Capability.Scope.TABLE, "myTable", NULL_NORMALIZING_CAPABILITY));
+  }
+
+  @Test
+  void testApplyCaseSensitiveOnNameAllowsNullNameToPassThrough() {
+    // A null name (e.g. an auto-generated identity partition name yet to be assigned) must be
+    // allowed to pass through as null rather than being rejected as an invalid normalizeName
+    // result.
+    String normalized =
+        CapabilityHelpers.applyCaseSensitiveOnName(
+            Capability.Scope.PARTITION, null, Capability.DEFAULT);
+    Assertions.assertNull(normalized);
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCapabilityHelpers.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCapabilityHelpers.java
@@ -19,6 +19,8 @@
 package org.apache.gravitino.catalog;
 
 import java.util.Locale;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.apache.gravitino.rel.expressions.literals.Literal;
@@ -49,6 +51,39 @@ public class TestCapabilityHelpers {
         @Override
         public String normalizeName(Scope scope, String name) {
           return null;
+        }
+      };
+
+  /**
+   * Mimics Oracle's quoting convention: a quoted name (e.g. {@code "My Table"}) is unquoted with
+   * its case and embedded spaces preserved, while an unquoted name must match a simple word
+   * pattern. {@code specificationOnName} must see the name as it was originally supplied (still
+   * quoted) rather than the already-unquoted result of {@code normalizeName}, or a quoted name with
+   * a space would be wrongly rejected after normalization even though it was valid as supplied.
+   */
+  static final Capability QUOTE_AWARE_CAPABILITY =
+      new Capability() {
+        @Override
+        public CapabilityResult specificationOnName(Scope scope, String name) {
+          if (name.startsWith("\"") && name.endsWith("\"") && name.length() >= 2) {
+            return CapabilityResult.SUPPORTED;
+          }
+          return name.matches("^\\w+$")
+              ? CapabilityResult.SUPPORTED
+              : CapabilityResult.unsupported("Illegal name: " + name);
+        }
+
+        @Override
+        public CapabilityResult caseSensitiveOnName(Scope scope) {
+          return CapabilityResult.unsupported("folding depends on quoting");
+        }
+
+        @Override
+        public String normalizeName(Scope scope, String name) {
+          if (name.startsWith("\"") && name.endsWith("\"") && name.length() >= 2) {
+            return name.substring(1, name.length() - 1);
+          }
+          return name.toUpperCase(Locale.ROOT);
         }
       };
 
@@ -91,5 +126,20 @@ public class TestCapabilityHelpers {
         CapabilityHelpers.applyCaseSensitiveOnName(
             Capability.Scope.PARTITION, null, Capability.DEFAULT);
     Assertions.assertNull(normalized);
+  }
+
+  @Test
+  void testApplyCapabilitiesValidatesNameBeforeNormalizing() {
+    // A quoted name with an embedded space is valid as supplied, but its normalized (unquoted)
+    // form no longer matches the plain-word pattern. specificationOnName must be checked against
+    // the original name, not the already-normalized one, or this would be wrongly rejected.
+    NameIdentifier quotedIdent =
+        NameIdentifier.of(Namespace.of("metalake", "catalog", "schema"), "\"My Table\"");
+
+    NameIdentifier result =
+        CapabilityHelpers.applyCapabilities(
+            quotedIdent, Capability.Scope.TABLE, QUOTE_AWARE_CAPABILITY);
+
+    Assertions.assertEquals("My Table", result.name());
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPartitionNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPartitionNormalizeDispatcher.java
@@ -30,6 +30,8 @@ import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 public class TestPartitionNormalizeDispatcher extends TestOperationDispatcher {
 
@@ -89,5 +91,75 @@ public class TestPartitionNormalizeDispatcher extends TestOperationDispatcher {
     Assertions.assertTrue(
         partitionNormalizeDispatcher.dropPartition(TABLE, partition.name().toUpperCase()));
     Assertions.assertFalse(partitionNormalizeDispatcher.partitionExists(TABLE, partition.name()));
+  }
+
+  @Test
+  public void testAddPartitionListPartitionsGetPartitionRoundTrip() throws Exception {
+    // Mirrors the correct usage pattern for a quote-aware catalog (e.g. Oracle):
+    // 1. addPartition is issued with a quoted, case-sensitive name, so the catalog stores the
+    //    physical partition with its case preserved: My Partition.
+    // 2. listPartitionNames()/listPartitions() surface that physical name unquoted (My
+    //    Partition) -- names are not re-folded by the core layer.
+    // 3. Getting the partition again requires re-quoting the case-sensitive name
+    //    ("My Partition"), not passing the bare listed name back in: normalizeName cannot tell
+    //    an already-canonical name apart from raw user input.
+    NameIdentifier tableIdent =
+        NameIdentifierUtil.ofTable(metalake, catalog, "schema", "quotedTable");
+    PartitionDispatcher mockDispatcher = Mockito.mock(PartitionDispatcher.class);
+
+    CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
+    CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Mockito.when(mockWrapper.capabilities())
+        .thenReturn(TestCapabilityHelpers.QUOTE_AWARE_CAPABILITY);
+    Mockito.when(mockCatalogManager.loadCatalogAndWrap(Mockito.any(NameIdentifier.class)))
+        .thenReturn(mockWrapper);
+
+    PartitionNormalizeDispatcher dispatcher =
+        new PartitionNormalizeDispatcher(mockDispatcher, mockCatalogManager);
+
+    // 1. Add the partition with a quoted, case-sensitive name.
+    Partition quotedPartition =
+        Partitions.identity(
+            "\"My Partition\"",
+            new String[][] {{"col1"}},
+            new Literal[] {Literals.stringLiteral("v1")},
+            Maps.newHashMap());
+    Mockito.when(mockDispatcher.addPartition(Mockito.any(NameIdentifier.class), Mockito.any()))
+        .thenReturn(quotedPartition);
+    dispatcher.addPartition(tableIdent, quotedPartition);
+
+    ArgumentCaptor<Partition> addedPartitionCaptor = ArgumentCaptor.forClass(Partition.class);
+    Mockito.verify(mockDispatcher)
+        .addPartition(Mockito.any(NameIdentifier.class), addedPartitionCaptor.capture());
+    String physicalName = addedPartitionCaptor.getValue().name();
+    Assertions.assertEquals("My Partition", physicalName);
+
+    // 2. listPartitionNames()/listPartitions() must surface that physical name unchanged.
+    Partition physicalPartition =
+        Partitions.identity(
+            physicalName,
+            new String[][] {{"col1"}},
+            new Literal[] {Literals.stringLiteral("v1")},
+            Maps.newHashMap());
+    Mockito.when(mockDispatcher.listPartitionNames(Mockito.any(NameIdentifier.class)))
+        .thenReturn(new String[] {physicalName});
+    Mockito.when(mockDispatcher.listPartitions(Mockito.any(NameIdentifier.class)))
+        .thenReturn(new Partition[] {physicalPartition});
+
+    String[] listedNames = dispatcher.listPartitionNames(tableIdent);
+    Assertions.assertEquals(1, listedNames.length);
+    Assertions.assertEquals("My Partition", listedNames[0]);
+
+    Partition[] listedPartitions = dispatcher.listPartitions(tableIdent);
+    Assertions.assertEquals(1, listedPartitions.length);
+    Assertions.assertEquals("My Partition", listedPartitions[0].name());
+
+    // 3. Getting the partition again requires re-quoting the listed name.
+    dispatcher.getPartition(tableIdent, "\"" + listedNames[0] + "\"");
+
+    ArgumentCaptor<String> gotPartitionNameCaptor = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(mockDispatcher)
+        .getPartition(Mockito.any(NameIdentifier.class), gotPartitionNameCaptor.capture());
+    Assertions.assertEquals("My Partition", gotPartitionNameCaptor.getValue());
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableNormalizeDispatcher.java
@@ -49,6 +49,8 @@ import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 public class TestTableNormalizeDispatcher extends TestOperationDispatcher {
   private static TableNormalizeDispatcher tableNormalizeDispatcher;
@@ -192,6 +194,86 @@ public class TestTableNormalizeDispatcher extends TestOperationDispatcher {
             () -> tableNormalizeDispatcher.createTable(tableIdent3, columns1, "comment", props));
     Assertions.assertEquals(
         "The COLUMN name '*' is reserved. Illegal name: *", exception.getMessage());
+  }
+
+  @Test
+  public void testCreateTableListTablesLoadTableRoundTrip() throws Exception {
+    // Mirrors the correct usage pattern for a quote-aware catalog (e.g. Oracle):
+    // 1. CREATE TABLE "My Table" is issued with a quoted name, so the catalog stores the
+    //    physical table with its case preserved: My Table.
+    // 2. listTables() surfaces that physical name unquoted (My Table) -- this is the behavior
+    //    this PR's fix guarantees: the name is not re-folded by the core layer.
+    // 3. Loading the table again requires re-quoting the case-sensitive name ("My Table"), not
+    //    passing the bare listed name back in: normalizeName cannot tell an already-canonical
+    //    name apart from raw user input, so an unquoted "My Table" would be folded to MY TABLE.
+    Namespace tableNs = Namespace.of(metalake, catalog, "schema");
+    TableDispatcher mockDispatcher = Mockito.mock(TableDispatcher.class);
+    Mockito.when(
+            mockDispatcher.createTable(
+                Mockito.any(NameIdentifier.class),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()))
+        .thenReturn(Mockito.mock(Table.class));
+    Mockito.when(mockDispatcher.loadTable(Mockito.any(NameIdentifier.class)))
+        .thenReturn(Mockito.mock(Table.class));
+
+    CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
+    CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Mockito.when(mockWrapper.capabilities())
+        .thenReturn(TestCapabilityHelpers.QUOTE_AWARE_CAPABILITY);
+    Mockito.when(mockCatalogManager.loadCatalogAndWrap(Mockito.any(NameIdentifier.class)))
+        .thenReturn(mockWrapper);
+
+    TableNormalizeDispatcher dispatcher =
+        new TableNormalizeDispatcher(mockDispatcher, mockCatalogManager);
+
+    // 1. Create the table with a quoted, case-sensitive name.
+    NameIdentifier quotedCreateIdent = NameIdentifier.of(tableNs, "\"My Table\"");
+    dispatcher.createTable(
+        quotedCreateIdent,
+        new Column[0],
+        "comment",
+        ImmutableMap.of(),
+        new Transform[0],
+        Distributions.NONE,
+        new SortOrder[0],
+        new Index[0]);
+
+    ArgumentCaptor<NameIdentifier> createdIdentCaptor =
+        ArgumentCaptor.forClass(NameIdentifier.class);
+    Mockito.verify(mockDispatcher)
+        .createTable(
+            createdIdentCaptor.capture(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any());
+    String physicalName = createdIdentCaptor.getValue().name();
+    Assertions.assertEquals("My Table", physicalName);
+
+    // 2. listTables() must surface that physical name unchanged.
+    Mockito.when(mockDispatcher.listTables(Mockito.any(Namespace.class)))
+        .thenReturn(new NameIdentifier[] {NameIdentifier.of(tableNs, physicalName)});
+    NameIdentifier[] listed = dispatcher.listTables(tableNs);
+    Assertions.assertEquals(1, listed.length);
+    Assertions.assertEquals("My Table", listed[0].name());
+
+    // 3. Loading the table again requires re-quoting the listed name.
+    NameIdentifier quotedLoadIdent = NameIdentifier.of(tableNs, "\"" + listed[0].name() + "\"");
+    dispatcher.loadTable(quotedLoadIdent);
+
+    ArgumentCaptor<NameIdentifier> loadedIdentCaptor =
+        ArgumentCaptor.forClass(NameIdentifier.class);
+    Mockito.verify(mockDispatcher).loadTable(loadedIdentCaptor.capture());
+    Assertions.assertEquals("My Table", loadedIdentCaptor.getValue().name());
   }
 
   private void assertTableCaseInsensitive(

--- a/core/src/test/java/org/apache/gravitino/connector/capability/TestCapability.java
+++ b/core/src/test/java/org/apache/gravitino/connector/capability/TestCapability.java
@@ -94,4 +94,12 @@ public class TestCapability {
       Assertions.assertTrue(result.unsupportedMessage().contains("is illegal"));
     }
   }
+
+  @Test
+  void testDefaultNormalizeNameMatchesCaseSensitiveOnName() {
+    for (Capability.Scope scope : Capability.Scope.values()) {
+      // The default capability is case-sensitive, so normalizeName must be a no-op.
+      Assertions.assertEquals("MixedCase", Capability.DEFAULT.normalizeName(scope, "MixedCase"));
+    }
+  }
 }


### PR DESCRIPTION
**Cherry-pick Information:**
- Original commit: 65d305fdaa380b6d629963ab807124cfda1d54da
- Target branch: `branch-1.3`
- Status: ✅ Clean cherry-pick (stacked on #12010's cherry-pick since it depends on `CapabilityHelpers`/`TestCapabilityHelpers` changes introduced there; will show only its own diff once #12010's cherry-pick PR merges)