### PR TITLE
[MINOR] docs(lance): update the Lance and generic lakehouse catalog pages

### DIFF
--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -13,6 +13,7 @@ license: "This software is licensed under the Apache License version 2."
 ## Overview
 
 Some table formats define a catalog of their own, and Apache Gravitino federates to it. Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
+
 Each table names its format with the required `format` property, which is immutable once set, and Gravitino selects the matching implementation. Two are registered today.
 
 - **Lance**, as `format=lance`. Fully supported, and documented in [Lance Tables](./lakehouse-generic-lance-table.md).

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -14,7 +14,6 @@ license: "This software is licensed under the Apache License version 2."
 
 Some table formats define a catalog of their own, and Apache Gravitino federates to it. Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
 
-Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
 
 Each table names its format with the required `format` property, which is immutable once set, and Gravitino selects the matching implementation. Two are registered today.
 

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -12,7 +12,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Overview
 
-Some table formats define a catalog of their own, and Apache Gravitino federates to it. 
+Some table formats define a catalog of their own, and Apache Gravitino federates to it. Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
 
 Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
 

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -12,7 +12,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Overview
 
-Some table formats define a catalog of their own, and Apache Gravitino federates to it. Apache Iceberg is the example: the Iceberg catalog connects to an existing Iceberg REST catalog or Hive metastore, which remains the system of record.
+Some table formats define a catalog of their own, and Apache Gravitino federates to it. 
 
 Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
 

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -14,7 +14,6 @@ license: "This software is licensed under the Apache License version 2."
 
 Some table formats define a catalog of their own, and Apache Gravitino federates to it. Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
 
-
 Each table names its format with the required `format` property, which is immutable once set, and Gravitino selects the matching implementation. Two are registered today.
 
 - **Lance**, as `format=lance`. Fully supported, and documented in [Lance Tables](./lakehouse-generic-lance-table.md).

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -13,7 +13,6 @@ license: "This software is licensed under the Apache License version 2."
 ## Overview
 
 Some table formats define a catalog of their own, and Apache Gravitino federates to it. Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
-
 Each table names its format with the required `format` property, which is immutable once set, and Gravitino selects the matching implementation. Two are registered today.
 
 - **Lance**, as `format=lance`. Fully supported, and documented in [Lance Tables](./lakehouse-generic-lance-table.md).

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -4,200 +4,166 @@ slug: "/lakehouse-generic-catalog"
 keywords:
   - lakehouse
   - lance
+  - delta
   - metadata
   - generic catalog
-  - file system
 license: "This software is licensed under the Apache License version 2."
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 ## Overview
 
-The Generic Lakehouse Catalog is a Gravitino catalog implementation designed to seamlessly integrate with lakehouse storage systems built on file system-based architectures. This catalog enables unified metadata management for lakehouse tables stored on various storage backends, providing a consistent interface for data discovery, governance, and access control. 
+Some table formats define a catalog of their own, and Apache Gravitino federates to it. Apache Iceberg is the example: the Iceberg catalog connects to an existing Iceberg REST catalog or Hive metastore, which remains the system of record.
 
-Gravitino fully supports the **Lance** lakehouse format, with plans to extend support to additional formats in the future.
+Lance and Delta define no catalog. A table in either format is a set of files, so the metadata needs a home. The Generic Lakehouse Catalog provides one, holding the metadata directly rather than federating. That is what makes it generic: a single catalog serves any format that arrives without one of its own.
 
-### Benefits
+Each table names its format with the required `format` property, which is immutable once set, and Gravitino selects the matching implementation. Two are registered today.
 
-1. **Unified Metadata Management**: Single source of truth for table metadata across multiple storage backends
-2. **Multi-Format Support**: Extensible architecture to support various lakehouse table formats such as Lance, Iceberg, Hudi, etc.
-3. **Storage Flexibility**: Work with any file system, local, or cloud object stores
-4. **Gravitino Integration**: Leverage Gravitino's metadata management, access control, lineage tracking, and data discovery
-5. **Easy Migration**: Register existing lakehouse tables without data movement
+- **Lance**, as `format=lance`. Fully supported, and documented in [Lance Tables](./lakehouse-generic-lance-table.md).
+- **Delta**, as `format=delta`. Registration of existing external tables only, documented in [Delta Lake Tables](./lakehouse-generic-delta-table.md).
 
-## Catalog Management
+Because the metadata lives in Gravitino, these tables participate in the same discovery, access control, and lineage as the rest of a metalake. Registering an existing dataset moves no data.
 
