### PR TITLE
[#12208] improvement(web-v2): Add unsupported column types for OceanBase/StarRocks/Hudi and support optional precision for time/timestamp/timestamp_tz

### DIFF
--- a/web-v2/web/src/app/catalogs/rightContent/CreateTableDialog.js
+++ b/web-v2/web/src/app/catalogs/rightContent/CreateTableDialog.js
@@ -650,7 +650,7 @@ export default function CreateTableDialog({ ...props }) {
                       column['defaultValue'] = {
                         type: 'literal',
                         dataType: col.defaultValue?.dataType || 'string',
-                        value: col.defaultValue?.value
+                        value: col.defaultValue?.value || 'NULL'
                       }
                   }
                 }

--- a/web-v2/web/src/app/catalogs/rightContent/CreateTableDialog.js
+++ b/web-v2/web/src/app/catalogs/rightContent/CreateTableDialog.js
@@ -650,7 +650,10 @@ export default function CreateTableDialog({ ...props }) {
                       column['defaultValue'] = {
                         type: 'literal',
                         dataType: col.defaultValue?.dataType || 'string',
-                        value: col.defaultValue?.value || 'NULL'
+                        value:
+                          col.defaultValue?.value === '' || col.defaultValue?.value == null
+                            ? 'NULL'
+                            : col.defaultValue?.value
                       }
                   }
                 }

--- a/web-v2/web/src/components/ColumnTypeComponent.js
+++ b/web-v2/web/src/components/ColumnTypeComponent.js
@@ -21,7 +21,7 @@ import React, { useRef, useState } from 'react'
 import { Button, Dropdown, Form, FormListOperation, Input, InputNumber, Popconfirm, Select, Tooltip } from 'antd'
 import { useClickAway } from 'react-use'
 import SpecialColumnTypeComponent from '@/components/SpecialColumnTypeComponent'
-import { ColumnSpesicalType, ColumnWithParamType } from '@/config'
+import { ColumnSpesicalType, ColumnWithParamType, ColumnWithPrecisionType } from '@/config'
 import { capitalizeFirstLetter, extractNumbersInParentheses } from '@/lib/utils'
 import { cn } from '@/lib/utils/tailwind'
 
@@ -35,6 +35,7 @@ export default function ColumnTypeComponent({ ...props }) {
   const [paramL, setParamL] = useState('')
   const [paramP, setParamP] = useState('')
   const [paramS, setParamS] = useState('')
+  const [paramPrecision, setParamPrecision] = useState('')
   const [open, setOpen] = useState(false)
   const [isEditSpecialColumnType, setIsEditSpecialColumnType] = useState(false)
   const currentType = Form.useWatch([...parentField, subField.name, 'typeObj', ...columnNamespace, 'type'], form)
@@ -51,6 +52,10 @@ export default function ColumnTypeComponent({ ...props }) {
     setParamS(value)
   }
 
+  const onChangeParamPrecision = value => {
+    setParamPrecision(value ?? '')
+  }
+
   const onFocus = e => {
     setErrorMsg('')
     setIsShowParamsInput(!isShowParamsInput)
@@ -60,6 +65,7 @@ export default function ColumnTypeComponent({ ...props }) {
     setParamL('')
     setParamP('')
     setParamS('')
+    setParamPrecision('')
     setErrorMsg('')
     if (value && ColumnSpesicalType.includes(value)) {
       setOpen(true)
@@ -121,6 +127,23 @@ export default function ColumnTypeComponent({ ...props }) {
         }
         if (errors.length) {
           setErrorMsg(errors.join(', '))
+        }
+      }
+      if (ColumnWithPrecisionType.includes(value)) {
+        const resolvedPrecision = paramPrecision || currentTypeParam
+        if (currentTypeParam && !paramPrecision) {
+          setParamPrecision(currentTypeParam)
+        }
+        if (resolvedPrecision) {
+          form.setFieldValue(
+            [...parentField, subField.name, 'typeObj', ...columnNamespace, 'type'],
+            capitalizeFirstLetter(value) + `(${resolvedPrecision})`
+          )
+        } else {
+          form.setFieldValue(
+            [...parentField, subField.name, 'typeObj', ...columnNamespace, 'type'],
+            capitalizeFirstLetter(value)
+          )
         }
       }
     }
@@ -240,6 +263,22 @@ export default function ColumnTypeComponent({ ...props }) {
                 />
               </div>
             </>
+          )}
+        {typeof currentType === 'string' &&
+          ColumnWithPrecisionType.includes(currentType?.replace(/\([^)]*\)/g, '').toLowerCase()) &&
+          isShowParamsInput && (
+            <div className='ml-1 border-b focus-within:border-[color:theme(colors.defaultPrimary)]'>
+              <InputNumber
+                size='small'
+                controls={false}
+                placeholder='Precision'
+                min={0}
+                max={12}
+                value={paramPrecision}
+                onChange={onChangeParamPrecision}
+                className='w-20 border-none focus-within:shadow-none'
+              />
+            </div>
           )}
       </div>
       <div className='text-red-500'>{errorMsg}</div>

