### PR TITLE
[#12238] fix(core): Make PostgreSQL table version soft delete idempotent

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableVersionPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableVersionPostgreSQLProvider.java
@@ -63,7 +63,7 @@ public class TableVersionPostgreSQLProvider extends TableVersionBaseSQLProvider 
         + TABLE_NAME
         + " SET deleted_at = round(extract(epoch from(current_timestamp -"
         + " timestamp '1970-01-01 00:00:00')) * 1000)"
-        + " WHERE table_id = #{tableId} AND version = #{version}";
+        + " WHERE table_id = #{tableId} AND version = #{version} AND deleted_at = 0";
   }
 
   @Override

--- a/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TestTableVersionPostgreSQLProvider.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TestTableVersionPostgreSQLProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TestTableVersionPostgreSQLProvider {
+
+  @Test
+  void testSoftDeleteOnlyActiveTableVersion() {
+    TableVersionPostgreSQLProvider provider = new TableVersionPostgreSQLProvider();
+
+    String sql = provider.softDeleteTableVersionByTableIdAndVersion(1L, 1L);
+
+    assertTrue(
+        sql.endsWith("WHERE table_id = #{tableId} AND version = #{version} AND deleted_at = 0"),
+        "Soft delete should only update an active table version");
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an active-record condition to the PostgreSQL table version soft-delete SQL and add a regression test for the generated SQL.

### Why are the changes needed?

Repeated soft deletes could update an already deleted table version. When both updates generated the same millisecond timestamp, PostgreSQL reported a duplicate key violation.

Fix: #12238

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. Repeated PostgreSQL table version soft deletes no longer fail with a duplicate key violation.

### How was this patch tested?

- `./gradlew spotlessApply`
- `./gradlew :core:test --tests org.apache.gravitino.storage.relational.mapper.provider.postgresql.TestTableVersionPostgreSQLProvider -PskipITs -PskipDockerTests=false`
- `./gradlew :core:check -PskipITs -PskipDockerTests=false`