-### Capabilities
+The Gravitino REST API creates these catalogs, as described below. Lance has a second route: the [Lance REST Service](./lance-rest-service.md) creates one itself when a Lance client first connects, producing the same object. See [Choosing an API](./lance-rest-service.md#choosing-an-api). Delta has no equivalent, so Delta tables always arrive through the Gravitino REST API.
 
-The Generic Lakehouse Catalog provides comprehensive relational metadata management capabilities equivalent to standard relational catalogs:
+## Creating a Catalog
 
-**Supported Operations:**
-- ✅ Create, read, update, and delete catalogs
-- ✅ List all catalogs in a metalake
-- ✅ Manage catalog properties and metadata
-- ✅ Set and modify catalog locations
-- ✅ Configure storage backend credentials
+`provider` selects this implementation and is a field on the request, not a property. What goes in `properties` depends on which format the catalog will hold.
 
-For detailed information on available operations, see [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md).
+### For Lance Tables
+
+Set the storage root and credentials on the catalog. Tables inherit the location, and Gravitino returns the `lance.storage.*` values to Lance clients so they can read the dataset files directly.
+
+```shell
+GRAVITINO_URL=http://localhost:8090
+CATALOGS=${GRAVITINO_URL}/api/metalakes/{metalake_name}/catalogs
+
+curl -X POST "${CATALOGS}" \
+  -H "Accept: application/vnd.gravitino.v1+json" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "{catalog_name}",
+  "type": "RELATIONAL",
+  "provider": "lakehouse-generic",
+  "comment": "Catalog for Lance tables",
+  "properties": {
+    "location": "s3://{bucket}/{prefix}",
+    "lance.storage.access_key_id": "{access_key}",
+    "lance.storage.secret_access_key": "{secret_key}",
+    "lance.storage.region": "us-east-1"
+  }
+}'
+```
+
+Then create tables as described in [Lance Tables](./lakehouse-generic-lance-table.md).
+
+### For Delta Tables
+
+No properties are needed. Delta tables normally carry their own `location`, because a registration has to land on a directory that already exists, and Gravitino hands nothing to Delta readers, so `lance.storage.*` has no effect. A catalog `location` is still honored if you set one.
+
+```shell
+curl -X POST "${CATALOGS}" \
+  -H "Accept: application/vnd.gravitino.v1+json" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "{catalog_name}",
+  "type": "RELATIONAL",
+  "provider": "lakehouse-generic",
+  "comment": "Catalog for Delta tables"
+}'
+```
+
+Then register tables as described in [Delta Lake Tables](./lakehouse-generic-delta-table.md).
+
+A single catalog can hold both formats. Setting the Lance properties does no harm to Delta tables alongside them.
+
+## Creating a Schema
+
+Schema creation does not vary by format. A schema `location` narrows where Lance tables land, and is ignored by Delta tables, which always name their own.
+
+```shell
+curl -X POST "${CATALOGS}/{catalog_name}/schemas" \
+  -H "Accept: application/vnd.gravitino.v1+json" \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "{schema_name}", "comment": "Sales department data"}'
+```
+
+## Properties
 
 ### Catalog Properties
 
-| Property                    | Description                                                                                                                                                                                                    | Example                 | Required | Since Version |
-|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------|---------------|
-| `provider`                  | Catalog provider type                                                                                                                                                                                          | `lakehouse-generic`     | Yes      | 1.1.0         |
-| `location`                  | Root storage path for all schemas and tables                                                                                                                                                                   | `s3://bucket/lakehouse` | No       | 1.1.0         |
-| `lance.schema-refresh-mode` | Lance table schema refresh mode. `DECLARED_AND_EMPTY` (default) refreshes declared tables and tables with empty stored columns. `VERSION_CHECK` additionally refreshes when the Lance dataset version changes. | `DECLARED_AND_EMPTY`    | No       | 1.3.0         |
+These go in the `properties` object of the catalog create request, `POST /api/metalakes/{metalake_name}/catalogs`, as shown in [Creating a Catalog](#creating-a-catalog). They can be changed afterward through the catalog alter request.
 
-#### Key Property: `location`
-
-The `location` property specifies the root directory for the lakehouse table. All schemas and tables are stored under this location unless explicitly overridden at the schema or table level.
-
-**Location Resolution Hierarchy:**
-1. Table-level `location` (highest priority)
-2. Schema-level `location`, then the location of the table will be `{schema_location}/{table_name}`
-3. Catalog-level `location` (fallback), then the location of the table will be `{catalog_location}/{schema_name}/{table_name}`
-
-**Example Location Hierarchy:**
-```
-Case1: only catalog location is set
-Catalog location: hdfs://namenode:9000/lakehouse
-└── Schema: sales
-    ├── Table: orders. Final location of table: hdfs://namenode:9000/lakehouse/sales/orders
-    └── Table: customers. Final location of table: hdfs://namenode:9000/lakehouse/sales/customers
-    
-case2: schema location is set, overriding catalog location and table location is not set   
-Catalog location: hdfs://namenode:9000/lakehouse
-└── Schema: sales: s3://sales-bucket/data
-    ├── Table: orders. Final location of table: s3://sales-bucket/data/orders
-    └── Table: customers. Final location of table: s3://sales-bucket/data/customers
-
-case3: table location is set, overriding both schema and catalog locations
-Catalog location: hdfs://namenode:9000/lakehouse
-└── Schema: sales: s3://sales-bucket/data
-    ├── Table: orders.  Table location: s3://sales-bucket/my_orders, Final location of table: s3://sales-bucket/my_orders
-    └── Table: customers. Table location: s3://sales-bucket/my_customers, Final location of table: s3://sales-bucket/my_customers
-    
-```
-
-### Create a Catalog
-
-Use `provider: "lakehouse-generic"` when creating a generic lakehouse catalog.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" -d '{
-  "name": "generic_lakehouse_catalog",
-  "type": "RELATIONAL",
-  "comment": "Generic lakehouse catalog for Lance datasets",
-  "provider": "lakehouse-generic",
-  "properties": {
-    "location": "hdfs://localhost:9000/user/lakehouse"
-  }
-}' http://localhost:8090/api/metalakes/metalake/catalogs
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .withMetalake("metalake")
-    .build();
-
-Map<String, String> catalogProperties = ImmutableMap.<String, String>builder()
-    .put("location", "hdfs://localhost:9000/user/lakehouse")
-    .build();
-
-Catalog catalog = gravitinoClient.createCatalog(
-    "generic_lakehouse_catalog",
-    Type.RELATIONAL,
-    "lakehouse-generic",
-    "Generic lakehouse catalog for Lance datasets",
-    catalogProperties
-);
-```
-
-</TabItem>
-</Tabs>
-
-Other catalog operations are general with relational catalogs. See [Catalog Operations](./manage-relational-metadata-using-gravitino.md#catalog-operations) for detailed documentation.
-
-## Schema Management
-
-### Capabilities
-
-Schema operations follow the same patterns as relational catalogs:
-
-**Supported Operations:**
-- ✅ Create schemas with custom properties
-- ✅ List all schemas in a catalog
-- ✅ Load schema metadata and properties
-- ✅ Update schema properties
-- ✅ Delete schemas
-- ✅ Check schema existence
-
-See [Schema Operations](./manage-relational-metadata-using-gravitino.md#schema-operations) for detailed documentation.
+| Property   | Description                                                  | Example                 | Required |
+|------------|--------------------------------------------------------------|-------------------------|----------|
+| `location` | Root storage path for schemas and tables beneath the catalog | `s3://bucket/lakehouse` | No       |
 
 ### Schema Properties
 
-Schemas inherit catalog properties and can override specific settings:
+These go in the `properties` object of the schema create request, `POST /api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas`.
 
-| Property   | Description                                              | Example                      | Required | Since version | 
-|------------|----------------------------------------------------------|------------------------------|----------|---------------|
-| `location` | Custom storage root path for all tables under the schema | 's3://bucket/path_to_schema' | No       | 1.1.0         |
+| Property   | Description                                                      | Example                      | Required |
+|------------|------------------------------------------------------------------|------------------------------|----------|
+| `location` | Storage root for tables under the schema, overriding the catalog | `s3://bucket/path_to_schema` | No       |
 
-For location resolution hierarchy, see [Key Property: `location`](#key-property-location) in the Catalog Management section for more details.
+Delta contributes no properties at either level. A Delta table names its own location, so it needs nothing from the catalog or schema to be reachable.
 
-### Schema Operations
+### Location Resolution
 
-**Creating a Schema:**
+Every table needs a location, and it can come from any of three levels. The most specific one set wins.
 
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+| Level Set | Resulting Table Location                        |
+|-----------|-------------------------------------------------|
+| Table     | The table `location`, used as given             |
+| Schema    | `{schema_location}/{table_name}`                |
+| Catalog   | `{catalog_location}/{schema_name}/{table_name}` |
 
-```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" -d '{
-  "name": "sales",
-  "comment": "Sales department data",
-  "properties": {
-    "location": "s3://sales-bucket/data",
-    "owner": "sales-team"
-  }
-}' http://localhost:8090/api/metalakes/metalake/catalogs/lakehouse_catalog/schemas
-```
+With only a catalog location of `s3://bucket/lakehouse`, a table `orders` in schema `sales` resolves to `s3://bucket/lakehouse/sales/orders`. Setting the schema `sales` to `s3://sales-bucket/data` moves it to `s3://sales-bucket/data/orders`. Setting the table location to `s3://sales-bucket/my_orders` overrides both and is used unchanged.
 
-</TabItem>
-<TabItem value="java" label="Java">
+If no level sets a location, table creation fails.
 
-```java
-Map<String, String> schemaProperties = ImmutableMap.<String, String>builder()
-    .put("location", "s3://sales-bucket/data")
-    .put("owner", "sales-team")
-    .build();
+### Lance Catalog Properties
 
-catalog.asSchemas().createSchema(
-    "sales",
-    "Sales department data",
-    schemaProperties
-);
-```
+Two further catalog properties apply only when the catalog holds Lance tables.
 
-</TabItem>
-</Tabs>
+| Property                    | Description                                                                             | Example                            | Required |
+|-----------------------------|-----------------------------------------------------------------------------------------|------------------------------------|----------|
+| `lance.storage.{option}`    | Storage options for Lance tables, such as credentials and endpoint, returned to clients | `lance.storage.region = us-east-1` | No       |
+| `lance.schema-refresh-mode` | When Gravitino re-reads Lance table columns from the dataset                            | `DECLARED_AND_EMPTY`               | No       |
 
-For additional operations, refer to [Schema Operations documentation](./manage-relational-metadata-using-gravitino.md#schema-operations).
+#### Storage Options
 
-## Table Management
+Set `lance.storage.*` on the catalog rather than repeating it in each engine. Gravitino resolves the values and returns them to clients, so an engine reading the dataset files directly receives the credentials it needs. They can be overridden per table, as described in [Table Properties](./lakehouse-generic-lance-table.md#table-properties).
 
-### Supported Operations
+Gravitino does not define the `lance.storage.*` option names. It strips the prefix and passes whatever it finds to the client, so the names come from Lance rather than from Gravitino and no key is validated or rejected.
 
-Since different lakehouse table formats have varying capabilities, table operation support may differ. The following are table operations for different lakehouse formats:
+The options below cover S3 and S3-compatible stores such as MinIO, and are the ones Gravitino's own integration tests exercise.
 
-- [Lance Format Support](./lakehouse-generic-lance-table.md)
+| Property                          | Description                                              |
+|-----------------------------------|----------------------------------------------------------|
+| `lance.storage.access_key_id`     | Access key                                               |
+| `lance.storage.secret_access_key` | Secret key                                               |
+| `lance.storage.region`            | Bucket region                                            |
+| `lance.storage.endpoint`          | Endpoint URL, needed for S3-compatible stores like MinIO |
+| `lance.storage.allow_http`        | Set to `true` to permit a plain HTTP endpoint            |
+
+For GCS, Azure, and the full option list per backend, see the [Lance storage documentation](https://lancedb.com/docs/storage/integrations/).
+
+#### Schema Refresh
+
+Gravitino stores table columns in its own metadata store, and some Lance writers update the dataset directly at its location. `lance.schema-refresh-mode` decides when Gravitino re-reads columns to stay in sync.
+
+| Mode                 | Behavior                                                                                                                       |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `DECLARED_AND_EMPTY` | Default. Refreshes declared tables whose schema has not yet been written, and tables whose Gravitino column list is empty      |
+| `VERSION_CHECK`      | Opens the dataset on every load, compares its version with `lance.version`, and refreshes columns when the version has changed |
+
+Use `VERSION_CHECK` only when tables are modified directly at their storage location outside Gravitino, since it adds a dataset open to every load.
+
+A dataset that genuinely has no columns is handled once. Under `DECLARED_AND_EMPTY`, the first load records the checked version in `lance.version` and later loads skip opening the dataset while that version holds. Once columns are written, the next `VERSION_CHECK` load or an explicit alter repairs the schema.
+
+## Related Pages
+
+- [Lance Tables](./lakehouse-generic-lance-table.md) for Lance table properties, type mappings, and operations
+- [Delta Lake Tables](./lakehouse-generic-delta-table.md) for registering external Delta tables
+- [Lance REST Service](./lance-rest-service.md) for the Lance-native path that creates this catalog for you
+- [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md) for the standard catalog, schema, and table operations

--- a/docs/lakehouse-generic-delta-table.md
+++ b/docs/lakehouse-generic-delta-table.md
@@ -10,381 +10,125 @@ keywords:
 license: "This software is licensed under the Apache License version 2."
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-
 ## Overview
 
-This document describes how to use Apache Gravitino to manage a generic lakehouse catalog using Delta Lake as the underlying table format. Gravitino supports registering and managing metadata for external Delta tables.
+Apache Gravitino registers existing Delta Lake tables in a `lakehouse-generic` catalog and holds their metadata: schema, location, properties, and identity partitions. It does not create, write, or modify Delta data.
 
-:::info Supported Operations
-Gravitino supports **external Delta tables only**. This means:
-- Register existing Delta tables in Gravitino
-- Gravitino manages metadata only (schema, location, properties)
-- The physical Delta table data remains independent
-- Dropping tables from Gravitino does not delete the underlying Delta data
-:::
+Every Delta table is external. `external=true` is required on create, and a create call is a registration of a table that already exists at `location`. Dropping the table removes the Gravitino entry and leaves the Delta table where it is.
 
-## Table Management
+The practical consequence is that Gravitino and the Delta transaction log are two records of the same table, and Gravitino does not reconcile them. It stores the schema you supply without checking it against the `_delta_log`, so a schema that drifts stays wrong until you correct it.
 
-### Supported Operations
+Delta tables are reached through the Gravitino REST API only.
 
-For Delta tables in a Generic Lakehouse Catalog, the following table summarizes supported operations:
+## Capabilities
 
-| Operation | Support Status                                 |
-|-----------|------------------------------------------------|
-| List      | ✅ Full                                         |
-| Load      | ✅ Full                                         |
-| Alter     | ❌ Not supported (use Delta Lake APIs directly) |
-| Create    | ✅ Register external tables only                |
-| Drop      | ✅ Metadata only (data preserved)               |
-| Purge     | ❌ Not supported for external tables            |
+| Capability                      | Gravitino REST API                                         |
+|---------------------------------|------------------------------------------------------------|
+| Adopt an existing table         | Create table with `external=true` and a `location`         |
+| Create a new table              | Not available. Gravitino never writes Delta data           |
+| List and describe               | List tables, load table                                    |
+| Drop or rename a column         | Not available ¹                                            |
+| Add an index                    | Not available                                              |
+| Remove metadata, keep the table | Drop table                                                 |
+| Remove metadata and the table   | Not available. Purge table is rejected for external tables |
 
-:::note Feature Limitations
-- **External Tables Only:** Must set `external=true` when creating Delta tables
-- **Alter Operations:** Not supported; modify tables using Delta Lake APIs or Spark, then update Gravitino metadata if needed
-- **Purge:** Not applicable for external tables; use DROP to remove metadata only
-- **Partitioning:** Identity partitions supported as metadata only; user must ensure consistency with actual Delta table
-- **Sort Orders:** Not supported in CREATE TABLE
-- **Distributions:** Not supported in CREATE TABLE
-- **Indexes:** Not supported in CREATE TABLE
-:::
+¹ Alter is not supported at all. See [Changing a Table](#changing-a-table).
 
-### Data Type Mappings
+Create also rejects distributions, sort orders, indexes, and any partition transform other than identity.
 
-Delta Lake uses Apache Spark data types. The following table shows type mappings between Gravitino and Delta/Spark:
+## Table Properties
 
-| Gravitino Type      | Delta/Spark Type       | Notes                           |
-|---------------------|------------------------|---------------------------------|
-| `Boolean`           | `BooleanType`          |                                 |
-| `Byte`              | `ByteType`             |                                 |
-| `Short`             | `ShortType`            |                                 |
-| `Integer`           | `IntegerType`          |                                 |
-| `Long`              | `LongType`             |                                 |
-| `Float`             | `FloatType`            |                                 |
-| `Double`            | `DoubleType`           |                                 |
-| `Decimal(p, s)`     | `DecimalType(p, s)`    |                                 |
-| `String`            | `StringType`           |                                 |
-| `Binary`            | `BinaryType`           |                                 |
-| `Date`              | `DateType`             |                                 |
-| `Timestamp`         | `TimestampNTZType`     | No timezone, Spark 3.4+         |
-| `Timestamp_tz`      | `TimestampType`        | With timezone                   |
-| `List`              | `ArrayType`            |                                 |
-| `Map`               | `MapType`              |                                 |
-| `Struct`            | `StructType`           |                                 |
+| Property   | Description                                                                                                    | Required          |
+|------------|----------------------------------------------------------------------------------------------------------------|-------------------|
+| `format`   | Selects the table implementation. Use `delta`                                                                  | Yes               |
+| `external` | Must be `true`. Gravitino holds metadata only and never deletes the Delta data                                 | Yes               |
+| `location` | Directory containing the Delta table, meaning the one holding `_delta_log`. Any Hadoop-compatible scheme works | Yes, or inherited |
 
-### Table Properties
+`location` resolves through the table, schema, and catalog in that order, as described in [Location Resolution](./lakehouse-generic-catalog.md#location-resolution), so an inherited value satisfies the requirement. In practice set it on the table, since a registration has to land on the directory where the Delta table already is.
 
-Required and optional properties for Delta tables in a Generic Lakehouse Catalog:
+## Data Type Mappings
 
-| Property   | Description                                                                                                                                                                                                            | Default | Required | Since Version |
-|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|----------|---------------|
-| `format`   | Table format: must be `delta`                                                                                                                                                                                          | (none)  | Yes      | 1.2.0         |
-| `location` | Storage path for the Delta table. Must point to a directory containing Delta Lake metadata (_delta_log). Supports file://, s3://, hdfs://, abfs://, gs://, and other Hadoop-compatible file systems.                  | (none)  | Yes      | 1.2.0         |
-| `external` | Must be `true` for Delta tables. Indicates that Gravitino manages metadata only <br/>and will not delete physical data when the table is dropped.                                                                           | (none)  | Yes      | 1.2.0         |
+Gravitino performs no type conversion for Delta. It stores the columns you declare and never reads the Delta schema, so use this correspondence to declare metadata that matches the real table.
 
-**Location Requirement:** Must be specified at table level for external Delta table. See [Location Resolution](./lakehouse-generic-catalog.md#key-property-location).
+| Gravitino Type  | Spark Type                                           |
+|-----------------|------------------------------------------------------|
+| `Boolean`       | `BooleanType`                                        |
+| `Byte`          | `ByteType`                                           |
+| `Short`         | `ShortType`                                          |
+| `Integer`       | `IntegerType`                                        |
+| `Long`          | `LongType`                                           |
+| `Float`         | `FloatType`                                          |
+| `Double`        | `DoubleType`                                         |
+| `Decimal(p, s)` | `DecimalType(p, s)`                                  |
+| `String`        | `StringType`                                         |
+| `Binary`        | `BinaryType`                                         |
+| `Date`          | `DateType`                                           |
+| `Timestamp`     | `TimestampNTZType`, no timezone, Spark 3.4 and later |
+| `Timestamp_tz`  | `TimestampType`, with timezone                       |
+| `List`          | `ArrayType`                                          |
+| `Map`           | `MapType`                                            |
+| `Struct`        | `StructType`                                         |
 
-### Table Operations
+## Examples
 
-Table operations follow standard relational catalog patterns with Delta-specific considerations. See [Table Operations](./manage-relational-metadata-using-gravitino.md#table-operations) for comprehensive documentation.
+### Registering a Table
 
-The following sections provide examples and important details for working with Delta tables.
-
-#### Register an External Delta Table
-
-Register an existing Delta table in Gravitino without moving or modifying the underlying data:
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+Supply the columns yourself. Gravitino stores them as given and does not read the Delta schema to check them.
 
 ```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" -d '{
-  "name": "customer_orders",
+GRAVITINO_URL=http://localhost:8090
+CATALOG=${GRAVITINO_URL}/api/metalakes/{metalake_name}/catalogs/{catalog_name}
+TABLES=${CATALOG}/schemas/{schema_name}/tables
+
+curl -X POST "${TABLES}" \
+  -H "Accept: application/vnd.gravitino.v1+json" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "{table_name}",
   "comment": "Customer orders Delta table",
   "columns": [
-    {
-      "name": "order_id",
-      "type": "long",
-      "comment": "Order identifier",
-      "nullable": false
-    },
-    {
-      "name": "customer_id",
-      "type": "long",
-      "comment": "Customer identifier",
-      "nullable": false
-    },
-    {
-      "name": "order_date",
-      "type": "date",
-      "comment": "Order date",
-      "nullable": false
-    },
-    {
-      "name": "total_amount",
-      "type": "decimal(10,2)",
-      "comment": "Total order amount",
-      "nullable": true
-    }
+    {"name": "order_id", "type": "long", "nullable": false},
+    {"name": "order_date", "type": "date", "nullable": false},
+    {"name": "total_amount", "type": "decimal(10,2)"}
   ],
   "properties": {
     "format": "delta",
     "external": "true",
-    "location": "s3://my-bucket/delta-tables/customer_orders"
+    "location": "s3://{bucket}/{prefix}/{table_name}"
   }
-}' http://localhost:8090/api/metalakes/test/catalogs/generic_lakehouse_delta_catalog/schemas/sales/tables
+}'
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
+Loading and dropping follow the standard patterns in [Table Operations](./manage-relational-metadata-using-gravitino.md#table-operations). A dropped table can be registered again from the same location.
 
-```java
-import org.apache.gravitino.Catalog;
-import org.apache.gravitino.NameIdentifier;
-import org.apache.gravitino.rel.Column;
-import org.apache.gravitino.rel.types.Types;
-import com.google.common.collect.ImmutableMap;
+## Partitioning
 
-Catalog catalog = gravitinoClient.loadCatalog("generic_lakehouse_delta_catalog");
-TableCatalog tableCatalog = catalog.asTableCatalog();
+Gravitino stores identity partitions as metadata. Non-identity transforms, including bucket, truncate, year, and month, are rejected on create.
 
-Map<String, String> tableProperties = ImmutableMap.<String, String>builder()
-    .put("format", "delta")
-    .put("external", "true")
-    .put("location", "s3://my-bucket/delta-tables/customer_orders")
-    .build();
+As with the schema, the partitions you declare are not validated against the Delta transaction log, where the real partitioning lives. Declaring partitions that do not match the table produces metadata that disagrees with the data.
 
-tableCatalog.createTable(
-    NameIdentifier.of("sales", "customer_orders"),
-    new Column[] {
-        Column.of("order_id", Types.LongType.get(), "Order identifier", false, false, null),
-        Column.of("customer_id", Types.LongType.get(), "Customer identifier", false, false, null),
-        Column.of("order_date", Types.DateType.get(), "Order date", false, false, null),
-        Column.of("total_amount", Types.DecimalType.of(10, 2), "Total order amount", true, false, null)
-    },
-    "Customer orders Delta table",
-    tableProperties,
-    null,  // partitions (optional, identity only)
-    null,  // distributions (not supported)
-    null,  // sortOrders (not supported)
-    null   // indexes (not supported)
-);
-```
+## Changing a Table
 
-</TabItem>
-</Tabs>
+Alter is not supported. Modify the table with Delta Lake tools such as Spark or delta-rs, then drop the Gravitino entry and register it again with the updated schema.
 
-:::important Schema Specification
-When registering a Delta table in Gravitino, you must provide the schema (columns) in the CREATE TABLE request. Gravitino stores this schema as metadata but does not validate it against the Delta table's actual schema. 
+Time travel is likewise a Delta Lake feature reached through those tools rather than through Gravitino.
 
-**Best Practice:** Ensure the schema you provide matches the actual Delta table schema to avoid inconsistencies.
-:::
+## Troubleshooting
 
-#### Load a Delta Table
+| Error                                                                 | Cause                                                      |
+|-----------------------------------------------------------------------|------------------------------------------------------------|
+| `Gravitino only supports creating external Delta tables`              | `external=true` was not set                                |
+| `'location' property is neither set in table properties`              | No location at the table, schema, or catalog level         |
+| `Delta table only supports identity partitioning`                     | A bucket, truncate, year, or month transform was passed    |
+| `ALTER TABLE operations are not supported`                            | Modify with Delta Lake tools, then drop and register again |
+| `Purge operation is not supported for external Delta tables`          | Drop removes the metadata; remove the files yourself       |
+| `Delta table doesn't support specifying distribution in CREATE TABLE` | Pass no distribution                                       |
+| `Delta table doesn't support specifying sort orders in CREATE TABLE`  | Pass no sort orders                                        |
+| `Delta table doesn't support specifying indexes in CREATE TABLE`      | Pass no indexes                                            |
 
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+## Related Pages
 
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-  http://localhost:8090/api/metalakes/test/catalogs/generic_lakehouse_delta_catalog/schemas/sales/tables/customer_orders
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-Table table = tableCatalog.loadTable(
-    NameIdentifier.of("sales", "customer_orders")
-);
-
-System.out.println("Table location: " + table.properties().get("location"));
-System.out.println("Columns: " + Arrays.toString(table.columns()));
-```
-
-</TabItem>
-</Tabs>
-
-#### Drop a Delta Table
-
-Dropping a Delta table from Gravitino removes only the metadata entry. The physical Delta table data remains intact.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
-  http://localhost:8090/api/metalakes/test/catalogs/generic_lakehouse_delta_catalog/schemas/sales/tables/customer_orders
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-boolean dropped = tableCatalog.dropTable(
-    NameIdentifier.of("sales", "customer_orders")
-);
-// The Delta table files at the location are NOT deleted
-```
-
-</TabItem>
-</Tabs>
-
-:::tip Metadata-Only Drop
-Since Delta tables are external, dropping them from Gravitino:
-- ✅ Removes the table from Gravitino's metadata
-- ✅ Preserves the Delta table data at its location
-- ✅ Allows you to re-register the same table later
-
-The Delta table can still be accessed directly via Delta Lake APIs, Spark, or other tools.
-:::
-
-## Work with Delta Tables
-
-### Modify Delta Tables with Spark
-
-Since Gravitino does not support ALTER operations for Delta tables, use Apache Spark or other Delta Lake tools to modify table structure:
-
-```java
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import io.delta.tables.DeltaTable;
-import static org.apache.spark.sql.functions.lit;
-
-// Create Spark session with Delta Lake support
-SparkSession spark = SparkSession.builder()
-    .appName("Delta Table Modification")
-    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
-    .getOrCreate();
-
-// Read the table location from Gravitino
-String tableLocation = "s3://my-bucket/delta-tables/customer_orders";
-
-// Add a new column using Delta Lake
-DeltaTable deltaTable = DeltaTable.forPath(spark, tableLocation);
-Dataset<Row> df = deltaTable.toDF()
-    .withColumn("status", lit("pending"));
-
-df.write()
-    .format("delta")
-    .mode("overwrite")
-    .option("overwriteSchema", "true")
-    .save(tableLocation);
-```
-
-After modifying the Delta table, you can:
-1. Drop the table from Gravitino
-2. Re-register it with the updated schema
-
-### Read Delta Tables via Gravitino
-
-Once registered in Gravitino, you can query Delta table metadata and use the location to read data:
-
-```java
-// Load table metadata from Gravitino
-Table table = tableCatalog.loadTable(NameIdentifier.of("sales", "customer_orders"));
-String location = table.properties().get("location");
-
-// Use the location to read the Delta table with Spark
-Dataset<Row> df = spark.read()
-    .format("delta")
-    .load(location);
-
-df.show();
-```
-
-### Partitioned Delta Tables
-
-Delta Lake supports partitioning, and Gravitino can store identity partition metadata for external Delta tables. The partition information is metadata-only and must match the actual Delta table's partitioning scheme defined in the Delta transaction log.
-
-```java
-// Register a partitioned Delta table
-Map<String, String> properties = ImmutableMap.<String, String>builder()
-    .put("format", "delta")
-    .put("external", "true")
-    .put("location", "s3://my-bucket/delta-tables/sales_partitioned")
-    .build();
-
-// Specify identity partitions (metadata only)
-Transform[] partitions = new Transform[] {
-    Transforms.identity("year"),
-    Transforms.identity("month")
-};
-
-tableCatalog.createTable(
-    NameIdentifier.of("sales", "sales_partitioned"),
-    columns,
-    "Partitioned sales data",
-    properties,
-    partitions,  // Identity partitions supported
-    null,
-    null,
-    null);
-```
-
-:::note
-Partition information in Gravitino is **metadata only**:
-- Only **identity transforms** are supported (e.g., `Transforms.identity("column")`)
-- Non-identity transforms (bucket, truncate, year, month, etc.) will be rejected
-- The actual partitioning is managed by Delta Lake in the _delta_log
-- **User responsibility**: Ensure the partition metadata you provide matches the actual Delta table's partitioning
-- Gravitino does not validate partition metadata against the Delta transaction log
-:::
-
-## Advanced Topics
-
-### Troubleshooting
-
-#### Common Issues
-
-**Issue: "Gravitino only supports creating external Delta tables"**
-```
-Solution: Ensure you set "external": "true" in the table properties
-```
-
-**Issue: "Property 'location' is required for external Delta tables"**
-```
-Solution: Specify the location property pointing to your Delta table directory
-```
-
-**Issue: "ALTER TABLE operations are not supported"**
-```
-Solution: Use Delta Lake APIs (Spark, Delta-rs, etc.) to modify the table,
-then optionally drop and re-register in Gravitino with updated schema
-```
-
-**Issue: "Purge operation is not supported for external Delta tables"**
-```
-Solution: Use dropTable() to remove metadata only. To delete data, 
-manually remove files from the storage location
-```
-
-## Limitations and Future Work
-
-### Limitations
-
-- **Managed Tables**: Not supported; only external tables are available
-- **ALTER Operations**: Cannot modify table schema through Gravitino; use Delta Lake APIs
-- **Partitioning**: Only identity partitions supported; stored as metadata only (not validated against Delta log)
-- **Indexes**: Not supported in CREATE TABLE
-- **Time Travel**: Access via Delta Lake APIs directly; not exposed through Gravitino
-
-### Planned Enhancements
-
-Future versions may include:
-- Support for managed Delta tables (requires Delta Lake 4.0+ CommitCoordinator)
-- Schema evolution tracking
-- Integration with Delta Lake time travel features
-- Enhanced metadata synchronization
-
-## Related
-
-- [Generic Lakehouse Catalog](./lakehouse-generic-catalog.md)
-- [Table Operations](./manage-relational-metadata-using-gravitino.md#table-operations)
-- [Delta Lake Documentation](https://docs.delta.io/)
-- [Delta Lake GitHub](https://github.com/delta-io/delta)
+- [Lakehouse Generic Catalog](./lakehouse-generic-catalog.md) for the catalog, its properties, and location resolution
+- [Lance Tables](./lakehouse-generic-lance-table.md) for the other format the same catalog holds
+- [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#table-operations) for the standard load, list, and drop calls
+- [Delta Lake documentation](https://docs.delta.io/) for writing and modifying the tables themselves

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -9,360 +9,211 @@ keywords:
 license: "This software is licensed under the Apache License version 2."
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-
 ## Overview
 
-This document describes how to use Apache Gravitino to manage a generic lakehouse catalog using Lance as the underlying table format. 
+A Lance table in Apache Gravitino is a Lance dataset on storage plus its metadata in a `lakehouse-generic` catalog. Two APIs reach the same tables.
 
+- **Lance REST API.** The [Lance REST Service](./lance-rest-service.md) speaks the Lance REST Catalog protocol on port 9101, for `lance-spark`, `lance-ray`, and any Lance SDK client.
+- **Gravitino REST API.** Tables are ordinary Gravitino relational objects on port 8090, with `format` set to `lance`.
 
-## Table Management
+This page describes the table itself, which is the same either way. Where the two APIs differ, the difference is named.
 
-### Supported Operations
+## Capabilities
 
-For Lance tables in a Generic Lakehouse Catalog, the following table summarizes supported operations:
+| Capability                        | Lance REST API                     | Gravitino REST API                      |
+|-----------------------------------|------------------------------------|-----------------------------------------|
+| Create a table                    | `CreateTable`                      | Create table with `format=lance`        |
+| Record a table without a dataset  | `DeclareTable`                     | Create table with `lance.declared=true` |
+| Adopt an existing dataset         | `RegisterTable`                    | Create table with `lance.register=true` |
+| List and describe                 | `ListTables`, `DescribeTable`      | List tables, load table                 |
+| Drop or rename a column           | `drop_columns`, `alter_columns`  ¹ | Alter table ¹                           |
+| Add an index                      | Not available ²                    | Alter table ³                           |
+| Remove metadata, keep the dataset | `DeregisterTable`                  | Drop table with `external=true`         |
+| Remove metadata and the dataset   | `DropTable`  ⁴                     | Purge table                             |
 
-| Operation | Support Status  |
-|-----------|-----------------|
-| List      | ✅ Full          |
-| Load      | ✅ Full          |
-| Alter     | Not support now |
-| Create    | ✅ Full          |
-| Register  | ✅ Full          |
-| Drop      | ✅ Full          |
-| Purge     | ✅ Full          |
+¹ Changes are applied to the Lance dataset before the metadata is updated, and are not atomic across multiple changes, so a failure part way through can leave a subset applied.
+² A workload that builds indexes needs the Gravitino REST API for that step.
+³ Vector and scalar index types are supported. Vector index parameters are not currently configurable.
+⁴ Removes the dataset files even though the service marks every table it creates `external`, so it behaves like Purge rather than like Drop.
 
-:::note Feature Limitations
-- **Partitioning:** Not supported
-- **Sort Orders:** Not supported
-- **Distributions:** Not supported
-- **Indexes:** Not supported
-:::
+Partitioning, sort orders, and distributions are not supported on either API. Column type changes are rejected.
 
-### Data Type Mappings
+## Table Properties
 
-Lance uses Apache Arrow for table schemas. The following table shows type mappings between Gravitino and Arrow:
+Every property below is a property of the table, whichever API created it. On the Gravitino REST API you set them directly. On the Lance REST API the service supplies them from the call you made, as the last column shows.
 
-| Gravitino Type                   | Arrow Type                              |
-|----------------------------------|-----------------------------------------|
-| `Struct`                         | `Struct`                                |
-| `Map`                            | Not supported by Lance                  |
-| `List`                           | `Array`                                 |
-| `Boolean`                        | `Boolean`                               |
-| `Byte`                           | `Int8`                                  |
-| `Short`                          | `Int16`                                 |
-| `Integer`                        | `Int32`                                 |
-| `Long`                           | `Int64`                                 |
-| `Float`                          | `Float`                                 |
-| `Double`                         | `Double`                                |
-| `String`                         | `Utf8`                                  |
-| `Binary`                         | `Binary`                                |
-| `Decimal(p, s)`                  | `Decimal(p, s)` (128-bit)               |
-| `Date`                           | `Date`                                  |
-| `Timestamp`/`Timestamp(6)`       | `TimestampType withoutZone`             |
-| `Timestamp(0)`                   | `TimestampType Second withoutZone`      |
-| `Timestamp(3)`                   | `TimestampType Millisecond withoutZone` |
-| `Timestamp(9)`                   | `TimestampType Nanosecond withoutZone`  |
-| `Timestamp_tz`/`Timestamp_tz(6)` | `TimestampType Microsecond withUtc`     |
-| `Timestamp_tz(0)`                | `TimestampType Second withUtc`          |
-| `Timestamp_tz(3)`                | `TimestampType Millisecond withUtc`     |
-| `Timestamp_tz(9)`                | `TimestampType Nanosecond withUtc`      |
-| `Time`/`Time(9)`                 | `Time Nanosecond`                       |
-| `Null`                           | `Null`                                  |
-| `Fixed(n)`                       | `Fixed-Size Binary(n)`                  |
-| `Interval_year`                  | Not supported by Lance                  |
-| `Interval_day`                   | `Duration(Microsecond)`                 |
-| `External(arrow_field_json_str)` | Any Arrow Field                         |
+| Property                 | Description                                                                                                                                          | Default  | Supplied on the Lance Path By   |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------------------------|
+| `format`                 | Selects the table implementation. Use `lance`                                                                                                        | (none)   | Always `lance`                  |
+| `location`               | Storage path for the dataset. Lance supports S3, GCS, OSS, Azure, HDFS, local files, and memory                                                      | (none)   | `x-lance-table-location` header |
+| `external`               | When `true`, dropping the table removes only the metadata and leaves the dataset. When `false`, dropping removes both                                | `false`  | Always `true`                   |
+| `lance.creation-mode`    | `CREATE` fails if the table exists, `EXIST_OK` does nothing if it exists, `OVERWRITE` replaces it and deletes the existing dataset unless registered | `CREATE` | The `mode` query parameter      |
+| `lance.register`         | When `true`, links an existing dataset instead of creating one. You manage the data directory                                                        | `false`  | `RegisterTable`                 |
+| `lance.declared`         | When `true`, records the table in metadata without creating a dataset                                                                                | `false`  | `DeclareTable`                  |
+| `lance.storage.{option}` | Storage options for this table, overriding the catalog values                                                                                        | (none)   | Inherited from the catalog      |
+| `lance.version`          | Dataset version Gravitino last read columns from                                                                                                     | (none)   | The server, on both paths       |
 
-### External Types
+`external` is the one row whose described behavior does not hold on the Lance REST API, because `DropTable` removes the dataset files regardless. It matters only if the same table is later dropped through the Gravitino REST API, where the files would be kept.
 
-For Arrow types not natively mapped in Gravitino, use the `External(arrow_field_json_str)` type, which accepts a JSON string representation of an Arrow `Field`.
+If `location` is set at neither the table nor the header, it resolves from the schema or catalog. See [Location Resolution](./lakehouse-generic-catalog.md#location-resolution).
 
-**Requirements:**
-- JSON must conform to Apache Arrow [Field specification](https://github.com/apache/arrow-java/blob/ed81e5981a2bee40584b3a411ed755cb4cc5b91f/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java#L80C1-L86C68)
-- `name` attribute must match column name exactly
-- `nullable` attribute must match column nullability
-- `children` array:
-  - Empty for primitive types
-  - Contains child field definitions for complex types (Struct, List)
+## Data Type Mappings
 
-**Examples:**
+Lance uses Apache Arrow for table schemas.
 
-| Arrow Type        | External Type Definition                                                                                                                                                                                                                |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Large Utf8`      | `External("{\"name\":\"col_name\",\"nullable\":true,\"type\":{\"name\":\"largeutf8\"},\"children\":[]}")`                                                                                                                               |
-| `Large Binary`    | `External("{\"name\":\"col_name\",\"nullable\":true,\"type\":{\"name\":\"largebinary\"},\"children\":[]}")`                                                                                                                             |
-| `Large List`      | `External("{\"name\":\"col_name\",\"nullable\":true,\"type\":{\"name\":\"largelist\"},\"children\":[{\"name\":\"element\",\"nullable\":true,\"type\":{\"name\":\"int\",\"bitWidth\":32,\"isSigned\":true},\"children\":[]}]}")`         |
-| `Fixed-Size List` | `External("{\"name\":\"col_name\",\"nullable\":true,\"type\":{\"name\":\"fixedsizelist\",\"listSize\":10},\"children\":[{\"name\":\"element\",\"nullable\":true,\"type\":{\"name\":\"int\",\"bitWidth\":32,\"isSigned\":true},\"children\":[]}]}")` |
+| Gravitino Type                   | Arrow Type                               |
+|----------------------------------|------------------------------------------|
+| `Boolean`                        | `Boolean`                                |
+| `Byte`                           | `Int8`                                   |
+| `Short`                          | `Int16`                                  |
+| `Integer`                        | `Int32`                                  |
+| `Long`                           | `Int64`                                  |
+| `Float`                          | `Float`                                  |
+| `Double`                         | `Double`                                 |
+| `Decimal(p, s)`                  | `Decimal(p, s)` (128-bit)                |
+| `String`                         | `Utf8`                                   |
+| `Binary`                         | `Binary`                                 |
+| `Fixed(n)`                       | `Fixed-Size Binary(n)`                   |
+| `Date`                           | `Date`                                   |
+| `Time`/`Time(9)`                 | `Time Nanosecond`                        |
+| `Timestamp`/`Timestamp(6)`       | `TimestampType Microsecond withoutZone`  |
+| `Timestamp(0)`                   | `TimestampType Second withoutZone`       |
+| `Timestamp(3)`                   | `TimestampType Millisecond withoutZone`  |
+| `Timestamp(9)`                   | `TimestampType Nanosecond withoutZone`   |
+| `Timestamp_tz`/`Timestamp_tz(6)` | `TimestampType Microsecond withUtc`      |
+| `Timestamp_tz(0)`                | `TimestampType Second withUtc`           |
+| `Timestamp_tz(3)`                | `TimestampType Millisecond withUtc`      |
+| `Timestamp_tz(9)`                | `TimestampType Nanosecond withUtc`       |
+| `Interval_day`                   | `Duration(Microsecond)`                  |
+| `List`                           | `List`                                   |
+| `Struct`                         | `Struct`                                 |
+| `Map`                            | `Map`                                    |
+| `Union`                          | `Union(Sparse)`, rejected by Lance       |
+| `Interval_year`                  | `Interval(YearMonth)`, rejected by Lance |
+| `Null`                           | `Null`                                   |
+| `External(arrow_field_json_str)` | Any Arrow field                          |
 
-### Table Properties
+Two rows convert cleanly to Arrow but are rejected at the dataset, because Lance defines no interval and no union type. `Interval_day` is fine, since it maps to an Arrow `Duration`, which Lance does have.
 
-Required and optional properties for tables in a Generic Lakehouse Catalog:
+Lance also has types with no Gravitino equivalent, including unsigned integers, `Float16`, `LargeUtf8`, `LargeBinary`, and dictionaries. Reach them with [External Types](#external-types).
 
-| Property              | Description                                                                                                                                                                                                                                                                                                                               | Default  | Required     | Since Version |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------|---------------|
-| `format`              | Table format: `lance`, only `lance` is fully supported.                                                                                                                                                                                                                                                                                   | (none)   | Yes          | 1.1.0         |
-| `location`            | Storage path for table metadata and data, Lance supports: S3, GCS, OSS, AZ, File, Memory and file-object-store.                                                                                                                                                                                                                           | (none)   | Conditional* | 1.1.0         |
-| `external`            | Whether the data directory is an external location. If it's `true`, dropping a table will only remove metadata in Gravitino and will not delete the data directory, and purge table will delete both. For a non-external table, dropping will drop both.                                                                                  | false    | No           | 1.1.0         |
-| `lance.creation-mode` | Create mode: for create table, it can be `CREATE`, `EXIST_OK` or `OVERWRITE`. and it should be `CREATE` or `OVERWRITE` for registering tables                                                                                                                                                                                             | `CREATE` | No           | 1.1.0         |
-| `lance.register`      | Whether it is a register table operation. If it's `true`, This API will not create data directory actually and it's the user's responsibility to create and manage the data directory. `false` it will actually create a table.                                                                                                           | false    | No           | 1.1.0         |
-| `lance.storage.xxxx`  | Any additional storage-specific properties required by Lance format (e.g., S3 credentials, HDFS configs). Replace `xxxx` with actual property names. For example, we can use `lance.storage.aws_access_key_id` to set S3 aws_access_key_id when using a S3 location, for detail, refer to https://lancedb.com/docs/storage/integrations/  | (none)   | No           | 1.1.0         |
+Vector columns need care. Gravitino `List` produces an Arrow `List`, which is variable length, while Lance stores embeddings as a fixed-size list, written `fixed_size_list:float:128` in its own type system. Declare one with `External` and a `fixedsizelist` type whose `listSize` is the embedding dimension. See [External Types](#external-types) for the form.
 
-- `CREATE`: Create a new table, fail if the table already exists.
-- `EXIST_OK`: Create a new table if it does not exist, otherwise do nothing.
-- `OVERWRITE`: Create a new table, overwrite if the table already exists, it will delete the existing data directory first if the table is not a registered table and then create a new one.
+## External Types
 
-**Location Requirement:** Must be specified at catalog, schema, or table level. See [Location Resolution](./lakehouse-generic-catalog.md#key-property-location).
+For Arrow types with no Gravitino equivalent, use `External(arrow_field_json_str)`, which takes a JSON string form of an Arrow [Field](https://github.com/apache/arrow-java/blob/main/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java). The `name` and `nullable` attributes have to match the column, and `children` is empty for primitive types and holds child field definitions for complex ones.
 
-Also set additional properties specific to your lakehouse format or custom requirements.
+| Arrow Type        | External Type Definition                                                                                                                                                                                                                       |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Large Utf8`      | `External("{\"name\":\"col\",\"nullable\":true,\"type\":{\"name\":\"largeutf8\"},\"children\":[]}")`                                                                                                                                           |
+| `Large Binary`    | `External("{\"name\":\"col\",\"nullable\":true,\"type\":{\"name\":\"largebinary\"},\"children\":[]}")`                                                                                                                                         |
+| `Large List`      | `External("{\"name\":\"col\",\"nullable\":true,\"type\":{\"name\":\"largelist\"},\"children\":[{\"name\":\"element\",\"nullable\":true,\"type\":{\"name\":\"int\",\"bitWidth\":32,\"isSigned\":true},\"children\":[]}]}")`                     |
+| `Fixed-Size List` | `External("{\"name\":\"col\",\"nullable\":true,\"type\":{\"name\":\"fixedsizelist\",\"listSize\":10},\"children\":[{\"name\":\"element\",\"nullable\":true,\"type\":{\"name\":\"int\",\"bitWidth\":32,\"isSigned\":true},\"children\":[]}]}")` |
 
-### Schema Refresh
+## Examples
 
-For Lance tables, Gravitino stores table columns in its metadata store. Some Lance writers can also
-update the dataset directly at the Lance location. To keep Gravitino metadata in sync, the Generic
-Lakehouse catalog supports catalog-level schema refresh modes:
+### Lance REST API
 
-| Mode                  | Behavior                                                                                                                                                                                                                                                                         |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DECLARED_AND_EMPTY`  | Default. Refreshes schema from the Lance dataset for two cases: (1) declared tables (`lance.declared=true`) whose schema has not yet been written to Gravitino; (2) tables whose Gravitino column list is empty, for example tables registered before their schema was captured. |
-| `VERSION_CHECK`       | Opens the Lance dataset on every `loadTable`, compares the dataset version with `lance.version`, and refreshes columns when the version has changed.                                                                                                                             |
+Endpoints and protocol details are on the [Lance REST Service](./lance-rest-service.md#lance-rest-api) page.
 
-Use `VERSION_CHECK` only when tables may be modified directly through the Lance path outside
-Gravitino. It adds a dataset version check to every `loadTable` call.
+**Creating a table.** The catalog and schema have to exist first, as the two levels of Lance namespace above the table. Creating them is covered in the [Lance REST Service](./lance-rest-service.md#quick-start) Quick Start.
 
-:::note Zero-column Lance dataset
-If a Lance dataset genuinely has no columns, `DECLARED_AND_EMPTY` mode records the checked dataset
-version (`lance.version`) on the first `loadTable` call. Subsequent loads skip opening the dataset
-as long as the stored version is unchanged. Once columns are written to the dataset, the next
-`VERSION_CHECK` load or an explicit `alterTable` will detect the change and repair the schema.
-:::
+The Arrow IPC body makes this the one call that is awkward to issue by hand. Write the schema to a file first:
 
-### Table Operations
+```python
+import pyarrow as pa
 
-Table operations follow standard relational catalog patterns. See [Table Operations](./manage-relational-metadata-using-gravitino.md#table-operations) for comprehensive documentation.
+schema = pa.schema([("id", pa.int32()), ("score", pa.float32())])
+with pa.ipc.new_stream("schema.arrows", schema):
+    pass
+```
 
-The following sections provide examples and important details for working with Lance tables. 
-
-#### Create a Lance Table
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+Then post it, naming the table with all three levels:
 
 ```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" -d '{
-  "name": "lance_table",
-  "comment": "Example Lance table",
+LANCE_URL=http://localhost:9101/lance
+TABLE_ID={catalog_name}%24{schema_name}%24{table_name}
+
+curl -X POST "${LANCE_URL}/v1/table/${TABLE_ID}/create?mode=create" \
+  -H 'Content-Type: application/vnd.apache.arrow.stream' \
+  -H 'x-lance-table-location: s3://{bucket}/{schema_name}/{table_name}.lance' \
+  --data-binary @schema.arrows
+```
+
+The response carries the resolved location and the `storageOptions` the client needs to read the dataset directly.
+
+**Registering an existing table.** Registration takes JSON and points at a dataset that already exists. Gravitino sets `lance.register` for you.
+
+```shell
+curl -X POST "${LANCE_URL}/v1/table/${TABLE_ID}/register" \
+  -H 'Content-Type: application/json' \
+  -d '{"location": "s3://{bucket}/{schema_name}/{table_name}.lance",
+       "mode": "create"}'
+```
+
+### Gravitino REST API
+
+**Creating a table.** A `lakehouse-generic` catalog and a schema have to exist first. See [Creating a Catalog](./lakehouse-generic-catalog.md#for-lance-tables). `format` is required and selects the Lance implementation.
+
+```shell
+GRAVITINO_URL=http://localhost:8090
+CATALOG=${GRAVITINO_URL}/api/metalakes/{metalake_name}/catalogs/{catalog_name}
+TABLES=${CATALOG}/schemas/{schema_name}/tables
+
+curl -X POST "${TABLES}" \
+  -H "Accept: application/vnd.gravitino.v1+json" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "{table_name}",
   "columns": [
-    {
-      "name": "id",
-      "type": "integer",
-      "comment": "Primary identifier",
-      "nullable": false
-    }
+    {"name": "id", "type": "integer", "nullable": false},
+    {"name": "score", "type": "float"}
   ],
-  "properties": {
-    "format": "lance",
-    "location": "/tmp/lance_catalog/schema/lance_table"
-  }
-}' http://localhost:8090/api/metalakes/test/catalogs/generic_lakehouse_lance_catalog/schemas/schema/tables
+  "properties": {"format": "lance"}
+}'
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
+The table location is derived from the catalog or schema location. Lance clients reading the table receive the catalog's resolved `lance.storage.*` values as storage options, so they need no credentials of their own.
 
-```java
-Catalog catalog = gravitinoClient.loadCatalog("generic_lakehouse_lance_catalog");
-TableCatalog tableCatalog = catalog.asTableCatalog();
-
-Map<String, String> tableProperties = ImmutableMap.<String, String>builder()
-    .put("format", "lance")
-    .put("location", "/tmp/lance_catalog/schema/example_table")
-    .build();
-
-tableCatalog.createTable(
-    NameIdentifier.of("schema", "lance_table"),
-    new Column[] {
-        Column.of("id", Types.IntegerType.get(), "Primary identifier", 
-                  true, false, null)
-    },
-    "Example Lance table",
-    tableProperties,
-    null,  // partitions
-    null,  // distributions
-    null,  // sortOrders
-    null   // indexes
-);
-```
-
-</TabItem>
-</Tabs>
-
-#### Register External Tables
-
-Register existing Lance tables without moving or copying data:
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+**Registering an existing table.** Registration links a dataset that already exists, without moving or copying data. Pass an empty column list and Gravitino reads the schema from the dataset.
 
 ```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" -d '{
-  "name": "register_lance_table",
-  "comment": "Registered existing Lance table",
+curl -X POST "${TABLES}" \
+  -H "Accept: application/vnd.gravitino.v1+json" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "{table_name}",
   "columns": [],
   "properties": {
     "format": "lance",
     "lance.register": "true",
-    "location": "/tmp/lance_catalog/schema/existing_lance_table"
+    "location": "s3://{bucket}/{prefix}/{table_name}.lance"
   }
-}' http://localhost:8090/api/metalakes/test/catalogs/generic_lakehouse_lance_catalog/schemas/schema/tables
+}'
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
+Creating and registering differ in what they do to storage. Create initializes a new dataset and needs the column definitions. Register touches no data and takes the schema from what is already there.
 
-```java
-Catalog catalog = gravitinoClient.loadCatalog("generic_lakehouse_lance_catalog");
-TableCatalog tableCatalog = catalog.asTableCatalog();
+Other table operations follow the standard relational catalog patterns described in [Table Operations](./manage-relational-metadata-using-gravitino.md#table-operations).
 
-Map<String, String> registerProperties = ImmutableMap.<String, String>builder()
-    .put("format", "lance")
-    .put("lance.register", "true")
-    .put("location", "/tmp/lance_catalog/schema/existing_lance_table")
-    .build();
+## Troubleshooting
 
-tableCatalog.createTable(
-    NameIdentifier.of("schema", "register_lance_table"),
-    new Column[] {},  // Schema auto-detected from existing table
-    "Registered existing Lance table",
-    registerProperties,
-    null, null, null, null
-);
-```
+| Error                                                     | Cause                                                                                      |
+|-----------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| `Catalog is not a lakehouse catalog`                      | A catalog of that name exists on another provider. Returned as a 404 on the Lance REST API |
+| `Expected at most 2-level and at least 1-level namespace` | A namespace identifier with three or more levels                                           |
+| `Expected at 3-level namespace but got`                   | A table identifier that is not `catalog$schema$table`                                      |
+| `'location' property is neither set in table properties`  | No location at the table, schema, or catalog level                                         |
+| `Unsupported Gravitino type`                              | A column type with no Arrow mapping. Use `External`                                        |
+| `Expected precision to be one of 0, 3, 6, 9 but got`      | A timestamp precision Arrow does not have                                                  |
+| `Only RENAME alteration is supported currently`           | An `alter_columns` request other than a rename                                             |
+| `Unsupported changes to lance table`                      | An alter other than drop column, rename column, or add index                               |
+| `EXIST_OK mode is not supported for register operation`   | Register accepts `create` or `overwrite` only                                              |
+| `deregisterTable only supports external tables`           | The table was created through the Gravitino REST API without `external=true`               |
 
-</TabItem>
-</Tabs>
+## Related Pages
 
-:::tip Registration vs Creation
-- **Registration** (`lance.register: true`):
-  - Links to existing Lance dataset or a path placeholder
-  - Schema automatically detected from Lance metadata
-  - Useful for importing existing datasets
-
-- **Creation** (default):
-  - Creates new Lance table from scratch
-  - Requires column schema definition
-  - Initializes new Lance dataset files
-:::
-
-## Advanced Topics
-
-### Troubleshooting
-
-#### Common Issues
-
-**Issue: "Location not specified" error**
-```
-Solution: Ensure at least one level (catalog/schema/table) specifies the location property
-```
-
-**Issue: Permission denied errors**
-```
-Solution: Check file system permissions and credentials for the storage backend
-```
-
-**Issue: Table not found after registration**
-```
-Solution: Verify the location path points to a valid Lance dataset directory
-```
-
-### Migration Guide
-
-#### Migrate Existing Lance Tables
-
-1. **Inventory**: List all existing Lance table locations
-2. **Create Catalog**: Create Generic Lakehouse catalog pointing to root location
-3. **Register Tables**: Use register operation for each table
-4. **Verify**: Confirm all tables are accessible through Gravitino
-5. **Update Clients**: Point applications to Gravitino metadata instead of direct Lance access
-
-**Example Migration Script:**
-
-```shell
-# List of existing Lance tables to register
-tables_to_migrate=(
-    "sales orders /data/sales/orders"
-    "sales customers /data/sales/customers"
-    "inventory products /data/inventory/products"
-)
-
-# Register each table
-for entry in "${tables_to_migrate[@]}"; do
-    read -r schema table location <<< "$entry"
-    echo ${schema}
-    echo ${table}
-
-    curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-      -H "Content-Type: application/json" -d "{
-      \"name\": \"${table}\",
-      \"comment\": \"Registered existing Lance table\",
-      \"columns\": [],
-      \"properties\": {
-        \"format\": \"lance\",
-        \"lance.register\": \"true\",
-        \"location\": \"${location}\"
-      }
-    }" http://localhost:8090/api/metalakes/test/catalogs/generic_lakehouse_lance_catalog/schemas/$schema/tables
-
-    echo "Registered ${schema}.${table}"
-done
-```
-
-Other table operations (load, alter, drop, truncate) follow standard relational catalog patterns. See [Table Operations](./manage-relational-metadata-using-gravitino.md#table-operations) for details.
-
-### Lance Table with MinIO
-
-To use Lance tables stored in MinIO with Gravitino, configure the MinIO storage backend once on the Lance catalog. Gravitino will then return those storage options to Lance clients and Spark does not need to repeat them.
-
-```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "name": "lance_catalog",
-  "type": "RELATIONAL",
-  "provider": "lakehouse-generic",
-  "comment": "catalog for Lance tables on MinIO",
-  "properties": {
-    "location": "s3://bucket1/lance",
-    "lance.storage.endpoint": "http://minio:9000",
-    "lance.storage.access_key_id": "ak",
-    "lance.storage.secret_access_key": "sk",
-    "lance.storage.allow_http": "true",
-    "lance.storage.region": "us-east-1"
-  }
-}' http://localhost:8090/api/metalakes/test/catalogs
-
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" -d '{
-  "name": "lance_orders",
-  "comment": "Order table stored in MinIO",
-  "columns": [
-    {
-      "name": "id",
-      "type": "integer",
-      "comment": "Primary identifier",
-      "nullable": false
-    }
-  ],
-  "properties": {
-    "format": "lance",
-    "location": "s3://bucket1/lance_orders"
-  }
-}' http://localhost:8090/api/metalakes/test/catalogs/lance_catalog/schemas/sales/tables
-
-```
-
-If you need to override storage on a single table, `lance.storage.*` table properties are still supported.
+- [Lance REST Service](./lance-rest-service.md) for the Lance-native path, service configuration, and the REST API
+- [Lance REST Integration](./lance-rest-integration.md) for `lance-spark` and `lance-ray` versions and examples
+- [Lakehouse Generic Catalog](./lakehouse-generic-catalog.md) for the catalog, storage options, and location resolution
+- [Delta Lake Tables](./lakehouse-generic-delta-table.md) for the other format the same catalog holds

--- a/docs/lance-rest-integration.md
+++ b/docs/lance-rest-integration.md
@@ -12,288 +12,183 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Overview
 
-This guide provides comprehensive instructions for integrating the Apache Gravitino Lance REST service with data processing engines that support the Lance format, including Apache Spark via the [Lance Spark connector](https://lance.org/integrations/spark/) and Ray via the [Lance Ray connector](https://lance.org/integrations/ray/).
+Engines reach the Apache Gravitino Lance REST service through a Lance client library. Two of them drive the service directly: [lance-spark](https://lance.org/integrations/spark/) for Apache Spark and [lance-ray](https://lance.org/integrations/ray/) for Ray. Both speak the Lance REST Catalog protocol, so they treat a Gravitino metalake as their namespace without knowing anything about Gravitino.
 
-This documentation assumes familiarity with the Lance REST service setup as described in the [Lance REST Service](./lance-rest-service) documentation.
+Set up the service first, as described in [Lance REST Service](./lance-rest-service.md). The examples below assume it is running on `http://localhost:9101/lance` and that `{catalog_name}` exists, which is where that page's Quick Start finishes.
 
-## Compatibility Matrix
+## Connecting an Engine
 
-The following table outlines the tested compatibility between Gravitino versions and Lance connector versions:
+Gravitino builds against `lance-namespace-core` 0.7.5, which is what most version incompatibilities below trace back to. Test the exact versions in your own environment before relying on them.
 
-| Gravitino Version (Lance REST) | Supported lance-spark Versions | Supported lance-ray Versions                  |
-|--------------------------------|--------------------------------|-----------------------------------------------|
-| 1.1.1 - 1.2.1                  | 0.0.10 - 0.0.15                | 0.0.6 - 0.0.8                                 |
-| 1.3.0                          | 0.2.0, 0.4.0, 0.5.1            | 0.3.0 - 0.4.2 (0.2.0 conditionally supported) |
+### Spark
 
-:::note
-- These version entries show which versions are expected to work together.
-- For Gravitino 1.3.0, the explicitly verified release versions are
-  `lance-spark` (0.2.0, 0.4.0, 0.5.1) and `lance-ray` (0.3.0, 0.4.2). `lance-ray`
-  0.2.0 is conditionally supported only with the conditions described below.
+#### Supported Versions
 
-- **`lance-spark` 0.1.0 and 0.1.1 are not supported on Gravitino 1.3.0.**
-  Those bundles create tables by calling the legacy
-  `POST /lance/v1/table/{id}/create-empty` endpoint, which 1.3.0 no longer
-  exposes — the table-declaration path was consolidated onto
-  `POST /lance/v1/table/{id}/declare` (`LanceTableOperations#declareTable`)
-  when the deprecated `createEmptyTable` API was removed during the
-  `lance-namespace-core` 0.7.5 upgrade. Running 0.1.x against 1.3.0 surfaces
-  as `404 Not Found` on every table-creation flow; the small set of
-  list/describe-only tests still works, but any write path will fail.
-- **`lance-ray` 0.1.0 is not supported on Gravitino 1.3.0.** It exposes
-  `write_lance(... namespace=<LanceNamespace>)`, whereas the 0.2.0+ test path
-  uses the new `write_lance(... namespace_impl="rest",
-  namespace_properties={...})` signature. Calling it on 0.1.0 raises
-  `TypeError: write_lance() got an unexpected keyword argument 'namespace_impl'`.
-- **`lance-ray` 0.2.0 is conditionally supported on Gravitino 1.3.0.** It
-  matches the new signature, but at runtime
-  `lance_ray.utils.create_storage_options_provider` does
-  `from lance import LanceNamespaceStorageOptionsProvider`, which no longer
-  exists in the `pylance` 6.0.0 wheel that `lance-namespace==0.7.5` pulls in,
-  raising `ImportError: cannot import name
-  'LanceNamespaceStorageOptionsProvider' from 'lance'`. You can use
-  `lance-ray` 0.2.0 with Gravitino 1.3.0 by pinning `pylance` to 3.x or 4.x.
-- Before using in production, test the exact connector versions in your own environment.
-- The Lance ecosystem is changing quickly, so some versions may introduce breaking changes.
-:::
+| lance-spark Version | Status                                            |
+|---------------------|---------------------------------------------------|
+| 0.5.1               | Verified                                          |
+| 0.4.0               | Verified                                          |
+| 0.2.0               | Verified                                          |
+| 0.1.1               | Not supported, `404` on every table-creation flow |
+| 0.1.0               | Not supported, `404` on every table-creation flow |
 
-### Reproducing the matrix locally
+`lance-spark` 0.1.0 and 0.1.1 create tables through `POST /v1/table/{id}/create-empty`, which Gravitino no longer exposes after the deprecated `createEmptyTable` API was removed and table declaration was consolidated onto `POST /v1/table/{id}/declare`. Every table-creation flow returns `404 Not Found`, while list and describe still work. Upgrade to 0.2.0 or later.
 
-Both connectors ship with a multi-version integration test driver so the
-matrix can be re-verified (and extended) without ad-hoc scripting:
+To re-verify or extend the list, run the bundled test driver once per version:
 
-```bash
-# lance-spark — runs LanceSparkRESTServiceIT once per bundle version.
-# The default list intentionally omits 0.1.0 / 0.1.1: those bundles call the
-# removed /create-empty endpoint and will fail with 404 against 1.3.0+.
+```shell
+# Per-version reports land under
+# lance/lance-rest-server/build/reports/lance-spark-matrix/{version}/
 ./gradlew :lance:lance-rest-server:lanceSparkMatrixTest \
     -PlanceSparkBundleVersions=0.2.0,0.4.0,0.5.1 \
     -PskipDockerTests=true
-# Per-version JUnit reports land under
-# lance/lance-rest-server/build/reports/lance-spark-matrix/<version>/.
-
-# lance-ray — provisions a venv per version under
-# clients/client-python/build/lance-ray-matrix/.venv-<version>/ and runs
-# tests/integration/test_lance_ray.py against each. The Gradle wrapper
-# below starts / stops Gravitino automatically.
-./gradlew :clients:client-python:lanceRayMatrixTest \
-    -PlanceRayVersions=0.4.2,0.3.0
 ```
 
-### Rationale
+#### Session Setup
 
-The Lance ecosystem is under active development, with frequent updates to APIs and features. Gravitino's Lance REST service depends on specific connector behaviors to ensure reliable operation. Using incompatible versions may result in:
-
-- Runtime errors or exceptions
-- Data corruption or loss
-- Unexpected behavior in query execution
-- Performance degradation
-
-## Prerequisites
-
-Before proceeding, ensure the following requirements are met:
-
-1. **Gravitino Server**: A running Gravitino server instance with the Lance REST service enabled
-    - Default endpoint: `http://localhost:9101/lance`
-
-2. **Lance Catalog**: A Lance catalog created in Gravitino using either:
-    - Lance REST namespace API (`CreateNamespace` operation - see [Lance REST Service documentation](./lance-rest-service.md)
-    - Gravitino REST API, for more, refer to [lakehouse-generic-catalog](./lakehouse-generic-catalog.md)
-    - Example catalog name: `lance_catalog`
-
-3. **Lance Spark Bundle** (for Spark integration):
-    - Downloaded `lance-spark` bundle JAR matching your Apache Spark version
-    - Note the absolute file path for configuration
-
-4. **Python Dependencies**:
-    - For Spark integration: `pyspark`
-    - For Ray integration: `ray`, `lance-namespace`, `lance-ray`
-
-## Spark Integration
-
-### Configuration
-
-The following example demonstrates how to configure a PySpark session to interact with Lance REST and perform table operations using Spark SQL.
+Pass the `lance-spark` bundle JAR matching your Spark version, and open the JDK internals the bundle needs.
 
 ```python
-from pyspark.sql import SparkSession
 import os
-import logging
+from pyspark.sql import SparkSession
 
-# Configure logging for debugging
-logging.basicConfig(level=logging.INFO)
-
-# Configure Spark to use the lance-spark bundle
-# Replace /path/to/lance-spark-bundle-3.5_2.12-X.X.XX.jar with your actual JAR path and version;
-# refer to the compatibility matrix for supported lance-spark versions.
 os.environ["PYSPARK_SUBMIT_ARGS"] = (
-    "--jars /path/to/lance-spark-bundle-3.5_2.12-0.4.0.jar "
+    "--jars /path/to/lance-spark-bundle-3.5_2.12-{version}.jar "
     "--conf \"spark.driver.extraJavaOptions=--add-opens=java.base/sun.nio.ch=ALL-UNNAMED\" "
     "--conf \"spark.executor.extraJavaOptions=--add-opens=java.base/sun.nio.ch=ALL-UNNAMED\" "
     "--master local[1] pyspark-shell"
 )
 
-# Initialize Spark session with Lance REST catalog configuration
-# Note: The catalog "lance_catalog" must exist in Gravitino before running this code, you can create
-# it via Lance REST API `CreateNamespace` or Gravitino REST API `CreateCatalog`.
 spark = SparkSession.builder \
     .appName("lance_rest_integration") \
     .config("spark.sql.catalog.lance", "com.lancedb.lance.spark.LanceNamespaceSparkCatalog") \
     .config("spark.sql.catalog.lance.impl", "rest") \
     .config("spark.sql.catalog.lance.uri", "http://localhost:9101/lance") \
-    .config("spark.sql.catalog.lance.parent", "lance_catalog") \
+    .config("spark.sql.catalog.lance.parent", "{catalog_name}") \
     .config("spark.sql.defaultCatalog", "lance") \
     .getOrCreate()
+```
 
-# Enable debug logging for troubleshooting
-spark.sparkContext.setLogLevel("DEBUG")
+The `parent` setting names the Gravitino catalog the Spark catalog is rooted at. Spark databases map to Gravitino schemas beneath it.
 
-# Create schema (database)
+#### Reading and Writing
+
+```python
 spark.sql("CREATE DATABASE IF NOT EXISTS sales")
-
-# Create Lance table with explicit location
 spark.sql("""
-    CREATE TABLE sales.orders (
-        id INT,
-        score FLOAT
-    )
+    CREATE TABLE sales.orders (id INT, score FLOAT)
     USING lance
-    LOCATION '/tmp/sales/orders.lance/'
     TBLPROPERTIES ('format' = 'lance')
 """)
-
-# Insert sample data
 spark.sql("INSERT INTO sales.orders VALUES (1, 1.1)")
-
-# Query data
 spark.sql("SELECT * FROM sales.orders").show()
 ```
 
-### Storage Location Configuration
+The database and table appear in Gravitino as a schema and a table under `{catalog_name}`.
 
-The `LOCATION` clause in the `CREATE TABLE` statement is optional. When omitted, lance-spark automatically determines an appropriate storage location based on catalog properties.
-For detailed information on location resolution logic, refer to the [Lakehouse Generic Catalog documentation](./lakehouse-generic-catalog.md#key-property-location).
+#### Table Location
 
-For Gravitino-managed Lance catalogs, put the storage configuration in the Gravitino catalog properties so Spark does not need to repeat it.
+The `LOCATION` clause on `CREATE TABLE` is optional. When it is omitted, `lance-spark` derives a location from the catalog properties Gravitino returns.
 
-For example, create the Gravitino catalog with catalog-level Lance storage properties:
+Put the storage configuration on the catalog rather than in the Spark session. The Lance REST service resolves `lance.storage.*` from the catalog and then the table, and returns the result to the client in the `storageOptions` of `CreateTable` and `DescribeTable` responses, so Spark does not need to repeat it.
+
+Set those properties when you create the catalog, by passing them to the Lance `CreateNamespace` call:
 
 ```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "name": "lance_catalog",
-  "type": "RELATIONAL",
-  "provider": "lakehouse-generic",
-  "comment": "catalog for Lance tables on MinIO",
-  "properties": {
-    "location": "s3://bucket/tmp",
-    "lance.storage.endpoint": "http://minio:9000",
-    "lance.storage.access_key_id": "ak",
-    "lance.storage.secret_access_key": "sk",
-    "lance.storage.allow_http": "true",
-    "lance.storage.region": "us-east-1"
-  }
-}' http://localhost:8090/api/metalakes/test/catalogs
+LANCE_URL=http://localhost:9101/lance
+
+curl -X POST "${LANCE_URL}/v1/namespace/{catalog_name}/create" \
+  -H 'Content-Type: application/json' \
+  -d '{"id": ["{catalog_name}"], "mode": "create",
+       "properties": {"location": "s3://{bucket}/{prefix}",
+                      "lance.storage.endpoint": "http://{minio_host}:9000",
+                      "lance.storage.access_key_id": "{access_key}",
+                      "lance.storage.secret_access_key": "{secret_key}"}}'
 ```
 
-```python
-spark.sql("""
-    CREATE TABLE sales.orders (
-        id INT,
-        score FLOAT
-    )
-    USING lance
-    LOCATION 's3://bucket/tmp/sales/orders.lance/'
-    TBLPROPERTIES ('format' = 'lance')
-""")
+See [Storage Options](./lakehouse-generic-catalog.md#storage-options) for the option names. A per-table override is available by setting them as table properties, which take precedence over the catalog values.
+
+### Ray
+
+#### Supported Versions
+
+| lance-ray Version | Status                                         |
+|-------------------|------------------------------------------------|
+| 0.4.2             | Verified                                       |
+| 0.3.0             | Verified                                       |
+| 0.2.0             | Works only with `pylance` pinned to 3.x or 4.x |
+| 0.1.0             | Not supported                                  |
+
+`lance-ray` 0.1.0 takes a constructed namespace object rather than an implementation name, so calls raise `TypeError: write_lance() got an unexpected keyword argument 'namespace_impl'`. Upgrade to 0.3.0 or later.
+
+`lance-ray` 0.2.0 works only with a pin. Its `lance_ray.utils.create_storage_options_provider` imports a symbol that no longer exists in the `pylance` 6.0.0 wheel that `lance-namespace` 0.7.5 pulls in, raising `ImportError: cannot import name 'LanceNamespaceStorageOptionsProvider' from 'lance'`. Pin `pylance` to 3.x or 4.x, or upgrade to 0.3.0.
+
+To re-verify or extend the list:
+
+```shell
+# Provisions a venv per version under
+# clients/client-python/build/lance-ray-matrix/.venv-{version}/
+# and runs tests/integration/test_lance_ray.py against each.
+# The Gradle wrapper starts and stops Gravitino automatically.
+./gradlew :clients:client-python:lanceRayMatrixTest \
+    -PlanceRayVersions=0.4.2,0.3.0
 ```
 
-If you need a per-table override, `lance.storage.*` table properties are still supported and take precedence over catalog defaults.
+#### Reading and Writing
 
-## Ray Integration
-
-### Installation
-
-Install the required Ray integration packages:
+Install `lance-ray`. Ray is pulled in automatically if it is not already present.
 
 ```shell
 pip install lance-ray
 ```
 
-:::info
-- Ray will be automatically installed if not already present
-- For Gravitino 1.3.0, use a `lance-namespace` client compatible with
-  server-side `lance-namespace-core` 0.7.5 or newer.
-- Ensure Ray version compatibility in your environment before deployment
-:::
-
-### Example
-
-The following example demonstrates reading and writing Lance datasets through the Lance REST namespace using Ray:
+Pass the namespace as an implementation name plus properties.
 
 ```python
 import ray
-import lance_namespace as ln
 from lance_ray import read_lance, write_lance
 
-# Initialize Ray runtime
 ray.init()
 
-# Connect to Lance REST namespace
-namespace = ln.connect("rest", {"uri":  "http://localhost:9101/lance"})
+ns_properties = {"uri": "http://localhost:9101/lance"}
+table_id = ["{catalog_name}", "sales", "orders"]
 
-# Create sample dataset
 data = ray.data.range(1000).map(
     lambda row: {"id": row["id"], "value": row["id"] * 2}
 )
 
-# Write dataset to Lance table
-# Note: Both the catalog "lance_catalog" and schema "sales" must exist in Gravitino, you can create
-# them via Lance REST API `CreateNamespace` or Gravitino REST API `CreateCatalog` and `CreateSchema`.
 write_lance(
-    data, 
-    namespace=namespace, 
-    table_id=["lance_catalog", "sales", "orders"]
+    data,
+    namespace_impl="rest",
+    namespace_properties=ns_properties,
+    table_id=table_id,
 )
 
-# Read dataset from Lance table
 ray_dataset = read_lance(
-    namespace=namespace, 
-    table_id=["lance_catalog", "sales", "orders"]
+    namespace_impl="rest",
+    namespace_properties=ns_properties,
+    table_id=table_id,
 )
 
-# Perform filtering operation
-result = ray_dataset.filter(lambda row: row["value"] < 100).count()
-print(f"Filtered row count: {result}")
+print(ray_dataset.filter(lambda row: row["value"] < 100).count())
 ```
 
-## Additional Engines
+The catalog and schema named in `table_id` have to exist before the write. Create them through the Lance REST service or the Gravitino REST API.
 
-The Lance REST service is compatible with other data processing engines that support the Lance format, including:
+### Engines Without Lance REST Support
 
-- **DuckDB**: For analytical SQL queries
-- **Pandas**: For Python-based data manipulation
-- **DataFusion**: For Rust-based query execution
+Lance publishes integrations for Trino, DuckDB, DataFusion, PyTorch, TensorFlow, and pandas, among others. None of them speaks the Lance REST Catalog protocol today. They read a dataset once they have its location, which you obtain from `DescribeTable` on the Lance REST service or from the Gravitino REST API, and then open the files directly.
 
-Note: These three engines do not support Lance REST natively yet, but can still interact with Lance datasets through table location paths retrieved from the Lance REST service.
+`DescribeTable` returns the storage options alongside the location, so the credentials are available, but you have to relay them into the engine's own configuration rather than the engine picking them up. The engine also sees a location rather than a catalog, so it has no view of the namespace hierarchy and no way to discover a table it was not given.
 
-For engine-specific integration instructions, consult the [Lance Integration Documentation](https://lance.org/integrations).
+See the [Lance integration documentation](https://lance.org/integrations) for the engine-side setup.
 
-### General Integration Pattern
+### Presenting Credentials
 
-Most Lance-compatible engines follow this general pattern:
+The examples above connect without credentials, which works when the Lance REST service is left at its `simple` default. Once the service is configured to validate callers, clients have to present a token on every request. See [Authenticating Callers](./lance-rest-service.md#authenticating-callers).
 
-1. Establish connection to Lance REST service endpoint
-2. Authenticate using appropriate credentials
-3. Reference tables using the hierarchical namespace structure
-4. Execute read/write operations using engine-native APIs
+## Related Pages
 
-Refer to each engine's specific documentation for detailed configuration parameters and code examples.
-
-## Related
-
-- [Lance REST Service Documentation](./lance-rest-service)
-- [Lance Format Specification](https://lance.org/)
-- [Apache Gravitino Documentation](https://gravitino.apache.org/)
-- [Lakehouse Generic Catalog Guide](./lakehouse-generic-catalog.md)
+- [Lance REST Service](./lance-rest-service.md) for service configuration, the API reference, and authentication
+- [Lance Tables](./lakehouse-generic-lance-table.md) for table properties, type mappings, and worked examples on both APIs
+- [Lance documentation](https://lance.org/) for the format and the client libraries themselves

--- a/docs/lance-rest-service.md
+++ b/docs/lance-rest-service.md
@@ -2,424 +2,298 @@
 title: "Lance REST Service"
 slug: "/lance-rest-service"
 keywords:
+  - Lance
   - Lance REST
   - Lance datasets
   - REST API
 license: "This software is licensed under the Apache License version 2."
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 ## Overview
 
-The Lance REST service provides a RESTful interface for managing Lance datasets through HTTP endpoints. Introduced in Gravitino version 1.1.0, this service enables seamless interaction with Lance datasets for data operations and metadata management.
-
-The service implements the [Lance REST API specification](https://docs.lancedb.com/api-reference/introduction). For detailed specification documentation, see the [official Lance REST documentation](https://lance.org/format/namespace/rest/catalog-spec/).
+The Lance REST service lets Lance clients read and write Lance tables while Apache Gravitino holds the catalog metadata. Gravitino implements the Lance REST Catalog protocol, so any tool built on a Lance SDK can treat a Gravitino metalake as its namespace.
 
 ### About Lance
 
-[Lance](https://lance.org/format/) is a modern columnar data format designed for AI/ML workloads. It provides:
+[Lance](https://lance.org/format/) is an open table and file format for multimodal AI data. A Lance table is a complete format in its own right, with its own file layout, manifests, and version history. It does not build on Parquet, and it does not store data in Iceberg format.
 
-- **High-performance vector search**: Native support for similarity search on high-dimensional embeddings
-- **Columnar storage**: Optimized for analytical queries and machine learning pipelines
-- **Fast random access**: Efficient row-level operations unlike traditional columnar formats
-- **Version control**: Built-in dataset versioning and time-travel capabilities
-- **Incremental updates**: Append and update data without full rewrites
+Where Iceberg over Parquet is built to scan analytical tables, Lance is built for the work that surrounds a model:
 
-### Architecture
+| Capability               | What It Provides                                                                                   |
+|--------------------------|----------------------------------------------------------------------------------------------------|
+| Fast random access       | Point lookups of individual rows, for training loops and retrieval rather than full scans          |
+| Vectors as columns       | Embeddings stored as fixed-size list columns next to the rest of the row                           |
+| Indexes inside the table | Vector, scalar, and full-text indexes stored with the data instead of in a separate service        |
+| Multimodal values        | Images, audio, and video stored alongside structured columns, with a blob API to skip them on scan |
+| Cheap schema evolution   | Adding a column, such as a new embedding, without rewriting the dataset                            |
 
-The Lance REST service acts as a bridge between Lance datasets and applications:
+Schemas are Apache Arrow schemas, and Arrow IPC is the wire format for data operations.
 
-```
-┌─────────────────┐
-│   Applications   │
-│  (Python/Java)   │
-└────────┬────────┘
-         │ HTTP/REST
-         ▼
-┌─────────────────┐
-│   Lance REST     │
-│    Service       │ 
-└────────┬────────┘
-         │ 
-         ▼ Gravitino Client API
-┌─────────────────┐
-│ Gravitino Server │ 
-│(Metadata Backend)│
-└────────┬────────┘
-         │ File System Operations
-         ▼
-┌─────────────────┐
-│  Lance Datasets  │ 
-│ (S3/GCS/Local)   │
-└─────────────────┘
-```
+### Choosing an API
 
-**Key Features:**
-- Full compliance with Lance REST API specification
-- Can run standalone or integrated with Gravitino server
-- Support for namespace and table management
-- Index creation and management capabilities (Index operations are not supported in version 1.1.0)
-- Metadata stored in Gravitino for unified governance
+Lance tables in Gravitino always live in a `lakehouse-generic` catalog. There are two ways to get one. Configure the Lance REST service, and it creates the catalog itself when a client first connects. Or create the catalog through the Gravitino REST API and skip the service entirely. The first has a server configuration step and no catalog step; the second has a catalog step and no server configuration.
 
-## Supported Operations
+| Path               | Choose It When                                                                                     | Documented In                                                       |
+|--------------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| Lance REST service | Lance-native tools drive the workload, such as `lance-spark`, `lance-ray`, or any Lance SDK client | This page and [Lance REST Integration](./lance-rest-integration.md) |
+| Gravitino REST API | Gravitino is the system of record and Lance is one table format among several                      | [Lance Tables](./lakehouse-generic-lance-table.md)                  |
 
-The Lance REST service provides comprehensive support for namespace management, table management, and index operations. The table below lists all supported operations:
+Both produce the same catalog, schema, and table objects, and either can read what the other wrote. Property names differ between the paths for the same concepts, so read both pages before mixing them in one deployment. See [Lakehouse Generic Catalog](./lakehouse-generic-catalog.md) for the catalog itself.
 
-| Operation         | Description                                                                                                                                                                        | HTTP Method | Endpoint Pattern                      | Since Version |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|---------------------------------------|---------------|
-| CreateNamespace   | Create a new Lance namespace                                                                                                                                                       | POST        | `/lance/v1/namespace/{id}/create`     | 1.1.0         |
-| ListNamespaces    | List all namespaces under a parent namespace                                                                                                                                       | GET         | `/lance/v1/namespace/{parent}/list`   | 1.1.0         |
-| DescribeNamespace | Retrieve detailed information about a specific namespace                                                                                                                           | POST        | `/lance/v1/namespace/{id}/describe`   | 1.1.0         |
-| DropNamespace     | Delete a namespace                                                                                                                                                                 | POST        | `/lance/v1/namespace/{id}/drop`       | 1.1.0         |
-| NamespaceExists   | Check whether a namespace exists                                                                                                                                                   | POST        | `/lance/v1/namespace/{id}/exists`     | 1.1.0         |
-| ListTables        | List all tables in a namespace                                                                                                                                                     | GET         | `/lance/v1/namespace/{id}/table/list` | 1.1.0         |
-| CreateTable       | Create a new table in a namespace                                                                                                                                                  | POST        | `/lance/v1/table/{id}/create`         | 1.1.0         |
-| DescribeTable     | Describe an existing Lance table                                                                                                                                                   | POST        | `/lance/v1/table/{id}/describe`       | 1.1.0         |
-| DropTable         | Delete a table including both metadata and data                                                                                                                                    | POST        | `/lance/v1/table/{id}/drop`           | 1.1.0         |
-| TableExists       | Check whether a table exists                                                                                                                                                       | POST        | `/lance/v1/table/{id}/exists`         | 1.1.0         |
-| RegisterTable     | Register an existing Lance table to a namespace                                                                                                                                    | POST        | `/lance/v1/table/{id}/register`       | 1.1.0         |
-| DeregisterTable   | Unregister a table from a namespace (metadata only, data remains)                                                                                                                  | POST        | `/lance/v1/table/{id}/deregister`     | 1.1.0         |
-| DeclareTable      | Declare a table and store the metadata without touching lance table data.                                                                                                           | POST        | `/lance/v1/table/{id}/declare`        | 1.3.0         |
+For the protocol itself, including the full operation list and request models, see the [Lance REST Catalog specification](https://lance.org/format/catalog/rest/). For the models the SDKs use, see the [Lance Namespace client spec](https://lance.org/format/namespace/).
 
-More details, refer to the [Lance REST API specification](https://lance.org/format/namespace/rest/catalog-spec/)
+## Quick Start
 
-### Operation Details
+These steps run the Lance REST service inside the Gravitino server, which is how it is normally deployed.
 
-Some operations have specific behaviors and modes. Below are important details to consider:
-
-Mode values are parsed case-insensitively. The examples below use lowercase values as the
-REST-style canonical form.
-
-#### Namespace Operations
-
-**CreateNamespace** supports three modes:
-- `create`: Fails if namespace already exists
-- `exist_ok`: Succeeds even if namespace exists  
-- `overwrite`: Replaces existing namespace
-
-**DropNamespace** behavior:
-- Recursively deletes all child namespaces and tables
-- Deletes both metadata and Lance data files
-- Operation is irreversible
-
-#### Table Operations
-
-**RegisterTable vs CreateTable**:
-- **RegisterTable**: Links existing Lance datasets into Gravitino catalog without data movement
-- **CreateTable**: Creates new Lance table with schema and write metadata files
-:::note
-The `version` field of `CreateTable` response is always null, which stands for the latest version. 
-:::
-
-**DropTable vs DeregisterTable**:
-- **DropTable**: Permanently deletes metadata and data files from storage
-- **DeregisterTable**: Removes metadata from Gravitino but preserves Lance data files
-
-
-## Deployment
-
-### Run with Gravitino Server
-
-To enable the Lance REST service within Gravitino server, configure the following properties in your Gravitino configuration file `${GRAVITINO_HOME}/conf/gravitino.conf`:
-
-| Configuration Property                    | Description                                                                  | Default Value           | Required | Since Version |
-|-------------------------------------------|------------------------------------------------------------------------------|-------------------------|----------|---------------|
-| `gravitino.auxService.names`              | Auxiliary services to run. Include `lance-rest` to enable Lance REST service | iceberg-rest,lance-rest | Yes      | 0.2.0         |
-| `gravitino.lance-rest.classpath`          | Classpath for Lance REST service, relative to Gravitino home directory       | lance-rest-server/libs  | Yes      | 1.1.0         |
-| `gravitino.lance-rest.httpPort`           | Port number for Lance REST service                                           | 9101                    | No       | 1.1.0         |
-| `gravitino.lance-rest.host`               | Hostname for Lance REST service                                              | 0.0.0.0                 | No       | 1.1.0         |
-| `gravitino.lance-rest.namespace-backend`  | Namespace metadata backend (only `gravitino` is supported)                   | gravitino               | Yes      | 1.1.0         |
-| `gravitino.lance-rest.gravitino-uri`      | Gravitino server URI (required when namespace-backend is `gravitino`)        | http://localhost:8090   | Yes      | 1.1.0         |
-| `gravitino.lance-rest.gravitino-metalake` | Gravitino metalake name (required when namespace-backend is `gravitino`)     | (none)                  | Yes      | 1.1.0         |
-
-**Example Configuration:**
+**1. Enable the service in `${GRAVITINO_HOME}/conf/gravitino.conf`.**
 
 ```properties
 gravitino.auxService.names = lance-rest
+gravitino.lance-rest.classpath = lance-rest-server/libs
 gravitino.lance-rest.httpPort = 9101
-gravitino.lance-rest.host = 0.0.0.0
 gravitino.lance-rest.namespace-backend = gravitino
 gravitino.lance-rest.gravitino-uri = http://localhost:8090
-gravitino.lance-rest.gravitino-metalake = my_metalake
+gravitino.lance-rest.gravitino-metalake = {metalake_name}
+gravitino.lance-rest.gravitino-auth-type = simple
 ```
 
-### Run Standalone
+`simple` accepts requests that arrive without credentials, which suits a local trial. For a deployment, see [Authenticating Callers](#authenticating-callers).
 
-To run Lance REST service independently without Gravitino server (You need to start Gravitino server first):
+**2. Start the Gravitino server.** The Lance REST service starts with it.
 
 ```shell
-{GRAVITINO_HOME}/bin/gravitino-lance-rest-server.sh start
+${GRAVITINO_HOME}/bin/gravitino.sh start
 ```
 
-Configure the service by editing `{GRAVITINO_HOME}/conf/gravitino-lance-rest-server.conf` or passing command-line arguments:
+**3. Create the metalake named in the configuration.** The service resolves it on its first call rather than at startup, so it does not have to exist before this point.
 
-| Configuration Property                    | Description                 | Default Value         | Required | Since Version |
-|-------------------------------------------|-----------------------------|-----------------------|----------|---------------|
-| `gravitino.lance-rest.namespace-backend`  | Namespace metadata backend  | gravitino             | Yes      | 1.1.0         |
-| `gravitino.lance-rest.gravitino-uri`      | Gravitino server URI        | http://localhost:8090 | Yes      | 1.1.0         |
-| `gravitino.lance-rest.gravitino-metalake` | Gravitino metalake name     | (none)                | Yes      | 1.1.0         |
-| `gravitino.lance-rest.httpPort`           | Service port number         | 9101                  | No       | 1.1.0         |
-| `gravitino.lance-rest.host`               | Service hostname            | 0.0.0.0               | No       | 1.1.0         |
+```shell
+GRAVITINO_URL=http://localhost:8090
 
-:::tip
-In most cases, you only need to configure `gravitino.lance-rest.gravitino-metalake` and other properties can use their default values.
-:::
+curl -X POST "${GRAVITINO_URL}/api/metalakes" \
+  -H "Accept: application/vnd.gravitino.v1+json" \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "{metalake_name}", "comment": "Lance metalake"}'
+```
 
+**4. Create a namespace.** A first-level namespace is a `lakehouse-generic` catalog. Set `location` and the `lance.storage.*` credentials here, so that tables inherit them and Lance clients receive them.
 
-### Run with Docker
+```shell
+LANCE_URL=http://localhost:9101/lance
 
-Launch Lance REST service using Docker(You need to start Gravitino server first):
+curl -X POST "${LANCE_URL}/v1/namespace/{catalog_name}/create" \
+  -H 'Content-Type: application/json' \
+  -d '{"id": ["{catalog_name}"], "mode": "create",
+       "properties": {"location": "s3://{bucket}/{prefix}",
+                      "lance.storage.access_key_id": "{access_key}",
+                      "lance.storage.secret_access_key": "{secret_key}",
+                      "lance.storage.region": "us-east-1"}}'
+```
+
+**5. Confirm it reached Gravitino.**
+
+```shell
+curl -H "Accept: application/vnd.gravitino.v1+json" \
+  "${GRAVITINO_URL}/api/metalakes/{metalake_name}/catalogs/{catalog_name}"
+
+curl "${LANCE_URL}/health/ready"
+```
+
+The namespace created through the Lance API appears as a catalog in `{metalake_name}`, which is the whole point of pointing Lance clients at Gravitino.
+
+Readiness returns 200 from this point on. The service connects to the Gravitino server on its first namespace or table call rather than at startup, so `/health/ready` returns 503 until step 4 runs. A 503 after that means initialization failed, and the body names the failing check.
+
+## Configuration
+
+Every property on this page goes in `${GRAVITINO_HOME}/conf/gravitino.conf`, alongside the rest of the Gravitino server configuration. Changes take effect on server restart. When the service runs as a separate process the same property names apply, but they go in `gravitino-lance-rest-server.conf` instead, as described in [Running as a Separate Process](#running-as-a-separate-process).
+
+### Service Properties
+
+| Configuration Property                             | Description                                                                        | Default Value         | Required          |
+|----------------------------------------------------|------------------------------------------------------------------------------------|-----------------------|-------------------|
+| `gravitino.auxService.names`                       | Auxiliary services to run. Include `lance-rest` to enable this service             | (none)                | Yes               |
+| `gravitino.lance-rest.classpath`                   | Classpath for the service, relative to the Gravitino home directory                | (none)                | Yes               |
+| `gravitino.lance-rest.namespace-backend`           | Namespace metadata backend. Only `gravitino` is supported                          | `gravitino`           | Yes               |
+| `gravitino.lance-rest.gravitino-uri`               | Gravitino server URI, required in all deployments                                  | http://localhost:8090 | Yes               |
+| `gravitino.lance-rest.gravitino-metalake`          | Gravitino metalake the service exposes as its root                                 | (none)                | Yes               |
+| `gravitino.lance-rest.gravitino-auth-type`         | Auth type used to reach the Gravitino server. Supported values: `simple`, `oauth2` | `simple`              | No                |
+| `gravitino.lance-rest.gravitino-simple.user-name`  | User name presented when the auth type is `simple`                                 | `lance-rest-server`   | No                |
+| `gravitino.lance-rest.gravitino-oauth2.server-uri` | OAuth2 server URI                                                                  | (none)                | Yes, for `oauth2` |
+| `gravitino.lance-rest.gravitino-oauth2.credential` | Credential used to request the OAuth2 token                                        | (none)                | Yes, for `oauth2` |
+| `gravitino.lance-rest.gravitino-oauth2.token-path` | Path on the OAuth2 server used to request the token                                | (none)                | Yes, for `oauth2` |
+| `gravitino.lance-rest.gravitino-oauth2.scope`      | Scope of the requested OAuth2 token                                                | (none)                | Yes, for `oauth2` |
+| `gravitino.lance-rest.host`                        | Hostname the service binds to                                                      | `0.0.0.0`             | No                |
+| `gravitino.lance-rest.httpPort`                    | Port the service listens on                                                        | `9101`                | No                |
+
+### Authenticating to the Gravitino Server
+
+The Quick Start needs no authentication setup. Both the Gravitino server and the Lance REST service default to `simple`, which treats a request arriving without an `Authorization` header as the anonymous user.
+
+Two settings have to agree. `gravitino.authenticators` decides how the Gravitino server validates callers, and `gravitino.lance-rest.gravitino-auth-type` decides how the Lance REST service identifies itself to that server. Setting one without the other breaks the service.
+
+### Authenticating Callers
+
+An external OAuth 2.0 server is required. Configure it as described in [How to authenticate](./security/how-to-authenticate.md), then set both sides:
+
+```properties
+# How the Gravitino server validates caller tokens
+gravitino.authenticators = oauth
+gravitino.authenticator.oauth.serverUri = https://{oauth_host}
+gravitino.authenticator.oauth.tokenPath = /oauth/token
+gravitino.authenticator.oauth.defaultSignKey = {sign_key}
+
+# How the Lance REST service identifies itself to the Gravitino server
+gravitino.lance-rest.gravitino-auth-type = oauth2
+gravitino.lance-rest.gravitino-oauth2.server-uri = https://{oauth_host}
+gravitino.lance-rest.gravitino-oauth2.credential = {client_id}:{client_secret}
+gravitino.lance-rest.gravitino-oauth2.token-path = /oauth/token
+gravitino.lance-rest.gravitino-oauth2.scope = {scope}
+```
+
+Callers then present a bearer token:
+
+```shell
+curl -H "Authorization: Bearer ${TOKEN}" "${LANCE_URL}/v1/namespace/list"
+```
+
+Health endpoints bypass the authentication filter, so `/health/ready` answers without a token in every configuration.
+
+JWKS validation is the alternative to a static signing key, and Basic and Kerberos are also supported. All are covered in [How to authenticate](./security/how-to-authenticate.md).
+
+## Lance REST API
+
+Gravitino implements the Lance REST Catalog protocol. For request and response models, see the [Lance REST Catalog specification](https://lance.org/format/catalog/rest/).
+
+### Identifiers
+
+Gravitino uses a three-level hierarchy of catalog, schema, and table. The Lance REST service maps namespaces onto the first two levels, so a namespace identifier holds at most two elements and tables are created beneath a schema.
+
+```
+{metalake_name}
+└── {catalog_name}          namespace level 1
+    └── {schema_name}       namespace level 2
+        └── {table_name}    table
+```
+
+A three-level namespace identifier is rejected, and tables cannot be created directly under a catalog.
+
+Levels are joined into a single path element using `$` by default. Because `$` is reserved in URIs it must be percent-encoded as `%24`.
+
+| Form        | Example                                               |
+|-------------|-------------------------------------------------------|
+| Identifier  | `["{catalog_name}", "{schema_name}", "{table_name}"]` |
+| Joined      | `{catalog_name}${schema_name}${table_name}`           |
+| URL encoded | `{catalog_name}%24{schema_name}%24{table_name}`       |
+
+Pass a different separator with the `delimiter` query parameter.
+
+### Operations
+
+Paths are relative to the service base URL, `http://{host}:9101/lance`.
+
+| Operation              | Method | Path                            |
+|------------------------|--------|---------------------------------|
+| ListNamespaces         | GET    | `/v1/namespace/list` ¹          |
+| ListNamespaces         | GET    | `/v1/namespace/{id}/list`       |
+| CreateNamespace        | POST   | `/v1/namespace/{id}/create`     |
+| DescribeNamespace      | POST   | `/v1/namespace/{id}/describe`   |
+| NamespaceExists        | POST   | `/v1/namespace/{id}/exists`     |
+| DropNamespace          | POST   | `/v1/namespace/{id}/drop`       |
+| ListTables             | GET    | `/v1/namespace/{id}/table/list` |
+| CreateTable            | POST   | `/v1/table/{id}/create`         |
+| DeclareTable           | POST   | `/v1/table/{id}/declare`        |
+| RegisterTable          | POST   | `/v1/table/{id}/register`       |
+| DescribeTable          | POST   | `/v1/table/{id}/describe`       |
+| TableExists            | POST   | `/v1/table/{id}/exists`         |
+| DropTable              | POST   | `/v1/table/{id}/drop`           |
+| DeregisterTable        | POST   | `/v1/table/{id}/deregister`     |
+| AlterTableDropColumns  | POST   | `/v1/table/{id}/drop_columns`   |
+| AlterTableAlterColumns | POST   | `/v1/table/{id}/alter_columns`  |
+
+¹ A Gravitino extension. The specification has no root-level list, so a portable Lance client cannot rely on it. It lists the top level and takes no identifier, where `/v1/namespace/{id}/list` lists the children of `{id}`.
+
+### Calling the Operations
+
+Details that are easy to get wrong when issuing these calls by hand.
+
+| Item               | Detail                                                                                                                                                               |
+|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| CreateTable body   | An Arrow IPC stream sent as `application/vnd.apache.arrow.stream`, not JSON. The schema is read from the stream                                                      |
+| CreateTable inputs | Location is passed in the `x-lance-table-location` header and properties in `x-lance-table-properties`. `mode` is a query parameter, defaulting to `create`          |
+| DropNamespace      | `behavior` defaults to `restrict`. Under `cascade`, child namespaces and tables are dropped along with their Lance dataset files, and the operation cannot be undone |
+| Pagination         | List operations accept `page_token` and `limit` query parameters                                                                                                     |
+
+### Limitations
+
+Gravitino implements a subset of the Lance REST Catalog specification. The operations above are the ones it serves; a client calling anything else gets a 404.
+
+Three gaps are worth naming.
+
+| Limitation       | Detail                                                                                                                                                                                            |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Identifier depth | The specification allows arbitrary namespace nesting. Gravitino allows one or two levels, and a table identifier of exactly three, because they map onto its catalog, schema, and table hierarchy |
+| Column changes   | `alter_columns` supports rename only. The specification also defines nullability, data type, and virtual column alterations                                                                       |
+| Indexes          | The specification defines `create_index`, `create_scalar_index`, and `index`. None are served. Indexes are created through the Gravitino REST API instead                                         |
+
+Data-plane operations are outside the implemented set entirely, including `insert`, `update`, `delete`, `merge_insert`, and `query`. Clients read and write the dataset files themselves.
+
+One behavior is worth knowing separately. `DropTable` removes the dataset files, even though every table this service creates is marked `external`. Use `DeregisterTable` to drop the metadata and keep the files.
+
+### Storage Options
+
+Lance clients open dataset files directly rather than reading them through the service, so they need the storage credentials themselves. Gravitino hands those credentials over.
+
+Set `lance.storage.*` properties on the catalog, or on an individual table to override the catalog. Schema properties are ignored. On `CreateTable` and `DescribeTable`, the service gathers those properties, strips the `lance.storage.` prefix, and returns what is left to the client as `storageOptions`.
+
+A catalog property of `lance.storage.region = us-east-1` therefore reaches the client as `region: us-east-1`, which is the key name the Lance SDK expects.
+
+See [Storage Options](./lakehouse-generic-catalog.md#storage-options) for the option names, and [Lance Tables](./lakehouse-generic-lance-table.md#lance-rest-api) for worked create and register examples.
+
+## Running as a Separate Process
+
+The service can also run as its own process, alongside a Gravitino server rather than inside it. A Gravitino server is still required, since `namespace-backend` accepts only `gravitino`. Access control is not available in this configuration. Docker and Kubernetes deployments use it.
+
+Configuration lives in `${GRAVITINO_HOME}/conf/gravitino-lance-rest-server.conf` and uses the same property names as the Quick Start.
+
+Callers to a separate process are authenticated by the `gravitino.authenticators` setting in `gravitino-lance-rest-server.conf`, not by the Gravitino server's. Nothing requires the two to match, so set both deliberately.
+
+### From the Command Line
+
+```shell
+${GRAVITINO_HOME}/bin/gravitino-lance-rest-server.sh start
+```
+
+### With Docker
+
+Start the Gravitino server first, then:
 
 ```shell
 docker run -d --name lance-rest-service -p 9101:9101 \
-  -e LANCE_REST_GRAVITINO_METALAKE_NAME=your_metalake_name \
-  -e LANCE_REST_GRAVITINO_URI=http://gravitino-host:port \
+  -e LANCE_REST_GRAVITINO_METALAKE_NAME={metalake_name} \
+  -e LANCE_REST_GRAVITINO_URI=http://{gravitino_host}:8090 \
   apache/gravitino-lance-rest:latest
 ```
 
-Access the service at `http://localhost:9101`.
+The image accepts five environment variables, which it writes into `gravitino-lance-rest-server.conf` on startup:
 
-**Environment Variables:**
+| Environment Variable                 | Configuration Property                    |
+|--------------------------------------|-------------------------------------------|
+| `LANCE_REST_GRAVITINO_METALAKE_NAME` | `gravitino.lance-rest.gravitino-metalake` |
+| `LANCE_REST_GRAVITINO_URI`           | `gravitino.lance-rest.gravitino-uri`      |
+| `LANCE_REST_NAMESPACE_BACKEND`       | `gravitino.lance-rest.namespace-backend`  |
+| `LANCE_REST_HOST`                    | `gravitino.lance-rest.host`               |
+| `LANCE_REST_PORT`                    | `gravitino.lance-rest.httpPort`           |
 
-| Environment Variable                 | Configuration Property                    | Required | Default Value           | Since Version |
-|--------------------------------------|-------------------------------------------|----------|-------------------------|---------------|
-| `LANCE_REST_NAMESPACE_BACKEND`       | `gravitino.lance-rest.namespace-backend`  | Yes      | `gravitino`             | 1.1.0         |
-| `LANCE_REST_GRAVITINO_METALAKE_NAME` | `gravitino.lance-rest.gravitino-metalake` | Yes      | (none)                  | 1.1.0         |
-| `LANCE_REST_GRAVITINO_URI`           | `gravitino.lance-rest.gravitino-uri`      | Yes      | `http://localhost:8090` | 1.1.0         |
-| `LANCE_REST_HOST`                    | `gravitino.lance-rest.host`               | No       | `0.0.0.0`               | 1.1.0         |
-| `LANCE_REST_PORT`                    | `gravitino.lance-rest.httpPort`           | No       | `9101`                  | 1.1.0         |
+Any other property, including the authentication properties, must be set in a `gravitino-lance-rest-server.conf` mounted into the container. Values already present in that file are preserved.
 
-:::tip Configuration Tips
-- **Required:** Set `LANCE_REST_GRAVITINO_METALAKE_NAME` to your Gravitino metalake name
-- **Conditional:** Update `LANCE_REST_GRAVITINO_URI` if Gravitino server is not on `localhost` in the Docker instance.
-- **Optional:** Other variables can use default values unless you have specific requirements
-:::
+### On Kubernetes
 
-## Usage Guidelines
+See [Install Lance REST Server on Kubernetes](./lance-rest-server-chart.md) for the Helm chart.
 
-When using Lance REST service with Gravitino backend, keep the following considerations in mind:
+## Related Pages
 
-### Prerequisites
-
-- A running Gravitino server with a metalake
-
-### Namespace Hierarchy
-
-Gravitino follows a three-level hierarchy: **catalog → schema → table**. When creating namespaces or tables:
-
-1. **Parent must exist:** Before creating `lance_catalog/schema`, ensure `lance_catalog` catalog exists in Gravitino metalake.
-2. **Two-level limit:** Create namespace `lance_catalog/schema`, but **not** `lance_catalog/schema/sub_schema`.
-3. **Table placement:** Tables can only be created under `lance_catalog/schema`, not at catalog level.
-
-**Example Hierarchy:**
-```
-metalake
-└── lance_catalog (catalog - create via REST)
-    └── schema (namespace - create via REST)
-        └── table01 (table - create via REST)
-```
-
-### Delimiter Convention
-
-The Lance REST API uses `$` as the default delimiter to separate namespace levels in URIs. When making HTTP requests:
-
-- **URL Encoding Required**: `$` must be URL-encoded as `%24`
-- **Example**: `lance_catalog$schema$table01` becomes `lance_catalog%24schema%24table01` in URLs
-
-**Common Delimiters:**
-```
-Namespace path:     lance_catalog.schema.table01
-URI representation: lance_catalog$schema$table01  
-URL encoded:        lance_catalog%24schema%24table01
-```
-
-:::caution Important Limitations
-- Supports only **two levels of namespaces** before tables
-- Tables **cannot** be nested deeper than schema level  
-- Parent catalog must be created in Gravitino before using Lance REST API
-- Namespace deletion is recursive and irreversible
-:::
-
-## Examples
-
-The following examples demonstrate how to interact with Lance REST service using different programming languages and tools.
-
-**Prerequisites:**
-- Gravitino server is running with Lance REST service enabled.
-- A metalake has been created in Gravitino.
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-# Create a catalog-level namespace
-# mode: "create" | "exist_ok" | "overwrite" for create namespace/table; mode: "create" | "overwrite" for register table
-curl -X POST http://localhost:9101/lance/v1/namespace/lance_catalog/create \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "id": ["lance_catalog"],
-    "mode": "create"
-  }'
-
-# Create a schema namespace
-# Note: %24 is URL-encoded '$' character used as delimiter
-curl -X POST http://localhost:9101/lance/v1/namespace/lance_catalog%24schema/create \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "id": ["lance_catalog", "schema"],
-    "mode": "create"
-  }'
-
-# Register an existing table
-curl -X POST http://localhost:9101/lance/v1/table/lance_catalog%24schema%24table01/register \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "id": ["lance_catalog", "schema", "table01"],
-    "location": "/tmp/lance_catalog/schema/table01",
-    "mode": "create"
-  }'
-
-# Declare a table
-curl -X POST http://localhost:9101/lance/v1/table/lance_catalog%24schema%24table04/declare \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "id": ["lance_catalog", "schema", "table04"],
-    "location": "/tmp/lance_catalog/schema/table04"
-  }'
-  
-# Create a table with schema, the schema is inferred from the Arrow IPC file
-curl -X POST \
-     "http://localhost:9101/lance/v1/table/lance_catalog%24schema%24table03/create" \
-     -H 'Content-Type: application/vnd.apache.arrow.stream' \
-     -H "x-lance-table-location: /tmp/lance_catalog/schema/table03" \
-     -H "x-lance-table-properties: {}" \
-     --data-binary "@${ARROW_FILE}"    
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// Add dependency: implementation("org.lance:lance-namespace-core:0.4.5")
-
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
-import org.lance.namespace.client.apache.ApiClient;
-import org.lance.namespace.client.apache.api.TableApi;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
-// Initialize allocator and namespace connection
-private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-
-Map<String, String> props = new HashMap<>();
-props.put("uri", "http://localhost:9101/lance");
-props.put("delimiter", "$");
-
-LanceNamespace ns = LanceNamespace.connect("rest", props, allocator);
-
-// Create catalog namespace
-CreateNamespaceRequest createCatalogNsRequest = new CreateNamespaceRequest();
-createCatalogNsRequest.addIdItem("lance_catalog");
-createCatalogNsRequest.setMode("create");
-ns.createNamespace(createCatalogNsRequest);
-
-// Create schema namespace
-CreateNamespaceRequest createSchemaNsRequest = new CreateNamespaceRequest();
-createSchemaNsRequest.addIdItem("lance_catalog");
-createSchemaNsRequest.addIdItem("schema");
-createSchemaNsRequest.setMode("create");
-ns.createNamespace(createSchemaNsRequest);
-
-// Register a table
-RegisterTableRequest registerTableRequest = new RegisterTableRequest();
-registerTableRequest.setLocation("/tmp/lance_catalog/schema/table01");
-registerTableRequest.setId(Arrays.asList("lance_catalog", "schema", "table01"));
-registerTableRequest.setMode("create");
-ns.registerTable(registerTableRequest);
-
-// Declare a table
-DeclareTableRequest declareTableRequest = new DeclareTableRequest();
-declareTableRequest.setLocation("/tmp/lance_catalog/schema/table02");
-declareTableRequest.setId(Arrays.asList("lance_catalog", "schema", "table02"));
-ns.declareTable(declareTableRequest);
-
-// Create a table with schema inferred from Arrow IPC file.
-// For REST create API, location/properties are passed via headers.
-org.apache.arrow.vector.types.pojo.Schema schema =
-        new org.apache.arrow.vector.types.pojo.Schema(
-                Arrays.asList(
-                        Field.nullable("id", new ArrowType.Int(32, true)),
-                        Field.nullable("value", new ArrowType.Utf8())));
-byte[] body = ArrowUtils.generateIpcStream(schema);
-TableApi tableApi = new TableApi(new ApiClient().setBasePath("http://localhost:9101/lance"));
-Map<String, String> createTableHeaders = new HashMap<>();
-createTableHeaders.put("x-lance-table-location", "/tmp/lance_catalog/schema/table03");
-createTableHeaders.put("x-lance-table-properties", "{}");
-tableApi.createTable(
-    "lance_catalog$schema$table03", body, "$", "create", createTableHeaders);
-
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-# Install: pip install lance-namespace==0.4.5
-
-import lance_namespace as ln
-import requests
-
-# Connect to Lance REST service
-ns = ln.connect("rest", {"uri": "http://your_lance_rest:9101/lance"})
-
-# Create catalog namespace
-create_catalog_ns_request = ln.CreateNamespaceRequest(id=["lance_catalog"])
-catalog = ns.create_namespace(create_catalog_ns_request)
-
-# Create schema namespace
-create_schema_ns_request = ln.CreateNamespaceRequest(id=["lance_catalog", "schema"])
-schema = ns.create_namespace(create_schema_ns_request)
-
-# Register a table
-register_table_request = ln.RegisterTableRequest(
-    id=['lance_catalog', 'schema', 'table01'],
-    location='/tmp/lance_catalog/schema/table01'
-)
-ns.register_table(register_table_request)
-
-# Declare a table
-declare_table_request = ln.DeclareTableRequest(
-    id=['lance_catalog', 'schema', 'table02'],
-    location='/tmp/lance_catalog/schema/table02'
-)
-ns.declare_table(declare_table_request)
-
-# Create a table with schema inferred from Arrow IPC file.
-# For REST create API, location/properties are passed via headers.
-with open('schema.ipc', 'rb') as f:
-    body = f.read()
-
-response = requests.post(
-    "http://your_lance_rest:9101/lance/v1/table/lance_catalog%24schema%24table03/create",
-    params={"delimiter": "$", "mode": "create"},
-    headers={
-        "Content-Type": "application/vnd.apache.arrow.stream",
-        "x-lance-table-location": "/tmp/lance_catalog/schema/table03",
-        "x-lance-table-properties": "{}",
-    },
-    data=body,
-    timeout=30,
-)
-response.raise_for_status()
-```
-
-</TabItem>
-</Tabs>
-
-## Integration with Lance REST
-
-To use the Lance REST service with Apache Spark, Ray and other engines, refer to [lance-rest-integration](./lance-rest-integration.md) for more details.
+- [Lance REST Integration](./lance-rest-integration.md) for `lance-spark` and `lance-ray` versions and examples
+- [Lance Tables](./lakehouse-generic-lance-table.md) for table properties, type mappings, and worked examples on both APIs
+- [Lakehouse Generic Catalog](./lakehouse-generic-catalog.md) for the catalog this service creates and its properties
+- [Install Lance REST Server on Kubernetes](./lance-rest-server-chart.md) for the Helm chart


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updates the five Lance and generic lakehouse catalog documentation pages around the model they never stated, and corrects claims that turned out to be wrong when checked against source. 681 insertions, 1351 deletions.

#### Corrections verified against source

- Alter is partially supported (drop column, rename column, add index), not "Not support now" (`LanceTableOperations.handleLanceTableChange`)
- Index creation is supported through alter; the page listed indexes under "Feature Limitations" (same)
- Name `lance.schema-refresh-mode`, which the refresh section described at length but never identified (`LanceConstants`)
- Add `lance.declared` to the table properties, which was missing (`LanceTableDelegator.tablePropertyEntries`)
- `Map` is supported by Lance; the page said it was not (lance `docs/src/format/table/schema.md`)
- `Union` is not supported by Lance; the page implied it was (same)
- `Interval_year` is not supported because Lance has no interval type at all; `Interval_day` is fine because it maps to an Arrow `Duration` (same)
- Vector columns need a fixed-size list. Gravitino `List` produces a variable-length Arrow `List`, which cannot carry a vector index (`LanceDataTypeConverter`, lance schema spec)
- Mark `GET /v1/namespace/list` as a Gravitino extension, absent from the specification and previously listed alongside spec endpoints with no distinction (lance-namespace `v0.7.5` `openapi.yaml`)
- Add three endpoints missing from the operations table: `/v1/namespace/list`, `drop_columns`, `alter_columns` (`LanceNamespaceOperations`, `LanceTableOperations`)
- Delta `location` inherits from schema and catalog; resolution happens before the format delegator runs (`GenericCatalogOperations.calculateTableLocation`)
- Gravitino performs no Delta type conversion; the mapping table is guidance for declaring metadata, not a conversion it applies (no converter exists in the `delta` package)
- Document three Delta create-time rejections that were undocumented: distributions, sort orders, indexes (`DeltaTableOperations.createTable`)
- Fix the `lance-ray` example, which used `write_lance(namespace=...)`, a signature the page's own compatibility notes call unsupported (`clients/client-python/tests/integration/test_lance_ray.py`)
- `provider` is a field on the create request, not a catalog property as the page listed it (`GenericCatalogPropertiesMetadata`)
- Add `lance.storage.*` to the catalog properties table, although three pages tell readers to set it there (same)
- The generic catalog supports Lance and Delta, not "Lance, Iceberg, Hudi" as the page claimed (`META-INF/services`)

#### `lance-rest-service.md`

- Delete the Deployment Modes table; state the recommended deployment, then the alternative and its limitations
- New `Lance REST API` section: endpoint table, identifiers, calling details, limitations, storage options
- Fold `Namespace Model` into the API section as `Identifiers`; hierarchy and delimiter exist only to let a reader build a request
- Dissolve the orphan `Authentication` and `Storage Configuration` sections into `Configuration` and the API section
- State where configuration properties go, and that a separate process uses the same names in a different file
- Structure configuration by outcome rather than by property
- Cut `Engine Integration`; which engines can read Lance is the integration page's subject
- Cut the Iceberg REST counterpart paragraph
- Add a Quick Start, correct the specification links, consolidate the configuration tables
- Move the endpoint examples to the Lance tables page so both APIs get equal treatment
- Reorder the Quick Start so the server starts once; the previous ordering implied start, stop, edit config, start again
- Correct readiness. `NamespaceWrapper` initializes lazily, so `/health/ready` returns 503 until the first namespace or table call. The Quick Start previously checked readiness before the call that triggers initialization, so the check failed as written
- Create the metalake in the Quick Start, which the service requires but the page never mentioned
- Pass `location` and `lance.storage.*` in the Quick Start namespace create; it previously used an `s3://` path with no credentials, so it could not work
- Split `Gravitino-Specific Behavior` into `Calling the Operations` and `Limitations`; the old heading claimed everything under it was a deviation, but several rows were plain specification mechanics
- State that Gravitino implements a subset. The `v0.7.5` specification defines 29 table endpoints; Gravitino serves 9, with the entire data plane absent
- Document that `DropTable` purges. Every table this service creates is marked `external`, but `DropTable` removes the dataset files anyway
- Rewrite storage options to say the prefix is stripped: `lance.storage.region` reaches the client as `region`
- Note that health endpoints bypass the authentication filter

#### `lance-rest-integration.md`

- Reorganize per engine; version information now sits with the engine it applies to, instead of a shared matrix that implied the two libraries were coupled
- Promote the compatibility content out of a `:::note` block into real sections
- Cut `Rationale`, which claimed incompatible versions cause data corruption
- Cut `General Integration Pattern`, which was contentless
- Remove the duplicated MinIO catalog example
- Keep Table Location on the Lance path; the old page reached for a Gravitino API call to set properties the Lance `CreateNamespace` call accepts directly
- Correct the claim that an engine without Lance REST support needs its own credentials; `DescribeTable` returns storage options alongside the location
- Drop the Quick Start; with only two engines it privileged Spark arbitrarily, and each engine section is its own quick start
- Add a credentials section pointing at the service page

#### `lakehouse-generic-catalog.md`

- Rewrite the Overview around what distinguishes this catalog: Lance and Delta define no catalog of their own, so Gravitino holds the metadata directly rather than federating. Explains the word "generic", which the page previously asserted without grounding
- Split catalog creation per format; a Lance catalog carries `location` and `lance.storage.*`, a Delta catalog needs no properties at all
- Reorganize properties so format-neutral ones come first and Lance-only ones are separated
- Move location resolution next to the `location` rows it explains, and convert a 20-line ASCII block into a table plus one worked paragraph
- Document the `lance.storage.*` option names; four pages told readers to set them and none listed them
- Cut the Benefits list and both bullet lists of "Supported Operations"
- Remove `"owner": "sales-team"` from the schema example, which implied a property that does not exist

#### `lakehouse-generic-lance-table.md`

- Restructure to be path-neutral; the page is reachable from both APIs and previously read as Gravitino-API-only, giving a Lance REST reader instructions that do not apply
- Replace `Supported Operations` with a `Capabilities` table giving both APIs side by side
- Add a column to the table properties showing how the Lance REST service supplies each one, instead of marking five of eight as irrelevant
- Cover both APIs symmetrically in Examples, with the Lance examples moved here from the service page
- Add Troubleshooting with ten error strings taken verbatim from source
- Cut the Migration Guide, a bash `for` loop registering tables
- Preserve `#data-type-mappings`, which `manage-relational-metadata-using-gravitino.md` links into

#### `lakehouse-generic-delta-table.md`

- Lead the Overview with the constraint that matters: every Delta table is external and a create is a registration
- State the consequence the old page only implied: Gravitino and the `_delta_log` are two records of the same table, and Gravitino never reconciles them
- Align the `Capabilities` table with the Lance page's phrasing so the two formats can be compared
- Add Troubleshooting with eight verbatim error strings, three of which the old page did not mention
- Cut Planned Enhancements, which speculated about unreleased features
- Cut the 20-line Spark modification example and the read-via-Spark snippet, both of which belong to Delta Lake's documentation

#### Conventions applied across all five pages

- No `:::` admonition blocks, no `<Tabs>` / `<TabItem>`, no ✅ / ❌ in tables, no em dashes
- No `Since Version` columns or "Introduced in X" sentences, since the docs are version-selected
- No raw HTML in table cells; `<sup>` renders literally, so footnote markers use Unicode superscripts
- Title Case headings, `{snake_case}` placeholders, aligned table pipes
- Shell variables declared once per code block so each block stands alone
- Code lines kept short enough to avoid horizontal scroll
- No one-column tables and no sections with a single child

### Why are the changes needed?

Five pages document Lance in Gravitino, and none of them states the model that makes the set coherent: Lance tables live in a `lakehouse-generic` catalog, and two APIs reach the same tables. Configure the Lance REST service and it creates the catalog when a client first connects, or create the catalog through the Gravitino REST API and skip the service entirely.

Because that was never written down, the pages were organized by artifact rather than by the model. Authentication appeared on two pages. Storage configuration lived on one page and engine configuration on another, with no cross-reference. A Lance REST user landing on the tables page got operations and properties that do not apply on their path. The word "generic" was never explained. Following the service page Quick Start in order did not work, because it checked readiness before the call that initializes the service.

The five files cannot be split into smaller PRs. Ten cross-page anchors point at headings that only exist after this rewrite, running in every direction between the files, so no ordering of smaller PRs avoids shipping broken links.

`lance-rest-server-chart.md` is deliberately not included. Its most useful content requires a chart change rather than a doc change, and its doc-only fixes will follow separately.

### Does this PR introduce _any_ user-facing change?

Documentation only. No API, property, or behavior changes.

The pages themselves change substantially, including headings. All inbound anchors from other documentation pages were checked and preserved, including `#data-type-mappings`, which `manage-relational-metadata-using-gravitino.md` links into.

### How was this patch tested?

Documentation only, so no code tests. Claims were checked as follows:

- Endpoint names, methods, and paths against lance-namespace `v0.7.5` `openapi.yaml`
- Type mappings against `LanceDataTypeConverter` and the Lance format schema specification
- Property names and defaults against `LanceConstants`, `GenericCatalogPropertiesMetadata`, `GenericTablePropertiesMetadata`, and `LanceTableDelegator`
- Operation support against `LanceTableOperations` and `DeltaTableOperations`
- Error strings copied verbatim from source
- The `lance-ray` example against `clients/client-python/tests/integration/test_lance_ray.py`
- All cross-page and in-page anchors verified to resolve

