### PR TITLE
[#12173] improvement(auth): use per-role policy index on JCasbin authorization hot path

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/CachedRolePolicies.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/CachedRolePolicies.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.authorization.jcasbin;
+
+import java.util.Map;
+
+/**
+ * Cached, indexed privileges of a single role. The {@code updatedAt} timestamp corresponds to the
+ * {@code role_meta.updated_at} column and is used as a version sentinel: if the DB value is newer,
+ * the cached index is stale and must be rebuilt from the role entity.
+ *
+ * <p>The {@code index} maps each {@link PolicyKey} the role grants or denies to its {@link Effect},
+ * with {@link Effect#DENY} already taking precedence over {@link Effect#ALLOW} within the role. A
+ * privilege probe becomes a single {@link Map#get(Object)} instead of a linear scan over every
+ * jcasbin policy line.
+ */
+final class CachedRolePolicies {
+
+  private final long updatedAt;
+  private final Map<PolicyKey, Effect> index;
+
+  CachedRolePolicies(long updatedAt, Map<PolicyKey, Effect> index) {
+    this.updatedAt = updatedAt;
+    this.index = index;
+  }
+
+  long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  Map<PolicyKey, Effect> getIndex() {
+    return index;
+  }
+}

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/Effect.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/Effect.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.authorization.jcasbin;
+
+/**
+ * The effect of a single privilege rule in the per-role policy index. {@link #DENY} beats {@link
+ * #ALLOW} both within a single role and across the roles a user holds, mirroring the jcasbin {@code
+ * policy_effect} {@code some(where (p.eft == allow)) && !some(where (p.eft == deny))}.
+ */
+enum Effect {
+  /** The rule grants the privilege. */
+  ALLOW,
+  /** The rule denies the privilege; wins over any {@link #ALLOW}. */
+  DENY
+}

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Configs;
@@ -108,34 +110,27 @@ import org.slf4j.LoggerFactory;
  * contracts they rely on (most notably that {@code entity_change_log.full_name} is the pre-mutation
  * name).
  *
- * <p>JCasbin enforcer state ({@link #allowEnforcer}/{@link #denyEnforcer}) is kept in sync with
- * {@link #loadedRoles} via the removal listener inside {@link JcasbinLoadedRolesCache} — evicting a
- * role id also deletes that role's policies from both enforcers.
+ * <p>Privilege probes do not go through {@code enforcer.enforce}, which linearly scans every policy
+ * line loaded in the enforcer (cost {@code O(total_policies)} per probe). Instead {@link
+ * #loadedRoles} caches a per-role {@link PolicyKey}→{@link Effect} index and probes resolve against
+ * only the roles the caller holds ({@code O(roles_per_user)} hash lookups). The {@link
+ * #allowEnforcer} is kept solely for the user/group→role grouping graph ({@code g} rows); it no
+ * longer stores privilege ({@code p}) policies.
  */
 public class JcasbinAuthorizer implements GravitinoAuthorizer {
 
   private static final Logger LOG = LoggerFactory.getLogger(JcasbinAuthorizer.class);
 
   /**
-   * Field index of {@code sub} (the role/user/group id) in a jcasbin {@code p} policy row. See the
-   * {@code policy_definition} in {@code jcasbin_model.conf}: {@code p = sub, metadataType,
-   * metadataId, act, eft}.
+   * Jcasbin enforcer that holds the user/group→role grouping graph ({@code g} rows). Privilege
+   * ({@code p}) policies are no longer stored here; they live in the {@link #loadedRoles} index.
    */
-  private static final int POLICY_SUBJECT_FIELD_INDEX = 0;
-
-  /** Field index of {@code act} (the privilege) in a jcasbin {@code p} policy row. */
-  private static final int POLICY_ACTION_FIELD_INDEX = 3;
-
-  /** Jcasbin enforcer is used for metadata authorization. */
   private Enforcer allowEnforcer;
 
-  /** Jcasbin deny enforcer is used for metadata authorization. */
-  private Enforcer denyEnforcer;
-
-  /** allow internal authorizer */
+  /** Resolves an allow decision; narrows to the request's active roles for role assumption. */
   private InternalAuthorizer allowInternalAuthorizer;
 
-  /** deny internal authorizer */
+  /** Resolves a deny decision over every role the caller holds. */
   private InternalAuthorizer denyInternalAuthorizer;
 
   // ---- Version-validated caches (strong consistency) ----
@@ -153,9 +148,10 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
   private GravitinoCache<String, CachedGroupRoleRels> groupRoleCache;
 
   /**
-   * loadedRoles: roleId -> updated_at. If the DB updated_at is newer, evict and reload policies.
+   * loadedRoles: roleId -> {@link CachedRolePolicies} (version sentinel + per-role privilege
+   * index). If the DB updated_at is newer, the index is rebuilt from the role entity.
    */
-  private GravitinoCache<Long, Long> loadedRoles;
+  private GravitinoCache<Long, CachedRolePolicies> loadedRoles;
 
   // ---- Eventual consistency caches (poller-driven) ----
 
@@ -192,15 +188,17 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
 
     long ttlMs = TimeUnit.SECONDS.toMillis(cacheExpirationSecs);
 
-    // Initialize enforcers before caches that reference them in removal listeners
+    // Single enforcer for the role-membership graph (g rows). Privilege probes resolve against the
+    // per-role index in loadedRoles, not enforce, so no second (deny) enforcer is needed.
     allowEnforcer = new SyncedEnforcer(getModel("/jcasbin_model.conf"), new GravitinoAdapter());
-    allowInternalAuthorizer = new InternalAuthorizer(allowEnforcer, true);
-    denyEnforcer = new SyncedEnforcer(getModel("/jcasbin_model.conf"), new GravitinoAdapter());
-    denyInternalAuthorizer = new InternalAuthorizer(denyEnforcer, false);
+    // Allow narrows to active roles (role assumption); deny always spans every role the caller
+    // holds. Both share the version-validated per-role index.
+    allowInternalAuthorizer = new InternalAuthorizer(Effect.ALLOW, true);
+    denyInternalAuthorizer = new InternalAuthorizer(Effect.DENY, false);
 
-    // loadedRoles: roleId -> updated_at.
-    // When evicted, we must clean up the corresponding JCasbin policies.
-    loadedRoles = new JcasbinLoadedRolesCache(ttlMs, roleCacheSize, this::clearRolePolicies);
+    // loadedRoles: roleId -> (role_meta.updated_at, per-role privilege index). Access-based TTL so
+    // hot roles stay indexed; correctness comes from per-request version validation, not the TTL.
+    loadedRoles = new JcasbinLoadedRolesCache(ttlMs, roleCacheSize);
 
     userRoleCache = new CaffeineGravitinoCache<>(ttlMs, roleCacheSize);
     groupRoleCache = new CaffeineGravitinoCache<>(ttlMs, roleCacheSize);
@@ -388,30 +386,26 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     }
     UserUpdatedAt userInfo = userInfoOpt.get();
     long userId = userInfo.getUserId();
-    // Bind the user's (direct + group-inherited) roles into the enforcers so the in-memory scan
-    // below sees every policy the user can carry. Idempotent within a request.
+    // Bind the user's (direct + group-inherited) roles and load their indexes so the scan below
+    // sees every policy the user can carry. Idempotent within a request.
     loadRolePrivilege(metalake, principal.getName(), userId, userInfo, requestContext);
 
     Set<String> privilegeNames = privileges.stream().map(Enum::name).collect(Collectors.toSet());
     String userIdStr = String.valueOf(userId);
     // This is an existence query, not a per-object check: it answers "does any deny on these
-    // privileges exist for the user's roles, at any scope?" The standard enforce path needs a
-    // concrete metadataId, so reusing it would mean iterating every listed object and defeat the
-    // short-circuit. Filtering the deny enforcer's policies by role keeps the scan bounded by the
-    // user's role/policy count, never by the number of listed objects. The match is intentionally
-    // scope-agnostic (no metadataType filter): a parent-scope deny hides the whole subtree and an
-    // object-scope deny hides one object, and both must disable the short-circuit.
-    for (String roleId : denyEnforcer.getRolesForUser(userIdStr)) {
-      // getFilteredNamedPolicy returns every "p" row (p = sub, metadataType, metadataId, act, eft)
-      // whose field at POLICY_SUBJECT_FIELD_INDEX (sub) equals roleId, i.e. all rules carried by
-      // this role. denyEnforcer is a dedicated enforcer that is only ever loaded with privileges
-      // whose condition is DENY (see loadPolicyByRoleEntity), so every row here represents a deny
-      // regardless of its stored eft string. Each returned row is the list of those five fields,
-      // so we read field POLICY_ACTION_FIELD_INDEX (act) to compare the denied privilege.
-      for (List<String> policy :
-          denyEnforcer.getFilteredNamedPolicy("p", POLICY_SUBJECT_FIELD_INDEX, roleId)) {
-        if (policy.size() > POLICY_ACTION_FIELD_INDEX
-            && privilegeNames.contains(policy.get(POLICY_ACTION_FIELD_INDEX))) {
+    // privileges exist for the user's roles, at any scope?" Scanning each role's index keeps the
+    // cost bounded by the user's role/policy count, never by the number of listed objects. The
+    // match is intentionally scope-agnostic (no metadataType/metadataId filter): a parent-scope
+    // deny hides the whole subtree and an object-scope deny hides one object, and both must
+    // disable the short-circuit.
+    for (String roleId : allowEnforcer.getRolesForUser(userIdStr)) {
+      CachedRolePolicies cached = loadedRoles.getIfPresent(Long.parseLong(roleId)).orElse(null);
+      if (cached == null) {
+        continue;
+      }
+      for (Map.Entry<PolicyKey, Effect> entry : cached.getIndex().entrySet()) {
+        if (entry.getValue() == Effect.DENY
+            && privilegeNames.contains(entry.getKey().privilege())) {
           return true;
         }
       }
@@ -696,17 +690,21 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
 
   private class InternalAuthorizer {
 
-    Enforcer enforcer;
+    /**
+     * The effect this authorizer reports as {@code true}: {@link Effect#ALLOW} or {@link
+     * Effect#DENY}.
+     */
+    private final Effect targetEffect;
 
     /**
-     * When {@code true}, evaluation considers only the request's active roles instead of every role
-     * the caller holds. Enabled for the allow authorizer so role assumption can drop allows; the
-     * deny authorizer leaves it {@code false} so denies always apply. See {@link #enforceNarrowed}.
+     * When {@code true}, the allow evaluation considers only the request's active roles instead of
+     * every role the caller holds. Enabled for the allow authorizer so role assumption can drop
+     * allows; the deny authorizer leaves it {@code false} so denies always apply.
      */
     private final boolean narrowByActiveRoles;
 
-    public InternalAuthorizer(Enforcer enforcer, boolean narrowByActiveRoles) {
-      this.enforcer = enforcer;
+    public InternalAuthorizer(Effect targetEffect, boolean narrowByActiveRoles) {
+      this.targetEffect = targetEffect;
       this.narrowByActiveRoles = narrowByActiveRoles;
     }
 
@@ -809,9 +807,12 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
         Long metadataId,
         String privilege,
         AuthorizationRequestContext requestContext) {
-      // Step 4: JCasbin enforce (pure in-memory) — except OWNER, which is resolved via the
-      // owner cache rather than g-rows.
+      // OWNER is resolved via the owner cache rather than the role index. Ownership grants ALLOW
+      // and never constitutes a DENY, so the deny authorizer always reports false for OWNER.
       if (AuthConstants.OWNER.equals(privilege)) {
+        if (targetEffect != Effect.ALLOW) {
+          return false;
+        }
         // Cold-path: resolveOwnerId loads from DB when neither the per-request nor the shared
         // Caffeine cache has the entry, ensuring the first OWNER check doesn't spuriously deny.
         Optional<OwnerInfo> owner =
@@ -820,49 +821,47 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
             owner, PrincipalUtils.getCurrentPrincipal(), metalake, requestContext);
       }
 
-      String metadataType = String.valueOf(metadataObject.type());
-      String metadataIdStr = String.valueOf(metadataId);
-
-      // Role assumption: if the caller activated only a subset of their roles, check this allow
-      // against just those roles (enforceNarrowed). ALL or an absent header falls through to the
-      // normal check over every role the caller holds.
-      ActiveRoles activeRoles = requestContext.getActiveRoles();
-      if (narrowByActiveRoles && !activeRoles.isAll()) {
-        return enforceNarrowed(
-            userId, metadataType, metadataIdStr, privilege, activeRoles, requestContext);
-      }
-
-      return enforcer.enforce(String.valueOf(userId), metadataType, metadataIdStr, privilege);
+      // Step 4: index lookup (pure in-memory) instead of enforce, which would linearly scan every
+      // policy line loaded across all roles.
+      PolicyKey key = new PolicyKey(String.valueOf(metadataObject.type()), metadataId, privilege);
+      return resolveRoleEffect(userId, key, requestContext) == targetEffect;
     }
 
     /**
-     * Enforces one object/privilege against only the active roles the caller actually holds, so
-     * narrowing can never grant access the caller lacks. {@link ActiveRoles#none()} activates no
-     * role and denies every role-derived privilege.
+     * Resolves the net effect of one object/privilege probe against the caller's per-role index.
      *
-     * <p>Deny stays global: denyEnforcer is checked over the caller's full role union first, so a
-     * deny on any held role still applies even when that role is inactive.
+     * <p>DENY is global and wins: it is evaluated over every role the caller holds (inactive roles
+     * included) and short-circuits, mirroring the jcasbin {@code policy_effect} {@code some(allow)
+     * && !some(deny)}. ALLOW may be narrowed to the request's active roles for role assumption;
+     * {@link ActiveRoles#none()} activates no role and grants nothing. Returns {@code null} when no
+     * role rule matches.
      */
-    private boolean enforceNarrowed(
-        long userId,
-        String metadataType,
-        String metadataIdStr,
-        String privilege,
-        ActiveRoles activeRoles,
-        AuthorizationRequestContext requestContext) {
-      String userIdStr = String.valueOf(userId);
-      if (denyEnforcer.enforce(userIdStr, metadataType, metadataIdStr, privilege)) {
-        return false;
-      }
-      if (activeRoles.isNone()) {
-        return false;
-      }
-      for (String roleId : activeRoleIds(userId, activeRoles, requestContext)) {
-        if (enforcer.enforce(roleId, metadataType, metadataIdStr, privilege)) {
-          return true;
+    @Nullable
+    private Effect resolveRoleEffect(
+        long userId, PolicyKey key, AuthorizationRequestContext requestContext) {
+      List<String> allRoleIds = allowEnforcer.getRolesForUser(String.valueOf(userId));
+      for (String roleId : allRoleIds) {
+        if (indexEffect(roleId, key) == Effect.DENY) {
+          return Effect.DENY;
         }
       }
-      return false;
+
+      Collection<String> allowRoleIds;
+      ActiveRoles activeRoles = requestContext.getActiveRoles();
+      if (narrowByActiveRoles && !activeRoles.isAll()) {
+        if (activeRoles.isNone()) {
+          return null;
+        }
+        allowRoleIds = activeRoleIds(userId, activeRoles, requestContext);
+      } else {
+        allowRoleIds = allRoleIds;
+      }
+      for (String roleId : allowRoleIds) {
+        if (indexEffect(roleId, key) == Effect.ALLOW) {
+          return Effect.ALLOW;
+        }
+      }
+      return null;
     }
 
     /**
@@ -877,13 +876,23 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       }
       Set<String> activeNames = activeRoles.roleNames();
       Set<String> result = new HashSet<>();
-      for (String roleId : enforcer.getRolesForUser(String.valueOf(userId))) {
+      for (String roleId : allowEnforcer.getRolesForUser(String.valueOf(userId))) {
         RoleUpdatedAt roleInfo = roleVersions.get(Long.parseLong(roleId));
         if (roleInfo != null && activeNames.contains(roleInfo.getRoleName())) {
           result.add(roleId);
         }
       }
       return result;
+    }
+
+    /**
+     * Returns the effect the given role's index assigns to {@code key}, or {@code null} when the
+     * role has no matching rule or its index is not currently cached.
+     */
+    @Nullable
+    private Effect indexEffect(String roleIdStr, PolicyKey key) {
+      CachedRolePolicies cached = loadedRoles.getIfPresent(Long.parseLong(roleIdStr)).orElse(null);
+      return cached == null ? null : cached.getIndex().get(key);
     }
   }
 
@@ -1093,7 +1102,6 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
           for (String currentRole : allowEnforcer.getRolesForUser(userIdStr)) {
             if (!desiredRoleIds.contains(currentRole)) {
               allowEnforcer.deleteRoleForUser(userIdStr, currentRole);
-              denyEnforcer.deleteRoleForUser(userIdStr, currentRole);
             }
           }
 
@@ -1226,7 +1234,7 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
               RoleMetaMapper.class, m -> m.batchGetRoleUpdatedAt(missingRoleIds)));
     }
 
-    // Any roleId asked about but not returned has been deleted in the DB; clear its policies so
+    // Any roleId asked about but not returned has been deleted in the DB; drop its cached index so
     // a stale grouping row in the enforcer can't keep granting privileges before the next
     // userRoleCache reload prunes the g-row itself.
     Set<Long> existingRoleIds = new HashSet<>(roleVersions.size());
@@ -1235,15 +1243,14 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     }
     for (Long roleId : uniqueRoleIds) {
       if (!existingRoleIds.contains(roleId)) {
-        clearRolePolicies(roleId);
         loadedRoles.invalidate(roleId);
       }
     }
 
     List<RoleUpdatedAt> staleRoleVersions = new ArrayList<>();
     for (RoleUpdatedAt rv : roleVersions) {
-      Optional<Long> cachedUpdatedAt = loadedRoles.getIfPresent(rv.getRoleId());
-      if (cachedUpdatedAt.isPresent() && cachedUpdatedAt.get() >= rv.getUpdatedAt()) {
+      Optional<CachedRolePolicies> cached = loadedRoles.getIfPresent(rv.getRoleId());
+      if (cached.isPresent() && cached.get().getUpdatedAt() >= rv.getUpdatedAt()) {
         continue;
       }
       staleRoleVersions.add(rv);
@@ -1297,28 +1304,18 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       }
       long roleId = rv.getRoleId();
       long dbUpdatedAt = rv.getUpdatedAt();
-      Optional<Long> cachedUpdatedAt = loadedRoles.getIfPresent(roleId);
 
-      // Refresh only permission policies. deleteRole would also remove the current user's freshly
-      // bound grouping links.
-      if (cachedUpdatedAt.isPresent()) {
-        clearRolePolicies(roleId);
-      }
-      loadPolicyByRoleEntity(roleEntity, requestContext);
-      loadedRoles.put(roleId, dbUpdatedAt);
+      // Rebuild the role's privilege index from the freshly loaded entity. put() atomically
+      // replaces any previous index, so there is no stale-policy window and grouping links are
+      // untouched.
+      Map<PolicyKey, Effect> index = loadPolicyByRoleEntity(roleEntity, requestContext);
+      loadedRoles.put(roleId, new CachedRolePolicies(dbUpdatedAt, index));
     }
-  }
-
-  private void clearRolePolicies(long roleId) {
-    String roleIdStr = String.valueOf(roleId);
-    allowEnforcer.removeFilteredPolicy(0, roleIdStr);
-    denyEnforcer.removeFilteredPolicy(0, roleIdStr);
   }
 
   private void bindUserRoles(long userId, List<Long> roleIds) {
     for (Long roleId : roleIds) {
       allowEnforcer.addRoleForUser(String.valueOf(userId), String.valueOf(roleId));
-      denyEnforcer.addRoleForUser(String.valueOf(userId), String.valueOf(roleId));
     }
   }
 
@@ -1326,10 +1323,18 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
   //  Policy loading from role entity
   // ---------------------------------------------------------------------------
 
-  private void loadPolicyByRoleEntity(
+  /**
+   * Builds the per-role privilege index from a role entity's securable objects. Each {@code (type,
+   * metadataId, privilege)} maps to {@link Effect#ALLOW} or {@link Effect#DENY}, with DENY taking
+   * precedence over ALLOW within the role so the index agrees with the jcasbin {@code
+   * policy_effect}. Privilege names are normalized (legacy names replaced, upper-cased) exactly as
+   * the previous {@code addPolicy} path stored them.
+   */
+  private Map<PolicyKey, Effect> loadPolicyByRoleEntity(
       RoleEntity roleEntity, AuthorizationRequestContext requestContext) {
     String metalake = NameIdentifierUtil.getMetalake(roleEntity.nameIdentifier());
     List<SecurableObject> securableObjects = roleEntity.securableObjects();
+    Map<PolicyKey, Effect> index = new HashMap<>();
 
     for (SecurableObject securableObject : securableObjects) {
       Optional<Long> metadataId =
@@ -1338,28 +1343,21 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       if (!metadataId.isPresent()) {
         continue;
       }
+      String typeName = securableObject.type().name();
+      long id = metadataId.get();
       for (Privilege privilege : securableObject.privileges()) {
         Privilege.Condition condition = privilege.condition();
-        if (AuthConstants.DENY.equalsIgnoreCase(condition.name())) {
-          denyEnforcer.addPolicy(
-              String.valueOf(roleEntity.id()),
-              securableObject.type().name(),
-              String.valueOf(metadataId.get()),
-              AuthorizationUtils.replaceLegacyPrivilegeName(privilege.name())
-                  .name()
-                  .toUpperCase(Locale.ROOT),
-              AuthConstants.ALLOW);
-        }
-
-        allowEnforcer.addPolicy(
-            String.valueOf(roleEntity.id()),
-            securableObject.type().name(),
-            String.valueOf(metadataId.get()),
+        String privilegeName =
             AuthorizationUtils.replaceLegacyPrivilegeName(privilege.name())
                 .name()
-                .toUpperCase(Locale.ROOT),
-            condition.name().toLowerCase(Locale.ROOT));
+                .toUpperCase(Locale.ROOT);
+        boolean isDeny = AuthConstants.DENY.equalsIgnoreCase(condition.name());
+        PolicyKey key = new PolicyKey(typeName, id, privilegeName);
+        Effect effect = isDeny ? Effect.DENY : Effect.ALLOW;
+        index.merge(
+            key, effect, (existing, incoming) -> existing == Effect.DENY ? existing : incoming);
       }
     }
+    return index;
   }
 }

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinLoadedRolesCache.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinLoadedRolesCache.java
@@ -20,56 +20,53 @@ package org.apache.gravitino.server.authorization.jcasbin;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalCause;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.LongConsumer;
 import org.apache.gravitino.cache.GravitinoCache;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * A {@link GravitinoCache} of {@code roleId -> updated_at} that synchronously deletes the role's
- * JCasbin policies from both enforcers when a key is evicted (by TTL, size, or explicit
- * invalidate).
+ * A {@link GravitinoCache} of {@code roleId -> }{@link CachedRolePolicies}, the per-role privilege
+ * index consulted on the authorization hot path.
  *
- * <p>This cache owns role permission policies only. Therefore, eviction must clear only {@code
- * p(roleId, ...)} policies and must not delete the role itself, because JCasbin's {@code
- * deleteRole(roleId)} also removes {@code g(user/group, roleId)} bindings that are managed
- * separately by {@link JcasbinAuthorizer}.
+ * <p><b>Policy ownership:</b> before privilege policies moved into {@link CachedRolePolicies}, this
+ * cache stored only {@code role_meta.updated_at}, while the corresponding {@code p(roleId, ...)}
+ * policies lived separately in JCasbin enforcers. Eviction therefore needed a synchronous removal
+ * listener to delete those orphaned {@code p} rows without deleting the independently managed
+ * {@code g(user/group, roleId)} bindings.
+ *
+ * <p>Now each cache value owns both the version sentinel and the role's complete privilege index,
+ * and the JCasbin enforcer owns only the {@code g} bindings; it contains no {@code p} policies.
+ * Eviction discards the policy index together with its cache entry, leaving no second policy copy
+ * to clean up. On the next request, {@link JcasbinAuthorizer} observes the cache miss, reloads the
+ * role from the database, and rebuilds the index. A removal listener must not delete the role from
+ * the enforcer because doing so would also remove valid {@code g} bindings whose lifecycle is
+ * managed by the user/group role caches.
+ *
+ * <p>Unlike {@link org.apache.gravitino.cache.CaffeineGravitinoCache} this cache is <b>access</b>
+ * based ({@code expireAfterAccess}): the index of a role that keeps being authorized against stays
+ * hot instead of being reloaded from the DB every TTL. Correctness never relies on the TTL — {@link
+ * JcasbinAuthorizer} version-validates each entry against {@code role_meta.updated_at} on every
+ * read, so eviction by TTL, size, or explicit invalidation only frees memory and forces a rebuild.
  */
-class JcasbinLoadedRolesCache implements GravitinoCache<Long, Long> {
+class JcasbinLoadedRolesCache implements GravitinoCache<Long, CachedRolePolicies> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(JcasbinLoadedRolesCache.class);
+  private final Cache<Long, CachedRolePolicies> cache;
 
-  private final Cache<Long, Long> cache;
-
-  JcasbinLoadedRolesCache(long ttlMs, long maxSize, LongConsumer rolePolicyCleaner) {
+  JcasbinLoadedRolesCache(long ttlMs, long maxSize) {
     this.cache =
         Caffeine.newBuilder()
             .expireAfterAccess(ttlMs, TimeUnit.MILLISECONDS)
             .maximumSize(maxSize)
-            .executor(Runnable::run)
-            .removalListener(
-                (Long roleId, Long value, RemovalCause cause) -> {
-                  LOG.debug(
-                      "Removed JCasbin loaded role cache entry, roleId={}, cause={}",
-                      roleId,
-                      cause);
-                  if (roleId != null && cause != RemovalCause.REPLACED) {
-                    rolePolicyCleaner.accept(roleId);
-                  }
-                })
             .build();
   }
 
   @Override
-  public Optional<Long> getIfPresent(Long key) {
+  public Optional<CachedRolePolicies> getIfPresent(Long key) {
     return Optional.ofNullable(cache.getIfPresent(key));
   }
 
   @Override
-  public void put(Long key, Long value) {
+  public void put(Long key, CachedRolePolicies value) {
     cache.put(key, value);
   }
 

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/PolicyKey.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/PolicyKey.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.authorization.jcasbin;
+
+import java.util.Objects;
+
+/**
+ * Composite key of the per-role policy index: {@code (metadataType, metadataId, privilege)}. It
+ * mirrors the non-subject fields of a jcasbin {@code p} policy row so that an index lookup answers
+ * the same question the old {@code enforcer.enforce} matcher did for one role, but in {@code O(1)}
+ * instead of a linear scan over every policy line.
+ *
+ * <p>The three fields are compared with exact equality, matching the jcasbin matcher's string
+ * comparison; {@code metadataType} and {@code privilege} are stored as they are passed on the
+ * authorization hot path (already upper-cased enum names).
+ */
+final class PolicyKey {
+
+  private final String metadataType;
+  private final long metadataId;
+  private final String privilege;
+  private final int hash;
+
+  PolicyKey(String metadataType, long metadataId, String privilege) {
+    this.metadataType = metadataType;
+    this.metadataId = metadataId;
+    this.privilege = privilege;
+    this.hash = Objects.hash(metadataType, metadataId, privilege);
+  }
+
+  String privilege() {
+    return privilege;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PolicyKey)) {
+      return false;
+    }
+    PolicyKey other = (PolicyKey) o;
+    return hash == other.hash
+        && metadataId == other.metadataId
+        && Objects.equals(metadataType, other.metadataType)
+        && Objects.equals(privilege, other.privilege);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "PolicyKey{type=" + metadataType + ", id=" + metadataId + ", priv=" + privilege + '}';
+  }
+}

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.authorization.Privilege.Name.USE_CATALOG;
 import static org.apache.gravitino.authorization.Privilege.Name.USE_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1536,6 +1537,41 @@ public class TestJcasbinAuthorizer {
         requestContext);
   }
 
+  /**
+   * Asserts both public policy decisions for one object and privilege. Keeping the two probes in
+   * one request context also verifies that the allow and deny paths observe the same loaded role
+   * snapshot.
+   */
+  private void assertAuthorizationDecision(
+      Principal principal,
+      MetadataObject metadataObject,
+      Privilege.Name privilege,
+      boolean expectedAuthorize,
+      boolean expectedDeny) {
+    AuthorizationRequestContext requestContext = new AuthorizationRequestContext();
+    assertEquals(
+        expectedAuthorize,
+        jcasbinAuthorizer.authorize(principal, METALAKE, metadataObject, privilege, requestContext),
+        "unexpected authorize decision");
+    assertEquals(
+        expectedDeny,
+        jcasbinAuthorizer.deny(principal, METALAKE, metadataObject, privilege, requestContext),
+        "unexpected deny decision");
+  }
+
+  /** Asserts the cached effect for a role and catalog privilege. */
+  private void assertCachedRoleEffect(
+      Long roleId, MetadataObject.Type metadataType, Privilege.Name privilege, Effect expected)
+      throws Exception {
+    CachedRolePolicies cached =
+        getLoadedRolesCache(jcasbinAuthorizer).getIfPresent(roleId).orElse(null);
+    assertNotNull(cached, "role index must be cached for role " + roleId);
+    assertEquals(
+        expected,
+        cached.getIndex().get(new PolicyKey(metadataType.name(), CATALOG_ID, privilege.name())),
+        "unexpected cached effect for role " + roleId);
+  }
+
   private Boolean doAuthorizeOwner(Principal currentPrincipal) {
     AuthorizationRequestContext authorizationRequestContext = new AuthorizationRequestContext();
     return jcasbinAuthorizer.isOwner(
@@ -1749,7 +1785,12 @@ public class TestJcasbinAuthorizer {
     when(roleMetaMapper.listRolesByUserId(eq(USER_ID)))
         .thenReturn(ImmutableList.of(buildRolePO(ALLOW_ROLE_ID, "allowRole")));
 
-    assertTrue(doAuthorize(currentPrincipal));
+    assertAuthorizationDecision(
+        currentPrincipal,
+        MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG),
+        USE_CATALOG,
+        true,
+        false);
 
     // The per-role index carries the granted privilege ...
     CachedRolePolicies cached =
@@ -1770,6 +1811,302 @@ public class TestJcasbinAuthorizer {
             .getRolesForUser(String.valueOf(USER_ID))
             .contains(String.valueOf(ALLOW_ROLE_ID)),
         "enforcer must still hold the user -> role grouping row");
+  }
+
+  @Test
+  public void testDenyPolicyUsesDenyIndexWithoutEnforcerPolicies() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+
+    RoleEntity denyRole =
+        mockRoleInStore(
+            DENY_ROLE_ID,
+            "denyRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    DENY_ROLE_ID,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "DENY")));
+    mockDirectUserRoles(denyRole);
+
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, false, true);
+    assertCachedRoleEffect(DENY_ROLE_ID, MetadataObject.Type.CATALOG, USE_CATALOG, Effect.DENY);
+
+    Enforcer allowEnforcer = getAllowEnforcer(jcasbinAuthorizer);
+    assertTrue(
+        allowEnforcer.getPolicy().isEmpty(), "enforcer must not store DENY privilege policies");
+    assertTrue(
+        allowEnforcer
+            .getRolesForUser(String.valueOf(USER_ID))
+            .contains(String.valueOf(DENY_ROLE_ID)),
+        "enforcer must retain the user -> deny-role grouping row");
+  }
+
+  @Test
+  public void testNoRolesReturnFalseForAllowAndDeny() {
+    mockUserRoles();
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, false, false);
+  }
+
+  @Test
+  public void testSameRoleDenyWinsRegardlessOfPolicyOrder() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+    Long allowThenDenyRoleId = 301L;
+    Long denyThenAllowRoleId = 302L;
+
+    RoleEntity allowThenDenyRole =
+        mockRoleInStore(
+            allowThenDenyRoleId,
+            "allowThenDenyRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    allowThenDenyRoleId,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "ALLOW"),
+                buildSecurableObject(
+                    allowThenDenyRoleId,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "DENY")));
+    RoleEntity denyThenAllowRole =
+        mockRoleInStore(
+            denyThenAllowRoleId,
+            "denyThenAllowRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    denyThenAllowRoleId,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "DENY"),
+                buildSecurableObject(
+                    denyThenAllowRoleId,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "ALLOW")));
+    mockDirectUserRoles(allowThenDenyRole, denyThenAllowRole);
+
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, false, true);
+    assertCachedRoleEffect(
+        allowThenDenyRoleId, MetadataObject.Type.CATALOG, USE_CATALOG, Effect.DENY);
+    assertCachedRoleEffect(
+        denyThenAllowRoleId, MetadataObject.Type.CATALOG, USE_CATALOG, Effect.DENY);
+    assertTrue(
+        getAllowEnforcer(jcasbinAuthorizer).getPolicy().isEmpty(),
+        "mixed effects must remain in the role indexes");
+  }
+
+  @Test
+  public void testDenyInOneRoleOverridesAllowInAnotherRole() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+
+    RoleEntity allowRole =
+        mockRoleInStore(
+            ALLOW_ROLE_ID,
+            "allowRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    ALLOW_ROLE_ID,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "ALLOW")));
+    RoleEntity denyRole =
+        mockRoleInStore(
+            DENY_ROLE_ID,
+            "denyRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    DENY_ROLE_ID,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "DENY")));
+    mockDirectUserRoles(allowRole, denyRole);
+
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, false, true);
+    assertCachedRoleEffect(ALLOW_ROLE_ID, MetadataObject.Type.CATALOG, USE_CATALOG, Effect.ALLOW);
+    assertCachedRoleEffect(DENY_ROLE_ID, MetadataObject.Type.CATALOG, USE_CATALOG, Effect.DENY);
+  }
+
+  @Test
+  public void testPolicyKeyRequiresMatchingTypeAndPrivilege() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+    MetadataObject schema =
+        MetadataObjects.of("testCatalog", "testSchema", MetadataObject.Type.SCHEMA);
+
+    RoleEntity allowRole =
+        mockRoleInStore(
+            ALLOW_ROLE_ID,
+            "allowRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    ALLOW_ROLE_ID,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "ALLOW")));
+    mockDirectUserRoles(allowRole);
+
+    assertAuthorizationDecision(currentPrincipal, catalog, SELECT_TABLE, false, false);
+    assertAuthorizationDecision(currentPrincipal, schema, USE_CATALOG, false, false);
+  }
+
+  @Test
+  public void testDifferentPrivilegesInOneRoleResolveIndependently() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+    Long mixedRoleId = 303L;
+
+    RoleEntity mixedRole =
+        mockRoleInStore(
+            mixedRoleId,
+            "mixedPrivilegeRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    mixedRoleId, MetadataObject.Type.CATALOG, "testCatalog", USE_CATALOG, "ALLOW"),
+                buildSecurableObject(
+                    mixedRoleId, MetadataObject.Type.CATALOG, "testCatalog", USE_SCHEMA, "DENY")));
+    mockDirectUserRoles(mixedRole);
+
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, true, false);
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_SCHEMA, false, true);
+    assertCachedRoleEffect(mixedRoleId, MetadataObject.Type.CATALOG, USE_CATALOG, Effect.ALLOW);
+    assertCachedRoleEffect(mixedRoleId, MetadataObject.Type.CATALOG, USE_SCHEMA, Effect.DENY);
+  }
+
+  @Test
+  public void testRolePolicyReloadChangesDenyToAllow() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+    Long mutableRoleId = 304L;
+
+    RoleEntity denyRole =
+        mockRoleInStore(
+            mutableRoleId,
+            "mutableRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    mutableRoleId,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "DENY")));
+    mockDirectUserRoles(denyRole);
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, false, true);
+
+    RoleEntity allowRole =
+        mockRoleInStore(
+            mutableRoleId,
+            "mutableRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    mutableRoleId,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "ALLOW")));
+    mockDirectUserRoles(allowRole);
+    jcasbinAuthorizer.handleRolePrivilegeChange(mutableRoleId);
+
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, true, false);
+    assertCachedRoleEffect(mutableRoleId, MetadataObject.Type.CATALOG, USE_CATALOG, Effect.ALLOW);
+  }
+
+  @Test
+  public void testDenyDisappearsAfterRoleAssignmentIsRemoved() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+
+    RoleEntity denyRole =
+        mockRoleInStore(
+            DENY_ROLE_ID,
+            "denyRole",
+            ImmutableList.of(
+                buildSecurableObject(
+                    DENY_ROLE_ID,
+                    MetadataObject.Type.CATALOG,
+                    "testCatalog",
+                    USE_CATALOG,
+                    "DENY")));
+    mockDirectUserRoles(denyRole);
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, false, true);
+
+    mockNoDirectUserRoles();
+
+    assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, false, false);
+    assertFalse(
+        getAllowEnforcer(jcasbinAuthorizer)
+            .getRolesForUser(String.valueOf(USER_ID))
+            .contains(String.valueOf(DENY_ROLE_ID)),
+        "removed role assignment must be pruned from the grouping graph");
+  }
+
+  @Test
+  public void testDroppedMetadataPolicyIsSkipped() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+    Long droppedRoleId = 305L;
+    SecurableObject droppedObject =
+        buildSecurableObject(
+            droppedRoleId, MetadataObject.Type.CATALOG, "droppedCatalog", USE_CATALOG, "ALLOW");
+    metadataIdConverterMockedStatic
+        .when(() -> MetadataIdConverter.getID(eq(droppedObject), eq(METALAKE)))
+        .thenReturn(Optional.empty());
+
+    try {
+      RoleEntity droppedRole =
+          mockRoleInStore(droppedRoleId, "droppedMetadataRole", ImmutableList.of(droppedObject));
+      mockDirectUserRoles(droppedRole);
+
+      assertAuthorizationDecision(currentPrincipal, catalog, USE_CATALOG, false, false);
+      CachedRolePolicies cached =
+          getLoadedRolesCache(jcasbinAuthorizer).getIfPresent(droppedRoleId).orElse(null);
+      assertNotNull(cached, "role must still be cached after skipping dropped metadata");
+      assertTrue(cached.getIndex().isEmpty(), "dropped metadata must not create an index entry");
+    } finally {
+      metadataIdConverterMockedStatic
+          .when(() -> MetadataIdConverter.getID(eq(droppedObject), eq(METALAKE)))
+          .thenReturn(Optional.of(CATALOG_ID));
+    }
+  }
+
+  @Test
+  public void testPolicyKeyValueSemantics() {
+    PolicyKey key = new PolicyKey("CATALOG", CATALOG_ID, USE_CATALOG.name());
+    PolicyKey sameKey = new PolicyKey("CATALOG", CATALOG_ID, USE_CATALOG.name());
+
+    assertEquals(key, key);
+    assertEquals(key, sameKey);
+    assertEquals(key.hashCode(), sameKey.hashCode());
+    assertEquals(USE_CATALOG.name(), key.privilege());
+    assertNotEquals(key, null);
+    assertNotEquals(key, "CATALOG");
+    assertNotEquals(key, new PolicyKey("SCHEMA", CATALOG_ID, USE_CATALOG.name()));
+    assertNotEquals(key, new PolicyKey("CATALOG", CATALOG_ID + 1, USE_CATALOG.name()));
+    assertNotEquals(key, new PolicyKey("CATALOG", CATALOG_ID, USE_SCHEMA.name()));
+    assertEquals(
+        "PolicyKey{type=CATALOG, id=" + CATALOG_ID + ", priv=USE_CATALOG}", key.toString());
   }
 
   /** Tests {@link JcasbinAuthorizer#hasMetadataPrivilegePermission} hierarchy walk */

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.server.authorization.jcasbin;
 import static org.apache.gravitino.authorization.Privilege.Name.SELECT_TABLE;
 import static org.apache.gravitino.authorization.Privilege.Name.USE_CATALOG;
 import static org.apache.gravitino.authorization.Privilege.Name.USE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -561,14 +562,13 @@ public class TestJcasbinAuthorizer {
     // re-primes userRoleCache before the next loadUserRoles call. This test covers
     // the defence-in-depth tier: if versionCheckAndLoadRoles is ever invoked with
     // a roleId whose version probe row is missing (e.g. cache window race, future
-    // code path bypassing the fat-JOIN), the fix must still clear that role's
-    // p-rows from both enforcers and evict its loadedRoles entry so that any
-    // residual user → deleted-role g-row grants nothing on subsequent enforce()s.
+    // code path bypassing the fat-JOIN), the fix must still evict that role's
+    // loadedRoles index entry so that any residual user → deleted-role g-row grants
+    // nothing on subsequent probes (an absent index resolves to no privilege).
     makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
     Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
 
-    // 1. Authorize once via the normal flow to populate loadedRoles + enforcer p-rows
-    //    for allowRole.
+    // 1. Authorize once via the normal flow to populate the loadedRoles index for allowRole.
     RoleEntity allowRole =
         mockRoleInStore(ALLOW_ROLE_ID, "allowRole", ImmutableList.of(getAllowSecurableObject()));
     long userVersion = nextUserVersion();
@@ -578,15 +578,10 @@ public class TestJcasbinAuthorizer {
         .thenReturn(ImmutableList.of(buildRolePO(ALLOW_ROLE_ID, allowRole.name())));
     assertTrue(doAuthorize(currentPrincipal));
 
-    // Sanity: loadedRoles now has an entry for ALLOW_ROLE_ID and the allowEnforcer
-    // contains a p-row whose subject (column 0) equals the role id.
+    // Sanity: loadedRoles now has an index entry for ALLOW_ROLE_ID.
     Assertions.assertTrue(
         getLoadedRolesCache(jcasbinAuthorizer).getIfPresent(ALLOW_ROLE_ID).isPresent(),
         "loadedRoles must be primed before the test");
-    Enforcer allowEnforcer = getAllowEnforcer(jcasbinAuthorizer);
-    Assertions.assertFalse(
-        allowEnforcer.getFilteredPolicy(0, String.valueOf(ALLOW_ROLE_ID)).isEmpty(),
-        "allowEnforcer must hold p-rows for allowRole before the test");
 
     // 2. Simulate the bug-trigger: batchGetRoleUpdatedAt returns NO row for the role
     //    (i.e. the role row is gone from role_meta), even though something is still
@@ -600,10 +595,7 @@ public class TestJcasbinAuthorizer {
     invokeVersionCheckAndLoadRoles(
         jcasbinAuthorizer, METALAKE, ImmutableList.of(ALLOW_ROLE_ID), freshCtx);
 
-    // 3. The fix must have cleared the role's p-rows and evicted loadedRoles.
-    Assertions.assertTrue(
-        allowEnforcer.getFilteredPolicy(0, String.valueOf(ALLOW_ROLE_ID)).isEmpty(),
-        "allowEnforcer p-rows for the deleted role must be cleared");
+    // 3. The fix must have evicted the deleted role's index entry.
     Assertions.assertFalse(
         getLoadedRolesCache(jcasbinAuthorizer).getIfPresent(ALLOW_ROLE_ID).isPresent(),
         "loadedRoles entry for the deleted role must be evicted");
@@ -1644,11 +1636,12 @@ public class TestJcasbinAuthorizer {
     makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
 
     // Get the loadedRoles cache via reflection
-    GravitinoCache<Long, Long> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
+    GravitinoCache<Long, CachedRolePolicies> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
 
     // Manually add a role to the cache
     Long testRoleId = 100L;
-    loadedRoles.put(testRoleId, System.currentTimeMillis());
+    loadedRoles.put(
+        testRoleId, new CachedRolePolicies(System.currentTimeMillis(), new HashMap<>()));
 
     // Verify it's in the cache
     assertTrue(loadedRoles.getIfPresent(testRoleId).isPresent());
@@ -1713,99 +1706,70 @@ public class TestJcasbinAuthorizer {
   }
 
   @Test
-  public void testRoleCacheSynchronousRemovalListenerDeletesPolicy() throws Exception {
-    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
-
-    // Get the enforcers via reflection
+  public void testRoleCacheInvalidationPreservesUserRoleBindings() throws Exception {
     Enforcer allowEnforcer = getAllowEnforcer(jcasbinAuthorizer);
-    Enforcer denyEnforcer = getDenyEnforcer(jcasbinAuthorizer);
+    GravitinoCache<Long, CachedRolePolicies> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
 
-    // Get the loadedRoles cache
-    GravitinoCache<Long, Long> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
-
-    // Add a role and its policy to the enforcer
     Long testRoleId = 300L;
     String roleIdStr = String.valueOf(testRoleId);
     String userIdStr = String.valueOf(USER_ID);
-
-    // Add a policy and a user-role binding for this role.
     allowEnforcer.addRoleForUser(userIdStr, roleIdStr);
-    denyEnforcer.addRoleForUser(userIdStr, roleIdStr);
-    allowEnforcer.addPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow");
-    denyEnforcer.addPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow");
+    loadedRoles.put(
+        testRoleId, new CachedRolePolicies(System.currentTimeMillis(), new HashMap<>()));
 
-    // Add role to cache
-    loadedRoles.put(testRoleId, System.currentTimeMillis());
-
-    // Verify role exists in enforcer (has policy and grouping).
-    assertTrue(allowEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
-    assertTrue(denyEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
-    assertTrue(allowEnforcer.getRolesForUser(userIdStr).contains(roleIdStr));
-    assertTrue(denyEnforcer.getRolesForUser(userIdStr).contains(roleIdStr));
-
-    // Invalidate the cache entry - this triggers the synchronous removal listener
-    // (using executor(Runnable::run) to ensure synchronous execution)
     loadedRoles.invalidate(testRoleId);
 
-    // Verify the role's policies have been deleted from enforcers (synchronous, no need to wait),
-    // but user-role bindings are preserved because loadedRoles owns role policies only.
-    assertFalse(allowEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
-    assertFalse(denyEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
+    assertFalse(loadedRoles.getIfPresent(testRoleId).isPresent());
     assertTrue(allowEnforcer.getRolesForUser(userIdStr).contains(roleIdStr));
-    assertTrue(denyEnforcer.getRolesForUser(userIdStr).contains(roleIdStr));
-  }
-
-  @Test
-  public void testRoleCacheReplacementDoesNotDeletePolicy() throws Exception {
-    Enforcer allowEnforcer = getAllowEnforcer(jcasbinAuthorizer);
-    Enforcer denyEnforcer = getDenyEnforcer(jcasbinAuthorizer);
-    GravitinoCache<Long, Long> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
-
-    Long testRoleId = 301L;
-    String roleIdStr = String.valueOf(testRoleId);
-    loadedRoles.put(testRoleId, 1L);
-
-    allowEnforcer.addPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow");
-    denyEnforcer.addPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow");
-
-    loadedRoles.put(testRoleId, 2L);
-
-    assertTrue(allowEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
-    assertTrue(denyEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
-  }
-
-  @Test
-  public void testClearRolePoliciesPreservesUserRoleBindings() throws Exception {
-    Enforcer allowEnforcer = getAllowEnforcer(jcasbinAuthorizer);
-    Enforcer denyEnforcer = getDenyEnforcer(jcasbinAuthorizer);
-
-    Long testRoleId = 302L;
-    String roleIdStr = String.valueOf(testRoleId);
-    String userIdStr = String.valueOf(USER_ID);
-    allowEnforcer.addRoleForUser(userIdStr, roleIdStr);
-    denyEnforcer.addRoleForUser(userIdStr, roleIdStr);
-    allowEnforcer.addPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow");
-    denyEnforcer.addPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow");
-
-    Method clearRolePolicies =
-        JcasbinAuthorizer.class.getDeclaredMethod("clearRolePolicies", long.class);
-    clearRolePolicies.setAccessible(true);
-    clearRolePolicies.invoke(jcasbinAuthorizer, testRoleId);
-
-    assertFalse(allowEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
-    assertFalse(denyEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
-    assertTrue(allowEnforcer.getRolesForUser(userIdStr).contains(roleIdStr));
-    assertTrue(denyEnforcer.getRolesForUser(userIdStr).contains(roleIdStr));
   }
 
   @Test
   public void testCacheInitialization() throws Exception {
     // Verify that caches are initialized
-    GravitinoCache<Long, Long> loadedRolesCache = getLoadedRolesCache(jcasbinAuthorizer);
+    GravitinoCache<Long, CachedRolePolicies> loadedRolesCache =
+        getLoadedRolesCache(jcasbinAuthorizer);
     GravitinoCache<Long, Optional<OwnerInfo>> ownerRelCache = getOwnerRelCache(jcasbinAuthorizer);
 
     assertNotNull(loadedRolesCache, "loadedRoles cache should be initialized");
     assertNotNull(ownerRelCache, "ownerRel cache should be initialized");
+  }
+
+  @Test
+  public void testPrivilegeProbesUseIndexNotEnforcerPolicies() throws Exception {
+    // Guards the O(roles_per_user) optimization: privilege probes resolve against the per-role
+    // index, and the enforcer holds only the role-membership (g) graph, never privilege (p)
+    // policies. If a future change reintroduces enforce/addPolicy on the hot path, the empty-policy
+    // assertion below fails.
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+
+    mockRoleInStore(ALLOW_ROLE_ID, "allowRole", ImmutableList.of(getAllowSecurableObject()));
+    when(userMetaMapper.getUserUpdatedAt(eq(METALAKE), eq(USERNAME)))
+        .thenReturn(new UserUpdatedAt(USER_ID, nextUserVersion()));
+    when(roleMetaMapper.listRolesByUserId(eq(USER_ID)))
+        .thenReturn(ImmutableList.of(buildRolePO(ALLOW_ROLE_ID, "allowRole")));
+
+    assertTrue(doAuthorize(currentPrincipal));
+
+    // The per-role index carries the granted privilege ...
+    CachedRolePolicies cached =
+        getLoadedRolesCache(jcasbinAuthorizer).getIfPresent(ALLOW_ROLE_ID).orElse(null);
+    assertNotNull(cached, "role index must be cached after authorize");
+    assertEquals(
+        Effect.ALLOW,
+        cached.getIndex().get(new PolicyKey("CATALOG", CATALOG_ID, USE_CATALOG.name())),
+        "index must resolve the granted allow");
+
+    // ... while the enforcer holds only membership (g) rows, never privilege (p) policies.
+    Enforcer allowEnforcer = getAllowEnforcer(jcasbinAuthorizer);
+    assertTrue(
+        allowEnforcer.getPolicy().isEmpty(),
+        "enforcer must not store privilege (p) policies; probes use the index");
+    assertTrue(
+        allowEnforcer
+            .getRolesForUser(String.valueOf(USER_ID))
+            .contains(String.valueOf(ALLOW_ROLE_ID)),
+        "enforcer must still hold the user -> role grouping row");
   }
 
   /** Tests {@link JcasbinAuthorizer#hasMetadataPrivilegePermission} hierarchy walk */
@@ -2221,11 +2185,11 @@ public class TestJcasbinAuthorizer {
   }
 
   @SuppressWarnings("unchecked")
-  private static GravitinoCache<Long, Long> getLoadedRolesCache(JcasbinAuthorizer authorizer)
-      throws Exception {
+  private static GravitinoCache<Long, CachedRolePolicies> getLoadedRolesCache(
+      JcasbinAuthorizer authorizer) throws Exception {
     Field field = JcasbinAuthorizer.class.getDeclaredField("loadedRoles");
     field.setAccessible(true);
-    return (GravitinoCache<Long, Long>) field.get(authorizer);
+    return (GravitinoCache<Long, CachedRolePolicies>) field.get(authorizer);
   }
 
   @SuppressWarnings("unchecked")
@@ -2290,12 +2254,6 @@ public class TestJcasbinAuthorizer {
 
   private static Enforcer getAllowEnforcer(JcasbinAuthorizer authorizer) throws Exception {
     Field field = JcasbinAuthorizer.class.getDeclaredField("allowEnforcer");
-    field.setAccessible(true);
-    return (Enforcer) field.get(authorizer);
-  }
-
-  private static Enforcer getDenyEnforcer(JcasbinAuthorizer authorizer) throws Exception {
-    Field field = JcasbinAuthorizer.class.getDeclaredField("denyEnforcer");
     field.setAccessible(true);
     return (Enforcer) field.get(authorizer);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Privilege probes on the JCasbin authorization hot path no longer call `enforcer.enforce`. They resolve against a per-role index instead:

- `loadedRoles` now caches `roleId → CachedRolePolicies` (a `role_meta.updated_at` version sentinel plus a `Map<PolicyKey, Effect>` index), built in `loadPolicyByRoleEntity`.
- `authorizeByJcasbin` / the new `resolveRoleEffect`, the active-role narrowing path, and `hasDenyPolicy` all resolve via index lookups over the roles the caller holds (`indexEffect`).
- The enforcer keeps only the user/group→role grouping graph (`g` rows); it no longer stores privilege (`p`) policies. The now-redundant second (`deny`) enforcer, `clearRolePolicies`, and the removal listener in `JcasbinLoadedRolesCache` are removed.
- New types: `PolicyKey`, `Effect`, `CachedRolePolicies`.

Semantics preserved: DENY wins within a role and globally across the caller's roles; active-role narrowing (role assumption) still narrows allows while deny stays global; `role_meta.updated_at` version validation is unchanged; OWNER still short-circuits to the owner cache.

#### Why `JcasbinLoadedRolesCache` no longer needs a removal listener

Policy ownership changes in this PR:

| | Before this PR | After this PR |
|---|---|---|
| `loadedRoles` value | `roleId → updatedAt` | `roleId → CachedRolePolicies(updatedAt, policyIndex)` |
| Privilege-policy storage | JCasbin enforcer `p` rows | `CachedRolePolicies.index` |
| Enforcer responsibility | `g` bindings and `p` policies | `g(user/group, role)` bindings only |
| Work on cache eviction | Delete the separate `p` rows | None; the index is removed with the cache entry |

Previously, evicting the version-only `loadedRoles` entry left a second copy of the role's policies in the enforcers. The removal listener therefore had to clear those `p(roleId, ...)` rows. The recently merged fix correctly changed that cleanup from `deleteRole`, which also removes independently managed `g` bindings, to policy-only cleanup.

This PR removes enforcer `p` rows entirely. The complete privilege index and its version sentinel now live in the same `CachedRolePolicies` cache value, so eviction atomically discards the policy data itself. On the next request, `versionCheckAndLoadRoles` observes the cache miss, reloads the role from the database, and rebuilds the index. There is no second policy copy for a listener to clean.

The enforcer's remaining `g` bindings have a separate lifecycle managed by the user/group role caches. Deleting them when a policy-index entry expires would be incorrect. A residual `g` binding cannot grant access without a corresponding `loadedRoles` index: a missing index resolves to no privilege and is reloaded or rejected by version validation before authorization.

### Why are the changes needed?

In jcasbin 1.99.0, `enforce` linearly scans **every** policy line loaded in the enforcer and evaluates the aviator matcher per line — `O(total_policies)` per probe — and the enforcer accumulates policies for up to `roleCacheSize` (default 10000) roles across all metalakes on a node. A benchmark against the real `jcasbin_model.conf` (one user, one role, one object) shows the scan is over all policies regardless of the user's bindings:

| roles | p-rules | `enforce` avg |
|---|---|---|
| 1,000 | 60,000 | ~12.8 ms |
| 10,000 | 600,000 | ~106 ms |

The index makes each probe `O(roles_per_user)` hash lookups (sub-microsecond, flat in total policy count). One `authorize` triggers many probes (schema chain, per-object list checks, allow+deny, per-active-role narrowing), so the saving compounds.

Fix: #12173

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`./gradlew :server-common:test --tests "org.apache.gravitino.server.authorization.jcasbin.TestJcasbinAuthorizer" -PskipITs` — 57 tests pass.

- `testPrivilegeProbesUseIndexNotEnforcerPolicies` asserts that the index carries the granted privilege while the enforcer contains no `p` policies.
- `testRoleCacheInvalidationPreservesUserRoleBindings` asserts that invalidating the policy-index entry removes it without deleting the enforcer's independently managed `g` binding.
- The deleted-role/version-miss test asserts that a residual `g` binding grants nothing after its `loadedRoles` index is evicted.

### Optimization approach and scope

Authorization no longer calls JCasbin enforce for privilege probes. allowEnforcer retains only the user/group-to-role (g) relationship graph. Privilege policies are stored in a per-role PolicyKey-to-Effect index in loadedRoles. A request first resolves the roles held by the user, then performs hash lookups only in those roles' indexes; DENY takes precedence globally, while active-role narrowing applies to ALLOW decisions.

This primarily addresses nodes with many cached roles and policies, where the old JCasbin path scanned all loaded p policy lines for every probe. It does not eliminate the cost of a single very large role: that role's complete policy index still needs to be loaded and retained. Likewise, a role shared by many users still has one shared index and the user-role (g) relationship remains a separate scale consideration. These cases are outside this PR's scope.