### PR TITLE
[#12166] improvement(core): enable version-CAS OCC for entity updates (alter half)

### DIFF
--- a/api/src/main/java/org/apache/gravitino/exceptions/OptimisticLockException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/OptimisticLockException.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/**
+ * Exception thrown when an optimistic-lock update fails because the entity changed after it was
+ * read.
+ */
+public class OptimisticLockException extends GravitinoRuntimeException {
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public OptimisticLockException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param cause the cause.
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public OptimisticLockException(Throwable cause, @FormatString String message, Object... args) {
+    super(cause, message, args);
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.connector.SupportsSchemas;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchTableException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.lance.common.ops.gravitino.LanceDataTypeConverter;
 import org.apache.gravitino.lance.common.utils.LanceConstants;
@@ -65,7 +66,6 @@ import org.apache.gravitino.rel.expressions.sorts.SortOrder;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.storage.IdGenerator;
-import org.apache.gravitino.storage.relational.service.TableMetaService;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.lance.Dataset;
 import org.lance.ReadOptions;
@@ -564,27 +564,18 @@ public class LanceTableOperations extends ManagedTableOperations {
    * Applies an idempotent update to the stored table, retrying when the optimistic-lock CAS is lost
    * to a concurrent update. The repair-on-load path runs on every {@code loadTable}, so concurrent
    * loads of the same table race on the version CAS; {@code store.update} surfaces the lost race as
-   * an {@link IOException} whose message starts with {@link
-   * TableMetaService#UPDATE_ENTITY_CONFLICT_MESSAGE_PREFIX}. Because the updater is idempotent, the
-   * loser sleeps a short randomized backoff (to avoid re-colliding), re-reads the latest (already
-   * repaired) entity, and retries instead of failing the whole load with a fatal error. Other IO
-   * failures (DB outage, serialization errors, etc.) are not conflicts and fail fast.
+   * an {@link OptimisticLockException}. Because the updater is idempotent, the loser sleeps a short
+   * randomized backoff (to avoid re-colliding), re-reads the latest (already repaired) entity, and
+   * retries instead of failing the whole load with a fatal error. Other IO failures (DB outage,
+   * serialization errors, etc.) are not conflicts and fail fast.
    */
   private TableEntity updateTableWithCasRetry(
       NameIdentifier ident, Function<TableEntity, TableEntity> updater) throws IOException {
-    IOException lastConflict = null;
+    OptimisticLockException lastConflict = null;
     for (int attempt = 1; attempt <= REPAIR_UPDATE_MAX_ATTEMPTS; attempt++) {
       try {
         return store.update(ident, TableEntity.class, Entity.EntityType.TABLE, updater);
-      } catch (IOException e) {
-        // Only retry when the update matched 0 rows (lost optimistic-lock CAS). Other IO failures
-        // (DB outage, serialization errors, etc.) should fail fast.
-        String message = e.getMessage();
-        if (message == null
-            || !message.startsWith(TableMetaService.UPDATE_ENTITY_CONFLICT_MESSAGE_PREFIX)) {
-          throw e;
-        }
-
+      } catch (OptimisticLockException e) {
         lastConflict = e;
         LOG.debug(
             "Optimistic-lock conflict updating table {} metadata (attempt {}/{}), {}",
@@ -599,11 +590,11 @@ public class LanceTableOperations extends ManagedTableOperations {
         }
       }
     }
-    throw new IOException(
-        String.format(
-            "Failed to update table %s after %d optimistic-lock retries",
-            ident, REPAIR_UPDATE_MAX_ATTEMPTS),
-        lastConflict);
+    throw new OptimisticLockException(
+        lastConflict,
+        "Failed to update table %s after %d optimistic-lock retries",
+        ident,
+        REPAIR_UPDATE_MAX_ATTEMPTS);
   }
 
   /**

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceConcurrentRepairStress.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceConcurrentRepairStress.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.HasIdentifier;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.catalog.ManagedSchemaOperations;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.rel.Table;
@@ -66,16 +67,16 @@ import org.mockito.Mockito;
 /**
  * Real multi-threaded reproduction of the repair-on-load optimistic-lock race behind #11891. Unlike
  * {@code TestLanceTableOperations#testLoadTableSurvivesConcurrentRepairVersionRace} (a
- * deterministic mock that throws one scripted {@code IOException}), this test drives {@link
- * LanceTableOperations#loadTable} from several threads at once against a {@link CasEntityStore}
- * that models the production relational store's compare-and-set semantics faithfully: every {@code
- * update} bumps a version guarded by the base version, so concurrent updates from the same base
- * conflict and exactly one wins per generation — just like {@code TableMetaService.updateTable}
- * ({@code UPDATE ... WHERE current_version = old}).
+ * deterministic mock that throws one scripted {@link OptimisticLockException}), this test drives
+ * {@link LanceTableOperations#loadTable} from several threads at once against a {@link
+ * CasEntityStore} that models the production relational store's compare-and-set semantics
+ * faithfully: every {@code update} bumps a version guarded by the base version, so concurrent
+ * updates from the same base conflict and exactly one wins per generation — just like {@code
+ * TableMetaService.updateTable} ({@code UPDATE ... WHERE current_version = old}).
  *
- * <p>Before the CAS retry, the loser of the race got {@code IOException("Failed to update the
- * entity")}, rethrown as a fatal {@code RuntimeException} (HTTP 500). This test asserts every
- * concurrent load returns the repaired table instead.
+ * <p>Before the CAS retry, the loser of the race got an {@link OptimisticLockException}, rethrown
+ * as a fatal {@code RuntimeException} (HTTP 500). This test asserts every concurrent load returns
+ * the repaired table instead.
  */
 public class TestLanceConcurrentRepairStress {
 
@@ -230,7 +231,8 @@ public class TestLanceConcurrentRepairStress {
       if (ref.compareAndSet(base, next)) {
         return updated;
       }
-      throw new IOException("Failed to update the entity: " + ident);
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", ident);
     }
 
     // --- unused surface ---------------------------------------------------

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Maps;
-import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +47,7 @@ import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.catalog.ManagedSchemaOperations;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ColumnEntity;
 import org.apache.gravitino.meta.TableEntity;
@@ -174,10 +174,10 @@ public class TestLanceTableOperations {
   /**
    * Reproduces the concurrent repair-on-load race seen in {@code LanceSparkRESTServiceIT}. When two
    * loads repair the same table at once, the optimistic-locked {@code store.update} of the slower
-   * one matches zero rows and {@code TableMetaService} surfaces it as {@code IOException("Failed to
-   * update the entity")}. Before the CAS retry, {@code repairTableMetadata} rethrew it as a fatal
-   * {@code RuntimeException} (HTTP 500) instead of tolerating the concurrent update. This test
-   * asserts that the lost race is benign and load returns a usable table.
+   * one matches zero rows and surfaces an {@link OptimisticLockException}. Before the CAS retry,
+   * {@code repairTableMetadata} rethrew it as a fatal {@code RuntimeException} (HTTP 500) instead
+   * of tolerating the concurrent update. This test asserts that the lost race is benign and load
+   * returns a usable table.
    */
   @Test
   public void testLoadTableSurvivesConcurrentRepairVersionRace() throws Exception {
@@ -219,10 +219,12 @@ public class TestLanceTableOperations {
     when(idGenerator.nextId()).thenReturn(10L, 11L);
 
     // First repair attempt loses the optimistic-lock CAS (a concurrent load already bumped the
-    // version): TableMetaService surfaces exactly this IOException. The retry re-reads the winner's
-    // already-repaired entity, against which the idempotent updater succeeds.
+    // version). The retry re-reads the winner's already-repaired entity, against which the
+    // idempotent updater succeeds.
     when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenThrow(new IOException("Failed to update the entity: " + ident))
+        .thenThrow(
+            new OptimisticLockException(
+                "Failed to update entity %s because it was modified concurrently", ident))
         .thenAnswer(
             invocation -> {
               @SuppressWarnings("unchecked")

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
@@ -57,6 +57,9 @@ public class ErrorConstants {
   /** Error codes for unauthorized access. */
   public static final int UNAUTHORIZED_CODE = 1011;
 
+  /** Error codes for optimistic-lock conflicts. */
+  public static final int OPTIMISTIC_LOCK_CONFLICT_CODE = 1012;
+
   /** Error codes for invalid state. */
   public static final int UNKNOWN_ERROR_CODE = 1100;
 

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
@@ -235,6 +235,20 @@ public class ErrorResponse extends BaseResponse {
   }
 
   /**
+   * Create a new optimistic-lock conflict error instance of {@link ErrorResponse}.
+   *
+   * @param type The type of the error.
+   * @param message The message of the error.
+   * @param throwable The throwable that caused the error.
+   * @return The new instance.
+   */
+  public static ErrorResponse optimisticLockConflict(
+      String type, String message, Throwable throwable) {
+    return new ErrorResponse(
+        ErrorConstants.OPTIMISTIC_LOCK_CONFLICT_CODE, type, message, getStackTrace(throwable));
+  }
+
+  /**
    * Create a new not in use error instance of {@link ErrorResponse}.
    *
    * @param type The type of the error.

--- a/common/src/test/java/org/apache/gravitino/dto/responses/TestResponses.java
+++ b/common/src/test/java/org/apache/gravitino/dto/responses/TestResponses.java
@@ -245,6 +245,16 @@ public class TestResponses {
   }
 
   @Test
+  void testOptimisticLockConflictErrorResponse() throws IllegalArgumentException {
+    ErrorResponse error =
+        ErrorResponse.optimisticLockConflict(
+            "OptimisticLockException", "optimistic lock conflict", null);
+    error.validate(); // No exception thrown
+    assertEquals(ErrorConstants.OPTIMISTIC_LOCK_CONFLICT_CODE, error.getCode());
+    assertEquals("OptimisticLockException", error.getType());
+  }
+
+  @Test
   void testNonEmptyErrorResponse() throws IllegalArgumentException {
     ErrorResponse error = ErrorResponse.nonEmpty("error type", "non empty error");
     error.validate(); // No exception thrown

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -35,6 +35,7 @@ import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.messaging.TopicChange;
 import org.apache.gravitino.rel.SupportsPartitions;
@@ -209,6 +210,8 @@ public abstract class OperationDispatcher {
     } catch (NoSuchEntityException e) {
       // Case 2: The table is created by Gravitino, but has no corresponding entity in Gravitino.
       LOG.error(FormattedErrorMessages.ENTITY_NOT_FOUND, ident);
+    } catch (OptimisticLockException e) {
+      throw e;
     } catch (Exception e) {
       // Case 3: The table is created by Gravitino, but failed to operate the corresponding entity
       // in Gravitino

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -211,6 +211,13 @@ public abstract class OperationDispatcher {
       // Case 2: The table is created by Gravitino, but has no corresponding entity in Gravitino.
       LOG.error(FormattedErrorMessages.ENTITY_NOT_FOUND, ident);
     } catch (OptimisticLockException e) {
+      // A lost CAS is a real conflict, not a best-effort store failure, so it must not be
+      // swallowed like Case 3 below: the caller needs it to surface as HTTP 409.
+      //
+      // NOTE: for an alter this is only the Gravitino-side entity write. The underlying catalog
+      // (Hive, Iceberg, ...) has already applied the change and is NOT rolled back, so the caller
+      // sees a conflict for a change that partly happened. Callers that can re-apply their update
+      // idempotently should retry (see LanceTableOperations#updateTableWithCasRetry).
       throw e;
     } catch (Exception e) {
       // Case 3: The table is created by Gravitino, but failed to operate the corresponding entity

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/CatalogMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/CatalogMetaBaseSQLProvider.java
@@ -205,17 +205,9 @@ public class CatalogMetaBaseSQLProvider {
         + " current_version = #{newCatalogMeta.currentVersion},"
         + " last_version = #{newCatalogMeta.lastVersion},"
         + " deleted_at = #{newCatalogMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE catalog_id = #{oldCatalogMeta.catalogId}"
-        + " AND catalog_name = #{oldCatalogMeta.catalogName}"
-        + " AND metalake_id = #{oldCatalogMeta.metalakeId}"
-        + " AND type = #{oldCatalogMeta.type}"
-        + " AND provider = #{oldCatalogMeta.provider}"
-        + " AND (catalog_comment = #{oldCatalogMeta.catalogComment} "
-        + "   OR (catalog_comment IS NULL and #{oldCatalogMeta.catalogComment} IS NULL))"
-        + " AND properties = #{oldCatalogMeta.properties}"
-        + " AND audit_info = #{oldCatalogMeta.auditInfo}"
         + " AND current_version = #{oldCatalogMeta.currentVersion}"
-        + " AND last_version = #{oldCatalogMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/CatalogMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/CatalogMetaBaseSQLProvider.java
@@ -185,8 +185,9 @@ public class CatalogMetaBaseSQLProvider {
         + " catalog_comment = #{catalogMeta.catalogComment},"
         + " properties = #{catalogMeta.properties},"
         + " audit_info = #{catalogMeta.auditInfo},"
-        + " current_version = #{catalogMeta.currentVersion},"
-        + " last_version = #{catalogMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{catalogMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetMetaBaseSQLProvider.java
@@ -287,6 +287,9 @@ public class FilesetMetaBaseSQLProvider {
         + " current_version = #{newFilesetMeta.currentVersion},"
         + " last_version = #{newFilesetMeta.lastVersion},"
         + " deleted_at = #{newFilesetMeta.deletedAt}"
+        // Fileset uses CONDITIONAL versioning: current_version only bumps on a versioned-field
+        // change, so a version-only CAS would miss an audit-only concurrent update. Keep the
+        // full-row compare, which is the actual OCC guard here.
         + " WHERE fileset_id = #{oldFilesetMeta.filesetId}"
         + " AND fileset_name = #{oldFilesetMeta.filesetName}"
         + " AND metalake_id = #{oldFilesetMeta.metalakeId}"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
@@ -302,15 +302,9 @@ public class FunctionMetaBaseSQLProvider {
         + " function_latest_version = #{newFunctionMeta.functionLatestVersion},"
         + " audit_info = #{newFunctionMeta.auditInfo},"
         + " deleted_at = #{newFunctionMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (function_current_version is monotonic).
         + " WHERE function_id = #{oldFunctionMeta.functionId}"
-        + " AND function_name = #{oldFunctionMeta.functionName}"
-        + " AND metalake_id = #{oldFunctionMeta.metalakeId}"
-        + " AND catalog_id = #{oldFunctionMeta.catalogId}"
-        + " AND schema_id = #{oldFunctionMeta.schemaId}"
-        + " AND function_type = #{oldFunctionMeta.functionType}"
         + " AND function_current_version = #{oldFunctionMeta.functionCurrentVersion}"
-        + " AND function_latest_version = #{oldFunctionMeta.functionLatestVersion}"
-        + " AND audit_info = #{oldFunctionMeta.auditInfo}"
         + " AND deleted_at = 0";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
@@ -211,12 +211,9 @@ public class GroupMetaBaseSQLProvider {
         + " current_version = #{newGroupMeta.currentVersion},"
         + " last_version = #{newGroupMeta.lastVersion},"
         + " deleted_at = #{newGroupMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE group_id = #{oldGroupMeta.groupId}"
-        + " AND group_name = #{oldGroupMeta.groupName}"
-        + " AND metalake_id = #{oldGroupMeta.metalakeId}"
-        + " AND audit_info = #{oldGroupMeta.auditInfo}"
         + " AND current_version = #{oldGroupMeta.currentVersion}"
-        + " AND last_version = #{oldGroupMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
@@ -179,8 +179,9 @@ public class GroupMetaBaseSQLProvider {
         + " metalake_id = #{groupMeta.metalakeId},"
         + " audit_info = #{groupMeta.auditInfo},"
         + " external_id = #{groupMeta.externalId},"
-        + " current_version = #{groupMeta.currentVersion},"
-        + " last_version = #{groupMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{groupMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/MetalakeMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/MetalakeMetaBaseSQLProvider.java
@@ -142,15 +142,9 @@ public class MetalakeMetaBaseSQLProvider {
         + " schema_version = #{newMetalakeMeta.schemaVersion},"
         + " current_version = #{newMetalakeMeta.currentVersion},"
         + " last_version = #{newMetalakeMeta.lastVersion}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE metalake_id = #{oldMetalakeMeta.metalakeId}"
-        + " AND metalake_name = #{oldMetalakeMeta.metalakeName}"
-        + " AND (metalake_comment = #{oldMetalakeMeta.metalakeComment} "
-        + "  OR (metalake_comment IS NULL and #{oldMetalakeMeta.metalakeComment} IS NULL))"
-        + " AND properties = #{oldMetalakeMeta.properties}"
-        + " AND audit_info = #{oldMetalakeMeta.auditInfo}"
-        + " AND schema_version = #{oldMetalakeMeta.schemaVersion}"
         + " AND current_version = #{oldMetalakeMeta.currentVersion}"
-        + " AND last_version = #{oldMetalakeMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/MetalakeMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/MetalakeMetaBaseSQLProvider.java
@@ -125,8 +125,9 @@ public class MetalakeMetaBaseSQLProvider {
         + " properties = #{metalakeMeta.properties},"
         + " audit_info = #{metalakeMeta.auditInfo},"
         + " schema_version = #{metalakeMeta.schemaVersion},"
-        + " current_version = #{metalakeMeta.currentVersion},"
-        + " last_version = #{metalakeMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{metalakeMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelMetaBaseSQLProvider.java
@@ -85,6 +85,8 @@ public class ModelMetaBaseSQLProvider {
             mo.model_comment AS modelComment,
             mo.model_properties AS modelProperties,
             mo.model_latest_version AS modelLatestVersion,
+            mo.current_version AS currentVersion,
+            mo.last_version AS lastVersion,
             mo.audit_info AS auditInfo,
             mo.deleted_at AS deletedAt
         FROM
@@ -156,6 +158,8 @@ public class ModelMetaBaseSQLProvider {
             mo.model_comment AS modelComment,
             mo.model_properties AS modelProperties,
             mo.model_latest_version AS modelLatestVersion,
+            mo.current_version AS currentVersion,
+            mo.last_version AS lastVersion,
             mo.audit_info AS auditInfo,
             mo.deleted_at AS deletedAt
         FROM
@@ -289,7 +293,9 @@ public class ModelMetaBaseSQLProvider {
         + "SELECT mm.model_id as modelId, mm.model_name as modelName,"
         + " mm.metalake_id as metalakeId, mm.catalog_id as catalogId, mm.schema_id as schemaId,"
         + " mm.model_comment as modelComment, mm.model_properties as modelProperties,"
-        + " mm.model_latest_version as modelLatestVersion, mm.audit_info as auditInfo,"
+        + " mm.model_latest_version as modelLatestVersion,"
+        + " mm.current_version as currentVersion, mm.last_version as lastVersion,"
+        + " mm.audit_info as auditInfo,"
         + " mm.deleted_at as deletedAt"
         + " FROM "
         + ModelMetaMapper.TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelMetaBaseSQLProvider.java
@@ -63,8 +63,9 @@ public class ModelMetaBaseSQLProvider {
   public String listModelPOsBySchemaId(@Param("schemaId") Long schemaId) {
     return "SELECT model_id AS modelId, model_name AS modelName, metalake_id AS metalakeId,"
         + " catalog_id AS catalogId, schema_id AS schemaId, model_comment AS modelComment,"
-        + " model_properties AS modelProperties, model_latest_version AS"
-        + " modelLatestVersion, audit_info AS auditInfo, deleted_at AS deletedAt"
+        + " model_properties AS modelProperties, model_latest_version AS modelLatestVersion,"
+        + " current_version AS currentVersion, last_version AS lastVersion,"
+        + " audit_info AS auditInfo, deleted_at AS deletedAt"
         + " FROM "
         + ModelMetaMapper.TABLE_NAME
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
@@ -114,8 +115,9 @@ public class ModelMetaBaseSQLProvider {
     return "<script>"
         + " SELECT model_id AS modelId, model_name AS modelName, metalake_id AS metalakeId,"
         + " catalog_id AS catalogId, schema_id AS schemaId, model_comment AS modelComment,"
-        + " model_properties AS modelProperties, model_latest_version AS"
-        + " modelLatestVersion, audit_info AS auditInfo, deleted_at AS deletedAt"
+        + " model_properties AS modelProperties, model_latest_version AS modelLatestVersion,"
+        + " current_version AS currentVersion, last_version AS lastVersion,"
+        + " audit_info AS auditInfo, deleted_at AS deletedAt"
         + " FROM "
         + ModelMetaMapper.TABLE_NAME
         + " WHERE deleted_at = 0"
@@ -131,8 +133,9 @@ public class ModelMetaBaseSQLProvider {
       @Param("schemaId") Long schemaId, @Param("modelName") String modelName) {
     return "SELECT model_id AS modelId, model_name AS modelName, metalake_id AS metalakeId,"
         + " catalog_id AS catalogId, schema_id AS schemaId, model_comment AS modelComment,"
-        + " model_properties AS modelProperties, model_latest_version AS"
-        + " modelLatestVersion, audit_info AS auditInfo, deleted_at AS deletedAt"
+        + " model_properties AS modelProperties, model_latest_version AS modelLatestVersion,"
+        + " current_version AS currentVersion, last_version AS lastVersion,"
+        + " audit_info AS auditInfo, deleted_at AS deletedAt"
         + " FROM "
         + ModelMetaMapper.TABLE_NAME
         + " WHERE schema_id = #{schemaId} AND model_name = #{modelName} AND deleted_at = 0";
@@ -191,8 +194,9 @@ public class ModelMetaBaseSQLProvider {
   public String selectModelMetaByModelId(@Param("modelId") Long modelId) {
     return "SELECT model_id AS modelId, model_name AS modelName, metalake_id AS metalakeId,"
         + " catalog_id AS catalogId, schema_id AS schemaId, model_comment AS modelComment,"
-        + " model_properties AS modelProperties, model_latest_version AS"
-        + " modelLatestVersion, audit_info AS auditInfo, deleted_at AS deletedAt"
+        + " model_properties AS modelProperties, model_latest_version AS modelLatestVersion,"
+        + " current_version AS currentVersion, last_version AS lastVersion,"
+        + " audit_info AS auditInfo, deleted_at AS deletedAt"
         + " FROM "
         + ModelMetaMapper.TABLE_NAME
         + " WHERE model_id = #{modelId} AND deleted_at = 0";
@@ -247,7 +251,10 @@ public class ModelMetaBaseSQLProvider {
   public String updateModelLatestVersion(@Param("modelId") Long modelId) {
     return "UPDATE "
         + ModelMetaMapper.TABLE_NAME
-        + " SET model_latest_version = model_latest_version + 1"
+        // Adding a model version modifies the model: also raise the OCC version so a concurrent
+        // updateModel (WHERE current_version = old) detects it. The +1s are atomic in the database.
+        + " SET model_latest_version = model_latest_version + 1,"
+        + " current_version = current_version + 1, last_version = last_version + 1"
         + " WHERE model_id = #{modelId} AND deleted_at = 0";
   }
 
@@ -262,18 +269,14 @@ public class ModelMetaBaseSQLProvider {
         + " model_comment = #{newModelMeta.modelComment},"
         + " model_properties = #{newModelMeta.modelProperties},"
         + " model_latest_version = #{newModelMeta.modelLatestVersion},"
+        + " current_version = #{newModelMeta.currentVersion},"
+        + " last_version = #{newModelMeta.lastVersion},"
         + " audit_info = #{newModelMeta.auditInfo},"
         + " deleted_at = #{newModelMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone. updateModel always raises current_version,
+        // and insertModelVersion also bumps it, so this catches both concurrent-write kinds.
         + " WHERE model_id = #{oldModelMeta.modelId}"
-        + " AND model_name = #{oldModelMeta.modelName}"
-        + " AND metalake_id = #{oldModelMeta.metalakeId}"
-        + " AND catalog_id = #{oldModelMeta.catalogId}"
-        + " AND schema_id = #{oldModelMeta.schemaId}"
-        + " AND (model_comment = #{oldModelMeta.modelComment}"
-        + "   OR (model_comment IS NULL and #{oldModelMeta.modelComment} IS NULL))"
-        + " AND model_properties = #{oldModelMeta.modelProperties}"
-        + " AND model_latest_version = #{oldModelMeta.modelLatestVersion}"
-        + " AND audit_info = #{oldModelMeta.auditInfo}"
+        + " AND current_version = #{oldModelMeta.currentVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/PolicyMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/PolicyMetaBaseSQLProvider.java
@@ -134,6 +134,9 @@ public class PolicyMetaBaseSQLProvider {
         + " current_version = #{newPolicyMeta.currentVersion},"
         + " last_version = #{newPolicyMeta.lastVersion},"
         + " deleted_at = #{newPolicyMeta.deletedAt}"
+        // Policy uses CONDITIONAL versioning (like fileset): current_version only bumps on a
+        // versioned-field change, so a version-only CAS would miss an audit-only concurrent
+        // update. Keep the full-row compare, which is the actual OCC guard here.
         + " WHERE policy_id = #{oldPolicyMeta.policyId}"
         + " AND policy_name = #{oldPolicyMeta.policyName}"
         + " AND policy_type = #{oldPolicyMeta.policyType}"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
@@ -163,11 +163,9 @@ public class RoleMetaBaseSQLProvider {
         + " current_version = #{newRoleMeta.currentVersion},"
         + " last_version = #{newRoleMeta.lastVersion},"
         + " deleted_at = #{newRoleMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE role_id = #{oldRoleMeta.roleId}"
-        + " AND role_name = #{oldRoleMeta.roleName}"
-        + " AND metalake_id = #{oldRoleMeta.metalakeId}"
         + " AND current_version = #{oldRoleMeta.currentVersion}"
-        + " AND last_version = #{oldRoleMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
@@ -147,8 +147,9 @@ public class RoleMetaBaseSQLProvider {
         + " metalake_id = #{roleMeta.metalakeId},"
         + " properties = #{roleMeta.properties},"
         + " audit_info = #{roleMeta.auditInfo},"
-        + " current_version = #{roleMeta.currentVersion},"
-        + " last_version = #{roleMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{roleMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
@@ -272,16 +272,9 @@ public class SchemaMetaBaseSQLProvider {
         + " current_version = #{newSchemaMeta.currentVersion},"
         + " last_version = #{newSchemaMeta.lastVersion},"
         + " deleted_at = #{newSchemaMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE schema_id = #{oldSchemaMeta.schemaId}"
-        + " AND schema_name = #{oldSchemaMeta.schemaName}"
-        + " AND metalake_id = #{oldSchemaMeta.metalakeId}"
-        + " AND catalog_id = #{oldSchemaMeta.catalogId}"
-        + " AND (schema_comment = #{oldSchemaMeta.schemaComment}"
-        + "   OR (schema_comment IS NULL and #{oldSchemaMeta.schemaComment} IS NULL))"
-        + " AND properties = #{oldSchemaMeta.properties}"
-        + " AND audit_info = #{oldSchemaMeta.auditInfo}"
         + " AND current_version = #{oldSchemaMeta.currentVersion}"
-        + " AND last_version = #{oldSchemaMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
@@ -215,8 +215,9 @@ public class SchemaMetaBaseSQLProvider {
         + " schema_comment = #{schemaMeta.schemaComment},"
         + " properties = #{schemaMeta.properties},"
         + " audit_info = #{schemaMeta.auditInfo},"
-        + " current_version = #{schemaMeta.currentVersion},"
-        + " last_version = #{schemaMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{schemaMeta.deletedAt}";
   }
 
@@ -253,8 +254,9 @@ public class SchemaMetaBaseSQLProvider {
         + " schema_comment = VALUES(schema_comment),"
         + " properties = VALUES(properties),"
         + " audit_info = VALUES(audit_info),"
-        + " current_version = VALUES(current_version),"
-        + " last_version = VALUES(last_version),"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = VALUES(deleted_at)"
         + "</script>";
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableMetaBaseSQLProvider.java
@@ -239,14 +239,9 @@ public class TableMetaBaseSQLProvider {
         + " current_version = #{newTableMeta.currentVersion},"
         + " last_version = #{newTableMeta.lastVersion},"
         + " deleted_at = #{newTableMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE table_id = #{oldTableMeta.tableId}"
-        + " AND table_name = #{oldTableMeta.tableName}"
-        + " AND metalake_id = #{oldTableMeta.metalakeId}"
-        + " AND catalog_id = #{oldTableMeta.catalogId}"
-        + " AND schema_id = #{oldTableMeta.schemaId}"
-        + " AND audit_info = #{oldTableMeta.auditInfo}"
         + " AND current_version = #{oldTableMeta.currentVersion}"
-        + " AND last_version = #{oldTableMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TagMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TagMetaBaseSQLProvider.java
@@ -157,15 +157,9 @@ public class TagMetaBaseSQLProvider {
         + " current_version = #{newTagMeta.currentVersion},"
         + " last_version = #{newTagMeta.lastVersion},"
         + " deleted_at = #{newTagMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE tag_id = #{oldTagMeta.tagId}"
-        + " AND metalake_id = #{oldTagMeta.metalakeId}"
-        + " AND tag_name = #{oldTagMeta.tagName}"
-        + " AND (tag_comment = #{oldTagMeta.comment}"
-        + "   OR (tag_comment IS NULL and #{oldTagMeta.comment} IS NULL))"
-        + " AND properties = #{oldTagMeta.properties}"
-        + " AND audit_info = #{oldTagMeta.auditInfo}"
         + " AND current_version = #{oldTagMeta.currentVersion}"
-        + " AND last_version = #{oldTagMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TagMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TagMetaBaseSQLProvider.java
@@ -141,8 +141,9 @@ public class TagMetaBaseSQLProvider {
         + " tag_comment = #{tagMeta.comment},"
         + " properties = #{tagMeta.properties},"
         + " audit_info = #{tagMeta.auditInfo},"
-        + " current_version = #{tagMeta.currentVersion},"
-        + " last_version = #{tagMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{tagMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TopicMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TopicMetaBaseSQLProvider.java
@@ -233,17 +233,11 @@ public class TopicMetaBaseSQLProvider {
         + " current_version = #{newTopicMeta.currentVersion},"
         + " last_version = #{newTopicMeta.lastVersion},"
         + " deleted_at = #{newTopicMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone. Because a successful update always raises
+        // current_version, matching id + current_version uniquely identifies the row the caller
+        // read; the old full-row comparison was redundant and fragile (JSON byte equality).
         + " WHERE topic_id = #{oldTopicMeta.topicId}"
-        + " AND topic_name = #{oldTopicMeta.topicName}"
-        + " AND metalake_id = #{oldTopicMeta.metalakeId}"
-        + " AND catalog_id = #{oldTopicMeta.catalogId}"
-        + " AND schema_id = #{oldTopicMeta.schemaId}"
-        + " AND (comment = #{oldTopicMeta.comment}"
-        + "   OR (comment IS NULL and #{oldTopicMeta.comment} IS NULL))"
-        + " AND properties = #{oldTopicMeta.properties}"
-        + " AND audit_info = #{oldTopicMeta.auditInfo}"
         + " AND current_version = #{oldTopicMeta.currentVersion}"
-        + " AND last_version = #{oldTopicMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TopicMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TopicMetaBaseSQLProvider.java
@@ -78,8 +78,9 @@ public class TopicMetaBaseSQLProvider {
         + " comment = #{topicMeta.comment},"
         + " properties = #{topicMeta.properties},"
         + " audit_info = #{topicMeta.auditInfo},"
-        + " current_version = #{topicMeta.currentVersion},"
-        + " last_version = #{topicMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{topicMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
@@ -163,12 +163,9 @@ public class UserMetaBaseSQLProvider {
         + " current_version = #{newUserMeta.currentVersion},"
         + " last_version = #{newUserMeta.lastVersion},"
         + " deleted_at = #{newUserMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE user_id = #{oldUserMeta.userId}"
-        + " AND user_name = #{oldUserMeta.userName}"
-        + " AND metalake_id = #{oldUserMeta.metalakeId}"
-        + " AND audit_info = #{oldUserMeta.auditInfo}"
         + " AND current_version = #{oldUserMeta.currentVersion}"
-        + " AND last_version = #{oldUserMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
@@ -130,8 +130,9 @@ public class UserMetaBaseSQLProvider {
         + " audit_info = #{userMeta.auditInfo},"
         + " external_id = #{userMeta.externalId},"
         + " enabled = #{userMeta.enabled},"
-        + " current_version = #{userMeta.currentVersion},"
-        + " last_version = #{userMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{userMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
@@ -100,18 +100,9 @@ public class CatalogMetaPostgreSQLProvider extends CatalogMetaBaseSQLProvider {
         + " current_version = #{newCatalogMeta.currentVersion},"
         + " last_version = #{newCatalogMeta.lastVersion},"
         + " deleted_at = #{newCatalogMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE catalog_id = #{oldCatalogMeta.catalogId}"
-        + " AND catalog_name = #{oldCatalogMeta.catalogName}"
-        + " AND metalake_id = #{oldCatalogMeta.metalakeId}"
-        + " AND type = #{oldCatalogMeta.type}"
-        + " AND provider = #{oldCatalogMeta.provider}"
-        + " AND (catalog_comment = #{oldCatalogMeta.catalogComment} "
-        + "   OR (CAST(catalog_comment AS VARCHAR) IS NULL AND "
-        + "   CAST(#{oldCatalogMeta.catalogComment} AS VARCHAR) IS NULL))"
-        + " AND properties = #{oldCatalogMeta.properties}"
-        + " AND audit_info = #{oldCatalogMeta.auditInfo}"
         + " AND current_version = #{oldCatalogMeta.currentVersion}"
-        + " AND last_version = #{oldCatalogMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
@@ -79,8 +79,9 @@ public class CatalogMetaPostgreSQLProvider extends CatalogMetaBaseSQLProvider {
         + " catalog_comment = #{catalogMeta.catalogComment},"
         + " properties = #{catalogMeta.properties},"
         + " audit_info = #{catalogMeta.auditInfo},"
-        + " current_version = #{catalogMeta.currentVersion},"
-        + " last_version = #{catalogMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{catalogMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
@@ -80,8 +80,12 @@ public class CatalogMetaPostgreSQLProvider extends CatalogMetaBaseSQLProvider {
         + " properties = #{catalogMeta.properties},"
         + " audit_info = #{catalogMeta.auditInfo},"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = #{catalogMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
@@ -164,15 +164,9 @@ public class FunctionMetaPostgreSQLProvider extends FunctionMetaBaseSQLProvider 
         + " function_latest_version = #{newFunctionMeta.functionLatestVersion},"
         + " audit_info = #{newFunctionMeta.auditInfo},"
         + " deleted_at = #{newFunctionMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (function_current_version is monotonic).
         + " WHERE function_id = #{oldFunctionMeta.functionId}"
-        + " AND function_name = #{oldFunctionMeta.functionName}"
-        + " AND metalake_id = #{oldFunctionMeta.metalakeId}"
-        + " AND catalog_id = #{oldFunctionMeta.catalogId}"
-        + " AND schema_id = #{oldFunctionMeta.schemaId}"
-        + " AND function_type = #{oldFunctionMeta.functionType}"
         + " AND function_current_version = #{oldFunctionMeta.functionCurrentVersion}"
-        + " AND function_latest_version = #{oldFunctionMeta.functionLatestVersion}"
-        + " AND audit_info = #{oldFunctionMeta.auditInfo}"
         + " AND deleted_at = 0";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/GroupMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/GroupMetaPostgreSQLProvider.java
@@ -67,8 +67,12 @@ public class GroupMetaPostgreSQLProvider extends GroupMetaBaseSQLProvider {
         + " external_id = #{groupMeta.externalId},"
         + " audit_info = #{groupMeta.auditInfo},"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + GROUP_TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + GROUP_TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = #{groupMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/GroupMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/GroupMetaPostgreSQLProvider.java
@@ -66,8 +66,9 @@ public class GroupMetaPostgreSQLProvider extends GroupMetaBaseSQLProvider {
         + " metalake_id = #{groupMeta.metalakeId},"
         + " external_id = #{groupMeta.externalId},"
         + " audit_info = #{groupMeta.auditInfo},"
-        + " current_version = #{groupMeta.currentVersion},"
-        + " last_version = #{groupMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{groupMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/MetalakeMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/MetalakeMetaPostgreSQLProvider.java
@@ -74,16 +74,9 @@ public class MetalakeMetaPostgreSQLProvider extends MetalakeMetaBaseSQLProvider 
         + " schema_version = #{newMetalakeMeta.schemaVersion},"
         + " current_version = #{newMetalakeMeta.currentVersion},"
         + " last_version = #{newMetalakeMeta.lastVersion}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE metalake_id = #{oldMetalakeMeta.metalakeId}"
-        + " AND metalake_name = #{oldMetalakeMeta.metalakeName}"
-        + " AND (metalake_comment = #{oldMetalakeMeta.metalakeComment} "
-        + "  OR (CAST(metalake_comment AS VARCHAR) IS NULL AND "
-        + "  CAST(#{oldMetalakeMeta.metalakeComment} AS VARCHAR) IS NULL))"
-        + " AND properties = #{oldMetalakeMeta.properties}"
-        + " AND audit_info = #{oldMetalakeMeta.auditInfo}"
-        + " AND schema_version = #{oldMetalakeMeta.schemaVersion}"
         + " AND current_version = #{oldMetalakeMeta.currentVersion}"
-        + " AND last_version = #{oldMetalakeMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/MetalakeMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/MetalakeMetaPostgreSQLProvider.java
@@ -57,8 +57,12 @@ public class MetalakeMetaPostgreSQLProvider extends MetalakeMetaBaseSQLProvider 
         + " audit_info = #{metalakeMeta.auditInfo},"
         + " schema_version = #{metalakeMeta.schemaVersion},"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = #{metalakeMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/MetalakeMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/MetalakeMetaPostgreSQLProvider.java
@@ -56,8 +56,9 @@ public class MetalakeMetaPostgreSQLProvider extends MetalakeMetaBaseSQLProvider 
         + " properties = #{metalakeMeta.properties},"
         + " audit_info = #{metalakeMeta.auditInfo},"
         + " schema_version = #{metalakeMeta.schemaVersion},"
-        + " current_version = #{metalakeMeta.currentVersion},"
-        + " last_version = #{metalakeMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{metalakeMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelMetaPostgreSQLProvider.java
@@ -109,19 +109,13 @@ public class ModelMetaPostgreSQLProvider extends ModelMetaBaseSQLProvider {
         + " model_comment = #{newModelMeta.modelComment},"
         + " model_properties = #{newModelMeta.modelProperties},"
         + " model_latest_version = #{newModelMeta.modelLatestVersion},"
+        + " current_version = #{newModelMeta.currentVersion},"
+        + " last_version = #{newModelMeta.lastVersion},"
         + " audit_info = #{newModelMeta.auditInfo},"
         + " deleted_at = #{newModelMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (see the base provider for rationale).
         + " WHERE model_id = #{oldModelMeta.modelId}"
-        + " AND model_name = #{oldModelMeta.modelName}"
-        + " AND metalake_id = #{oldModelMeta.metalakeId}"
-        + " AND catalog_id = #{oldModelMeta.catalogId}"
-        + " AND schema_id = #{oldModelMeta.schemaId}"
-        + " AND (model_comment = #{oldModelMeta.modelComment}"
-        + "   OR (CAST(model_comment AS VARCHAR) IS NULL"
-        + "   AND CAST(#{oldModelMeta.modelComment} AS VARCHAR) IS NULL))"
-        + " AND model_properties = #{oldModelMeta.modelProperties}"
-        + " AND model_latest_version = #{oldModelMeta.modelLatestVersion}"
-        + " AND audit_info = #{oldModelMeta.auditInfo}"
+        + " AND current_version = #{oldModelMeta.currentVersion}"
         + " AND deleted_at = 0";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/RoleMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/RoleMetaPostgreSQLProvider.java
@@ -62,8 +62,9 @@ public class RoleMetaPostgreSQLProvider extends RoleMetaBaseSQLProvider {
         + " metalake_id = #{roleMeta.metalakeId},"
         + " properties = #{roleMeta.properties},"
         + " audit_info = #{roleMeta.auditInfo},"
-        + " current_version = #{roleMeta.currentVersion},"
-        + " last_version = #{roleMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{roleMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/RoleMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/RoleMetaPostgreSQLProvider.java
@@ -63,8 +63,12 @@ public class RoleMetaPostgreSQLProvider extends RoleMetaBaseSQLProvider {
         + " properties = #{roleMeta.properties},"
         + " audit_info = #{roleMeta.auditInfo},"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + ROLE_TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + ROLE_TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = #{roleMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
@@ -97,17 +97,9 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + " current_version = #{newSchemaMeta.currentVersion},"
         + " last_version = #{newSchemaMeta.lastVersion},"
         + " deleted_at = #{newSchemaMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE schema_id = #{oldSchemaMeta.schemaId}"
-        + " AND schema_name = #{oldSchemaMeta.schemaName}"
-        + " AND metalake_id = #{oldSchemaMeta.metalakeId}"
-        + " AND catalog_id = #{oldSchemaMeta.catalogId}"
-        + " AND (schema_comment = #{oldSchemaMeta.schemaComment}"
-        + "   OR (CAST(schema_comment AS VARCHAR) IS NULL"
-        + "   AND CAST(#{oldSchemaMeta.schemaComment} AS VARCHAR) IS NULL))"
-        + " AND properties = #{oldSchemaMeta.properties}"
-        + " AND audit_info = #{oldSchemaMeta.auditInfo}"
         + " AND current_version = #{oldSchemaMeta.currentVersion}"
-        + " AND last_version = #{oldSchemaMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
@@ -52,8 +52,9 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + " schema_comment = #{schemaMeta.schemaComment},"
         + " properties = #{schemaMeta.properties},"
         + " audit_info = #{schemaMeta.auditInfo},"
-        + " current_version = #{schemaMeta.currentVersion},"
-        + " last_version = #{schemaMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{schemaMeta.deletedAt}";
   }
 
@@ -77,8 +78,9 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + " schema_comment = EXCLUDED.schema_comment,"
         + " properties = EXCLUDED.properties,"
         + " audit_info = EXCLUDED.audit_info,"
-        + " current_version = EXCLUDED.current_version,"
-        + " last_version = EXCLUDED.last_version,"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = EXCLUDED.deleted_at"
         + "</script>";
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
@@ -53,8 +53,12 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + " properties = #{schemaMeta.properties},"
         + " audit_info = #{schemaMeta.auditInfo},"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = #{schemaMeta.deletedAt}";
   }
 
@@ -79,8 +83,12 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + " properties = EXCLUDED.properties,"
         + " audit_info = EXCLUDED.audit_info,"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = EXCLUDED.deleted_at"
         + "</script>";
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetaPostgreSQLProvider.java
@@ -87,15 +87,9 @@ public class TagMetaPostgreSQLProvider extends TagMetaBaseSQLProvider {
         + " current_version = #{newTagMeta.currentVersion},"
         + " last_version = #{newTagMeta.lastVersion},"
         + " deleted_at = #{newTagMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (current_version is monotonic on update).
         + " WHERE tag_id = #{oldTagMeta.tagId}"
-        + " AND metalake_id = #{oldTagMeta.metalakeId}"
-        + " AND tag_name = #{oldTagMeta.tagName}"
-        + " AND (tag_comment = #{oldTagMeta.comment} "
-        + "   OR (CAST(tag_comment AS VARCHAR) IS NULL AND CAST(#{oldTagMeta.comment} AS VARCHAR) IS NULL))"
-        + " AND properties = #{oldTagMeta.properties}"
-        + " AND audit_info = #{oldTagMeta.auditInfo}"
         + " AND current_version = #{oldTagMeta.currentVersion}"
-        + " AND last_version = #{oldTagMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetaPostgreSQLProvider.java
@@ -71,8 +71,12 @@ public class TagMetaPostgreSQLProvider extends TagMetaBaseSQLProvider {
         + " properties = #{tagMeta.properties},"
         + " audit_info = #{tagMeta.auditInfo},"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + TAG_TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + TAG_TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = #{tagMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetaPostgreSQLProvider.java
@@ -70,8 +70,9 @@ public class TagMetaPostgreSQLProvider extends TagMetaBaseSQLProvider {
         + " tag_comment = #{tagMeta.comment},"
         + " properties = #{tagMeta.properties},"
         + " audit_info = #{tagMeta.auditInfo},"
-        + " current_version = #{tagMeta.currentVersion},"
-        + " last_version = #{tagMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{tagMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
@@ -42,18 +42,9 @@ public class TopicMetaPostgreSQLProvider extends TopicMetaBaseSQLProvider {
         + " current_version = #{newTopicMeta.currentVersion},"
         + " last_version = #{newTopicMeta.lastVersion},"
         + " deleted_at = #{newTopicMeta.deletedAt}"
+        // OCC: compare-and-set on the version alone (see the base provider for rationale).
         + " WHERE topic_id = #{oldTopicMeta.topicId}"
-        + " AND topic_name = #{oldTopicMeta.topicName}"
-        + " AND metalake_id = #{oldTopicMeta.metalakeId}"
-        + " AND catalog_id = #{oldTopicMeta.catalogId}"
-        + " AND schema_id = #{oldTopicMeta.schemaId}"
-        + " AND (comment = #{oldTopicMeta.comment}"
-        + "   OR (CAST(comment AS VARCHAR) IS NULL"
-        + "   AND CAST(#{oldTopicMeta.comment} AS VARCHAR) IS NULL))"
-        + " AND properties = #{oldTopicMeta.properties}"
-        + " AND audit_info = #{oldTopicMeta.auditInfo}"
         + " AND current_version = #{oldTopicMeta.currentVersion}"
-        + " AND last_version = #{oldTopicMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
@@ -114,8 +114,9 @@ public class TopicMetaPostgreSQLProvider extends TopicMetaBaseSQLProvider {
         + " comment = #{topicMeta.comment},"
         + " properties = #{topicMeta.properties},"
         + " audit_info = #{topicMeta.auditInfo},"
-        + " current_version = #{topicMeta.currentVersion},"
-        + " last_version = #{topicMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{topicMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
@@ -115,8 +115,12 @@ public class TopicMetaPostgreSQLProvider extends TopicMetaBaseSQLProvider {
         + " properties = #{topicMeta.properties},"
         + " audit_info = #{topicMeta.auditInfo},"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = #{topicMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/UserMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/UserMetaPostgreSQLProvider.java
@@ -68,8 +68,12 @@ public class UserMetaPostgreSQLProvider extends UserMetaBaseSQLProvider {
         + " enabled = #{userMeta.enabled},"
         + " audit_info = #{userMeta.auditInfo},"
         // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
-        + " current_version = current_version + 1,"
-        + " last_version = last_version + 1,"
+        + " current_version = "
+        + USER_TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + USER_TABLE_NAME
+        + ".last_version + 1,"
         + " deleted_at = #{userMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/UserMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/UserMetaPostgreSQLProvider.java
@@ -67,8 +67,9 @@ public class UserMetaPostgreSQLProvider extends UserMetaBaseSQLProvider {
         + " external_id = #{userMeta.externalId},"
         + " enabled = #{userMeta.enabled},"
         + " audit_info = #{userMeta.auditInfo},"
-        + " current_version = #{userMeta.currentVersion},"
-        + " last_version = #{userMeta.lastVersion},"
+        // OCC: bump (not reset) the version so overwrite-create can't revive a stale CAS token.
+        + " current_version = current_version + 1,"
+        + " last_version = last_version + 1,"
         + " deleted_at = #{userMeta.deletedAt}";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/ModelPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/ModelPO.java
@@ -41,6 +41,10 @@ public class ModelPO {
 
   private Integer modelLatestVersion;
 
+  private Long currentVersion;
+
+  private Long lastVersion;
+
   private String modelProperties;
 
   private String auditInfo;
@@ -93,6 +97,16 @@ public class ModelPO {
 
     public Builder withModelLatestVersion(Integer modelLatestVersion) {
       modelPO.modelLatestVersion = modelLatestVersion;
+      return this;
+    }
+
+    public Builder withCurrentVersion(Long currentVersion) {
+      modelPO.currentVersion = currentVersion;
+      return this;
+    }
+
+    public Builder withLastVersion(Long lastVersion) {
+      modelPO.lastVersion = lastVersion;
       return this;
     }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -259,7 +260,8 @@ public class CatalogMetaService {
     if (updateResult.get() > 0) {
       return newEntity;
     } else {
-      throw new IOException("Failed to update the entity: " + identifier);
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", identifier);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.metrics.Monitored;
@@ -243,7 +244,9 @@ public class FilesetMetaService {
                         FilesetMetaMapper.class,
                         mapper -> mapper.updateFilesetMeta(newFilesetPO, oldFilesetPO));
                 if (metaUpdateCountRef[0] == 0) {
-                  throw new RuntimeException("Failed to update the entity: " + identifier);
+                  throw new OptimisticLockException(
+                      "Failed to update entity %s because it was modified concurrently",
+                      identifier);
                 }
               },
               () -> {
@@ -263,7 +266,8 @@ public class FilesetMetaService {
           if (metaUpdateCountRef[0] == 0) {
             // The meta update matched no rows; the transaction was rolled back,
             // including the version insert above.
-            throw new IOException("Failed to update the entity: " + identifier);
+            throw new OptimisticLockException(
+                re, "Failed to update entity %s because it was modified concurrently", identifier);
           } else {
             ExceptionUtils.checkSQLException(
                 re, Entity.EntityType.FILESET, newEntity.nameIdentifier().toString());
@@ -301,7 +305,8 @@ public class FilesetMetaService {
     if (updateResult > 0) {
       return newEntity;
     } else {
-      throw new IOException("Failed to update the entity: " + identifier);
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", identifier);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
@@ -231,7 +231,6 @@ public class FilesetMetaService {
         // insert is protected by a unique constraint on `fileset_id + version + deleted_at`. If
         // the meta update affects 0 rows (concurrent modification), the transaction is rolled
         // back — including the version insert — and the update is treated as a conflict.
-        int[] metaUpdateCountRef = new int[1];
         try {
           SessionUtils.doMultipleWithCommit(
               () ->
@@ -239,18 +238,18 @@ public class FilesetMetaService {
                       FilesetVersionMapper.class,
                       mapper -> mapper.insertFilesetVersions(newFilesetPO.getFilesetVersionPOs())),
               () -> {
-                metaUpdateCountRef[0] =
+                int updated =
                     SessionUtils.getWithoutCommit(
                         FilesetMetaMapper.class,
                         mapper -> mapper.updateFilesetMeta(newFilesetPO, oldFilesetPO));
-                if (metaUpdateCountRef[0] == 0) {
+                if (updated == 0) {
                   throw new OptimisticLockException(
                       "Failed to update entity %s because it was modified concurrently",
                       identifier);
                 }
               },
               () -> {
-                if (isRenamed && metaUpdateCountRef[0] > 0) {
+                if (isRenamed) {
                   SessionUtils.doWithoutCommit(
                       EntityChangeLogMapper.class,
                       mapper ->
@@ -262,17 +261,13 @@ public class FilesetMetaService {
                 }
               });
           updateResult = 1;
+        } catch (OptimisticLockException ole) {
+          // The CAS was lost; the transaction was rolled back, including the version insert above.
+          throw ole;
         } catch (RuntimeException re) {
-          if (metaUpdateCountRef[0] == 0) {
-            // The meta update matched no rows; the transaction was rolled back,
-            // including the version insert above.
-            throw new OptimisticLockException(
-                re, "Failed to update entity %s because it was modified concurrently", identifier);
-          } else {
-            ExceptionUtils.checkSQLException(
-                re, Entity.EntityType.FILESET, newEntity.nameIdentifier().toString());
-            throw re;
-          }
+          ExceptionUtils.checkSQLException(
+              re, Entity.EntityType.FILESET, newEntity.nameIdentifier().toString());
+          throw re;
         }
       } else {
         int[] metaUpdateCountRef = new int[1];
@@ -296,6 +291,8 @@ public class FilesetMetaService {
             });
         updateResult = metaUpdateCountRef[0];
       }
+    } catch (OptimisticLockException ole) {
+      throw ole;
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.FILESET, newEntity.nameIdentifier().toString());

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
@@ -259,21 +259,30 @@ public class FunctionMetaService {
         newEntity.id(),
         oldFunctionEntity.id());
 
+    AtomicInteger updateResult = new AtomicInteger(-1);
     try {
       FunctionPO newFunctionPO = updateFunctionPO(oldFunctionPO, newEntity);
-      // Insert a new version and update function meta
+      // Update the function meta first so a stale writer rolls back before writing a version row.
       SessionUtils.doMultipleWithCommit(
+          () -> {
+            updateResult.set(
+                SessionUtils.getWithoutCommit(
+                    FunctionMetaMapper.class,
+                    mapper -> ops.updatePO(mapper, newFunctionPO, oldFunctionPO)));
+            if (updateResult.get() == 0) {
+              throw new RuntimeException("Failed to update the entity: " + identifier);
+            }
+          },
           () ->
               SessionUtils.doWithoutCommit(
                   FunctionVersionMetaMapper.class,
-                  mapper -> mapper.insertFunctionVersionMeta(newFunctionPO.functionVersionPO())),
-          () ->
-              SessionUtils.doWithoutCommit(
-                  FunctionMetaMapper.class,
-                  mapper -> ops.updatePO(mapper, newFunctionPO, oldFunctionPO)));
+                  mapper -> mapper.insertFunctionVersionMeta(newFunctionPO.functionVersionPO())));
 
       return newEntity;
     } catch (RuntimeException re) {
+      if (updateResult.get() == 0) {
+        throw new IOException("Failed to update the entity: " + identifier, re);
+      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.FUNCTION, newEntity.nameIdentifier().toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
@@ -260,17 +260,16 @@ public class FunctionMetaService {
         newEntity.id(),
         oldFunctionEntity.id());
 
-    AtomicInteger updateResult = new AtomicInteger(-1);
     try {
       FunctionPO newFunctionPO = updateFunctionPO(oldFunctionPO, newEntity);
       // Update the function meta first so a stale writer rolls back before writing a version row.
       SessionUtils.doMultipleWithCommit(
           () -> {
-            updateResult.set(
+            int updated =
                 SessionUtils.getWithoutCommit(
                     FunctionMetaMapper.class,
-                    mapper -> ops.updatePO(mapper, newFunctionPO, oldFunctionPO)));
-            if (updateResult.get() == 0) {
+                    mapper -> ops.updatePO(mapper, newFunctionPO, oldFunctionPO));
+            if (updated == 0) {
               throw new OptimisticLockException(
                   "Failed to update entity %s because it was modified concurrently", identifier);
             }
@@ -281,11 +280,10 @@ public class FunctionMetaService {
                   mapper -> mapper.insertFunctionVersionMeta(newFunctionPO.functionVersionPO())));
 
       return newEntity;
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
-      if (updateResult.get() == 0) {
-        throw new OptimisticLockException(
-            re, "Failed to update entity %s because it was modified concurrently", identifier);
-      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.FUNCTION, newEntity.nameIdentifier().toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
@@ -38,6 +38,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.FunctionEntity;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.metrics.Monitored;
@@ -270,7 +271,8 @@ public class FunctionMetaService {
                     FunctionMetaMapper.class,
                     mapper -> ops.updatePO(mapper, newFunctionPO, oldFunctionPO)));
             if (updateResult.get() == 0) {
-              throw new RuntimeException("Failed to update the entity: " + identifier);
+              throw new OptimisticLockException(
+                  "Failed to update entity %s because it was modified concurrently", identifier);
             }
           },
           () ->
@@ -281,7 +283,8 @@ public class FunctionMetaService {
       return newEntity;
     } catch (RuntimeException re) {
       if (updateResult.get() == 0) {
-        throw new IOException("Failed to update the entity: " + identifier, re);
+        throw new OptimisticLockException(
+            re, "Failed to update entity %s because it was modified concurrently", identifier);
       }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.FUNCTION, newEntity.nameIdentifier().toString());

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
@@ -267,15 +267,21 @@ public class GroupMetaService {
     if (insertRoleIds.isEmpty() && deleteRoleIds.isEmpty()) {
       return newEntity;
     }
+    int[] updateResult = new int[] {-1};
     try {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              SessionUtils.doWithoutCommit(
-                  GroupMetaMapper.class,
-                  mapper ->
-                      mapper.updateGroupMeta(
-                          POConverters.updateGroupPOWithVersion(oldGroupPO, newEntity),
-                          oldGroupPO)),
+          () -> {
+            updateResult[0] =
+                SessionUtils.getWithoutCommit(
+                    GroupMetaMapper.class,
+                    mapper ->
+                        mapper.updateGroupMeta(
+                            POConverters.updateGroupPOWithVersion(oldGroupPO, newEntity),
+                            oldGroupPO));
+            if (updateResult[0] == 0) {
+              throw new RuntimeException("Failed to update the entity: " + identifier);
+            }
+          },
           () -> {
             if (insertRoleIds.isEmpty()) {
               return;
@@ -302,6 +308,9 @@ public class GroupMetaService {
                   GroupMetaMapper.class,
                   mapper -> mapper.touchGroupUpdatedAt(oldGroupPO.getGroupId())));
     } catch (RuntimeException re) {
+      if (updateResult[0] == 0) {
+        throw new IOException("Failed to update the entity: " + identifier, re);
+      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.GROUP, newEntity.nameIdentifier().toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.GroupEntity;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -279,7 +280,8 @@ public class GroupMetaService {
                             POConverters.updateGroupPOWithVersion(oldGroupPO, newEntity),
                             oldGroupPO));
             if (updateResult[0] == 0) {
-              throw new RuntimeException("Failed to update the entity: " + identifier);
+              throw new OptimisticLockException(
+                  "Failed to update entity %s because it was modified concurrently", identifier);
             }
           },
           () -> {
@@ -309,7 +311,8 @@ public class GroupMetaService {
                   mapper -> mapper.touchGroupUpdatedAt(oldGroupPO.getGroupId())));
     } catch (RuntimeException re) {
       if (updateResult[0] == 0) {
-        throw new IOException("Failed to update the entity: " + identifier, re);
+        throw new OptimisticLockException(
+            re, "Failed to update entity %s because it was modified concurrently", identifier);
       }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.GROUP, newEntity.nameIdentifier().toString());

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
@@ -268,18 +268,17 @@ public class GroupMetaService {
     if (insertRoleIds.isEmpty() && deleteRoleIds.isEmpty()) {
       return newEntity;
     }
-    int[] updateResult = new int[] {-1};
     try {
       SessionUtils.doMultipleWithCommit(
           () -> {
-            updateResult[0] =
+            int updated =
                 SessionUtils.getWithoutCommit(
                     GroupMetaMapper.class,
                     mapper ->
                         mapper.updateGroupMeta(
                             POConverters.updateGroupPOWithVersion(oldGroupPO, newEntity),
                             oldGroupPO));
-            if (updateResult[0] == 0) {
+            if (updated == 0) {
               throw new OptimisticLockException(
                   "Failed to update entity %s because it was modified concurrently", identifier);
             }
@@ -309,11 +308,10 @@ public class GroupMetaService {
               SessionUtils.doWithoutCommit(
                   GroupMetaMapper.class,
                   mapper -> mapper.touchGroupUpdatedAt(oldGroupPO.getGroupId())));
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
-      if (updateResult[0] == 0) {
-        throw new OptimisticLockException(
-            re, "Failed to update entity %s because it was modified concurrently", identifier);
-      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.GROUP, newEntity.nameIdentifier().toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
@@ -33,6 +33,7 @@ import org.apache.gravitino.HasIdentifier;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -209,7 +210,8 @@ public class MetalakeMetaService {
     if (updateResult.get() > 0) {
       return newMetalakeEntity;
     } else {
-      throw new IOException("Failed to update the entity: " + ident);
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", ident);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
@@ -378,18 +378,22 @@ public class ModelMetaService {
             .toString();
     boolean isRenamed = !Objects.equals(oldModelEntity.name(), newEntity.name());
 
-    AtomicInteger updateResult = new AtomicInteger(0);
     try {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              updateResult.set(
-                  SessionUtils.getWithoutCommit(
-                      ModelMetaMapper.class,
-                      mapper ->
-                          mapper.updateModelMeta(
-                              POConverters.updateModelPO(oldModelPO, newEntity), oldModelPO))),
           () -> {
-            if (isRenamed && updateResult.get() > 0) {
+            int updated =
+                SessionUtils.getWithoutCommit(
+                    ModelMetaMapper.class,
+                    mapper ->
+                        mapper.updateModelMeta(
+                            POConverters.updateModelPO(oldModelPO, newEntity), oldModelPO));
+            if (updated == 0) {
+              throw new OptimisticLockException(
+                  "Failed to update entity %s because it was modified concurrently", identifier);
+            }
+          },
+          () -> {
+            if (isRenamed) {
               SessionUtils.doWithoutCommit(
                   EntityChangeLogMapper.class,
                   mapper ->
@@ -400,18 +404,16 @@ public class ModelMetaService {
                           OperateType.ALTER));
             }
           });
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.MODEL, newEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult.get() > 0) {
-      return newEntity;
-    } else {
-      throw new OptimisticLockException(
-          "Failed to update entity %s because it was modified concurrently", identifier);
-    }
+    return newEntity;
   }
 
   @Monitored(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.metrics.Monitored;
@@ -408,7 +409,8 @@ public class ModelMetaService {
     if (updateResult.get() > 0) {
       return newEntity;
     } else {
-      throw new IOException("Failed to update the entity: " + identifier);
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", identifier);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelVersionMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelVersionMetaService.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.HasIdentifier;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -409,7 +410,10 @@ public class ModelVersionMetaService {
     if (updateResult.get() > 0) {
       return newModelVersionEntity;
     } else {
-      throw new IOException("Failed to update the entity: " + ident);
+      // model_version_info has no OCC version columns yet, so the guard is still the full-row
+      // compare; a zero-row match means the same thing, i.e. someone else changed the row.
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", ident);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/PolicyMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/PolicyMetaService.java
@@ -143,7 +143,7 @@ public class PolicyMetaService {
         updatedPolicyEntity.id(),
         oldPolicyEntity.id());
 
-    Integer updateResult;
+    int[] updateResult = new int[] {-1};
     try {
       boolean checkNeedUpdateVersion =
           POConverters.checkPolicyVersionNeedUpdate(
@@ -153,29 +153,35 @@ public class PolicyMetaService {
               oldPolicyPO, updatedPolicyEntity, checkNeedUpdateVersion);
       if (checkNeedUpdateVersion) {
         SessionUtils.doMultipleWithCommit(
+            () -> {
+              updateResult[0] =
+                  SessionUtils.getWithoutCommit(
+                      PolicyMetaMapper.class,
+                      mapper -> mapper.updatePolicyMeta(newPolicyPO, oldPolicyPO));
+              if (updateResult[0] == 0) {
+                throw new RuntimeException("Failed to update the entity: " + ident);
+              }
+            },
             () ->
                 SessionUtils.doWithoutCommit(
                     PolicyVersionMapper.class,
-                    mapper -> mapper.insertPolicyVersion(newPolicyPO.getPolicyVersionPO())),
-            () ->
-                SessionUtils.doWithoutCommit(
-                    PolicyMetaMapper.class,
-                    mapper -> mapper.updatePolicyMeta(newPolicyPO, oldPolicyPO)));
-        // we set the updateResult to 1 to indicate that the update is successful
-        updateResult = 1;
+                    mapper -> mapper.insertPolicyVersion(newPolicyPO.getPolicyVersionPO())));
       } else {
-        updateResult =
+        updateResult[0] =
             SessionUtils.doWithCommitAndFetchResult(
                 PolicyMetaMapper.class,
                 mapper -> mapper.updatePolicyMeta(newPolicyPO, oldPolicyPO));
       }
     } catch (RuntimeException re) {
+      if (updateResult[0] == 0) {
+        throw new IOException("Failed to update the entity: " + ident, re);
+      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.POLICY, updatedPolicyEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult > 0) {
+    if (updateResult[0] > 0) {
       return updatedPolicyEntity;
     } else {
       throw new IOException("Failed to update the entity: " + updatedPolicyEntity);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/PolicyMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/PolicyMetaService.java
@@ -35,6 +35,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.GenericEntity;
 import org.apache.gravitino.meta.PolicyEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -159,7 +160,8 @@ public class PolicyMetaService {
                       PolicyMetaMapper.class,
                       mapper -> mapper.updatePolicyMeta(newPolicyPO, oldPolicyPO));
               if (updateResult[0] == 0) {
-                throw new RuntimeException("Failed to update the entity: " + ident);
+                throw new OptimisticLockException(
+                    "Failed to update entity %s because it was modified concurrently", ident);
               }
             },
             () ->
@@ -174,7 +176,8 @@ public class PolicyMetaService {
       }
     } catch (RuntimeException re) {
       if (updateResult[0] == 0) {
-        throw new IOException("Failed to update the entity: " + ident, re);
+        throw new OptimisticLockException(
+            re, "Failed to update entity %s because it was modified concurrently", ident);
       }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.POLICY, updatedPolicyEntity.nameIdentifier().toString());
@@ -184,7 +187,8 @@ public class PolicyMetaService {
     if (updateResult[0] > 0) {
       return updatedPolicyEntity;
     } else {
-      throw new IOException("Failed to update the entity: " + updatedPolicyEntity);
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", ident);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/PolicyMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/PolicyMetaService.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -144,7 +145,9 @@ public class PolicyMetaService {
         updatedPolicyEntity.id(),
         oldPolicyEntity.id());
 
-    int[] updateResult = new int[] {-1};
+    // Only the non-versioned branch reports its row count back here; the versioned branch aborts
+    // the transaction from inside the first operation instead.
+    AtomicInteger updateResult = new AtomicInteger(-1);
     try {
       boolean checkNeedUpdateVersion =
           POConverters.checkPolicyVersionNeedUpdate(
@@ -153,38 +156,39 @@ public class PolicyMetaService {
           POConverters.updatePolicyPOWithVersion(
               oldPolicyPO, updatedPolicyEntity, checkNeedUpdateVersion);
       if (checkNeedUpdateVersion) {
+        // The meta update runs first so a stale writer rolls back before writing a version row.
         SessionUtils.doMultipleWithCommit(
             () -> {
-              updateResult[0] =
+              int updated =
                   SessionUtils.getWithoutCommit(
                       PolicyMetaMapper.class,
                       mapper -> mapper.updatePolicyMeta(newPolicyPO, oldPolicyPO));
-              if (updateResult[0] == 0) {
+              if (updated == 0) {
                 throw new OptimisticLockException(
                     "Failed to update entity %s because it was modified concurrently", ident);
               }
+              updateResult.set(updated);
             },
             () ->
                 SessionUtils.doWithoutCommit(
                     PolicyVersionMapper.class,
                     mapper -> mapper.insertPolicyVersion(newPolicyPO.getPolicyVersionPO())));
       } else {
-        updateResult[0] =
+        updateResult.set(
             SessionUtils.doWithCommitAndFetchResult(
                 PolicyMetaMapper.class,
-                mapper -> mapper.updatePolicyMeta(newPolicyPO, oldPolicyPO));
+                mapper -> mapper.updatePolicyMeta(newPolicyPO, oldPolicyPO)));
       }
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
-      if (updateResult[0] == 0) {
-        throw new OptimisticLockException(
-            re, "Failed to update entity %s because it was modified concurrently", ident);
-      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.POLICY, updatedPolicyEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult[0] > 0) {
+    if (updateResult.get() > 0) {
       return updatedPolicyEntity;
     } else {
       throw new OptimisticLockException(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -203,6 +203,7 @@ public class RoleMetaService {
       NameIdentifier identifier, Function<E, E> updater) throws IOException {
     AuthorizationUtils.checkRole(identifier);
 
+    int[] updateResult = new int[] {-1};
     try {
       String metalake = NameIdentifierUtil.getMetalake(identifier);
       Long metalakeId = MetalakeMetaService.getInstance().getMetalakeIdByName(metalake);
@@ -236,12 +237,17 @@ public class RoleMetaService {
           toSecurableObjectPOs(insertObjects, oldRoleEntity, metalake);
 
       SessionUtils.doMultipleWithCommit(
-          () ->
-              SessionUtils.doWithoutCommit(
-                  RoleMetaMapper.class,
-                  mapper ->
-                      mapper.updateRoleMeta(
-                          POConverters.updateRolePOWithVersion(rolePO, newRoleEntity), rolePO)),
+          () -> {
+            updateResult[0] =
+                SessionUtils.getWithoutCommit(
+                    RoleMetaMapper.class,
+                    mapper ->
+                        mapper.updateRoleMeta(
+                            POConverters.updateRolePOWithVersion(rolePO, newRoleEntity), rolePO));
+            if (updateResult[0] == 0) {
+              throw new RuntimeException("Failed to update the entity: " + identifier);
+            }
+          },
           () -> {
             if (deleteSecurableObjectPOs.isEmpty()) {
               return;
@@ -266,6 +272,9 @@ public class RoleMetaService {
 
       return newRoleEntity;
     } catch (RuntimeException re) {
+      if (updateResult[0] == 0) {
+        throw new IOException("Failed to update the entity: " + identifier, re);
+      }
       ExceptionUtils.checkSQLException(re, Entity.EntityType.ROLE, identifier.toString());
       throw re;
     }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -41,6 +41,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -245,7 +246,8 @@ public class RoleMetaService {
                         mapper.updateRoleMeta(
                             POConverters.updateRolePOWithVersion(rolePO, newRoleEntity), rolePO));
             if (updateResult[0] == 0) {
-              throw new RuntimeException("Failed to update the entity: " + identifier);
+              throw new OptimisticLockException(
+                  "Failed to update entity %s because it was modified concurrently", identifier);
             }
           },
           () -> {
@@ -273,7 +275,8 @@ public class RoleMetaService {
       return newRoleEntity;
     } catch (RuntimeException re) {
       if (updateResult[0] == 0) {
-        throw new IOException("Failed to update the entity: " + identifier, re);
+        throw new OptimisticLockException(
+            re, "Failed to update entity %s because it was modified concurrently", identifier);
       }
       ExceptionUtils.checkSQLException(re, Entity.EntityType.ROLE, identifier.toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -204,7 +204,6 @@ public class RoleMetaService {
       NameIdentifier identifier, Function<E, E> updater) throws IOException {
     AuthorizationUtils.checkRole(identifier);
 
-    int[] updateResult = new int[] {-1};
     try {
       String metalake = NameIdentifierUtil.getMetalake(identifier);
       Long metalakeId = MetalakeMetaService.getInstance().getMetalakeIdByName(metalake);
@@ -239,13 +238,13 @@ public class RoleMetaService {
 
       SessionUtils.doMultipleWithCommit(
           () -> {
-            updateResult[0] =
+            int updated =
                 SessionUtils.getWithoutCommit(
                     RoleMetaMapper.class,
                     mapper ->
                         mapper.updateRoleMeta(
                             POConverters.updateRolePOWithVersion(rolePO, newRoleEntity), rolePO));
-            if (updateResult[0] == 0) {
+            if (updated == 0) {
               throw new OptimisticLockException(
                   "Failed to update entity %s because it was modified concurrently", identifier);
             }
@@ -273,11 +272,10 @@ public class RoleMetaService {
                   RoleMetaMapper.class, mapper -> mapper.touchRoleUpdatedAt(rolePO.getRoleId())));
 
       return newRoleEntity;
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
-      if (updateResult[0] == 0) {
-        throw new OptimisticLockException(
-            re, "Failed to update entity %s because it was modified concurrently", identifier);
-      }
       ExceptionUtils.checkSQLException(re, Entity.EntityType.ROLE, identifier.toString());
       throw re;
     }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.NamespacedEntityId;
@@ -260,7 +261,8 @@ public class SchemaMetaService {
     if (updateResult.get() > 0) {
       return newEntity;
     } else {
-      throw new IOException("Failed to update the entity: " + identifier);
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", identifier);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
@@ -202,14 +202,17 @@ public class TableMetaService {
     boolean isFullNameChanged =
         isSchemaChanged || !Objects.equals(oldTableEntity.name(), newTableEntity.name());
 
-    final AtomicInteger updateResult = new AtomicInteger(0);
+    final AtomicInteger updateResult = new AtomicInteger(-1);
     try {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              updateResult.set(
-                  SessionUtils.getWithoutCommit(
-                      TableMetaMapper.class,
-                      mapper -> ops.updatePO(mapper, newTablePO, oldTablePO))),
+          () -> {
+            updateResult.set(
+                SessionUtils.getWithoutCommit(
+                    TableMetaMapper.class, mapper -> ops.updatePO(mapper, newTablePO, oldTablePO)));
+            if (updateResult.get() == 0) {
+              throw new RuntimeException(UPDATE_ENTITY_CONFLICT_MESSAGE_PREFIX + identifier);
+            }
+          },
           () ->
               SessionUtils.doWithoutCommit(
                   TableVersionMapper.class,
@@ -238,16 +241,15 @@ public class TableMetaService {
           });
 
     } catch (RuntimeException re) {
+      if (updateResult.get() == 0) {
+        throw new IOException(UPDATE_ENTITY_CONFLICT_MESSAGE_PREFIX + identifier, re);
+      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.TABLE, newTableEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult.get() > 0) {
-      return newTableEntity;
-    } else {
-      throw new IOException(UPDATE_ENTITY_CONFLICT_MESSAGE_PREFIX + identifier);
-    }
+    return newTableEntity;
   }
 
   @Monitored(metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME, baseMetricName = "deleteTable")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
@@ -194,14 +194,15 @@ public class TableMetaService {
     boolean isFullNameChanged =
         isSchemaChanged || !Objects.equals(oldTableEntity.name(), newTableEntity.name());
 
-    final AtomicInteger updateResult = new AtomicInteger(-1);
     try {
+      // The meta update runs first and aborts the transaction on a lost CAS, so every operation
+      // below only ever runs for the writer that won.
       SessionUtils.doMultipleWithCommit(
           () -> {
-            updateResult.set(
+            int updated =
                 SessionUtils.getWithoutCommit(
-                    TableMetaMapper.class, mapper -> ops.updatePO(mapper, newTablePO, oldTablePO)));
-            if (updateResult.get() == 0) {
+                    TableMetaMapper.class, mapper -> ops.updatePO(mapper, newTablePO, oldTablePO));
+            if (updated == 0) {
               throw new OptimisticLockException(
                   "Failed to update entity %s because it was modified concurrently", identifier);
             }
@@ -214,14 +215,11 @@ public class TableMetaService {
                         oldTablePO.getTableId(), oldTablePO.getCurrentVersion());
                     mapper.insertTableVersionOnDuplicateKeyUpdate(newTablePO);
                   }),
-          () -> {
-            if (updateResult.get() > 0) {
+          () ->
               TableColumnMetaService.getInstance()
-                  .updateColumnPOsFromTableDiff(oldTableEntity, newTableEntity, newTablePO);
-            }
-          },
+                  .updateColumnPOsFromTableDiff(oldTableEntity, newTableEntity, newTablePO),
           () -> {
-            if (isFullNameChanged && updateResult.get() > 0) {
+            if (isFullNameChanged) {
               SessionUtils.doWithoutCommit(
                   EntityChangeLogMapper.class,
                   mapper ->
@@ -233,11 +231,10 @@ public class TableMetaService {
             }
           });
 
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
-      if (updateResult.get() == 0) {
-        throw new OptimisticLockException(
-            re, "Failed to update entity %s because it was modified concurrently", identifier);
-      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.TABLE, newTableEntity.nameIdentifier().toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -56,15 +57,6 @@ import org.apache.gravitino.utils.NamespaceUtil;
 
 /** The service class for table metadata. It provides the basic database operations for table. */
 public class TableMetaService {
-
-  /**
-   * Message prefix of the {@link java.io.IOException} thrown by {@link #updateTable} when the
-   * optimistic-lock CAS matches zero rows (the stored version advanced under a concurrent update).
-   * Exposed so callers that retry the lost race (e.g. the Lance repair-on-load path) can recognize
-   * the conflict without re-declaring the literal.
-   */
-  public static final String UPDATE_ENTITY_CONFLICT_MESSAGE_PREFIX =
-      "Failed to update the entity: ";
 
   private static final TableMetaService INSTANCE = new TableMetaService();
   private BasePOStorageOps<TablePO, TableMetaMapper> ops;
@@ -210,7 +202,8 @@ public class TableMetaService {
                 SessionUtils.getWithoutCommit(
                     TableMetaMapper.class, mapper -> ops.updatePO(mapper, newTablePO, oldTablePO)));
             if (updateResult.get() == 0) {
-              throw new RuntimeException(UPDATE_ENTITY_CONFLICT_MESSAGE_PREFIX + identifier);
+              throw new OptimisticLockException(
+                  "Failed to update entity %s because it was modified concurrently", identifier);
             }
           },
           () ->
@@ -242,7 +235,8 @@ public class TableMetaService {
 
     } catch (RuntimeException re) {
       if (updateResult.get() == 0) {
-        throw new IOException(UPDATE_ENTITY_CONFLICT_MESSAGE_PREFIX + identifier, re);
+        throw new OptimisticLockException(
+            re, "Failed to update entity %s because it was modified concurrently", identifier);
       }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.TABLE, newTableEntity.nameIdentifier().toString());

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TagMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TagMetaService.java
@@ -38,6 +38,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.GenericEntity;
 import org.apache.gravitino.meta.TagEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -132,7 +133,8 @@ public class TagMetaService {
                       POConverters.updateTagPOWithVersion(tagPO, updatedTagEntity), tagPO));
 
       if (result == null || result == 0) {
-        throw new IOException("Failed to update the entity: " + identifier);
+        throw new OptimisticLockException(
+            "Failed to update entity %s because it was modified concurrently", identifier);
       }
 
       return updatedTagEntity;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TopicMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TopicMetaService.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.meta.TopicEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -153,7 +154,8 @@ public class TopicMetaService {
     if (updateResult.get() > 0) {
       return newEntity;
     } else {
-      throw new IOException("Failed to update the entity: " + ident);
+      throw new OptimisticLockException(
+          "Failed to update entity %s because it was modified concurrently", ident);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
@@ -224,14 +224,20 @@ public class UserMetaService {
       return newEntity;
     }
 
+    int[] updateResult = new int[] {-1};
     try {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              SessionUtils.doWithoutCommit(
-                  UserMetaMapper.class,
-                  mapper ->
-                      mapper.updateUserMeta(
-                          POConverters.updateUserPOWithVersion(oldUserPO, newEntity), oldUserPO)),
+          () -> {
+            updateResult[0] =
+                SessionUtils.getWithoutCommit(
+                    UserMetaMapper.class,
+                    mapper ->
+                        mapper.updateUserMeta(
+                            POConverters.updateUserPOWithVersion(oldUserPO, newEntity), oldUserPO));
+            if (updateResult[0] == 0) {
+              throw new RuntimeException("Failed to update the entity: " + identifier);
+            }
+          },
           () -> {
             if (insertRoleIds.isEmpty()) {
               return;
@@ -258,6 +264,9 @@ public class UserMetaService {
                   UserMetaMapper.class,
                   mapper -> mapper.touchUserUpdatedAt(oldUserPO.getUserId())));
     } catch (RuntimeException re) {
+      if (updateResult[0] == 0) {
+        throw new IOException("Failed to update the entity: " + identifier, re);
+      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.USER, newEntity.nameIdentifier().toString());
       throw re;
@@ -368,19 +377,28 @@ public class UserMetaService {
         newEntity.id(),
         oldEntity.id());
 
+    int[] updateResult = new int[] {-1};
     try {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              SessionUtils.doWithoutCommit(
-                  UserMetaMapper.class,
-                  mapper ->
-                      mapper.updateUserMetaByExternalId(
-                          POConverters.updateUserPOWithVersion(oldUserPO, newEntity), oldUserPO)),
+          () -> {
+            updateResult[0] =
+                SessionUtils.getWithoutCommit(
+                    UserMetaMapper.class,
+                    mapper ->
+                        mapper.updateUserMetaByExternalId(
+                            POConverters.updateUserPOWithVersion(oldUserPO, newEntity), oldUserPO));
+            if (updateResult[0] == 0) {
+              throw new RuntimeException("Failed to update the entity: " + ident);
+            }
+          },
           () ->
               SessionUtils.doWithoutCommit(
                   UserMetaMapper.class,
                   mapper -> mapper.touchUserUpdatedAt(oldUserPO.getUserId())));
     } catch (RuntimeException re) {
+      if (updateResult[0] == 0) {
+        throw new IOException("Failed to update the entity: " + ident, re);
+      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.USER, newEntity.nameIdentifier().toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -235,7 +236,8 @@ public class UserMetaService {
                         mapper.updateUserMeta(
                             POConverters.updateUserPOWithVersion(oldUserPO, newEntity), oldUserPO));
             if (updateResult[0] == 0) {
-              throw new RuntimeException("Failed to update the entity: " + identifier);
+              throw new OptimisticLockException(
+                  "Failed to update entity %s because it was modified concurrently", identifier);
             }
           },
           () -> {
@@ -265,7 +267,8 @@ public class UserMetaService {
                   mapper -> mapper.touchUserUpdatedAt(oldUserPO.getUserId())));
     } catch (RuntimeException re) {
       if (updateResult[0] == 0) {
-        throw new IOException("Failed to update the entity: " + identifier, re);
+        throw new OptimisticLockException(
+            re, "Failed to update entity %s because it was modified concurrently", identifier);
       }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.USER, newEntity.nameIdentifier().toString());
@@ -388,7 +391,8 @@ public class UserMetaService {
                         mapper.updateUserMetaByExternalId(
                             POConverters.updateUserPOWithVersion(oldUserPO, newEntity), oldUserPO));
             if (updateResult[0] == 0) {
-              throw new RuntimeException("Failed to update the entity: " + ident);
+              throw new OptimisticLockException(
+                  "Failed to update entity %s because it was modified concurrently", ident);
             }
           },
           () ->
@@ -397,7 +401,8 @@ public class UserMetaService {
                   mapper -> mapper.touchUserUpdatedAt(oldUserPO.getUserId())));
     } catch (RuntimeException re) {
       if (updateResult[0] == 0) {
-        throw new IOException("Failed to update the entity: " + ident, re);
+        throw new OptimisticLockException(
+            re, "Failed to update entity %s because it was modified concurrently", ident);
       }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.USER, newEntity.nameIdentifier().toString());

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
@@ -225,17 +225,16 @@ public class UserMetaService {
       return newEntity;
     }
 
-    int[] updateResult = new int[] {-1};
     try {
       SessionUtils.doMultipleWithCommit(
           () -> {
-            updateResult[0] =
+            int updated =
                 SessionUtils.getWithoutCommit(
                     UserMetaMapper.class,
                     mapper ->
                         mapper.updateUserMeta(
                             POConverters.updateUserPOWithVersion(oldUserPO, newEntity), oldUserPO));
-            if (updateResult[0] == 0) {
+            if (updated == 0) {
               throw new OptimisticLockException(
                   "Failed to update entity %s because it was modified concurrently", identifier);
             }
@@ -265,11 +264,10 @@ public class UserMetaService {
               SessionUtils.doWithoutCommit(
                   UserMetaMapper.class,
                   mapper -> mapper.touchUserUpdatedAt(oldUserPO.getUserId())));
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
-      if (updateResult[0] == 0) {
-        throw new OptimisticLockException(
-            re, "Failed to update entity %s because it was modified concurrently", identifier);
-      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.USER, newEntity.nameIdentifier().toString());
       throw re;
@@ -380,17 +378,16 @@ public class UserMetaService {
         newEntity.id(),
         oldEntity.id());
 
-    int[] updateResult = new int[] {-1};
     try {
       SessionUtils.doMultipleWithCommit(
           () -> {
-            updateResult[0] =
+            int updated =
                 SessionUtils.getWithoutCommit(
                     UserMetaMapper.class,
                     mapper ->
                         mapper.updateUserMetaByExternalId(
                             POConverters.updateUserPOWithVersion(oldUserPO, newEntity), oldUserPO));
-            if (updateResult[0] == 0) {
+            if (updated == 0) {
               throw new OptimisticLockException(
                   "Failed to update entity %s because it was modified concurrently", ident);
             }
@@ -399,11 +396,10 @@ public class UserMetaService {
               SessionUtils.doWithoutCommit(
                   UserMetaMapper.class,
                   mapper -> mapper.touchUserUpdatedAt(oldUserPO.getUserId())));
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
-      if (updateResult[0] == 0) {
-        throw new OptimisticLockException(
-            re, "Failed to update entity %s because it was modified concurrently", ident);
-      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.USER, newEntity.nameIdentifier().toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
@@ -143,7 +143,6 @@ public class ViewMetaService {
         newEntity.id(),
         oldViewEntity.id());
 
-    AtomicInteger updateResult = new AtomicInteger(0);
     try {
       ViewPO newViewPO = updateViewPO(oldViewPO, newEntity);
       String metalakeName = ident.namespace().level(0);
@@ -160,16 +159,16 @@ public class ViewMetaService {
                   ViewVersionInfoMapper.class,
                   mapper -> mapper.insertViewVersionInfo(newViewPO.getViewVersionInfoPO())),
           () -> {
-            updateResult.set(
+            int updated =
                 SessionUtils.getWithoutCommit(
-                    ViewMetaMapper.class, mapper -> ops.updatePO(mapper, newViewPO, oldViewPO)));
-            if (updateResult.get() == 0) {
+                    ViewMetaMapper.class, mapper -> ops.updatePO(mapper, newViewPO, oldViewPO));
+            if (updated == 0) {
               throw new OptimisticLockException(
                   "Failed to update entity %s because it was modified concurrently", ident);
             }
           },
           () -> {
-            if (isRenamed && updateResult.get() > 0) {
+            if (isRenamed) {
               SessionUtils.doWithoutCommit(
                   EntityChangeLogMapper.class,
                   mapper ->
@@ -181,11 +180,10 @@ public class ViewMetaService {
             }
           });
       return newEntity;
+    } catch (OptimisticLockException ole) {
+      // The CAS was lost; doMultipleWithCommit already rolled the whole transaction back.
+      throw ole;
     } catch (RuntimeException re) {
-      if (updateResult.get() == 0) {
-        throw new OptimisticLockException(
-            re, "Failed to update entity %s because it was modified concurrently", ident);
-      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.VIEW, newEntity.nameIdentifier().toString());
       throw re;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.ViewEntity;
 import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
@@ -163,7 +164,8 @@ public class ViewMetaService {
                 SessionUtils.getWithoutCommit(
                     ViewMetaMapper.class, mapper -> ops.updatePO(mapper, newViewPO, oldViewPO)));
             if (updateResult.get() == 0) {
-              throw new RuntimeException("Failed to update the entity: " + ident);
+              throw new OptimisticLockException(
+                  "Failed to update entity %s because it was modified concurrently", ident);
             }
           },
           () -> {
@@ -181,7 +183,8 @@ public class ViewMetaService {
       return newEntity;
     } catch (RuntimeException re) {
       if (updateResult.get() == 0) {
-        throw new IOException("Failed to update the entity: " + ident);
+        throw new OptimisticLockException(
+            re, "Failed to update entity %s because it was modified concurrently", ident);
       }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.VIEW, newEntity.nameIdentifier().toString());

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -1627,6 +1627,8 @@ public class POConverters {
           .withModelName(modelEntity.name())
           .withModelComment(modelEntity.comment())
           .withModelLatestVersion(modelEntity.latestVersion())
+          .withCurrentVersion(INIT_VERSION)
+          .withLastVersion(INIT_VERSION)
           .withModelProperties(
               JsonUtils.anyFieldMapper().writeValueAsString(modelEntity.properties()))
           .withAuditInfo(JsonUtils.anyFieldMapper().writeValueAsString(modelEntity.auditInfo()))
@@ -1688,6 +1690,10 @@ public class POConverters {
           .withSchemaId(oldModelPO.getSchemaId())
           .withModelComment(newModel.comment())
           .withModelLatestVersion(newModel.latestVersion())
+          // Raise the version on every successful update so OCC (version CAS) can detect a
+          // concurrent write: the racing updater's `WHERE current_version = old` matches 0 rows.
+          .withCurrentVersion(oldModelPO.getLastVersion() + 1)
+          .withLastVersion(oldModelPO.getLastVersion() + 1)
           .withModelProperties(JsonUtils.anyFieldMapper().writeValueAsString(newModel.properties()))
           .withAuditInfo(JsonUtils.anyFieldMapper().writeValueAsString(newModel.auditInfo()))
           .withDeletedAt(DEFAULT_DELETED_AT)

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -137,8 +137,9 @@ public class POConverters {
   public static MetalakePO updateMetalakePOWithVersion(
       MetalakePO oldMetalakePO, BaseMetalake newMetalake) {
     Long lastVersion = oldMetalakePO.getLastVersion();
-    // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion;
+    // Raise the version on every successful update so OCC (version CAS) can detect a concurrent
+    // write: the racing updater's `WHERE current_version = old` matches 0 rows and loses.
+    Long nextVersion = lastVersion + 1;
     try {
       return MetalakePO.builder()
           .withMetalakeId(newMetalake.id())
@@ -234,8 +235,9 @@ public class POConverters {
   public static CatalogPO updateCatalogPOWithVersion(
       CatalogPO oldCatalogPO, CatalogEntity newCatalog, Long metalakeId) {
     Long lastVersion = oldCatalogPO.getLastVersion();
-    // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion;
+    // Raise the version on every successful update so OCC (version CAS) can detect a concurrent
+    // write: the racing updater's `WHERE current_version = old` matches 0 rows and loses.
+    Long nextVersion = lastVersion + 1;
     try {
       return CatalogPO.builder()
           .withCatalogId(newCatalog.id())
@@ -330,8 +332,9 @@ public class POConverters {
    */
   public static SchemaPO updateSchemaPOWithVersion(SchemaPO oldSchemaPO, SchemaEntity newSchema) {
     Long lastVersion = oldSchemaPO.getLastVersion();
-    // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion;
+    // Raise the version on every successful update so OCC (version CAS) can detect a concurrent
+    // write: the racing updater's `WHERE current_version = old` matches 0 rows and loses.
+    Long nextVersion = lastVersion + 1;
     try {
       return SchemaPO.builder()
           .withSchemaId(oldSchemaPO.getSchemaId())
@@ -922,8 +925,9 @@ public class POConverters {
 
   public static TopicPO updateTopicPOWithVersion(TopicPO oldTopicPO, TopicEntity newEntity) {
     Long lastVersion = oldTopicPO.getLastVersion();
-    // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion;
+    // Raise the version on every successful update so OCC (version CAS) can detect a concurrent
+    // write: the racing updater's `WHERE current_version = old` matches 0 rows and loses.
+    Long nextVersion = lastVersion + 1;
     try {
       return TopicPO.builder()
           .withTopicId(oldTopicPO.getTopicId())
@@ -977,9 +981,9 @@ public class POConverters {
    */
   public static UserPO updateUserPOWithVersion(UserPO oldUserPO, UserEntity newUser) {
     Long lastVersion = oldUserPO.getLastVersion();
-    // TODO: set the version to the last version + 1 when having some fields need be multiple
-    // version
-    Long nextVersion = lastVersion;
+    // Raise the version on every successful update so OCC (version CAS) can detect a concurrent
+    // write: the racing updater's `WHERE current_version = old` matches 0 rows and loses.
+    Long nextVersion = lastVersion + 1;
     try {
       return UserPO.builder()
           .withUserId(oldUserPO.getUserId())
@@ -1259,9 +1263,9 @@ public class POConverters {
    */
   public static GroupPO updateGroupPOWithVersion(GroupPO oldGroupPO, GroupEntity newGroup) {
     Long lastVersion = oldGroupPO.getLastVersion();
-    // TODO: set the version to the last version + 1 when having some fields need be multiple
-    // version
-    Long nextVersion = lastVersion;
+    // Raise the version on every successful update so OCC (version CAS) can detect a concurrent
+    // write: the racing updater's `WHERE current_version = old` matches 0 rows and loses.
+    Long nextVersion = lastVersion + 1;
     try {
       return GroupPO.builder()
           .withGroupId(oldGroupPO.getGroupId())
@@ -1387,9 +1391,9 @@ public class POConverters {
 
   public static RolePO updateRolePOWithVersion(RolePO oldRolePO, RoleEntity newRole) {
     Long lastVersion = oldRolePO.getLastVersion();
-    // TODO: set the version to the last version + 1 when having some fields need be multiple
-    // version
-    Long nextVersion = lastVersion;
+    // Raise the version on every successful update so OCC (version CAS) can detect a concurrent
+    // write: the racing updater's `WHERE current_version = old` matches 0 rows and loses.
+    Long nextVersion = lastVersion + 1;
     try {
       return RolePO.builder()
           .withRoleId(oldRolePO.getRoleId())
@@ -1445,9 +1449,9 @@ public class POConverters {
 
   public static TagPO updateTagPOWithVersion(TagPO oldTagPO, TagEntity newEntity) {
     Long lastVersion = oldTagPO.getLastVersion();
-    // TODO: set the version to the last version + 1 when having some fields need be multiple
-    // version
-    Long nextVersion = lastVersion;
+    // Raise the version on every successful update so OCC (version CAS) can detect a concurrent
+    // write: the racing updater's `WHERE current_version = old` matches 0 rows and loses.
+    Long nextVersion = lastVersion + 1;
     try {
       return TagPO.builder()
           .withTagId(oldTagPO.getTagId())

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -58,6 +58,7 @@ import org.apache.gravitino.TestColumn;
 import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.connector.TestCatalogOperations;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ColumnEntity;
@@ -474,7 +475,16 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("test", alteredTable2.auditInfo().creator());
     Assertions.assertEquals("test", alteredTable2.auditInfo().lastModifier());
 
-    // Case 3: Test if the entity store is failed to update the table entity
+    // Case 3: An optimistic-lock conflict must propagate so REST can return HTTP 409.
+    reset(entityStore);
+    doThrow(new OptimisticLockException("Conflict"))
+        .when(entityStore)
+        .update(any(), any(), any(), any());
+    Assertions.assertThrows(
+        OptimisticLockException.class,
+        () -> tableOperationDispatcher.alterTable(tableIdent, changes));
+
+    // Case 4: Test if the entity store is failed to update the table entity
     reset(entityStore);
     doThrow(new IOException()).when(entityStore).update(any(), any(), any(), any());
     Table alteredTable3 = tableOperationDispatcher.alterTable(tableIdent, changes);
@@ -482,7 +492,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("test", alteredTable3.auditInfo().creator());
     Assertions.assertEquals("test", alteredTable3.auditInfo().lastModifier());
 
-    // Case 4: Test if the table entity is not matched
+    // Case 5: Test if the table entity is not matched
     reset(entityStore);
     TableEntity unmatchedEntity =
         TableEntity.builder()

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
@@ -47,6 +47,7 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
 import org.apache.gravitino.meta.AuditInfo;
@@ -429,7 +430,7 @@ public class TestFilesetMetaService extends TestJDBCBackend {
 
     Exception exception =
         Assertions.assertThrows(
-            IOException.class,
+            OptimisticLockException.class,
             () ->
                 FilesetMetaService.getInstance()
                     .updateFileset(
@@ -455,8 +456,7 @@ public class TestFilesetMetaService extends TestJDBCBackend {
                           }
                           return updatedFilesetEntity;
                         }));
-    Assertions.assertTrue(
-        exception.getMessage().contains("Failed to update the entity: " + filesetIdent));
+    Assertions.assertTrue(exception.getMessage().contains("because it was modified concurrently"));
 
     FilesetEntity persistedEntity =
         FilesetMetaService.getInstance().getFilesetByIdentifier(filesetIdent);

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
@@ -35,6 +35,12 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
@@ -239,6 +245,57 @@ public class TestFunctionMetaService extends TestJDBCBackend {
     assertEquals(2, versions.size());
     assertTrue(versions.containsKey(1));
     assertTrue(versions.containsKey(2));
+  }
+
+  @TestTemplate
+  public void testUpdateAfterConcurrentDropRollsBackVersionWrite() throws Exception {
+    String functionName = GravitinoITUtils.genRandomName("concurrent_function");
+    Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    CountDownLatch snapshotLoaded = new CountDownLatch(1);
+    CountDownLatch continueUpdate = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<FunctionEntity> staleUpdate =
+          executor.submit(
+              () ->
+                  FunctionMetaService.getInstance()
+                      .updateFunction(
+                          function.nameIdentifier(),
+                          (FunctionEntity oldFunction) -> {
+                            snapshotLoaded.countDown();
+                            awaitLatch(continueUpdate);
+                            return FunctionEntity.builder()
+                                .withId(oldFunction.id())
+                                .withName(oldFunction.name())
+                                .withNamespace(oldFunction.namespace())
+                                .withComment("stale update")
+                                .withFunctionType(oldFunction.functionType())
+                                .withDeterministic(oldFunction.deterministic())
+                                .withDefinitions(oldFunction.definitions())
+                                .withAuditInfo(oldFunction.auditInfo())
+                                .build();
+                          }));
+
+      assertTrue(snapshotLoaded.await(10, TimeUnit.SECONDS));
+      assertTrue(FunctionMetaService.getInstance().deleteFunction(function.nameIdentifier()));
+      continueUpdate.countDown();
+
+      ExecutionException exception =
+          assertThrows(ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
+      assertTrue(exception.getCause() instanceof IOException);
+    } finally {
+      continueUpdate.countDown();
+      executor.shutdownNow();
+    }
+
+    Map<Integer, Long> versions = listFunctionVersions(function.id());
+    assertEquals(1, versions.size());
+    assertVersionSoftDeleted(versions, 1);
   }
 
   @TestTemplate
@@ -638,5 +695,14 @@ public class TestFunctionMetaService extends TestJDBCBackend {
   private void assertVersionSoftDeleted(Map<Integer, Long> versionDeletedMap, int version) {
     assertTrue(versionDeletedMap.containsKey(version));
     assertTrue(versionDeletedMap.get(version) > 0L);
+  }
+
+  private void awaitLatch(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for concurrent update", e);
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.authorization.Privileges;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
 import org.apache.gravitino.meta.FunctionEntity;
 import org.apache.gravitino.meta.RoleEntity;
@@ -287,7 +288,7 @@ public class TestFunctionMetaService extends TestJDBCBackend {
 
       ExecutionException exception =
           assertThrows(ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
-      assertTrue(exception.getCause() instanceof IOException);
+      assertTrue(exception.getCause() instanceof OptimisticLockException);
     } finally {
       continueUpdate.countDown();
       executor.shutdownNow();

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
@@ -35,6 +35,12 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
@@ -752,6 +758,84 @@ class TestGroupMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  void testConcurrentUpdateDoesNotChangeRolesOnConflict() throws Exception {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+
+    RoleEntity role1 =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(metalakeName),
+            "role1",
+            AUDIT_INFO,
+            catalogName);
+    RoleEntity role2 =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(metalakeName),
+            "role2",
+            AUDIT_INFO,
+            catalogName);
+    RoleMetaService.getInstance().insertRole(role1, false);
+    RoleMetaService.getInstance().insertRole(role2, false);
+
+    GroupEntity group =
+        createGroupEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofGroupNamespace(metalakeName),
+            "concurrent-group",
+            AUDIT_INFO,
+            Lists.newArrayList(role1.name()),
+            Lists.newArrayList(role1.id()));
+    GroupMetaService.getInstance().insertGroup(group, false);
+
+    CountDownLatch snapshotLoaded = new CountDownLatch(1);
+    CountDownLatch continueUpdate = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<GroupEntity> staleUpdate =
+          executor.submit(
+              () ->
+                  GroupMetaService.getInstance()
+                      .updateGroup(
+                          group.nameIdentifier(),
+                          (GroupEntity oldGroup) -> {
+                            snapshotLoaded.countDown();
+                            awaitLatch(continueUpdate);
+                            List<String> roleNames = Lists.newArrayList(oldGroup.roleNames());
+                            List<Long> roleIds = Lists.newArrayList(oldGroup.roleIds());
+                            roleNames.add(role2.name());
+                            roleIds.add(role2.id());
+                            return GroupEntity.builder()
+                                .withId(oldGroup.id())
+                                .withName(oldGroup.name())
+                                .withNamespace(oldGroup.namespace())
+                                .withExternalId(oldGroup.externalId())
+                                .withRoleNames(roleNames)
+                                .withRoleIds(roleIds)
+                                .withAuditInfo(oldGroup.auditInfo())
+                                .build();
+                          }));
+
+      assertTrue(snapshotLoaded.await(10, TimeUnit.SECONDS));
+      advanceGroupVersion(group.id());
+      continueUpdate.countDown();
+
+      ExecutionException exception =
+          Assertions.assertThrows(
+              ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
+      assertTrue(exception.getCause() instanceof IOException);
+    } finally {
+      continueUpdate.countDown();
+      executor.shutdownNow();
+    }
+
+    GroupEntity storedGroup =
+        GroupMetaService.getInstance().getGroupByIdentifier(group.nameIdentifier());
+    assertEquals(Sets.newHashSet(role1.id()), Sets.newHashSet(storedGroup.roleIds()));
+  }
+
+  @TestTemplate
   void testDeleteMetalake() throws IOException {
     BaseMetalake metalake = createAndInsertMakeLake(metalakeName);
     createAndInsertCatalog(metalakeName, catalogName);
@@ -1133,5 +1217,29 @@ class TestGroupMetaService extends TestJDBCBackend {
         .withRoleIds(null)
         .withAuditInfo(auditInfo)
         .build();
+  }
+
+  private void advanceGroupVersion(long groupId) {
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        Statement statement = connection.createStatement()) {
+      assertEquals(
+          1,
+          statement.executeUpdate(
+              "UPDATE group_meta SET current_version = current_version + 1 WHERE group_id = "
+                  + groupId));
+    } catch (SQLException e) {
+      throw new RuntimeException("Advance group version failed", e);
+    }
+  }
+
+  private void awaitLatch(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for concurrent group update", e);
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
@@ -48,6 +48,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.GroupEntity;
@@ -824,7 +825,7 @@ class TestGroupMetaService extends TestJDBCBackend {
       ExecutionException exception =
           Assertions.assertThrows(
               ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
-      assertTrue(exception.getCause() instanceof IOException);
+      assertTrue(exception.getCause() instanceof OptimisticLockException);
     } finally {
       continueUpdate.countDown();
       executor.shutdownNow();

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelMetaService.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.service;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Instant;
@@ -34,6 +35,8 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.ModelEntity;
+import org.apache.gravitino.meta.ModelVersionEntity;
+import org.apache.gravitino.model.ModelVersion;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
 import org.apache.gravitino.storage.relational.po.ModelPO;
@@ -51,6 +54,56 @@ public class TestModelMetaService extends TestJDBCBackend {
   private static final String SCHEMA_NAME = "schema_for_model_meta_test";
 
   private static final Namespace MODEL_NS = Namespace.of(METALAKE_NAME, CATALOG_NAME, SCHEMA_NAME);
+
+  @TestTemplate
+  public void testModelUpdateAndVersionAddRaiseCurrentVersion() throws IOException {
+    createAndInsertMakeLake(METALAKE_NAME);
+    createAndInsertCatalog(METALAKE_NAME, CATALOG_NAME);
+    createAndInsertSchema(METALAKE_NAME, CATALOG_NAME, SCHEMA_NAME);
+
+    ModelEntity model =
+        createModelEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            MODEL_NS,
+            "cas_model",
+            "comment",
+            0,
+            ImmutableMap.of(),
+            AUDIT_INFO);
+    ModelMetaService.getInstance().insertModel(model, false);
+    Assertions.assertEquals(
+        1L, ModelMetaService.getInstance().getModelPOById(model.id()).getCurrentVersion());
+
+    // updateModel raises current_version (1 -> 2).
+    ModelEntity updated =
+        createModelEntity(
+            model.id(),
+            model.namespace(),
+            model.name(),
+            "comment2",
+            0,
+            ImmutableMap.of(),
+            AUDIT_INFO);
+    Function<ModelEntity, ModelEntity> updater = old -> updated;
+    ModelMetaService.getInstance().updateModel(model.nameIdentifier(), updater);
+    Assertions.assertEquals(
+        2L, ModelMetaService.getInstance().getModelPOById(model.id()).getCurrentVersion());
+
+    // Adding a model version modifies the model, so it also raises current_version (2 -> 3).
+    ModelVersionEntity version =
+        ModelVersionEntity.builder()
+            .withModelIdentifier(model.nameIdentifier())
+            .withVersion(0)
+            .withUris(ImmutableMap.of(ModelVersion.URI_NAME_UNKNOWN, "model_path"))
+            .withAliases(ImmutableList.of())
+            .withComment("version comment")
+            .withProperties(ImmutableMap.of())
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+    ModelVersionMetaService.getInstance().insertModelVersion(version);
+    Assertions.assertEquals(
+        3L, ModelMetaService.getInstance().getModelPOById(model.id()).getCurrentVersion());
+  }
 
   @TestTemplate
   public void testMetaLifeCycleFromCreationToDeletion() throws IOException {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelMetaService.java
@@ -28,8 +28,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
+import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -44,6 +48,7 @@ import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
+import org.mockito.Mockito;
 
 public class TestModelMetaService extends TestJDBCBackend {
 
@@ -54,6 +59,49 @@ public class TestModelMetaService extends TestJDBCBackend {
   private static final String SCHEMA_NAME = "schema_for_model_meta_test";
 
   private static final Namespace MODEL_NS = Namespace.of(METALAKE_NAME, CATALOG_NAME, SCHEMA_NAME);
+
+  @TestTemplate
+  public void testUpdateModelWithCacheDisabled() throws IOException, IllegalAccessException {
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.get(Configs.CACHE_ENABLED)).thenReturn(false);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "config", config, true);
+
+    createAndInsertMakeLake(METALAKE_NAME);
+    createAndInsertCatalog(METALAKE_NAME, CATALOG_NAME);
+    createAndInsertSchema(METALAKE_NAME, CATALOG_NAME, SCHEMA_NAME);
+
+    ModelEntity model =
+        createModelEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            MODEL_NS,
+            "cache_disabled_model",
+            "comment",
+            0,
+            ImmutableMap.of(),
+            AUDIT_INFO);
+    ModelMetaService.getInstance().insertModel(model, false);
+
+    ModelMetaService.getInstance()
+        .updateModel(
+            model.nameIdentifier(),
+            entity -> {
+              ModelEntity oldModel = (ModelEntity) entity;
+              return ModelEntity.builder()
+                  .withId(oldModel.id())
+                  .withName(oldModel.name())
+                  .withNamespace(oldModel.namespace())
+                  .withComment("updated comment")
+                  .withLatestVersion(oldModel.latestVersion())
+                  .withProperties(oldModel.properties())
+                  .withAuditInfo(oldModel.auditInfo())
+                  .build();
+            });
+
+    ModelPO updatedModel =
+        ModelMetaService.getInstance().getModelPOByIdentifier(model.nameIdentifier());
+    Assertions.assertEquals(2L, updatedModel.getCurrentVersion());
+    Assertions.assertEquals(2L, updatedModel.getLastVersion());
+  }
 
   @TestTemplate
   public void testModelUpdateAndVersionAddRaiseCurrentVersion() throws IOException {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelMetaService.java
@@ -62,45 +62,52 @@ public class TestModelMetaService extends TestJDBCBackend {
 
   @TestTemplate
   public void testUpdateModelWithCacheDisabled() throws IOException, IllegalAccessException {
+    // GravitinoEnv is a JVM-wide singleton, so the original config has to be restored before
+    // leaving this test; otherwise every later test in the same JVM sees the mock.
+    Object originalConfig = FieldUtils.readField(GravitinoEnv.getInstance(), "config", true);
     Config config = Mockito.mock(Config.class);
     Mockito.when(config.get(Configs.CACHE_ENABLED)).thenReturn(false);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "config", config, true);
 
-    createAndInsertMakeLake(METALAKE_NAME);
-    createAndInsertCatalog(METALAKE_NAME, CATALOG_NAME);
-    createAndInsertSchema(METALAKE_NAME, CATALOG_NAME, SCHEMA_NAME);
+    try {
+      createAndInsertMakeLake(METALAKE_NAME);
+      createAndInsertCatalog(METALAKE_NAME, CATALOG_NAME);
+      createAndInsertSchema(METALAKE_NAME, CATALOG_NAME, SCHEMA_NAME);
 
-    ModelEntity model =
-        createModelEntity(
-            RandomIdGenerator.INSTANCE.nextId(),
-            MODEL_NS,
-            "cache_disabled_model",
-            "comment",
-            0,
-            ImmutableMap.of(),
-            AUDIT_INFO);
-    ModelMetaService.getInstance().insertModel(model, false);
+      ModelEntity model =
+          createModelEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              MODEL_NS,
+              "cache_disabled_model",
+              "comment",
+              0,
+              ImmutableMap.of(),
+              AUDIT_INFO);
+      ModelMetaService.getInstance().insertModel(model, false);
 
-    ModelMetaService.getInstance()
-        .updateModel(
-            model.nameIdentifier(),
-            entity -> {
-              ModelEntity oldModel = (ModelEntity) entity;
-              return ModelEntity.builder()
-                  .withId(oldModel.id())
-                  .withName(oldModel.name())
-                  .withNamespace(oldModel.namespace())
-                  .withComment("updated comment")
-                  .withLatestVersion(oldModel.latestVersion())
-                  .withProperties(oldModel.properties())
-                  .withAuditInfo(oldModel.auditInfo())
-                  .build();
-            });
+      ModelMetaService.getInstance()
+          .updateModel(
+              model.nameIdentifier(),
+              entity -> {
+                ModelEntity oldModel = (ModelEntity) entity;
+                return ModelEntity.builder()
+                    .withId(oldModel.id())
+                    .withName(oldModel.name())
+                    .withNamespace(oldModel.namespace())
+                    .withComment("updated comment")
+                    .withLatestVersion(oldModel.latestVersion())
+                    .withProperties(oldModel.properties())
+                    .withAuditInfo(oldModel.auditInfo())
+                    .build();
+              });
 
-    ModelPO updatedModel =
-        ModelMetaService.getInstance().getModelPOByIdentifier(model.nameIdentifier());
-    Assertions.assertEquals(2L, updatedModel.getCurrentVersion());
-    Assertions.assertEquals(2L, updatedModel.getLastVersion());
+      ModelPO updatedModel =
+          ModelMetaService.getInstance().getModelPOByIdentifier(model.nameIdentifier());
+      Assertions.assertEquals(2L, updatedModel.getCurrentVersion());
+      Assertions.assertEquals(2L, updatedModel.getLastVersion());
+    } finally {
+      FieldUtils.writeField(GravitinoEnv.getInstance(), "config", originalConfig, true);
+    }
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestPolicyMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestPolicyMetaService.java
@@ -34,6 +34,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
@@ -41,6 +47,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.FilesetEntity;
@@ -221,6 +228,67 @@ public class TestPolicyMetaService extends TestJDBCBackend {
     assertTrue(versionDeletedMap2.containsKey(3));
     assertEquals(0L, versionDeletedMap2.get(3));
     assertEquals(1, versionDeletedMap2.values().stream().filter(value -> value == 0L).count());
+  }
+
+  @TestTemplate
+  public void testVersionedUpdateRollsBackAfterConcurrentAuditUpdate() throws Exception {
+    createAndInsertMakeLake(METALAKE_NAME);
+    PolicyEntity policy =
+        createPolicy(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofPolicy(METALAKE_NAME),
+            "concurrent-policy",
+            AUDIT_INFO);
+    PolicyMetaService.getInstance().insertPolicy(policy, false);
+
+    CountDownLatch snapshotLoaded = new CountDownLatch(1);
+    CountDownLatch continueVersionedUpdate = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<PolicyEntity> versionedUpdate =
+          executor.submit(
+              () ->
+                  PolicyMetaService.getInstance()
+                      .updatePolicy(
+                          policy.nameIdentifier(),
+                          (PolicyEntity oldPolicy) -> {
+                            snapshotLoaded.countDown();
+                            awaitLatch(continueVersionedUpdate);
+                            return copyPolicy(
+                                oldPolicy,
+                                "stale versioned update",
+                                (AuditInfo) oldPolicy.auditInfo());
+                          }));
+
+      assertTrue(snapshotLoaded.await(10, TimeUnit.SECONDS));
+      AuditInfo concurrentAudit =
+          AuditInfo.builder()
+              .withCreator(policy.auditInfo().creator())
+              .withCreateTime(policy.auditInfo().createTime())
+              .withLastModifier("audit-writer")
+              .withLastModifiedTime(Instant.now())
+              .build();
+      PolicyMetaService.getInstance()
+          .updatePolicy(
+              policy.nameIdentifier(),
+              (PolicyEntity oldPolicy) ->
+                  copyPolicy(oldPolicy, oldPolicy.comment(), concurrentAudit));
+      continueVersionedUpdate.countDown();
+
+      ExecutionException exception =
+          assertThrows(ExecutionException.class, () -> versionedUpdate.get(10, TimeUnit.SECONDS));
+      assertTrue(exception.getCause() instanceof IOException);
+    } finally {
+      continueVersionedUpdate.countDown();
+      executor.shutdownNow();
+    }
+
+    Map<Integer, Long> versions = listPolicyVersions(policy.id());
+    assertEquals(1, versions.size());
+    assertEquals(0L, versions.get(1));
+    PolicyEntity storedPolicy =
+        PolicyMetaService.getInstance().getPolicyByIdentifier(policy.nameIdentifier());
+    assertEquals("audit-writer", storedPolicy.auditInfo().lastModifier());
   }
 
   @TestTemplate
@@ -1076,6 +1144,28 @@ public class TestPolicyMetaService extends TestJDBCBackend {
       }
     } catch (SQLException se) {
       throw new RuntimeException("SQL execution failed", se);
+    }
+  }
+
+  private PolicyEntity copyPolicy(PolicyEntity policy, String comment, AuditInfo auditInfo) {
+    return PolicyEntity.builder()
+        .withId(policy.id())
+        .withNamespace(policy.namespace())
+        .withName(policy.name())
+        .withPolicyType(policy.policyType())
+        .withComment(comment)
+        .withEnabled(policy.enabled())
+        .withContent(policy.content())
+        .withAuditInfo(auditInfo)
+        .build();
+  }
+
+  private void awaitLatch(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for concurrent operation", e);
     }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestPolicyMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestPolicyMetaService.java
@@ -47,6 +47,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
@@ -277,7 +278,7 @@ public class TestPolicyMetaService extends TestJDBCBackend {
 
       ExecutionException exception =
           assertThrows(ExecutionException.class, () -> versionedUpdate.get(10, TimeUnit.SECONDS));
-      assertTrue(exception.getCause() instanceof IOException);
+      assertTrue(exception.getCause() instanceof OptimisticLockException);
     } finally {
       continueVersionedUpdate.countDown();
       executor.shutdownNow();

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestRoleMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestRoleMetaService.java
@@ -37,6 +37,12 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
@@ -836,6 +842,72 @@ class TestRoleMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  void testConcurrentUpdateDoesNotChangeSecurableObjectsOnConflict() throws Exception {
+    createAndInsertMakeLake(METALAKE_NAME);
+    createAndInsertCatalog(METALAKE_NAME, "catalog");
+
+    RoleEntity role =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(METALAKE_NAME),
+            "concurrent-role",
+            AUDIT_INFO,
+            "catalog");
+    RoleMetaService.getInstance().insertRole(role, false);
+
+    CountDownLatch snapshotLoaded = new CountDownLatch(1);
+    CountDownLatch continueUpdate = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<RoleEntity> staleUpdate =
+          executor.submit(
+              () ->
+                  RoleMetaService.getInstance()
+                      .updateRole(
+                          role.nameIdentifier(),
+                          (RoleEntity oldRole) -> {
+                            snapshotLoaded.countDown();
+                            awaitLatch(continueUpdate);
+                            List<SecurableObject> securableObjects =
+                                Lists.newArrayList(oldRole.securableObjects());
+                            securableObjects.add(
+                                SecurableObjects.ofMetalake(
+                                    METALAKE_NAME,
+                                    Lists.newArrayList(Privileges.CreateTable.allow())));
+                            return RoleEntity.builder()
+                                .withId(oldRole.id())
+                                .withName(oldRole.name())
+                                .withNamespace(oldRole.namespace())
+                                .withProperties(oldRole.properties())
+                                .withSecurableObjects(securableObjects)
+                                .withAuditInfo(oldRole.auditInfo())
+                                .build();
+                          }));
+
+      assertTrue(snapshotLoaded.await(10, TimeUnit.SECONDS));
+      advanceRoleVersion(role.id());
+      continueUpdate.countDown();
+
+      ExecutionException exception =
+          Assertions.assertThrows(
+              ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
+      assertTrue(exception.getCause() instanceof IOException);
+    } finally {
+      continueUpdate.countDown();
+      executor.shutdownNow();
+    }
+
+    RoleEntity storedRole =
+        RoleMetaService.getInstance().getRoleByIdentifier(role.nameIdentifier());
+    assertTrue(
+        CollectionUtils.isEqualCollection(
+            Lists.newArrayList(
+                SecurableObjects.ofCatalog(
+                    "catalog", Lists.newArrayList(Privileges.UseCatalog.allow()))),
+            storedRole.securableObjects()));
+  }
+
+  @TestTemplate
   void testDeleteMetalakeCascade() throws IOException {
     BaseMetalake metalake = createAndInsertMakeLake(METALAKE_NAME);
     createAndInsertCatalog(METALAKE_NAME, "catalog");
@@ -1126,5 +1198,29 @@ class TestRoleMetaService extends TestJDBCBackend {
       throw new RuntimeException("SQL execution failed", e);
     }
     return count;
+  }
+
+  private void advanceRoleVersion(long roleId) {
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        Statement statement = connection.createStatement()) {
+      assertEquals(
+          1,
+          statement.executeUpdate(
+              "UPDATE role_meta SET current_version = current_version + 1 WHERE role_id = "
+                  + roleId));
+    } catch (SQLException e) {
+      throw new RuntimeException("Advance role version failed", e);
+    }
+  }
+
+  private void awaitLatch(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for concurrent role update", e);
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestRoleMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestRoleMetaService.java
@@ -52,6 +52,7 @@ import org.apache.gravitino.authorization.Privileges;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
@@ -891,7 +892,7 @@ class TestRoleMetaService extends TestJDBCBackend {
       ExecutionException exception =
           Assertions.assertThrows(
               ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
-      assertTrue(exception.getCause() instanceof IOException);
+      assertTrue(exception.getCause() instanceof OptimisticLockException);
     } finally {
       continueUpdate.countDown();
       executor.shutdownNow();

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTableMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTableMetaService.java
@@ -27,6 +27,12 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -175,6 +181,61 @@ public class TestTableMetaService extends TestJDBCBackend {
       backend.hardDeleteLegacyData(entityType, Instant.now().toEpochMilli() + 1000);
     }
     assertFalse(legacyRecordExistsInDB(table.id(), Entity.EntityType.TABLE));
+  }
+
+  @TestTemplate
+  public void testConcurrentUpdateRollsBackLosingVersionWrite() throws Exception {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+    createAndInsertSchema(metalakeName, catalogName, schemaName);
+
+    TableEntity table =
+        createTableEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofTable(metalakeName, catalogName, schemaName),
+            "concurrent-table",
+            AUDIT_INFO);
+    TableMetaService.getInstance().insertTable(table, false);
+
+    CountDownLatch snapshotsLoaded = new CountDownLatch(2);
+    CountDownLatch startUpdates = new CountDownLatch(1);
+    Queue<TableEntity> successfulUpdates = new ConcurrentLinkedQueue<>();
+    Queue<Throwable> failedUpdates = new ConcurrentLinkedQueue<>();
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      executor.submit(
+          concurrentTableUpdate(
+              table.nameIdentifier(),
+              "first update",
+              snapshotsLoaded,
+              startUpdates,
+              successfulUpdates,
+              failedUpdates));
+      executor.submit(
+          concurrentTableUpdate(
+              table.nameIdentifier(),
+              "second update",
+              snapshotsLoaded,
+              startUpdates,
+              successfulUpdates,
+              failedUpdates));
+
+      assertTrue(snapshotsLoaded.await(10, TimeUnit.SECONDS));
+      startUpdates.countDown();
+      executor.shutdown();
+      assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    } finally {
+      startUpdates.countDown();
+      executor.shutdownNow();
+    }
+
+    Assertions.assertEquals(1, successfulUpdates.size());
+    Assertions.assertEquals(1, failedUpdates.size());
+    assertTrue(failedUpdates.peek() instanceof IOException);
+
+    TableEntity storedTable =
+        TableMetaService.getInstance().getTableByIdentifier(table.nameIdentifier());
+    Assertions.assertEquals(successfulUpdates.peek().comment(), storedTable.comment());
   }
 
   @TestTemplate
@@ -451,5 +512,46 @@ public class TestTableMetaService extends TestJDBCBackend {
           Assertions.assertEquals(expectedColumn.defaultValue(), column.defaultValue());
           Assertions.assertEquals(expectedColumn.auditInfo(), column.auditInfo());
         });
+  }
+
+  private Runnable concurrentTableUpdate(
+      NameIdentifier identifier,
+      String comment,
+      CountDownLatch snapshotsLoaded,
+      CountDownLatch startUpdates,
+      Queue<TableEntity> successfulUpdates,
+      Queue<Throwable> failedUpdates) {
+    return () -> {
+      try {
+        TableEntity result =
+            TableMetaService.getInstance()
+                .updateTable(
+                    identifier,
+                    (TableEntity oldTable) -> {
+                      snapshotsLoaded.countDown();
+                      awaitLatch(startUpdates);
+                      return TableEntity.builder()
+                          .withId(oldTable.id())
+                          .withName(oldTable.name())
+                          .withNamespace(oldTable.namespace())
+                          .withComment(comment)
+                          .withColumns(oldTable.columns())
+                          .withAuditInfo(oldTable.auditInfo())
+                          .build();
+                    });
+        successfulUpdates.add(result);
+      } catch (Throwable t) {
+        failedUpdates.add(t);
+      }
+    };
+  }
+
+  private void awaitLatch(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for concurrent update", e);
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTableMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTableMetaService.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.ColumnEntity;
@@ -231,7 +232,7 @@ public class TestTableMetaService extends TestJDBCBackend {
 
     Assertions.assertEquals(1, successfulUpdates.size());
     Assertions.assertEquals(1, failedUpdates.size());
-    assertTrue(failedUpdates.peek() instanceof IOException);
+    assertTrue(failedUpdates.peek() instanceof OptimisticLockException);
 
     TableEntity storedTable =
         TableMetaService.getInstance().getTableByIdentifier(table.nameIdentifier());

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTopicMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTopicMetaService.java
@@ -33,11 +33,17 @@ import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.meta.TopicEntity;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
+import org.apache.gravitino.storage.relational.po.TopicPO;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
+import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -46,12 +52,48 @@ public class TestTopicMetaService extends TestJDBCBackend {
   private final String metalakeName = "metalake_for_topic_test";
   private final String catalogName = "catalog_for_topic_test";
   private final String schemaName = "schema_for_topic_test";
+  private long schemaId;
 
   @BeforeEach
   public void prepare() throws IOException {
     createAndInsertMakeLake(metalakeName);
     createAndInsertCatalog(metalakeName, catalogName);
-    createAndInsertSchema(metalakeName, catalogName, schemaName);
+    SchemaEntity schema = createAndInsertSchema(metalakeName, catalogName, schemaName);
+    schemaId = schema.id();
+  }
+
+  @TestTemplate
+  public void testUpdateTopicMetaIsVersionCas() throws IOException {
+    TopicEntity topic =
+        createTopicEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofTopic(metalakeName, catalogName, schemaName),
+            "cas_topic",
+            AUDIT_INFO);
+    backend.insert(topic, false);
+
+    TopicEntity updated =
+        createTopicEntity(
+            topic.id(),
+            NamespaceUtil.ofTopic(metalakeName, catalogName, schemaName),
+            "cas_topic",
+            AUDIT_INFO);
+
+    try (SqlSession session =
+        SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true)) {
+      TopicMetaMapper mapper = session.getMapper(TopicMetaMapper.class);
+      TopicPO oldPO = mapper.selectTopicMetaBySchemaIdAndName(schemaId, "cas_topic");
+      Assertions.assertEquals(1L, oldPO.getCurrentVersion());
+
+      // A write against the current version succeeds and advances the version (1 -> 2).
+      TopicPO newPO = POConverters.updateTopicPOWithVersion(oldPO, updated);
+      Assertions.assertEquals(2L, newPO.getCurrentVersion());
+      Assertions.assertEquals(1, mapper.updateTopicMeta(newPO, oldPO));
+
+      // A second write reusing the now-stale snapshot (version 1) matches 0 rows: version CAS lost.
+      TopicPO staleNewPO = POConverters.updateTopicPOWithVersion(oldPO, updated);
+      Assertions.assertEquals(0, mapper.updateTopicMeta(staleNewPO, oldPO));
+    }
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTopicMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTopicMetaService.java
@@ -97,6 +97,50 @@ public class TestTopicMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  public void testInsertWithOverwriteAdvancesVersionCas() throws IOException {
+    TopicEntity topic =
+        createTopicEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofTopic(metalakeName, catalogName, schemaName),
+            "overwrite_cas_topic",
+            AUDIT_INFO);
+    backend.insert(topic, false);
+
+    TopicPO staleSnapshot;
+    try (SqlSession session =
+        SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true)) {
+      staleSnapshot =
+          session
+              .getMapper(TopicMetaMapper.class)
+              .selectTopicMetaBySchemaIdAndName(schemaId, "overwrite_cas_topic");
+    }
+    Assertions.assertEquals(1L, staleSnapshot.getCurrentVersion());
+
+    // An overwrite-create replaces the row's content. It must advance the version instead of
+    // rewriting it from the new PO, otherwise it would reset the CAS token back to 1.
+    TopicEntity overwritten =
+        createTopicEntity(
+            topic.id(),
+            NamespaceUtil.ofTopic(metalakeName, catalogName, schemaName),
+            "overwrite_cas_topic",
+            AUDIT_INFO);
+    backend.insert(overwritten, true);
+
+    // A fresh session is required: MyBatis serves a repeated query from the session-local cache.
+    try (SqlSession session =
+        SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true)) {
+      TopicMetaMapper mapper = session.getMapper(TopicMetaMapper.class);
+      TopicPO reloaded = mapper.selectTopicMetaBySchemaIdAndName(schemaId, "overwrite_cas_topic");
+      Assertions.assertEquals(2L, reloaded.getCurrentVersion());
+      Assertions.assertEquals(2L, reloaded.getLastVersion());
+
+      // A writer still holding the pre-overwrite snapshot must lose the CAS.
+      TopicPO staleNewPO = POConverters.updateTopicPOWithVersion(staleSnapshot, overwritten);
+      Assertions.assertEquals(0, mapper.updateTopicMeta(staleNewPO, staleSnapshot));
+    }
+  }
+
+  @TestTemplate
   public void testInsertAlreadyExistsException() throws IOException {
     TopicEntity topic =
         createTopicEntity(

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestUserMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestUserMetaService.java
@@ -36,6 +36,12 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -874,6 +880,85 @@ class TestUserMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  void testConcurrentUpdateDoesNotChangeRolesOnConflict() throws Exception {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, "catalog");
+
+    RoleEntity role1 =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(metalakeName),
+            "role1",
+            AUDIT_INFO,
+            "catalog");
+    RoleEntity role2 =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(metalakeName),
+            "role2",
+            AUDIT_INFO,
+            "catalog");
+    RoleMetaService.getInstance().insertRole(role1, false);
+    RoleMetaService.getInstance().insertRole(role2, false);
+
+    UserEntity user =
+        createUserEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofUserNamespace(metalakeName),
+            "concurrent-user",
+            AUDIT_INFO,
+            Lists.newArrayList(role1.name()),
+            Lists.newArrayList(role1.id()));
+    UserMetaService.getInstance().insertUser(user, false);
+
+    CountDownLatch snapshotLoaded = new CountDownLatch(1);
+    CountDownLatch continueUpdate = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<UserEntity> staleUpdate =
+          executor.submit(
+              () ->
+                  UserMetaService.getInstance()
+                      .updateUser(
+                          user.nameIdentifier(),
+                          (UserEntity oldUser) -> {
+                            snapshotLoaded.countDown();
+                            awaitLatch(continueUpdate);
+                            List<String> roleNames = Lists.newArrayList(oldUser.roleNames());
+                            List<Long> roleIds = Lists.newArrayList(oldUser.roleIds());
+                            roleNames.add(role2.name());
+                            roleIds.add(role2.id());
+                            return UserEntity.builder()
+                                .withId(oldUser.id())
+                                .withName(oldUser.name())
+                                .withNamespace(oldUser.namespace())
+                                .withExternalId(oldUser.externalId())
+                                .withEnabled(oldUser.enabled())
+                                .withRoleNames(roleNames)
+                                .withRoleIds(roleIds)
+                                .withAuditInfo(oldUser.auditInfo())
+                                .build();
+                          }));
+
+      assertTrue(snapshotLoaded.await(10, TimeUnit.SECONDS));
+      advanceUserVersion(user.id());
+      continueUpdate.countDown();
+
+      ExecutionException exception =
+          Assertions.assertThrows(
+              ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
+      assertTrue(exception.getCause() instanceof IOException);
+    } finally {
+      continueUpdate.countDown();
+      executor.shutdownNow();
+    }
+
+    UserEntity storedUser =
+        UserMetaService.getInstance().getUserByIdentifier(user.nameIdentifier());
+    assertEquals(Sets.newHashSet(role1.id()), Sets.newHashSet(storedUser.roleIds()));
+  }
+
+  @TestTemplate
   void deleteMetalake() throws IOException {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
@@ -1300,6 +1385,52 @@ class TestUserMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  void testConcurrentExternalIdUpdateRollsBackOnConflict() throws Exception {
+    UserMetaService service = userMetaService();
+    UserEntity user = userWithExtId("concurrent-user", "concurrent-ext-id");
+    service.insertUser(user, false);
+
+    CountDownLatch snapshotLoaded = new CountDownLatch(1);
+    CountDownLatch continueUpdate = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<UserEntity> staleUpdate =
+          executor.submit(
+              () ->
+                  service.updateUserByExternalId(
+                      userExtIdent(user.externalId()),
+                      (UserEntity oldUser) -> {
+                        snapshotLoaded.countDown();
+                        awaitLatch(continueUpdate);
+                        return UserEntity.builder()
+                            .withId(oldUser.id())
+                            .withName(oldUser.name())
+                            .withNamespace(oldUser.namespace())
+                            .withExternalId(oldUser.externalId())
+                            .withEnabled(false)
+                            .withRoleNames(oldUser.roleNames())
+                            .withRoleIds(oldUser.roleIds())
+                            .withAuditInfo(oldUser.auditInfo())
+                            .build();
+                      }));
+
+      assertTrue(snapshotLoaded.await(10, TimeUnit.SECONDS));
+      advanceUserVersion(user.id());
+      continueUpdate.countDown();
+
+      ExecutionException exception =
+          Assertions.assertThrows(
+              ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
+      assertTrue(exception.getCause() instanceof IOException);
+    } finally {
+      continueUpdate.countDown();
+      executor.shutdownNow();
+    }
+
+    assertTrue(queryEnabledByExtId(user.externalId()));
+  }
+
+  @TestTemplate
   void testExtEnableDel() throws IOException {
     UserMetaService svc = userMetaService();
     UserEntity user = userWithExtId("u1", "ext-del");
@@ -1440,5 +1571,29 @@ class TestUserMetaService extends TestJDBCBackend {
       throw new RuntimeException("SQL execution failed", e);
     }
     return count;
+  }
+
+  private void advanceUserVersion(long userId) {
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        Statement statement = connection.createStatement()) {
+      assertEquals(
+          1,
+          statement.executeUpdate(
+              "UPDATE user_meta SET current_version = current_version + 1 WHERE user_id = "
+                  + userId));
+    } catch (SQLException e) {
+      throw new RuntimeException("Advance user version failed", e);
+    }
+  }
+
+  private void awaitLatch(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for concurrent user update", e);
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestUserMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestUserMetaService.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
@@ -947,7 +948,7 @@ class TestUserMetaService extends TestJDBCBackend {
       ExecutionException exception =
           Assertions.assertThrows(
               ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
-      assertTrue(exception.getCause() instanceof IOException);
+      assertTrue(exception.getCause() instanceof OptimisticLockException);
     } finally {
       continueUpdate.countDown();
       executor.shutdownNow();
@@ -1421,7 +1422,7 @@ class TestUserMetaService extends TestJDBCBackend {
       ExecutionException exception =
           Assertions.assertThrows(
               ExecutionException.class, () -> staleUpdate.get(10, TimeUnit.SECONDS));
-      assertTrue(exception.getCause() instanceof IOException);
+      assertTrue(exception.getCause() instanceof OptimisticLockException);
     } finally {
       continueUpdate.countDown();
       executor.shutdownNow();

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestViewMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestViewMetaService.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TagEntity;
@@ -185,7 +186,7 @@ public class TestViewMetaService extends TestJDBCBackend {
             .build();
 
     assertThrows(
-        IOException.class,
+        OptimisticLockException.class,
         () ->
             ViewMetaService.getInstance()
                 .updateView(

--- a/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
@@ -806,6 +806,43 @@ public class TestPOConverters {
   }
 
   @Test
+  public void testUpdateModelPOVersionIncrements() throws JsonProcessingException {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
+    Namespace ns = Namespace.of("test_metalake", "test_catalog", "test_schema");
+    ModelEntity model =
+        ModelEntity.builder()
+            .withId(1L)
+            .withName("test")
+            .withNamespace(ns)
+            .withComment("this is test")
+            .withProperties(ImmutableMap.of("key", "value"))
+            .withLatestVersion(1)
+            .withAuditInfo(auditInfo)
+            .build();
+    ModelEntity updatedModel =
+        ModelEntity.builder()
+            .withId(1L)
+            .withName("test")
+            .withNamespace(ns)
+            .withComment("this is test2")
+            .withProperties(ImmutableMap.of("key", "value"))
+            .withLatestVersion(1)
+            .withAuditInfo(auditInfo)
+            .build();
+    ModelPO initPO =
+        POConverters.initializeModelPO(
+            model, ModelPO.builder().withMetalakeId(1L).withCatalogId(1L).withSchemaId(1L));
+    assertEquals(1L, initPO.getCurrentVersion());
+
+    ModelPO updatePO = POConverters.updateModelPO(initPO, updatedModel);
+
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2L, updatePO.getCurrentVersion());
+    assertEquals(2L, updatePO.getLastVersion());
+  }
+
+  @Test
   public void testUpdateFilesetPOVersion() throws JsonProcessingException {
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");

--- a/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
@@ -51,9 +51,11 @@ import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.ColumnEntity;
 import org.apache.gravitino.meta.FilesetEntity;
+import org.apache.gravitino.meta.GroupEntity;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.meta.PolicyEntity;
+import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.meta.StatisticEntity;
@@ -61,6 +63,7 @@ import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.meta.TableStatisticEntity;
 import org.apache.gravitino.meta.TagEntity;
 import org.apache.gravitino.meta.TopicEntity;
+import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.policy.Policy;
 import org.apache.gravitino.policy.PolicyContent;
 import org.apache.gravitino.policy.PolicyContents;
@@ -79,6 +82,7 @@ import org.apache.gravitino.storage.relational.po.CatalogPO;
 import org.apache.gravitino.storage.relational.po.ColumnPO;
 import org.apache.gravitino.storage.relational.po.FilesetPO;
 import org.apache.gravitino.storage.relational.po.FilesetVersionPO;
+import org.apache.gravitino.storage.relational.po.GroupPO;
 import org.apache.gravitino.storage.relational.po.MetalakePO;
 import org.apache.gravitino.storage.relational.po.ModelPO;
 import org.apache.gravitino.storage.relational.po.ModelVersionAliasRelPO;
@@ -86,6 +90,7 @@ import org.apache.gravitino.storage.relational.po.ModelVersionPO;
 import org.apache.gravitino.storage.relational.po.OwnerRelPO;
 import org.apache.gravitino.storage.relational.po.PolicyPO;
 import org.apache.gravitino.storage.relational.po.PolicyVersionPO;
+import org.apache.gravitino.storage.relational.po.RolePO;
 import org.apache.gravitino.storage.relational.po.SchemaPO;
 import org.apache.gravitino.storage.relational.po.SecurableObjectPO;
 import org.apache.gravitino.storage.relational.po.StatisticPO;
@@ -93,6 +98,7 @@ import org.apache.gravitino.storage.relational.po.TablePO;
 import org.apache.gravitino.storage.relational.po.TagMetadataObjectRelPO;
 import org.apache.gravitino.storage.relational.po.TagPO;
 import org.apache.gravitino.storage.relational.po.TopicPO;
+import org.apache.gravitino.storage.relational.po.UserPO;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.junit.jupiter.api.Assertions;
@@ -666,6 +672,9 @@ public class TestPOConverters {
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
     assertEquals("this is test2", updatePO.getMetalakeComment());
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
   }
 
   @Test
@@ -680,6 +689,9 @@ public class TestPOConverters {
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
     assertEquals("this is test2", updatePO.getCatalogComment());
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
   }
 
   @Test
@@ -697,6 +709,9 @@ public class TestPOConverters {
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
     assertEquals("this is test2", updatePO.getSchemaComment());
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
   }
 
   @Test
@@ -715,6 +730,79 @@ public class TestPOConverters {
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
     assertEquals("test", updatePO.getTableName());
+  }
+
+  @Test
+  public void testUpdateTopicPOVersionIncrements() throws JsonProcessingException {
+    TopicPO initPO =
+        createTopicPO(1L, "test", 1L, 1L, 1L, "this is test", ImmutableMap.of("key", "value"));
+    TopicEntity updatedTopic =
+        createTopic(
+            1L,
+            "test",
+            NamespaceUtil.ofTopic("test_metalake", "test_catalog", "test_schema"),
+            "this is test2",
+            ImmutableMap.of("key", "value"));
+
+    TopicPO updatePO = POConverters.updateTopicPOWithVersion(initPO, updatedTopic);
+
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
+  }
+
+  @Test
+  public void testUpdateUserPOVersionIncrements() throws JsonProcessingException {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
+    UserEntity user =
+        UserEntity.builder().withId(1L).withName("test").withAuditInfo(auditInfo).build();
+    UserEntity updatedUser =
+        UserEntity.builder().withId(1L).withName("test2").withAuditInfo(auditInfo).build();
+    UserPO initPO =
+        POConverters.initializeUserPOWithVersion(user, UserPO.builder().withMetalakeId(1L));
+
+    UserPO updatePO = POConverters.updateUserPOWithVersion(initPO, updatedUser);
+
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
+  }
+
+  @Test
+  public void testUpdateGroupPOVersionIncrements() throws JsonProcessingException {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
+    GroupEntity group =
+        GroupEntity.builder().withId(1L).withName("test").withAuditInfo(auditInfo).build();
+    GroupEntity updatedGroup =
+        GroupEntity.builder().withId(1L).withName("test2").withAuditInfo(auditInfo).build();
+    GroupPO initPO =
+        POConverters.initializeGroupPOWithVersion(group, GroupPO.builder().withMetalakeId(1L));
+
+    GroupPO updatePO = POConverters.updateGroupPOWithVersion(initPO, updatedGroup);
+
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
+  }
+
+  @Test
+  public void testUpdateRolePOVersionIncrements() throws JsonProcessingException {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
+    RoleEntity role =
+        RoleEntity.builder().withId(1L).withName("test").withAuditInfo(auditInfo).build();
+    RoleEntity updatedRole =
+        RoleEntity.builder().withId(1L).withName("test2").withAuditInfo(auditInfo).build();
+    RolePO initPO =
+        POConverters.initializeRolePOWithVersion(role, RolePO.builder().withMetalakeId(1L));
+
+    RolePO updatePO = POConverters.updateRolePOWithVersion(initPO, updatedRole);
+
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
   }
 
   @Test
@@ -880,6 +968,9 @@ public class TestPOConverters {
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
     assertEquals("this is test2", updatePO.getComment());
+    // A successful update must raise the version so OCC (version CAS) can detect concurrent writes.
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
   }
 
   @Test

--- a/scripts/h2/schema-2.0.0-h2.sql
+++ b/scripts/h2/schema-2.0.0-h2.sql
@@ -346,6 +346,8 @@ CREATE TABLE IF NOT EXISTS `model_meta` (
     `model_comment` CLOB DEFAULT NULL COMMENT 'model comment',
     `model_properties` CLOB DEFAULT NULL COMMENT 'model properties',
     `model_latest_version` INT UNSIGNED DEFAULT 0 COMMENT 'model latest version',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'model current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'model last version',
     `audit_info` CLOB NOT NULL COMMENT 'model audit info',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model deleted at',
     PRIMARY KEY (`model_id`),

--- a/scripts/h2/upgrade-1.3.0-to-2.0.0-h2.sql
+++ b/scripts/h2/upgrade-1.3.0-to-2.0.0-h2.sql
@@ -27,3 +27,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS `uk_mid_geid_del` ON `group_meta` (`metalake_i
 
 ALTER TABLE `table_column_version_info`
     ALTER COLUMN `column_comment` VARCHAR(4096) DEFAULT '';
+
+ALTER TABLE `model_meta` ADD COLUMN `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'model current version' AFTER `model_latest_version`;
+ALTER TABLE `model_meta` ADD COLUMN `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'model last version' AFTER `current_version`;

--- a/scripts/mysql/schema-2.0.0-mysql.sql
+++ b/scripts/mysql/schema-2.0.0-mysql.sql
@@ -337,6 +337,8 @@ CREATE TABLE IF NOT EXISTS `model_meta` (
     `model_comment` TEXT DEFAULT NULL COMMENT 'model comment',
     `model_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model properties',
     `model_latest_version` INT UNSIGNED DEFAULT 0 COMMENT 'model latest version',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'model current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'model last version',
     `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model audit info',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model deleted at',
     PRIMARY KEY (`model_id`),

--- a/scripts/mysql/upgrade-1.3.0-to-2.0.0-mysql.sql
+++ b/scripts/mysql/upgrade-1.3.0-to-2.0.0-mysql.sql
@@ -29,3 +29,7 @@ CREATE UNIQUE INDEX `uk_mid_geid_del` ON `group_meta` (`metalake_id`, `external_
 
 ALTER TABLE `table_column_version_info`
     MODIFY COLUMN `column_comment` VARCHAR(4096) DEFAULT '' COMMENT 'column comment';
+
+ALTER TABLE `model_meta`
+    ADD COLUMN `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'model current version' AFTER `model_latest_version`,
+    ADD COLUMN `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'model last version' AFTER `current_version`;

--- a/scripts/postgresql/schema-2.0.0-postgresql.sql
+++ b/scripts/postgresql/schema-2.0.0-postgresql.sql
@@ -591,11 +591,15 @@ CREATE TABLE IF NOT EXISTS model_meta (
     model_comment VARCHAR(65535) DEFAULT NULL,
     model_properties TEXT DEFAULT NULL,
     model_latest_version INT NOT NULL DEFAULT 0,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
     audit_info TEXT NOT NULL,
     deleted_at BIGINT NOT NULL DEFAULT 0,
     PRIMARY KEY (model_id),
     UNIQUE (schema_id, model_name, deleted_at)
 );
+COMMENT ON COLUMN model_meta.current_version IS 'model current version';
+COMMENT ON COLUMN model_meta.last_version IS 'model last version';
 
 CREATE INDEX IF NOT EXISTS model_meta_idx_metalake_id ON model_meta (metalake_id);
 CREATE INDEX IF NOT EXISTS model_meta_idx_catalog_id ON model_meta (catalog_id);

--- a/scripts/postgresql/upgrade-1.3.0-to-2.0.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-1.3.0-to-2.0.0-postgresql.sql
@@ -31,3 +31,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_mid_geid_del ON group_meta (metalake_id, ex
 
 ALTER TABLE table_column_version_info
     ALTER COLUMN column_comment TYPE VARCHAR(4096);
+
+ALTER TABLE model_meta ADD COLUMN IF NOT EXISTS current_version INT NOT NULL DEFAULT 1;
+ALTER TABLE model_meta ADD COLUMN IF NOT EXISTS last_version INT NOT NULL DEFAULT 1;
+COMMENT ON COLUMN model_meta.current_version IS 'model current version';
+COMMENT ON COLUMN model_meta.last_version IS 'model last version';

--- a/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -136,6 +136,22 @@ public class Utils {
         .build();
   }
 
+  /**
+   * Creates an HTTP conflict response for a failed optimistic-lock update.
+   *
+   * @param message the conflict message
+   * @param throwable the conflict exception
+   * @return the HTTP conflict response
+   */
+  public static Response optimisticLockConflict(String message, Throwable throwable) {
+    return Response.status(Response.Status.CONFLICT)
+        .entity(
+            ErrorResponse.optimisticLockConflict(
+                throwable.getClass().getSimpleName(), message, throwable))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
   public static Response notInUse(String message, Throwable throwable) {
     return notInUse(throwable.getClass().getSimpleName(), message, throwable);
   }

--- a/server-common/src/test/java/org/apache/gravitino/server/web/TestUtils.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/web/TestUtils.java
@@ -31,6 +31,7 @@ import org.apache.gravitino.audit.FilesetAuditConstants;
 import org.apache.gravitino.audit.FilesetDataOperation;
 import org.apache.gravitino.audit.InternalClientType;
 import org.apache.gravitino.dto.responses.ErrorResponse;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -162,6 +163,19 @@ public class TestUtils {
     ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
     assertEquals("RuntimeException", errorResponse.getType());
     assertEquals("New message", errorResponse.getMessage());
+  }
+
+  @Test
+  public void testOptimisticLockConflict() {
+    OptimisticLockException exception = new OptimisticLockException("Conflict");
+    Response response = Utils.optimisticLockConflict("Conflict", exception);
+
+    assertNotNull(response);
+    assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+    assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
+    ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+    assertEquals(OptimisticLockException.class.getSimpleName(), errorResponse.getType());
+    assertEquals("Conflict", errorResponse.getMessage());
   }
 
   @Test

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -43,6 +43,7 @@ import org.apache.gravitino.exceptions.NonEmptyMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.exceptions.NotInUseException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
 import org.apache.gravitino.exceptions.PolicyAlreadyExistsException;
@@ -1103,6 +1104,11 @@ public class ExceptionHandlers {
         // WARN, not ERROR: a dependency outage is not a Gravitino bug, but still trace it here.
         LOG.warn(errorMsg, e);
         return Utils.connectionFailed(errorMsg, e);
+      }
+
+      if (e instanceof OptimisticLockException) {
+        LOG.warn(errorMsg, e);
+        return Utils.optimisticLockConflict(errorMsg, e);
       }
 
       LOG.error(errorMsg, e);

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
@@ -18,6 +18,10 @@
  */
 package org.apache.gravitino.server.web.rest;
 
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.dto.responses.ErrorConstants;
+import org.apache.gravitino.dto.responses.ErrorResponse;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -49,5 +53,20 @@ public class TestExceptionHandlers {
 
     String msg6 = ExceptionHandlers.BaseExceptionHandler.getErrorMsg(e6);
     Assertions.assertEquals("", msg6);
+  }
+
+  @Test
+  public void testOptimisticLockConflictReturnsConflict() {
+    Response response =
+        ExceptionHandlers.handleTableException(
+            OperationType.ALTER,
+            "table",
+            "schema",
+            new OptimisticLockException("The table was modified concurrently"));
+
+    Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+    ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+    Assertions.assertEquals(ErrorConstants.OPTIMISTIC_LOCK_CONFLICT_CODE, errorResponse.getCode());
+    Assertions.assertEquals(OptimisticLockException.class.getSimpleName(), errorResponse.getType());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Makes the Gravitino store's entity **update** path a real optimistic-concurrency (version CAS) operation. Three parts:

1. **Always raise `current_version` on update** for every entity that was freezing it (metalake, catalog, schema, topic, tag, user, group, role). table/view/function already did; fileset/policy stay conditional (they version-history on change).
2. **Slim the `UPDATE ... WHERE`** to `id + current_version + deleted_at` for the always-increment entities, dropping the fragile full-row / JSON-byte compare. fileset/policy keep the full-row compare (their conditional version cannot guard an audit-only concurrent update — proven by an existing OCC test).
3. **model migration**: `model_meta` had no version columns, so it could not do CAS. Adds `current_version`/`last_version` (mysql/postgresql/h2 base schema + 1.3.0->2.0.0 upgrade scripts, `DEFAULT 1`), raises them on `updateModel`, and makes a model-version add also bump `current_version` (adding a version modifies the model).

### Why are the changes needed?

Today no entity does a clean version CAS: updates froze the version and leaned on a byte-for-byte row compare, which is fragile and, under HA, cannot reliably detect concurrent writes. This is the "alter" half of #12166.

Fix: #12166

### Does this PR introduce _any_ user-facing change?

No API change. A write that loses a concurrent race now matches 0 rows (surfaced as the existing update-failure path). Storage: two additive columns on `model_meta` (with an upgrade script); no data migration.

### How was this patch tested?

New unit tests pin post-update version increments across all entities; a DB-level CAS test (topic) asserts stale-version -> 0 rows, current -> 1 row + bump; a model test asserts insert=1 -> updateModel=2 -> add-version=3. Full `storage.relational.*` suite green on H2.

### Note

This is the **alter** half. A follow-up PR (drop-side version-checked soft-delete) will be based on this branch.
