### PR TITLE
[#12277] fix(ci): Guard cherry-pick conflict PRs with title, label, and CI check

### DIFF
--- a/.github/workflows/cherry-pick-branch.yml
+++ b/.github/workflows/cherry-pick-branch.yml
@@ -138,9 +138,15 @@ jobs:
           BODY="${BODY//\$\{TARGET_BRANCH\}/${TARGET_BRANCH}}"
 
           # Ensure labels exist (forks may not have them yet).
-          gh label create cherry-pick             --description "Automatically opened cherry-pick PR"             --color 1D76DB             --force >/dev/null 2>&1 || true
+          gh label create cherry-pick \
+            --description "Automatically opened cherry-pick PR" \
+            --color 1D76DB \
+            --force >/dev/null 2>&1 || true
           if [ "${SUCCESS}" != "true" ]; then
-            gh label create cherry-pick-conflict               --description "Cherry-pick has conflicts; needs human resolution before merge"               --color B60205               --force >/dev/null 2>&1 || true
+            gh label create cherry-pick-conflict \
+              --description "Cherry-pick has conflicts; needs human resolution before merge" \
+              --color B60205 \
+              --force >/dev/null 2>&1 || true
           fi
 
           LABEL_ARGS=()

--- a/.github/workflows/cherry-pick-branch.yml
+++ b/.github/workflows/cherry-pick-branch.yml
@@ -39,6 +39,10 @@ jobs:
   cherry-pick:
     runs-on: ubuntu-latest
     name: Cherry-pick to ${{ inputs.target-branch }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -114,10 +118,6 @@ jobs:
             # Make conflicts visible in the PR list (title + label), not only in the body.
             TITLE="[DO NOT MERGE] ${TITLE}"
             LABELS+=(cherry-pick-conflict)
-            gh label create cherry-pick-conflict \
-              --description "Cherry-pick has conflicts; needs human resolution before merge" \
-              --color B60205 \
-              --force >/dev/null 2>&1 || true
 
             BODY=$(cat <<'EOF'
           **Cherry-pick Information:**
@@ -137,15 +137,26 @@ jobs:
           BODY="${BODY//\$\{COMMIT_SHA\}/${COMMIT_SHA}}"
           BODY="${BODY//\$\{TARGET_BRANCH\}/${TARGET_BRANCH}}"
 
+          # Ensure labels exist (forks may not have them yet).
+          gh label create cherry-pick             --description "Automatically opened cherry-pick PR"             --color 1D76DB             --force >/dev/null 2>&1 || true
+          if [ "${SUCCESS}" != "true" ]; then
+            gh label create cherry-pick-conflict               --description "Cherry-pick has conflicts; needs human resolution before merge"               --color B60205               --force >/dev/null 2>&1 || true
+          fi
+
           LABEL_ARGS=()
           for label in "${LABELS[@]}"; do
             LABEL_ARGS+=(--label "$label")
           done
 
-          gh pr create \
-            --title "$TITLE" \
-            --body "$BODY" \
-            --base ${{ inputs.target-branch }} \
-            --head ${{ steps.cherry-pick.outputs.branch-name }} \
-            "${LABEL_ARGS[@]}" \
-            --reviewer jerryshao || echo "Failed to create PR, may already exist"
+          CREATE_ARGS=(
+            --title "$TITLE"
+            --body "$BODY"
+            --base "${{ inputs.target-branch }}"
+            --head "${{ steps.cherry-pick.outputs.branch-name }}"
+            "${LABEL_ARGS[@]}"
+          )
+          # Reviewer is only valid on apache/gravitino.
+          if [ "${{ github.repository }}" = "apache/gravitino" ]; then
+            CREATE_ARGS+=(--reviewer jerryshao)
+          fi
+          gh pr create "${CREATE_ARGS[@]}" || echo "Failed to create PR, may already exist"

--- a/.github/workflows/cherry-pick-branch.yml
+++ b/.github/workflows/cherry-pick-branch.yml
@@ -99,7 +99,8 @@ jobs:
         run: |
           # Use original commit message with branch prefix
           TITLE="[Cherry-pick to ${TARGET_BRANCH}] ${COMMIT_MESSAGE}"
-          
+          LABELS=(cherry-pick)
+
           # Prepare body with cherry-pick info
           if [ "${SUCCESS}" = "true" ]; then
             BODY=$(cat <<'EOF'
@@ -110,25 +111,41 @@ jobs:
           EOF
           )
           else
+            # Make conflicts visible in the PR list (title + label), not only in the body.
+            TITLE="[DO NOT MERGE] ${TITLE}"
+            LABELS+=(cherry-pick-conflict)
+            gh label create cherry-pick-conflict \
+              --description "Cherry-pick has conflicts; needs human resolution before merge" \
+              --color B60205 \
+              --force >/dev/null 2>&1 || true
+
             BODY=$(cat <<'EOF'
           **Cherry-pick Information:**
           - Original commit: ${COMMIT_SHA}
           - Target branch: `${TARGET_BRANCH}`
           - Status: ⚠️ **Has conflicts - manual resolution required**
-          
+
+          **Do not merge** until conflict markers are resolved and the
+          `cherry-pick-conflict` label is removed.
+
           Please review and resolve the conflicts before merging.
           EOF
           )
           fi
-          
+
           # Replace placeholders with actual values
           BODY="${BODY//\$\{COMMIT_SHA\}/${COMMIT_SHA}}"
           BODY="${BODY//\$\{TARGET_BRANCH\}/${TARGET_BRANCH}}"
-          
+
+          LABEL_ARGS=()
+          for label in "${LABELS[@]}"; do
+            LABEL_ARGS+=(--label "$label")
+          done
+
           gh pr create \
             --title "$TITLE" \
             --body "$BODY" \
             --base ${{ inputs.target-branch }} \
             --head ${{ steps.cherry-pick.outputs.branch-name }} \
-            --label cherry-pick \
+            "${LABEL_ARGS[@]}" \
             --reviewer jerryshao || echo "Failed to create PR, may already exist"

--- a/.github/workflows/conflict-marker-check.yml
+++ b/.github/workflows/conflict-marker-check.yml
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Conflict Marker Check
+
+# Standalone workflow so path filters on build.yml cannot skip this check.
+# Catches cherry-pick / sync PRs that commit unresolved git conflict markers.
+on:
+  pull_request:
+    branches: ["main", "branch-*"]
+  push:
+    branches: ["main", "branch-*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: conflict-marker-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conflict-marker-check:
+    name: conflict-marker-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail if unresolved git conflict markers are introduced
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+            # First push / force-push edge case: before may be all zeros.
+            if [ -z "${BASE_SHA}" ] || [[ "${BASE_SHA}" =~ ^0+$ ]]; then
+              BASE_SHA="$(git rev-parse "${HEAD_SHA}^")"
+            fi
+          fi
+
+          echo "Checking range ${BASE_SHA}...${HEAD_SHA}"
+
+          # git's built-in check for conflict markers introduced in the diff.
+          git diff --check "${BASE_SHA}...${HEAD_SHA}"
+
+          # Explicit line-start scan on changed files (======= must be a whole line).
+          failed=0
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            if grep -nE '^(<<<<<<< |>>>>>>> |=======$)' "$f"; then
+              echo "::error file=${f}::Unresolved conflict markers remain in ${f}"
+              failed=1
+            fi
+          done < <(git diff --name-only --diff-filter=ACMR "${BASE_SHA}...${HEAD_SHA}")
+
+          if [ "${failed}" -ne 0 ]; then
+            echo "Unresolved git conflict markers found. Resolve them before merging."
+            exit 1
+          fi
+
+          echo "No unresolved conflict markers found."


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve handling of auto cherry-pick PRs that contain unresolved conflicts:

1. **CI check** (`.github/workflows/conflict-marker-check.yml`)
   - Fail when a PR/push introduces unresolved git conflict markers
     (`<<<<<<< ` / whole-line `=======` / `>>>>>>> `).
   - Standalone workflow so `build.yml` path filters cannot skip it.

2. **Cherry-pick PR signaling** (`.github/workflows/cherry-pick-branch.yml`)
   - On conflict: prefix the PR title with `[DO NOT MERGE]`.
   - On conflict: add a `cherry-pick-conflict` label (created if missing).
   - Keep opening the PR so humans can still resolve conflicts in place.

### Why are the changes needed?

When auto cherry-pick fails, `cherry-pick-branch.yml` commits conflict markers and opens a PR. Today only the PR body says there are conflicts. GitHub mergeability stays clean, and existing CI can stay green for docs/conf/shell conflicts.

Maintainers asked for clearer signaling (title + label, similar to the enterprise conflict flow) plus a CI check so these PRs are hard to merge by mistake.

Fix: #12277

### Does this PR introduce _any_ user-facing change?

No. CI / automation only. No API, configuration, or runtime behaviour changes.

### How was this patch tested?

Locally ran `git diff --check`: commits with conflict markers fail, clean commits pass.