--- a/web-v2/web/src/components/ColumnTypeComponent.js
+++ b/web-v2/web/src/components/ColumnTypeComponent.js
@@ -130,11 +130,11 @@ export default function ColumnTypeComponent({ ...props }) {
         }
       }
       if (ColumnWithPrecisionType.includes(value)) {
-        const resolvedPrecision = paramPrecision || currentTypeParam
-        if (currentTypeParam && !paramPrecision) {
+        const resolvedPrecision = paramPrecision === '' ? currentTypeParam : paramPrecision
+        if (currentTypeParam && paramPrecision === '') {
           setParamPrecision(currentTypeParam)
         }
-        if (resolvedPrecision) {
+        if (resolvedPrecision !== '') {
           form.setFieldValue(
             [...parentField, subField.name, 'typeObj', ...columnNamespace, 'type'],
             capitalizeFirstLetter(value) + `(${resolvedPrecision})`

--- a/web-v2/web/src/config/index.js
+++ b/web-v2/web/src/config/index.js
@@ -123,6 +123,8 @@ export const ColumnTypeSupportAutoIncrement = [
 
 export const ColumnWithParamType = ['char', 'varchar', 'fixed']
 
+export const ColumnWithPrecisionType = ['time', 'timestamp', 'timestamp_tz']
+
 export const ColumnSpesicalType = ['union', 'list', 'map', 'struct']
 
 export const UnsupportColumnType = {
@@ -155,7 +157,22 @@ export const UnsupportColumnType = {
     'binary',
     'time'
   ],
+  'jdbc-oceanbase': ['boolean', 'fixed', 'struct', 'list', 'map', 'interval_day', 'interval_year', 'union', 'uuid'],
+  'jdbc-starrocks': ['fixed', 'timestamp_tz', 'interval_day', 'interval_year', 'union', 'uuid'],
   'lakehouse-generic': ['char', 'varchar', 'time', 'timestamp_tz'],
+  'lakehouse-hudi': [
+    'byte',
+    'char',
+    'fixed',
+    'interval_day',
+    'interval_year',
+    'short',
+    'time',
+    'timestamp_tz',
+    'union',
+    'uuid',
+    'varchar'
+  ],
   'lakehouse-paimon': ['interval_day', 'interval_year', 'union', 'uuid'],
   'jdbc-clickhouse': [
     'binary',


### PR DESCRIPTION
## Summary

- Add unsupported column types for OceanBase, StarRocks, and Hudi catalogs in the web UI config
- Support optional precision for `time`, `timestamp`, and `timestamp_tz` types in the column type component
- Fix defaultValue empty value handling: when a literal type's value is empty/null, set it to `'NULL'` instead of sending an empty string to the backend

## Changes

### 1. Unsupported column types (`web-v2/web/src/config/index.js`)
- **jdbc-oceanbase**: Added `boolean`, `fixed`, `struct`, `list`, `map`, `interval_day`, `interval_year`, `union`, `uuid`
- **jdbc-starrocks**: Added `fixed`, `timestamp_tz`, `interval_day`, `interval_year`, `union`, `uuid`
- **lakehouse-hudi**: Added `byte`, `char`, `fixed`, `interval_day`, `interval_year`, `short`, `time`, `timestamp_tz`, `union`, `uuid`, `varchar`

### 2. Optional precision for time/timestamp types (`web-v2/web/src/components/ColumnTypeComponent.js`)
- Added `ColumnWithPrecisionType` config for `time`, `timestamp`, `timestamp_tz`
- Added precision input field (InputNumber, range 0-12) for these types
- Type string is constructed as `time(3)` or `timestamp(6)` when precision is set, or just `time`/`timestamp` when omitted

### 3. Fix defaultValue empty value handling (`web-v2/web/src/app/catalogs/rightContent/CreateTableDialog.js`)
- When `defaultValue.value` is empty/null for a literal type, set it to `'NULL'` instead of sending an empty string to the backend

🤖 Generated with CodeArts Agent