### PR TITLE
[#12255] fix(lance): authenticate the Lance REST service to the Gravitino server

### DIFF
--- a/docs/lance-rest-service.md
+++ b/docs/lance-rest-service.md
@@ -141,14 +141,14 @@ credentials, otherwise a Gravitino server configured with an authenticator other
 rejects them and every Lance operation fails. Configure the auth type to match the Gravitino
 server:
 
-| Configuration Property                            | Description                                                                       | Default Value      | Required          | Since Version |
-|---------------------------------------------------|-----------------------------------------------------------------------------------|--------------------|-------------------|---------------|
-| `gravitino.lance-rest.gravitino-auth-type`        | Auth type used to reach the Gravitino server. Supported values: `simple`, `oauth2` | `simple`           | No                | 1.3.0         |
-| `gravitino.lance-rest.gravitino-simple.user-name` | User name presented when the auth type is `simple`                                | `lance-rest-server` | No                | 1.3.0         |
-| `gravitino.lance-rest.gravitino-oauth2.server-uri`| OAuth2 server URI                                                                 | (none)             | Yes, for `oauth2` | 1.3.0         |
-| `gravitino.lance-rest.gravitino-oauth2.credential`| Credential used to request the OAuth2 token                                       | (none)             | Yes, for `oauth2` | 1.3.0         |
-| `gravitino.lance-rest.gravitino-oauth2.token-path`| Path on the OAuth2 server used to request the token                               | (none)             | Yes, for `oauth2` | 1.3.0         |
-| `gravitino.lance-rest.gravitino-oauth2.scope`     | Scope of the requested OAuth2 token                                               | (none)             | Yes, for `oauth2` | 1.3.0         |
+| Configuration Property                             | Description                                                                        | Default Value       | Required          | Since Version |
+|----------------------------------------------------|------------------------------------------------------------------------------------|---------------------|-------------------|---------------|
+| `gravitino.lance-rest.gravitino-auth-type`         | Auth type used to reach the Gravitino server. Supported values: `simple`, `oauth2` | `simple`            | No                | 2.0.0         |
+| `gravitino.lance-rest.gravitino-simple.user-name`  | User name presented when the auth type is `simple`                                 | `lance-rest-server` | No                | 2.0.0         |
+| `gravitino.lance-rest.gravitino-oauth2.server-uri` | OAuth2 server URI                                                                  | (none)              | Yes, for `oauth2` | 2.0.0         |
+| `gravitino.lance-rest.gravitino-oauth2.credential` | Credential used to request the OAuth2 token                                        | (none)              | Yes, for `oauth2` | 2.0.0         |
+| `gravitino.lance-rest.gravitino-oauth2.token-path` | Path on the OAuth2 server used to request the token                                | (none)              | Yes, for `oauth2` | 2.0.0         |
+| `gravitino.lance-rest.gravitino-oauth2.scope`      | Scope of the requested OAuth2 token                                                | (none)              | Yes, for `oauth2` | 2.0.0         |
 
 This setting controls how the service authenticates to the Gravitino server. It does not change how
 callers authenticate to the Lance REST service itself.

--- a/docs/lance-rest-service.md
+++ b/docs/lance-rest-service.md
@@ -134,6 +134,25 @@ To enable the Lance REST service within Gravitino server, configure the followin
 | `gravitino.lance-rest.gravitino-uri`      | Gravitino server URI (required when namespace-backend is `gravitino`)        | http://localhost:8090   | Yes      | 1.1.0         |
 | `gravitino.lance-rest.gravitino-metalake` | Gravitino metalake name (required when namespace-backend is `gravitino`)     | (none)                  | Yes      | 1.1.0         |
 
+**Authentication to the Gravitino Server**
+
+The Lance REST service makes its own requests to the Gravitino server. Those requests must carry
+credentials, otherwise a Gravitino server configured with an authenticator other than `simple`
+rejects them and every Lance operation fails. Configure the auth type to match the Gravitino
+server:
+
+| Configuration Property                            | Description                                                                       | Default Value      | Required          | Since Version |
+|---------------------------------------------------|-----------------------------------------------------------------------------------|--------------------|-------------------|---------------|
+| `gravitino.lance-rest.gravitino-auth-type`        | Auth type used to reach the Gravitino server. Supported values: `simple`, `oauth2` | `simple`           | No                | 1.3.0         |
+| `gravitino.lance-rest.gravitino-simple.user-name` | User name presented when the auth type is `simple`                                | `lance-rest-server` | No                | 1.3.0         |
+| `gravitino.lance-rest.gravitino-oauth2.server-uri`| OAuth2 server URI                                                                 | (none)             | Yes, for `oauth2` | 1.3.0         |
+| `gravitino.lance-rest.gravitino-oauth2.credential`| Credential used to request the OAuth2 token                                       | (none)             | Yes, for `oauth2` | 1.3.0         |
+| `gravitino.lance-rest.gravitino-oauth2.token-path`| Path on the OAuth2 server used to request the token                               | (none)             | Yes, for `oauth2` | 1.3.0         |
+| `gravitino.lance-rest.gravitino-oauth2.scope`     | Scope of the requested OAuth2 token                                               | (none)             | Yes, for `oauth2` | 1.3.0         |
+
+This setting controls how the service authenticates to the Gravitino server. It does not change how
+callers authenticate to the Lance REST service itself.
+
 **Example Configuration:**
 
 ```properties

--- a/lance/lance-common/build.gradle.kts
+++ b/lance/lance-common/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
 
 dependencies {
   implementation(project(":api"))
+  implementation(project(":catalogs:catalog-common"))
   implementation(project(":clients:client-java"))
   implementation(project(":common")) {
     exclude("*")

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.OverwriteDefaultConfig;
+import org.apache.gravitino.auth.AuthProperties;
 import org.apache.gravitino.config.ConfigBuilder;
 import org.apache.gravitino.config.ConfigConstants;
 import org.apache.gravitino.config.ConfigEntry;
@@ -33,6 +34,8 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
   public static final String CONFIG_NAMESPACE_BACKEND = "namespace-backend";
   public static final String CONFIG_METALAKE = "metalake";
   public static final String CONFIG_URI = "uri";
+  public static final String CONFIG_AUTH_TYPE = "auth-type";
+  public static final String DEFAULT_SIMPLE_USERNAME = "lance-rest-server";
 
   public static final int DEFAULT_LANCE_REST_SERVICE_HTTP_PORT = 9101;
   public static final int DEFAULT_LANCE_REST_SERVICE_HTTPS_PORT = 9533;
@@ -60,6 +63,50 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
           .stringConf()
           .createWithDefault(GRAVITINO_URI);
 
+  public static final ConfigEntry<String> GRAVITINO_AUTH_TYPE =
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "-" + CONFIG_AUTH_TYPE)
+          .doc(
+              "The auth type used when the Lance REST service communicates with the Gravitino "
+                  + "server. Supported values are `simple` and `oauth2`.")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .createWithDefault(AuthProperties.SIMPLE_AUTH_TYPE);
+
+  public static final ConfigEntry<String> GRAVITINO_SIMPLE_USERNAME =
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "-simple.user-name")
+          .doc("The user name used when the auth type is `simple`")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .createWithDefault(DEFAULT_SIMPLE_USERNAME);
+
+  public static final ConfigEntry<String> GRAVITINO_OAUTH2_SERVER_URI =
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "-oauth2.server-uri")
+          .doc("The OAuth2 server URI, required when the auth type is `oauth2`")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .create();
+
+  public static final ConfigEntry<String> GRAVITINO_OAUTH2_CREDENTIAL =
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "-oauth2.credential")
+          .doc("The credential used to request the OAuth2 token, required for `oauth2`")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .create();
+
+  public static final ConfigEntry<String> GRAVITINO_OAUTH2_TOKEN_PATH =
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "-oauth2.token-path")
+          .doc("The path on the OAuth2 server used to request the token, required for `oauth2`")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .create();
+
+  public static final ConfigEntry<String> GRAVITINO_OAUTH2_SCOPE =
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "-oauth2.scope")
+          .doc("The scope of the requested OAuth2 token, required for `oauth2`")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .create();
+
   public LanceConfig(Map<String, String> properties) {
     super(false);
     loadFromMap(properties, key -> true);
@@ -79,6 +126,10 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
 
   public String getGravitinoMetalake() {
     return get(METALAKE_NAME);
+  }
+
+  public String getGravitinoAuthType() {
+    return get(GRAVITINO_AUTH_TYPE);
   }
 
   @Override

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceNamespaceWrapper.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceNamespaceWrapper.java
@@ -27,7 +27,11 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Catalog;
+import org.apache.gravitino.auth.AuthProperties;
+import org.apache.gravitino.client.DefaultOAuth2TokenProvider;
 import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.client.GravitinoClient.ClientBuilder;
+import org.apache.gravitino.config.ConfigEntry;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.lance.common.config.LanceConfig;
 import org.apache.gravitino.lance.common.ops.LanceNamespaceOperations;
@@ -78,14 +82,11 @@ public class GravitinoLanceNamespaceWrapper extends NamespaceWrapper {
               }
             });
 
-    this.client =
-        GravitinoClient.builder(uri)
-            .withMetalake(metalakeName)
-            .withClientConfig(clientProperties)
-            .build();
+    this.client = createGravitinoClient(uri, metalakeName, clientProperties, config());
 
     LOG.info(
-        "GravitinoClient initialized with {} client properties for metalake: {}",
+        "GravitinoClient initialized with auth type {} and {} client properties for metalake: {}",
+        config().getGravitinoAuthType(),
         clientProperties.size(),
         metalakeName);
 
@@ -134,5 +135,66 @@ public class GravitinoLanceNamespaceWrapper extends NamespaceWrapper {
           catalogName);
     }
     return catalog;
+  }
+
+  static GravitinoClient createGravitinoClient(
+      String uri, String metalake, Map<String, String> clientProperties, LanceConfig config) {
+    return newClientBuilder(uri, metalake, clientProperties, config).build();
+  }
+
+  /**
+   * Builds and configures the client builder, including the credentials the Lance REST service
+   * presents to the Gravitino server. Separated from {@link #createGravitinoClient} so that the
+   * configuration can be exercised without contacting a server.
+   *
+   * @param uri the Gravitino server URI
+   * @param metalake the metalake name
+   * @param clientProperties additional client properties, such as connection pool settings
+   * @param config the Lance REST service configuration holding the auth settings
+   * @return a configured client builder
+   */
+  @VisibleForTesting
+  static ClientBuilder newClientBuilder(
+      String uri, String metalake, Map<String, String> clientProperties, LanceConfig config) {
+    ClientBuilder builder = GravitinoClient.builder(uri).withMetalake(metalake);
+    builder.withClientConfig(clientProperties);
+    String authType = config.getGravitinoAuthType();
+    if (AuthProperties.isSimple(authType)) {
+      builder.withSimpleAuth(config.get(LanceConfig.GRAVITINO_SIMPLE_USERNAME));
+    } else if (AuthProperties.isOAuth2(authType)) {
+      DefaultOAuth2TokenProvider tokenProvider =
+          DefaultOAuth2TokenProvider.builder()
+              .withUri(requireConfig(config, LanceConfig.GRAVITINO_OAUTH2_SERVER_URI, "server-uri"))
+              .withCredential(
+                  requireConfig(config, LanceConfig.GRAVITINO_OAUTH2_CREDENTIAL, "credential"))
+              .withPath(
+                  requireConfig(config, LanceConfig.GRAVITINO_OAUTH2_TOKEN_PATH, "token-path"))
+              .withScope(requireConfig(config, LanceConfig.GRAVITINO_OAUTH2_SCOPE, "scope"))
+              .build();
+      builder.withOAuth(tokenProvider);
+    } else {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Unsupported value for %sgravitino-%s: %s. Supported values are %s and %s.",
+              LanceConfig.LANCE_CONFIG_PREFIX,
+              LanceConfig.CONFIG_AUTH_TYPE,
+              authType,
+              AuthProperties.SIMPLE_AUTH_TYPE,
+              AuthProperties.OAUTH2_AUTH_TYPE));
+    }
+    return builder;
+  }
+
+  private static String requireConfig(LanceConfig config, ConfigEntry<String> entry, String name) {
+    String value = config.get(entry);
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(value),
+        "%sgravitino-oauth2.%s must be set when %sgravitino-%s is %s",
+        LanceConfig.LANCE_CONFIG_PREFIX,
+        name,
+        LanceConfig.LANCE_CONFIG_PREFIX,
+        LanceConfig.CONFIG_AUTH_TYPE,
+        AuthProperties.OAUTH2_AUTH_TYPE);
+    return value;
   }
 }

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestGravitinoLanceClientAuth.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/gravitino/TestGravitinoLanceClientAuth.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.gravitino.lance.common.ops.gravitino;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.auth.AuthProperties;
+import org.apache.gravitino.lance.common.config.LanceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestGravitinoLanceClientAuth {
+
+  private static final String URI = "http://localhost:8090";
+  private static final String METALAKE = "test_metalake";
+
+  private static LanceConfig configOf(Map<String, String> properties) {
+    return new LanceConfig(properties);
+  }
+
+  @Test
+  void testAuthTypeDefaultsToSimple() {
+    LanceConfig config = configOf(ImmutableMap.of("gravitino-metalake", METALAKE));
+    Assertions.assertEquals(AuthProperties.SIMPLE_AUTH_TYPE, config.getGravitinoAuthType());
+    Assertions.assertEquals(
+        LanceConfig.DEFAULT_SIMPLE_USERNAME, config.get(LanceConfig.GRAVITINO_SIMPLE_USERNAME));
+  }
+
+  @Test
+  void testSimpleAuthUsesConfiguredUserName() {
+    LanceConfig config =
+        configOf(
+            ImmutableMap.of(
+                "gravitino-metalake", METALAKE,
+                "gravitino-auth-type", "simple",
+                "gravitino-simple.user-name", "svc_lance"));
+    Assertions.assertEquals("svc_lance", config.get(LanceConfig.GRAVITINO_SIMPLE_USERNAME));
+    Assertions.assertDoesNotThrow(
+        () ->
+            GravitinoLanceNamespaceWrapper.newClientBuilder(
+                URI, METALAKE, ImmutableMap.of(), config));
+  }
+
+  @Test
+  void testAuthTypeIsCaseInsensitive() {
+    LanceConfig config =
+        configOf(ImmutableMap.of("gravitino-metalake", METALAKE, "gravitino-auth-type", "SIMPLE"));
+    Assertions.assertDoesNotThrow(
+        () ->
+            GravitinoLanceNamespaceWrapper.newClientBuilder(
+                URI, METALAKE, ImmutableMap.of(), config));
+  }
+
+  @Test
+  void testOAuth2RequiresServerUri() {
+    LanceConfig config =
+        configOf(
+            ImmutableMap.of(
+                "gravitino-metalake", METALAKE,
+                "gravitino-auth-type", "oauth2",
+                "gravitino-oauth2.credential", "client:secret",
+                "gravitino-oauth2.token-path", "/oauth/token",
+                "gravitino-oauth2.scope", "test"));
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                GravitinoLanceNamespaceWrapper.newClientBuilder(
+                    URI, METALAKE, ImmutableMap.of(), config));
+    Assertions.assertTrue(exception.getMessage().contains("gravitino-oauth2.server-uri"));
+  }
+
+  @Test
+  void testOAuth2RequiresCredential() {
+    LanceConfig config =
+        configOf(
+            ImmutableMap.of(
+                "gravitino-metalake", METALAKE,
+                "gravitino-auth-type", "oauth2",
+                "gravitino-oauth2.server-uri", "http://localhost:8177",
+                "gravitino-oauth2.token-path", "/oauth/token",
+                "gravitino-oauth2.scope", "test"));
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                GravitinoLanceNamespaceWrapper.newClientBuilder(
+                    URI, METALAKE, ImmutableMap.of(), config));
+    Assertions.assertTrue(exception.getMessage().contains("gravitino-oauth2.credential"));
+  }
+
+  @Test
+  void testUnsupportedAuthTypeIsRejected() {
+    LanceConfig config =
+        configOf(
+            ImmutableMap.of("gravitino-metalake", METALAKE, "gravitino-auth-type", "kerberos"));
+    UnsupportedOperationException exception =
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                GravitinoLanceNamespaceWrapper.newClientBuilder(
+                    URI, METALAKE, ImmutableMap.of(), config));
+    Assertions.assertTrue(exception.getMessage().contains("kerberos"));
+  }
+}

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceAuthIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceAuthIT.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.gravitino.lance.integration.test;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.CreateNamespaceRequest;
+
+/**
+ * Verifies that the Lance REST service authenticates to the Gravitino server as its configured
+ * identity rather than anonymously.
+ *
+ * <p>Before the service was given an {@code AuthDataProvider}, its requests to the Gravitino server
+ * carried no authorization header and were recorded against the anonymous user. Objects created
+ * through the Lance REST service therefore had {@code anonymous} as their creator.
+ */
+public class LanceRESTServiceAuthIT extends BaseIT {
+
+  private static final String SIMPLE_USER_NAME = "lance_rest_service_user";
+  private static final String USER_NAME_CONFIG_KEY =
+      "gravitino.lance-rest.gravitino-simple.user-name";
+
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+  private GravitinoMetalake metalake;
+  private LanceNamespace ns;
+
+  @BeforeAll
+  public void startIntegrationTest() throws Exception {
+    super.ignoreLanceAuxRestService = false;
+    registerCustomConfigs(new HashMap<>(Map.of(USER_NAME_CONFIG_KEY, SIMPLE_USER_NAME)));
+    super.startIntegrationTest();
+
+    this.metalake =
+        client.createMetalake(
+            getLanceRESTServerMetalakeName(), "metalake for lance rest auth tests", null);
+
+    Map<String, String> props = new HashMap<>();
+    props.put("uri", getLanceRestServiceUrl());
+    props.put("delimiter", ".");
+    this.ns = LanceNamespace.connect("rest", props, allocator);
+  }
+
+  @AfterAll
+  public void clean() throws Exception {
+    Exception failure = null;
+
+    try {
+      if (client != null) {
+        client.dropMetalake(getLanceRESTServerMetalakeName(), true);
+      }
+    } catch (Exception e) {
+      failure = e;
+    }
+
+    try {
+      allocator.close();
+    } catch (Exception e) {
+      failure = failure == null ? e : failure;
+    }
+
+    try {
+      super.stopIntegrationTest();
+    } catch (Exception e) {
+      failure = failure == null ? e : failure;
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  @Test
+  public void testCatalogCreatedViaLanceRestIsNotAnonymous() {
+    String catalogName = GravitinoITUtils.genRandomName("lance_auth_catalog");
+
+    CreateNamespaceRequest createNamespaceReq = new CreateNamespaceRequest();
+    createNamespaceReq.addIdItem(catalogName);
+    ns.createNamespace(createNamespaceReq);
+
+    Catalog catalog = metalake.loadCatalog(catalogName);
+    Assertions.assertEquals(
+        SIMPLE_USER_NAME,
+        catalog.auditInfo().creator(),
+        "The Lance REST service should act as its configured user, not "
+            + AuthConstants.ANONYMOUS_USER);
+    Assertions.assertNotEquals(AuthConstants.ANONYMOUS_USER, catalog.auditInfo().creator());
+
+    metalake.dropCatalog(catalogName, true);
+  }
+
+  private String getLanceRestServiceUrl() {
+    return String.format("http://%s:%d/lance", "localhost", getLanceRESTServerPort());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `gravitino.lance-rest.gravitino-auth-type` with `simple` and `oauth2`
support, plus the supporting `gravitino-simple.user-name` and
`gravitino-oauth2.*` properties, and uses them when constructing the
`GravitinoClient` in `GravitinoLanceNamespaceWrapper`. The property names and
the dispatch logic mirror `DynamicIcebergConfigProvider.createGravitinoClient`.

The builder configuration is split into `newClientBuilder` so it can be tested
without opening a connection. Runtime behavior of `initialize()` is unchanged
apart from the credentials now being attached.

### Why are the changes needed?

The Lance REST service built its client with no `AuthDataProvider`, so its
requests to the Gravitino server carried no `Authorization` header. Under the
`simple` authenticator those requests are accepted as the anonymous user.
Under `oauth2` or `kerberos` no authenticator accepts a null token, so every
Lance operation fails. Since `gravitino.authenticators` is server-wide, the
only configuration where the service works alongside OAuth2 also lists
`simple`, which leaves an anonymous bypass open for all callers of the server.

Fix: #12255

### Does this PR introduce any user-facing change?

Yes, six new configuration properties, documented in
`docs/lance-rest-service.md`. The default is `simple` with user name
`lance-rest-server`, so existing deployments continue to work and gain a named
identity in place of anonymous.

Documentation here is limited to a config table for the six new properties. A
broader rewrite of `lance-rest-service.md` will follow in a separate PR.

### How was this patch tested?

Unit tests in TestGravitinoLanceClientAuth cover the default auth type, a configured simple user name, case-insensitive parsing, both missing-required-OAuth2-property cases, and rejection of an unsupported auth type.

LanceRESTServiceAuthIT covers the behavior end to end: with a configured simple user name, a catalog created through the Lance REST service records that user as its creator. Against the current code the test fails with:

```
expected: <lance_rest_service_user> but was: <anonymous>
```

The OAuth2 path is covered at the configuration level only, since end-to-end coverage would need a token issuer in the test harness.

### Target branch

The config entries are marked `1.3.0` because this fixes behavior in the 1.3
line: the Lance REST service cannot operate against a server with
authentication enabled. Requesting the branch-1.3 cherry-pick label.