### PR TITLE
[#12170] fix(core): don't hold cache locks across the backend DB call in batchListEntitiesByRelation

### DIFF
--- a/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
@@ -211,6 +211,7 @@ public class CaffeineEntityCache extends BaseEntityCache {
           // bypasses the removal listener; reverseIndex.remove(key) then cleans up only this
           // entry's own bookkeeping (entityToReverseIndexMap + reverseIndex references to it).
           cacheData.invalidate(key);
+          segmentedLock.incrementGeneration(key);
           reverseIndex.remove(key);
           cacheIndex.remove(key.toString());
           return true;
@@ -293,6 +294,7 @@ public class CaffeineEntityCache extends BaseEntityCache {
     segmentedLock.withGlobalLock(
         () -> {
           cacheData.invalidateAll();
+          segmentedLock.incrementAllGenerations();
         });
   }
 
@@ -309,6 +311,39 @@ public class CaffeineEntityCache extends BaseEntityCache {
     segmentedLock.withLock(
         entityCacheKey,
         () -> {
+          syncEntitiesToCache(
+              entityCacheKey, entities.stream().map(e -> (Entity) e).collect(Collectors.toList()));
+        });
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public long relationGeneration(
+      NameIdentifier ident, Entity.EntityType type, SupportsRelationOperations.Type relType) {
+    checkArguments(ident, type, relType);
+    return segmentedLock.generation(EntityCacheRelationKey.of(ident, type, relType));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <E extends Entity & HasIdentifier> void putIfNotInvalidatedSince(
+      NameIdentifier ident,
+      Entity.EntityType type,
+      SupportsRelationOperations.Type relType,
+      List<E> entities,
+      long sinceGeneration) {
+    checkArguments(ident, type, relType);
+    Preconditions.checkArgument(entities != null, "Entities cannot be null");
+    EntityCacheRelationKey entityCacheKey = EntityCacheRelationKey.of(ident, type, relType);
+    segmentedLock.withLock(
+        entityCacheKey,
+        () -> {
+          // The stripe's generation changing means the relation was invalidated after the caller
+          // observed the cache miss. Skip the put so a possibly-stale backend result cannot
+          // overwrite the concurrent invalidation; the entry is rebuilt on the next read.
+          if (segmentedLock.generation(entityCacheKey) != sinceGeneration) {
+            return;
+          }
           syncEntitiesToCache(
               entityCacheKey, entities.stream().map(e -> (Entity) e).collect(Collectors.toList()));
         });
@@ -484,6 +519,7 @@ public class CaffeineEntityCache extends BaseEntityCache {
       visited.add(currentKeyToRemove);
 
       cacheData.invalidate(currentKeyToRemove);
+      segmentedLock.incrementGeneration(currentKeyToRemove);
       cacheIndex.remove(currentKeyToRemove.toString());
 
       // Remove related entity keys

--- a/core/src/main/java/org/apache/gravitino/cache/NoOpsCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/NoOpsCache.java
@@ -148,4 +148,22 @@ public class NoOpsCache extends BaseEntityCache {
       List<E> entities) {
     // do nothing
   }
+
+  /** {@inheritDoc} */
+  @Override
+  public long relationGeneration(
+      NameIdentifier ident, Entity.EntityType type, SupportsRelationOperations.Type relType) {
+    return 0L;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <E extends Entity & HasIdentifier> void putIfNotInvalidatedSince(
+      NameIdentifier ident,
+      Entity.EntityType type,
+      SupportsRelationOperations.Type relType,
+      List<E> entities,
+      long sinceGeneration) {
+    // do nothing
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/cache/SegmentedLock.java
+++ b/core/src/main/java/org/apache/gravitino/cache/SegmentedLock.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
@@ -44,6 +45,15 @@ public class SegmentedLock {
    * #getDistinctSortedLocks} with a guaranteed total order (no hash-collision ties).
    */
   private final Map<Lock, Integer> lockIndices;
+
+  /**
+   * Per-stripe monotonic generation counters. A caller can snapshot a key's counter via {@link
+   * #generation} and later detect whether {@link #incrementGeneration} ran on the same stripe in
+   * the meantime. Counters are per-stripe (not per-key) to reuse the existing striping and stay
+   * bounded; keys that share a stripe share a counter, so an unrelated increment only yields a
+   * false-positive (an increment is never missed), which callers must tolerate.
+   */
+  private final AtomicLong[] generations;
 
   /** CountDownLatch for global operations - null when no operation is in progress */
   private final AtomicReference<CountDownLatch> globalOperationLatch = new AtomicReference<>();
@@ -66,6 +76,10 @@ public class SegmentedLock {
         IntStream.range(0, this.stripedLocks.size())
             .boxed()
             .collect(Collectors.toMap(this.stripedLocks::getAt, i -> i));
+    this.generations = new AtomicLong[this.stripedLocks.size()];
+    for (int i = 0; i < this.generations.length; i++) {
+      this.generations[i] = new AtomicLong();
+    }
   }
 
   /**
@@ -234,6 +248,39 @@ public class SegmentedLock {
     } finally {
       releaseAllLocks(sortedLocks);
     }
+  }
+
+  /**
+   * Returns the current generation of the stripe that guards the given key. A caller can snapshot
+   * this value and later confirm, under {@link #withLock}, that no {@link #incrementGeneration}
+   * touched the stripe in the meantime (the generation is unchanged).
+   *
+   * @param key Key to determine the stripe
+   * @return the current generation counter for the key's stripe
+   */
+  public long generation(Object key) {
+    return generationCounter(key).get();
+  }
+
+  /**
+   * Increments the generation of the stripe that guards the given key, so callers that snapshotted
+   * the generation before this call can detect the change.
+   *
+   * @param key Key to determine the stripe
+   */
+  public void incrementGeneration(Object key) {
+    generationCounter(key).incrementAndGet();
+  }
+
+  /** Increments the generation of every stripe. Used by global clearing operations. */
+  public void incrementAllGenerations() {
+    for (AtomicLong generation : generations) {
+      generation.incrementAndGet();
+    }
+  }
+
+  private AtomicLong generationCounter(Object key) {
+    return generations[lockIndices.get(getSegmentLock(key))];
   }
 
   /** Checks if a global operation is currently in progress. */

--- a/core/src/main/java/org/apache/gravitino/cache/SupportsRelationEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/SupportsRelationEntityCache.java
@@ -102,4 +102,40 @@ public interface SupportsRelationEntityCache {
       Entity.EntityType type,
       SupportsRelationOperations.Type relType,
       List<E> entities);
+
+  /**
+   * Returns an opaque generation token for the cache slot that holds the given relation. Callers
+   * that populate the cache from a backend using a cache-aside pattern should snapshot this token
+   * before reading the backend (right after observing a cache miss) and pass it to {@link
+   * #putIfNotInvalidatedSince}, so a concurrent invalidation that happens during the backend read
+   * is detected and the possibly-stale result is not written.
+   *
+   * @param ident the name identifier
+   * @param type the entity type
+   * @param relType the relation type
+   * @return the current generation token for the relation's cache slot
+   */
+  long relationGeneration(
+      NameIdentifier ident, Entity.EntityType type, SupportsRelationOperations.Type relType);
+
+  /**
+   * Puts a list of related entities into the cache only if the relation has not been invalidated
+   * since the given generation token was snapshotted. If the relation was invalidated in the
+   * meantime, the put is skipped so a stale backend result cannot overwrite a concurrent
+   * invalidation; the entry is left absent and rebuilt on the next read.
+   *
+   * @param ident The name identifier of the entity to cache the related entities for
+   * @param type The type of the entity to cache the related entities for
+   * @param relType The relation type to cache the related entities for
+   * @param entities The list of related entities to cache
+   * @param sinceGeneration The generation token snapshotted via {@link #relationGeneration} before
+   *     the backend read
+   * @param <E> The class of the related entities
+   */
+  <E extends Entity & HasIdentifier> void putIfNotInvalidatedSince(
+      NameIdentifier ident,
+      Entity.EntityType type,
+      SupportsRelationOperations.Type relType,
+      List<E> entities,
+      long sinceGeneration);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
@@ -46,7 +46,6 @@ import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.cache.CacheFactory;
 import org.apache.gravitino.cache.CachedEntityIdResolver;
 import org.apache.gravitino.cache.EntityCache;
-import org.apache.gravitino.cache.EntityCacheKey;
 import org.apache.gravitino.cache.EntityCacheRelationKey;
 import org.apache.gravitino.cache.NoOpsCache;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -317,37 +316,31 @@ public class RelationalEntityStore
       return new ArrayList<>();
     }
 
-    List<EntityCacheKey> lockKeys = new ArrayList<>();
-    for (NameIdentifier id : nameIdentifiers) {
-      lockKeys.add(EntityCacheRelationKey.of(id, identType, relType));
+    // Cache-aside: never hold a cache lock across the backend call. getIfPresent is lock-free and
+    // cache.put takes its own brief per-key lock, so loading uncached entries from the backend does
+    // not block concurrent cache mutations for the duration of the DB round-trip.
+    List<RelationalEntity<?>> result = new ArrayList<>();
+    List<NameIdentifier> uncachedIdentifiers = new ArrayList<>();
+
+    for (NameIdentifier nameIdentifier : nameIdentifiers) {
+      Optional<List<RelationalEntity<?>>> cachedRelations =
+          getCachedRelations(relType, nameIdentifier, identType);
+      if (cachedRelations.isPresent()) {
+        result.addAll(cachedRelations.get());
+      } else {
+        uncachedIdentifiers.add(nameIdentifier);
+      }
     }
 
-    return cache.withMultipleKeyCacheLock(
-        lockKeys,
-        () -> {
-          List<RelationalEntity<?>> result = new ArrayList<>();
-          List<NameIdentifier> uncachedIdentifiers = new ArrayList<>();
+    if (!uncachedIdentifiers.isEmpty()) {
+      List<RelationalEntity<?>> backendRelations =
+          backend.batchListEntitiesByRelation(relType, uncachedIdentifiers, identType);
+      result.addAll(backendRelations);
 
-          for (NameIdentifier nameIdentifier : nameIdentifiers) {
-            Optional<List<RelationalEntity<?>>> cachedRelations =
-                getCachedRelations(relType, nameIdentifier, identType);
-            if (cachedRelations.isPresent()) {
-              result.addAll(cachedRelations.get());
-            } else {
-              uncachedIdentifiers.add(nameIdentifier);
-            }
-          }
+      batchPopulateRelationCache(relType, identType, uncachedIdentifiers, backendRelations);
+    }
 
-          if (!uncachedIdentifiers.isEmpty()) {
-            List<RelationalEntity<?>> backendRelations =
-                backend.batchListEntitiesByRelation(relType, uncachedIdentifiers, identType);
-            result.addAll(backendRelations);
-
-            batchPopulateRelationCache(relType, identType, uncachedIdentifiers, backendRelations);
-          }
-
-          return result;
-        });
+    return result;
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
@@ -321,6 +321,10 @@ public class RelationalEntityStore
     // not block concurrent cache mutations for the duration of the DB round-trip.
     List<RelationalEntity<?>> result = new ArrayList<>();
     List<NameIdentifier> uncachedIdentifiers = new ArrayList<>();
+    // Generation of each uncached key's cache slot, snapshotted at the miss (before the backend
+    // read). If the key is invalidated during the read, the generation changes and the populate
+    // below skips it, so a stale backend result cannot overwrite the concurrent invalidation.
+    Map<NameIdentifier, Long> uncachedGenerations = new HashMap<>();
 
     for (NameIdentifier nameIdentifier : nameIdentifiers) {
       Optional<List<RelationalEntity<?>>> cachedRelations =
@@ -328,6 +332,8 @@ public class RelationalEntityStore
       if (cachedRelations.isPresent()) {
         result.addAll(cachedRelations.get());
       } else {
+        uncachedGenerations.put(
+            nameIdentifier, cache.relationGeneration(nameIdentifier, identType, relType));
         uncachedIdentifiers.add(nameIdentifier);
       }
     }
@@ -337,7 +343,8 @@ public class RelationalEntityStore
           backend.batchListEntitiesByRelation(relType, uncachedIdentifiers, identType);
       result.addAll(backendRelations);
 
-      batchPopulateRelationCache(relType, identType, uncachedIdentifiers, backendRelations);
+      batchPopulateRelationCache(
+          relType, identType, uncachedIdentifiers, backendRelations, uncachedGenerations);
     }
 
     return result;
@@ -476,7 +483,8 @@ public class RelationalEntityStore
       SupportsRelationOperations.Type relType,
       Entity.EntityType identType,
       List<NameIdentifier> uncachedIdentifiers,
-      List<RelationalEntity<?>> backendRelations) {
+      List<RelationalEntity<?>> backendRelations,
+      Map<NameIdentifier, Long> uncachedGenerations) {
     Map<NameIdentifier, List<RelationalEntity<?>>> relationsBySource = new HashMap<>();
     for (RelationalEntity<?> relation : backendRelations) {
       relationsBySource.computeIfAbsent(relation.source(), k -> new ArrayList<>()).add(relation);
@@ -493,7 +501,8 @@ public class RelationalEntityStore
         }
       }
 
-      cache.put(sourceId, identType, relType, entityList);
+      cache.putIfNotInvalidatedSince(
+          sourceId, identType, relType, entityList, uncachedGenerations.get(sourceId));
     }
   }
 

--- a/core/src/test/java/org/apache/gravitino/cache/TestSegmentedLock.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestSegmentedLock.java
@@ -380,4 +380,33 @@ public class TestSegmentedLock {
               });
         });
   }
+
+  @Test
+  void testGenerationStartsAtZero() {
+    SegmentedLock lock = new SegmentedLock(4);
+    assertEquals(0L, lock.generation("key1"));
+    assertEquals(0L, lock.generation(null));
+  }
+
+  @Test
+  void testIncrementGenerationBumpsOnlyTheKeyStripe() {
+    SegmentedLock lock = new SegmentedLock(16);
+    long before = lock.generation("key1");
+    lock.incrementGeneration("key1");
+    assertEquals(before + 1, lock.generation("key1"));
+
+    // The same key stays consistent, and its stripe reflects the increment.
+    lock.incrementGeneration("key1");
+    assertEquals(before + 2, lock.generation("key1"));
+  }
+
+  @Test
+  void testIncrementAllGenerationsBumpsEveryStripe() {
+    SegmentedLock lock = new SegmentedLock(8);
+    long g1 = lock.generation("key1");
+    long g2 = lock.generation("another-key");
+    lock.incrementAllGenerations();
+    assertEquals(g1 + 1, lock.generation("key1"));
+    assertEquals(g2 + 1, lock.generation("another-key"));
+  }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestRelationalEntityStore.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestRelationalEntityStore.java
@@ -22,8 +22,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -36,11 +38,14 @@ import org.apache.gravitino.Configs;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
 import org.apache.gravitino.RelationalEntity;
 import org.apache.gravitino.SupportsRelationOperations;
 import org.apache.gravitino.cache.CaffeineEntityCache;
 import org.apache.gravitino.cache.NoOpsCache;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.TagEntity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -294,5 +299,113 @@ public class TestRelationalEntityStore {
       Assertions.assertTrue(
           executor.awaitTermination(5, TimeUnit.SECONDS), "executor should terminate");
     }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBatchListSkipsPopulateWhenInvalidatedDuringBackendCall()
+      throws IOException, IllegalAccessException, InterruptedException {
+    SupportsRelationOperations.Type relType =
+        SupportsRelationOperations.Type.TAG_METADATA_OBJECT_REL;
+    Entity.EntityType identType = Entity.EntityType.TABLE;
+    NameIdentifier src = NameIdentifier.of("metalake", "catalog", "schema", "table1");
+
+    Config config = new Config(false) {};
+    CaffeineEntityCache realCache = new CaffeineEntityCache(config);
+    FieldUtils.writeField(store, "cache", realCache, true);
+
+    // The backend returns a relation for src (the value that would become stale once the key is
+    // invalidated mid-call).
+    TagEntity staleTag =
+        TagEntity.builder()
+            .withId(1L)
+            .withName("stale-tag")
+            .withNamespace(Namespace.of("metalake"))
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
+            .build();
+    RelationalEntity<TagEntity> staleRelation =
+        new RelationalEntity<>(relType, src, identType, staleTag);
+
+    CountDownLatch backendEntered = new CountDownLatch(1);
+    CountDownLatch releaseBackend = new CountDownLatch(1);
+    Mockito.when(backend.batchListEntitiesByRelation(eq(relType), any(List.class), eq(identType)))
+        .thenAnswer(
+            invocation -> {
+              backendEntered.countDown();
+              // Hold the backend "DB" call open so the invalidation can complete first.
+              releaseBackend.await(10, TimeUnit.SECONDS);
+              List<RelationalEntity<?>> backendResult = new ArrayList<>();
+              backendResult.add(staleRelation);
+              return backendResult;
+            });
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<List<RelationalEntity<?>>> listFuture =
+          executor.submit(
+              () -> store.batchListEntitiesByRelation(relType, List.of(src), identType));
+
+      // Wait until the list is blocked inside the backend call, then invalidate the key. The
+      // invalidation completes while the (soon-to-be-stale) backend result is still in flight.
+      Assertions.assertTrue(
+          backendEntered.await(5, TimeUnit.SECONDS), "backend call should have been entered");
+      realCache.invalidate(src, identType, relType);
+
+      // Release the backend and let the list finish; it still returns the read value to the caller.
+      releaseBackend.countDown();
+      List<RelationalEntity<?>> listResult =
+          Assertions.assertDoesNotThrow(() -> listFuture.get(5, TimeUnit.SECONDS));
+      Assertions.assertEquals(1, listResult.size(), "caller still receives the backend result");
+
+      // The stale result must NOT have been cached over the concurrent invalidation: the slot is
+      // left absent and rebuilt on the next read.
+      Optional<List<TagEntity>> cached = realCache.getIfPresent(relType, src, identType);
+      Assertions.assertFalse(
+          cached.isPresent(),
+          "populate must be skipped when the key was invalidated during the backend call");
+    } finally {
+      releaseBackend.countDown();
+      executor.shutdownNow();
+      Assertions.assertTrue(
+          executor.awaitTermination(5, TimeUnit.SECONDS), "executor should terminate");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBatchListPopulatesWhenNotInvalidatedDuringBackendCall()
+      throws IOException, IllegalAccessException {
+    SupportsRelationOperations.Type relType =
+        SupportsRelationOperations.Type.TAG_METADATA_OBJECT_REL;
+    Entity.EntityType identType = Entity.EntityType.TABLE;
+    NameIdentifier src = NameIdentifier.of("metalake", "catalog", "schema", "table1");
+
+    Config config = new Config(false) {};
+    CaffeineEntityCache realCache = new CaffeineEntityCache(config);
+    FieldUtils.writeField(store, "cache", realCache, true);
+
+    TagEntity tag =
+        TagEntity.builder()
+            .withId(1L)
+            .withName("tag")
+            .withNamespace(Namespace.of("metalake"))
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
+            .build();
+    RelationalEntity<TagEntity> relation = new RelationalEntity<>(relType, src, identType, tag);
+    List<RelationalEntity<?>> backendResult = new ArrayList<>();
+    backendResult.add(relation);
+    Mockito.when(backend.batchListEntitiesByRelation(eq(relType), any(List.class), eq(identType)))
+        .thenReturn(backendResult);
+
+    // Control: with no concurrent invalidation, the generation is unchanged and the result is
+    // cached, so the guard does not spuriously skip valid populates.
+    store.batchListEntitiesByRelation(relType, List.of(src), identType);
+
+    Optional<List<TagEntity>> cached = realCache.getIfPresent(relType, src, identType);
+    Assertions.assertTrue(cached.isPresent(), "result must be cached when not invalidated");
+    Assertions.assertEquals(1, cached.get().size());
+    Assertions.assertEquals("tag", cached.get().get(0).name());
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestRelationalEntityStore.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestRelationalEntityStore.java
@@ -22,7 +22,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
@@ -30,7 +36,9 @@ import org.apache.gravitino.Configs;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.RelationalEntity;
 import org.apache.gravitino.SupportsRelationOperations;
+import org.apache.gravitino.cache.CaffeineEntityCache;
 import org.apache.gravitino.cache.NoOpsCache;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.junit.jupiter.api.Assertions;
@@ -227,5 +235,62 @@ public class TestRelationalEntityStore {
             destToRemove,
             Entity.EntityType.TABLE,
             SupportsRelationOperations.Type.TAG_METADATA_OBJECT_REL);
+  }
+
+  /**
+   * Verifies that {@link RelationalEntityStore#batchListEntitiesByRelation} does not hold a cache
+   * lock across the backend call: with the backend blocked mid-call, a concurrent {@code
+   * invalidate} on the same key must still complete.
+   */
+  @Test
+  void testBatchListDoesNotHoldCacheLockAcrossBackendCall()
+      throws IOException, IllegalAccessException, InterruptedException {
+    SupportsRelationOperations.Type relType =
+        SupportsRelationOperations.Type.TAG_METADATA_OBJECT_REL;
+    Entity.EntityType identType = Entity.EntityType.TABLE;
+    NameIdentifier src = NameIdentifier.of("metalake", "catalog", "schema", "table1");
+
+    Config config = new Config(false) {};
+    CaffeineEntityCache realCache = new CaffeineEntityCache(config);
+    FieldUtils.writeField(store, "cache", realCache, true);
+
+    CountDownLatch backendEntered = new CountDownLatch(1);
+    CountDownLatch releaseBackend = new CountDownLatch(1);
+    Mockito.when(backend.batchListEntitiesByRelation(eq(relType), any(List.class), eq(identType)))
+        .thenAnswer(
+            invocation -> {
+              backendEntered.countDown();
+              // Hold the backend "DB" call open to simulate a slow round-trip.
+              releaseBackend.await(10, TimeUnit.SECONDS);
+              return new ArrayList<RelationalEntity<?>>();
+            });
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<List<RelationalEntity<?>>> listFuture =
+          executor.submit(
+              () -> store.batchListEntitiesByRelation(relType, List.of(src), identType));
+
+      // Wait until the list is blocked inside the backend call.
+      Assertions.assertTrue(
+          backendEntered.await(5, TimeUnit.SECONDS), "backend call should have been entered");
+
+      // A concurrent cache mutation on the same key must not be blocked by the in-flight list.
+      Future<Boolean> invalidateFuture =
+          executor.submit(
+              () -> {
+                realCache.invalidate(src, identType, relType);
+                return Boolean.TRUE;
+              });
+      Assertions.assertDoesNotThrow(
+          () -> invalidateFuture.get(5, TimeUnit.SECONDS),
+          "concurrent cache invalidate must not block on the in-flight batch list");
+
+      releaseBackend.countDown();
+      Assertions.assertDoesNotThrow(() -> listFuture.get(5, TimeUnit.SECONDS));
+    } finally {
+      releaseBackend.countDown();
+      executor.shutdownNow();
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestRelationalEntityStore.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestRelationalEntityStore.java
@@ -262,7 +262,7 @@ public class TestRelationalEntityStore {
               backendEntered.countDown();
               // Hold the backend "DB" call open to simulate a slow round-trip.
               releaseBackend.await(10, TimeUnit.SECONDS);
-              return new ArrayList<RelationalEntity<?>>();
+              return new ArrayList<>();
             });
 
     ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -291,6 +291,8 @@ public class TestRelationalEntityStore {
     } finally {
       releaseBackend.countDown();
       executor.shutdownNow();
+      Assertions.assertTrue(
+          executor.awaitTermination(5, TimeUnit.SECONDS), "executor should terminate");
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes #12170.

`batchListEntitiesByRelation` runs the backend batch-list inside `cache.withMultipleKeyCacheLock(...)`, so it holds the cache segment locks across the DB call. List authorization preloads owners for the whole page, so one list grabs a near-global set of locks for the full DB latency, and a concurrent `createTable` invalidation that needs one of those locks blocks until the list's DB call finishes (and can be starved under sustained lists).

This switches the method to cache-aside: read lock-free with `getIfPresent`, run the backend query with no lock held, then populate each key under its own short per-key lock (guarded against overwriting a concurrent invalidation — see Cache safety). The multi-key lock and the now-unused `EntityCacheKey` import are removed.

### Cache safety

- **Unchanged:** writes still invalidate after committing; single-key reads (`get`, single `listEntitiesByRelation`, `getEntityByRelation`) still load under their per-key lock; `put` stays atomic per key.
- **Guarded:** the batch read populates cache-aside (not atomically), but a per-stripe generation guard prevents a stale write. The reader snapshots the relation's generation right after the miss (before the backend call) and, under the per-key lock, skips the `put` if the generation changed during the backend read — leaving the slot absent to be rebuilt on the next read (a miss, never a stale hit). Two cases:
  - **Direct invalidate** (the key `K` itself is invalidated): the generation bump runs under `K`'s stripe lock — the same lock the populate takes — so they can't interleave. Fully closed, zero window.
  - **Cascade invalidate** (`K` is evicted as a side-effect of invalidating a *related* key — e.g. an owner change evicts every co-owned table's owner entry through the reverse index): that eviction runs under the *related* key's lock, not `K`'s, so it can still race `K`'s populate. The guard bumps `K`'s generation on eviction too, closing all but the narrow gap between the generation check and the write. This race isn't introduced here — that cascade path never held `K`'s populate lock before this PR either; the guard only shrinks it.

  The counter is per-stripe (not per-key) to reuse the existing striping and stay bounded; a shared-stripe collision can only cause a benign false-skip (a miss), never a stale hit.
- **Still useful:** only the lock scope changed, so cache hits and population are the same.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test blocks the backend mid-call and asserts a concurrent same-key `invalidate` still completes — it fails on the old code and passes here. A second test reproduces the exact reader/writer ordering from review (block the backend, invalidate the key mid-call, release, and assert the stale result is not subsequently cached), plus a control that a normal populate still caches; `SegmentedLock` gets unit tests for the generation counter. Also load-tested on a large schema (25 concurrent listers + 25 creators): `create_table` went from 0 completions in 5 min to ~1,450, with list latency unchanged.

A separate, pre-existing list-latency item (the per-object DB work list authorization does even without concurrency) is out of scope here.


