### PR TITLE
[#12270] fix(glue): Ignore blank AWS static credentials

### DIFF
--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
@@ -74,17 +74,9 @@ public final class GlueClientProvider {
     //   6. EC2 instance profile (IMDSv2)
     String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
     String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
-    boolean hasAccessKey = StringUtils.isNotBlank(accessKey);
-    boolean hasSecretKey = StringUtils.isNotBlank(secretKey);
-    Preconditions.checkArgument(
-        hasAccessKey == hasSecretKey,
-        "Both '%s' and '%s' must be set together. "
-            + "Either provide both keys for static authentication, "
-            + "or omit both to use the default credential chain.",
-        GlueConstants.AWS_ACCESS_KEY_ID,
-        GlueConstants.AWS_SECRET_ACCESS_KEY);
+    boolean hasStaticCredentials = hasAwsStaticCredentials(accessKey, secretKey);
 
-    if (hasAccessKey) {
+    if (hasStaticCredentials) {
       builder.credentialsProvider(
           StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)));
     } else {
@@ -98,5 +90,19 @@ public final class GlueClientProvider {
     }
 
     return builder.build();
+  }
+
+  static boolean hasAwsStaticCredentials(String accessKey, String secretKey) {
+    boolean hasAccessKey = StringUtils.isNotBlank(accessKey);
+    boolean hasSecretKey = StringUtils.isNotBlank(secretKey);
+    Preconditions.checkArgument(
+        hasAccessKey == hasSecretKey,
+        "Both '%s' and '%s' must be set together. "
+            + "Either provide both keys for static authentication, "
+            + "or omit both to use the default credential chain.",
+        GlueConstants.AWS_ACCESS_KEY_ID,
+        GlueConstants.AWS_SECRET_ACCESS_KEY);
+
+    return hasAccessKey;
   }
 }

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
@@ -143,6 +143,15 @@ final class GlueIcebergTableHelper {
    * @throws IllegalArgumentException if {@code aws-region} or {@code warehouse} is not configured
    */
   static Catalog createGlueCatalog(Map<String, String> config) {
+    Map<String, String> icebergProps = buildIcebergCatalogProperties(config);
+
+    GlueCatalog glueCatalog = new GlueCatalog();
+    glueCatalog.initialize("gravitino-glue-iceberg", icebergProps);
+    LOG.info("Initialized Iceberg GlueCatalog for region {}", config.get(GlueConstants.AWS_REGION));
+    return glueCatalog;
+  }
+
+  static Map<String, String> buildIcebergCatalogProperties(Map<String, String> config) {
     String region = config.get(GlueConstants.AWS_REGION);
     Preconditions.checkArgument(region != null, "AWS region is required for Iceberg Glue catalog");
 
@@ -164,18 +173,14 @@ final class GlueIcebergTableHelper {
 
     String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
     String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
-    boolean hasAccessKey = StringUtils.isNotBlank(accessKey);
-    boolean hasSecretKey = StringUtils.isNotBlank(secretKey);
-    Preconditions.checkArgument(
-        hasAccessKey == hasSecretKey,
-        "Both '%s' and '%s' must be set together.",
-        GlueConstants.AWS_ACCESS_KEY_ID,
-        GlueConstants.AWS_SECRET_ACCESS_KEY);
-    if (hasAccessKey) {
+    boolean hasCredential = GlueClientProvider.hasAwsStaticCredentials(accessKey, secretKey);
+    if (hasCredential) {
       icebergProps.put(
           CLIENT_CREDENTIALS_PROVIDER, GravitinoGlueCredentialsProvider.class.getName());
       icebergProps.put(CLIENT_CREDENTIALS_PROVIDER_ACCESS_KEY_ID, accessKey);
       icebergProps.put(CLIENT_CREDENTIALS_PROVIDER_SECRET_ACCESS_KEY, secretKey);
+      icebergProps.put(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID, accessKey);
+      icebergProps.put(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY, secretKey);
     }
 
     String endpoint = config.get(GlueConstants.AWS_GLUE_ENDPOINT);
@@ -183,17 +188,8 @@ final class GlueIcebergTableHelper {
       icebergProps.put(GLUE_ENDPOINT, endpoint);
     }
 
-    if (hasAccessKey) {
-      icebergProps.put(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID, accessKey);
-      icebergProps.put(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY, secretKey);
-    }
-
     icebergProps.put(IcebergConstants.IO_IMPL, "org.apache.iceberg.aws.s3.S3FileIO");
-
-    GlueCatalog glueCatalog = new GlueCatalog();
-    glueCatalog.initialize("gravitino-glue-iceberg", icebergProps);
-    LOG.info("Initialized Iceberg GlueCatalog for region {}", region);
-    return glueCatalog;
+    return icebergProps;
   }
 
   /**

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
@@ -164,7 +164,8 @@ final class GlueIcebergTableHelper {
 
     String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
     String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
-    if (accessKey != null && secretKey != null) {
+    boolean validated = validateAwsStaticCredential(accessKey, secretKey);
+    if (validated) {
       icebergProps.put(
           CLIENT_CREDENTIALS_PROVIDER, GravitinoGlueCredentialsProvider.class.getName());
       icebergProps.put(CLIENT_CREDENTIALS_PROVIDER_ACCESS_KEY_ID, accessKey);
@@ -176,7 +177,7 @@ final class GlueIcebergTableHelper {
       icebergProps.put(GLUE_ENDPOINT, endpoint);
     }
 
-    if (accessKey != null && secretKey != null) {
+    if (validated) {
       icebergProps.put(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID, accessKey);
       icebergProps.put(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY, secretKey);
     }
@@ -187,6 +188,20 @@ final class GlueIcebergTableHelper {
     glueCatalog.initialize("gravitino-glue-iceberg", icebergProps);
     LOG.info("Initialized Iceberg GlueCatalog for region {}", region);
     return glueCatalog;
+  }
+
+  @VisibleForTesting
+  static boolean validateAwsStaticCredential(String accessKey, String secretKey) {
+    boolean hasAccessKey = StringUtils.isNotBlank(accessKey);
+    boolean hasSecretKey = StringUtils.isNotBlank(secretKey);
+    Preconditions.checkArgument(
+        hasAccessKey == hasSecretKey,
+        "Both '%s' and '%s' must be set together. "
+            + "Either provide both keys for static authentication, "
+            + "or omit both to use the default credential chain.",
+        GlueConstants.AWS_ACCESS_KEY_ID,
+        GlueConstants.AWS_SECRET_ACCESS_KEY);
+    return hasAccessKey;
   }
 
   /**

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueIcebergTableHelper.java
@@ -164,8 +164,14 @@ final class GlueIcebergTableHelper {
 
     String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
     String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
-    boolean validated = validateAwsStaticCredential(accessKey, secretKey);
-    if (validated) {
+    boolean hasAccessKey = StringUtils.isNotBlank(accessKey);
+    boolean hasSecretKey = StringUtils.isNotBlank(secretKey);
+    Preconditions.checkArgument(
+        hasAccessKey == hasSecretKey,
+        "Both '%s' and '%s' must be set together.",
+        GlueConstants.AWS_ACCESS_KEY_ID,
+        GlueConstants.AWS_SECRET_ACCESS_KEY);
+    if (hasAccessKey) {
       icebergProps.put(
           CLIENT_CREDENTIALS_PROVIDER, GravitinoGlueCredentialsProvider.class.getName());
       icebergProps.put(CLIENT_CREDENTIALS_PROVIDER_ACCESS_KEY_ID, accessKey);
@@ -177,7 +183,7 @@ final class GlueIcebergTableHelper {
       icebergProps.put(GLUE_ENDPOINT, endpoint);
     }
 
-    if (validated) {
+    if (hasAccessKey) {
       icebergProps.put(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID, accessKey);
       icebergProps.put(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY, secretKey);
     }
@@ -188,20 +194,6 @@ final class GlueIcebergTableHelper {
     glueCatalog.initialize("gravitino-glue-iceberg", icebergProps);
     LOG.info("Initialized Iceberg GlueCatalog for region {}", region);
     return glueCatalog;
-  }
-
-  @VisibleForTesting
-  static boolean validateAwsStaticCredential(String accessKey, String secretKey) {
-    boolean hasAccessKey = StringUtils.isNotBlank(accessKey);
-    boolean hasSecretKey = StringUtils.isNotBlank(secretKey);
-    Preconditions.checkArgument(
-        hasAccessKey == hasSecretKey,
-        "Both '%s' and '%s' must be set together. "
-            + "Either provide both keys for static authentication, "
-            + "or omit both to use the default credential chain.",
-        GlueConstants.AWS_ACCESS_KEY_ID,
-        GlueConstants.AWS_SECRET_ACCESS_KEY);
-    return hasAccessKey;
   }
 
   /**

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueIcebergTableHelper.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.catalog.glue.GlueIcebergTableHelper.fromIcebe
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -234,5 +235,16 @@ class TestGlueIcebergTableHelper {
     assertEquals(Types.TimestampType.withTimeZone(6), cols[0].dataType());
     assertEquals(Types.TimeType.of(6), cols[1].dataType());
     assertEquals(Types.DecimalType.of(10, 2), cols[2].dataType());
+  }
+
+  @Test
+  void testValidateAwsStaticCredential() {
+    // validate blank aws credential
+    assertFalse(GlueIcebergTableHelper.validateAwsStaticCredential("", ""));
+
+    // should throw error when only have access key or secret key
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> GlueIcebergTableHelper.validateAwsStaticCredential("test-access-key", ""));
   }
 }

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueIcebergTableHelper.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.glue;
 
 import static org.apache.gravitino.catalog.glue.GlueIcebergTableHelper.fromIcebergType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.Map;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.types.Types;
@@ -36,6 +38,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.aws.glue.GlueCatalog;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types.BooleanType;
@@ -238,13 +241,73 @@ class TestGlueIcebergTableHelper {
   }
 
   @Test
-  void testValidateAwsStaticCredential() {
-    // validate blank aws credential
-    assertFalse(GlueIcebergTableHelper.validateAwsStaticCredential("", ""));
+  void testCreateGlueCatalogWithoutStaticCredentials() {
+    Map<String, String> config = new HashMap<>();
+    config.put(GlueConstants.AWS_REGION, "us-east-1");
+    config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
 
-    // should throw error when only have access key or secret key
+    assertDoesNotThrow(
+        () -> {
+          try (GlueCatalog ignored =
+              (GlueCatalog) GlueIcebergTableHelper.createGlueCatalog(config)) {
+            // No-op.
+          }
+        });
+  }
+
+  @Test
+  void testCreateGlueCatalogWithBlankStaticCredentials() {
+    Map<String, String> config = new HashMap<>();
+    config.put(GlueConstants.AWS_REGION, "us-east-1");
+    config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
+    config.put(GlueConstants.AWS_ACCESS_KEY_ID, "");
+    config.put(GlueConstants.AWS_SECRET_ACCESS_KEY, " ");
+
+    assertDoesNotThrow(
+        () -> {
+          try (GlueCatalog ignored =
+              (GlueCatalog) GlueIcebergTableHelper.createGlueCatalog(config)) {
+            // No-op.
+          }
+        });
+  }
+
+  @Test
+  void testCreateGlueCatalogWithStaticCredentials() {
+    Map<String, String> config = new HashMap<>();
+    config.put(GlueConstants.AWS_REGION, "us-east-1");
+    config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
+    config.put(GlueConstants.AWS_ACCESS_KEY_ID, "test-access-key");
+    config.put(GlueConstants.AWS_SECRET_ACCESS_KEY, "test-secret-key");
+
+    assertDoesNotThrow(
+        () -> {
+          try (GlueCatalog ignored =
+              (GlueCatalog) GlueIcebergTableHelper.createGlueCatalog(config)) {
+            // No-op.
+          }
+        });
+  }
+
+  @Test
+  void testCreateGlueCatalogWithOnlyAccessKey() {
+    Map<String, String> config = new HashMap<>();
+    config.put(GlueConstants.AWS_REGION, "us-east-1");
+    config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
+    config.put(GlueConstants.AWS_ACCESS_KEY_ID, "test-access-key");
+
     assertThrows(
-        IllegalArgumentException.class,
-        () -> GlueIcebergTableHelper.validateAwsStaticCredential("test-access-key", ""));
+        IllegalArgumentException.class, () -> GlueIcebergTableHelper.createGlueCatalog(config));
+  }
+
+  @Test
+  void testCreateGlueCatalogWithOnlySecretKey() {
+    Map<String, String> config = new HashMap<>();
+    config.put(GlueConstants.AWS_REGION, "us-east-1");
+    config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
+    config.put(GlueConstants.AWS_SECRET_ACCESS_KEY, "test-secret-key");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> GlueIcebergTableHelper.createGlueCatalog(config));
   }
 }

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueIcebergTableHelper.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueIcebergTableHelper.java
@@ -19,7 +19,6 @@
 package org.apache.gravitino.catalog.glue;
 
 import static org.apache.gravitino.catalog.glue.GlueIcebergTableHelper.fromIcebergType;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -29,8 +28,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.types.Types;
@@ -38,6 +39,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.glue.GlueCatalog;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -241,73 +243,97 @@ class TestGlueIcebergTableHelper {
   }
 
   @Test
-  void testCreateGlueCatalogWithoutStaticCredentials() {
+  void testCreateGlueCatalog() throws IOException {
     Map<String, String> config = new HashMap<>();
     config.put(GlueConstants.AWS_REGION, "us-east-1");
     config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
 
-    assertDoesNotThrow(
-        () -> {
-          try (GlueCatalog ignored =
-              (GlueCatalog) GlueIcebergTableHelper.createGlueCatalog(config)) {
-            // No-op.
-          }
-        });
+    Catalog catalog = GlueIcebergTableHelper.createGlueCatalog(config);
+    GlueCatalog glueCatalog = assertInstanceOf(GlueCatalog.class, catalog);
+    glueCatalog.close();
   }
 
   @Test
-  void testCreateGlueCatalogWithBlankStaticCredentials() {
+  void testBuildIcebergCatalogPropertiesWithoutStaticCredentials() {
     Map<String, String> config = new HashMap<>();
     config.put(GlueConstants.AWS_REGION, "us-east-1");
     config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
+
+    Map<String, String> icebergProps = GlueIcebergTableHelper.buildIcebergCatalogProperties(config);
+    assertFalse(icebergProps.containsKey(AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER));
+    assertFalse(
+        icebergProps.containsKey(
+            AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER + ".access-key-id"));
+    assertFalse(
+        icebergProps.containsKey(
+            AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER + ".secret-access-key"));
+    assertFalse(icebergProps.containsKey(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID));
+    assertFalse(icebergProps.containsKey(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY));
+
     config.put(GlueConstants.AWS_ACCESS_KEY_ID, "");
     config.put(GlueConstants.AWS_SECRET_ACCESS_KEY, " ");
-
-    assertDoesNotThrow(
-        () -> {
-          try (GlueCatalog ignored =
-              (GlueCatalog) GlueIcebergTableHelper.createGlueCatalog(config)) {
-            // No-op.
-          }
-        });
+    icebergProps = GlueIcebergTableHelper.buildIcebergCatalogProperties(config);
+    assertFalse(icebergProps.containsKey(AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER));
+    assertFalse(
+        icebergProps.containsKey(
+            AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER + ".access-key-id"));
+    assertFalse(
+        icebergProps.containsKey(
+            AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER + ".secret-access-key"));
+    assertFalse(icebergProps.containsKey(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID));
+    assertFalse(icebergProps.containsKey(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY));
   }
 
   @Test
-  void testCreateGlueCatalogWithStaticCredentials() {
+  void testBuildIcebergCatalogPropertiesWithStaticCredentials() {
     Map<String, String> config = new HashMap<>();
     config.put(GlueConstants.AWS_REGION, "us-east-1");
     config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
     config.put(GlueConstants.AWS_ACCESS_KEY_ID, "test-access-key");
     config.put(GlueConstants.AWS_SECRET_ACCESS_KEY, "test-secret-key");
 
-    assertDoesNotThrow(
-        () -> {
-          try (GlueCatalog ignored =
-              (GlueCatalog) GlueIcebergTableHelper.createGlueCatalog(config)) {
-            // No-op.
-          }
-        });
+    Map<String, String> icebergProps = GlueIcebergTableHelper.buildIcebergCatalogProperties(config);
+    assertEquals(
+        GravitinoGlueCredentialsProvider.class.getName(),
+        icebergProps.get(AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER));
+    assertEquals(
+        "test-access-key",
+        icebergProps.get(AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER + ".access-key-id"));
+    assertEquals(
+        "test-secret-key",
+        icebergProps.get(AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER + ".secret-access-key"));
+    assertEquals("test-access-key", icebergProps.get(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID));
+    assertEquals(
+        "test-secret-key", icebergProps.get(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY));
   }
 
   @Test
-  void testCreateGlueCatalogWithOnlyAccessKey() {
+  void testBuildIcebergCatalogPropertiesWithOnlyAccessKey() {
     Map<String, String> config = new HashMap<>();
     config.put(GlueConstants.AWS_REGION, "us-east-1");
     config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
     config.put(GlueConstants.AWS_ACCESS_KEY_ID, "test-access-key");
 
-    assertThrows(
-        IllegalArgumentException.class, () -> GlueIcebergTableHelper.createGlueCatalog(config));
+    assertEquals(
+        "Both 'aws-access-key-id' and 'aws-secret-access-key' must be set together. Either provide both keys for static authentication, or omit both to use the default credential chain.",
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GlueIcebergTableHelper.buildIcebergCatalogProperties(config))
+            .getMessage());
   }
 
   @Test
-  void testCreateGlueCatalogWithOnlySecretKey() {
+  void testBuildIcebergCatalogPropertiesWithOnlySecretKey() {
     Map<String, String> config = new HashMap<>();
     config.put(GlueConstants.AWS_REGION, "us-east-1");
     config.put(GlueConstants.WAREHOUSE, "s3://test-bucket/warehouse");
     config.put(GlueConstants.AWS_SECRET_ACCESS_KEY, "test-secret-key");
 
-    assertThrows(
-        IllegalArgumentException.class, () -> GlueIcebergTableHelper.createGlueCatalog(config));
+    assertEquals(
+        "Both 'aws-access-key-id' and 'aws-secret-access-key' must be set together. Either provide both keys for static authentication, or omit both to use the default credential chain.",
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GlueIcebergTableHelper.buildIcebergCatalogProperties(config))
+            .getMessage());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Treat blank Glue AWS access and secret keys as absent so that Iceberg uses the AWS default credential chain.

Validate that static access and secret keys are configured together, and add unit coverage for blank and partial credential values.

### Why are the changes needed?

Optional Glue credential properties may be stored as empty strings. `GlueIcebergTableHelper` previously checked only for null values and installed `GravitinoGlueCredentialsProvider`, which then failed with `Access key ID is not set`.

This prevented Iceberg metadata enrichment and caused Gravitino to fall back to Glue-derived metadata.

Fix: #12270

### Does this PR introduce _any_ user-facing change?

Yes. Glue Iceberg catalogs with blank static credential properties now use the AWS default credential chain. A partially configured static credential pair fails fast.

No API or property keys are changed.

### How was this patch tested?

```bash
./gradlew :catalogs:catalog-glue:test \
  --tests org.apache.gravitino.catalog.glue.TestGlueIcebergTableHelper \
  -PskipITs
```
