### PR TITLE
[#12248] test(catalog-kafka): wait for topic deletion in testNameSpec

### DIFF
--- a/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -450,6 +450,7 @@ public class CatalogKafkaIT extends BaseIT {
         Arrays.stream(topics).anyMatch(topic -> topic.name().equals(illegalName)));
 
     Assertions.assertTrue(catalog.asTopicCatalog().dropTopic(ident));
+    awaitTopicDeletedInKafka(illegalName);
     Assertions.assertFalse(catalog.asTopicCatalog().topicExists(ident));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Wait for Kafka topic deletion metadata to converge in
`CatalogKafkaIT.testNameSpec` before asserting that the topic no longer exists.

### Why are the changes needed?

Kafka topic deletion is asynchronous. `dropTopic` may return before subsequent
metadata reads stop reporting the deleted topic, making the immediate
`topicExists` assertion flaky.

Fix: #12248

### Does this PR introduce _any_ user-facing change?

No. This change only stabilizes a Kafka catalog integration test.

### How was this patch tested?

- `./gradlew :catalogs:catalog-kafka:spotlessCheck`
- Ran `CatalogKafkaIT.testNameSpec` 10 consecutive times with Docker tests
  enabled in embedded H2 mode; all 10 runs passed.
- `./gradlew :catalogs:catalog-kafka:cleanTest
  :catalogs:catalog-kafka:test -PtestMode=embedded -PjdbcBackend=h2
  -PskipDockerTests=false -PskipWeb=true --console=plain`
