### PR TITLE
[#12289] web-v2(UI): fix about retains the previous sub-path when switching filesets

### DIFF
--- a/web-v2/web/src/app/catalogs/page.js
+++ b/web-v2/web/src/app/catalogs/page.js
@@ -253,6 +253,7 @@ const CatalogsListPage = () => {
               case 'fileset':
                 store.filesets.length === 0 &&
                   (await dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema })))
+                await dispatch(resetActivatedDetails())
                 await dispatch(setActivatedDetailsLoading(true))
                 await dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
                 await dispatch(setActivatedDetailsLoading(false))

--- a/web-v2/web/src/app/catalogs/rightContent/entitiesContent/FilesetDetailsPage.js
+++ b/web-v2/web/src/app/catalogs/rightContent/entitiesContent/FilesetDetailsPage.js
@@ -265,7 +265,7 @@ export default function FilesetDetailsPage({ ...props }) {
         </Space>
       </Spin>
       <Tabs items={tabOptions} activeKey={activeTab} onChange={setActiveTab} />
-      {activeTab === 'files' && (
+      {activeTab === 'files' && !store.activatedDetailsLoading && (
         <div data-refer='tab-files-panel'>
           <ListFiles
             metalake={currentMetalake}

--- a/web-v2/web/src/app/catalogs/rightContent/entitiesContent/FilesetDetailsPage.js
+++ b/web-v2/web/src/app/catalogs/rightContent/entitiesContent/FilesetDetailsPage.js
@@ -268,6 +268,7 @@ export default function FilesetDetailsPage({ ...props }) {
       {activeTab === 'files' && !store.activatedDetailsLoading && (
         <div data-refer='tab-files-panel'>
           <ListFiles
+            key={`${catalog}.${schema}.${fileset}`}
             metalake={currentMetalake}
             catalog={catalog}
             schema={schema}

--- a/web-v2/web/src/app/catalogs/rightContent/entitiesContent/ListFiles.js
+++ b/web-v2/web/src/app/catalogs/rightContent/entitiesContent/ListFiles.js
@@ -19,7 +19,7 @@
 
 'use client'
 
-import { useEffect, useState, useMemo, useRef } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 
 import { ArrowLeftOutlined, CopyOutlined, FileOutlined, FolderOutlined } from '@ant-design/icons'
 import { App, Button, Select, Space, Spin, Table, Typography } from 'antd'
@@ -41,40 +41,9 @@ const ListFiles = ({ metalake, catalog, schema, fileset, storageLocations, defau
   const store = useAppSelector(state => state.metalakes)
   const dispatch = useAppDispatch()
 
-  // Track the current fileset identity to detect switches.
-  // Reset navigation state immediately during render (before useEffects run)
-  // so that no stale state can trigger API calls with wrong parameters.
-  const filesetIdentity = `${catalog}.${schema}.${fileset}`
-  const prevFilesetIdentityRef = useRef(filesetIdentity)
-
-  // Track which filesetIdentity the storageLocations prop belongs to.
-  // We record the identity when storageLocations reference changes,
-  // so we can detect when storageLocations is stale (from a previous fileset).
-  const prevStorageLocationsRef = useRef(storageLocations)
-  const storageLocationsIdentityRef = useRef(filesetIdentity)
-  if (prevStorageLocationsRef.current !== storageLocations) {
-    prevStorageLocationsRef.current = storageLocations
-
-    // storageLocations reference changed — record which fileset it belongs to
-    if (storageLocations && Object.keys(storageLocations).length > 0) {
-      storageLocationsIdentityRef.current = filesetIdentity
-    }
-  }
-
-  const filesetSwitched = prevFilesetIdentityRef.current !== filesetIdentity
-  if (filesetSwitched) {
-    prevFilesetIdentityRef.current = filesetIdentity
-    setSubPath('')
-    setPathSegments([])
-    setCurrentLocation(undefined)
-  }
-
-  // Whether storageLocations matches the current fileset (not stale)
-  const storageLocationsIsStale = storageLocationsIdentityRef.current !== filesetIdentity
-
   // Sync currentLocation with storageLocations/defaultLocationName.
-  // When currentLocation is undefined (after fileset switch) or no longer
-  // exists in storageLocations, derive the correct value from props.
+  // When currentLocation is undefined or no longer exists in
+  // storageLocations, derive the correct value from props.
   useEffect(() => {
     if (!storageLocations || Object.keys(storageLocations).length === 0) {
       setCurrentLocation(undefined)
@@ -104,15 +73,7 @@ const ListFiles = ({ metalake, catalog, schema, fileset, storageLocations, defau
   }, [sub_path])
 
   useEffect(() => {
-    if (
-      metalake &&
-      catalog &&
-      schema &&
-      fileset &&
-      currentLocation &&
-      storageLocations?.[currentLocation] &&
-      !storageLocationsIsStale
-    ) {
+    if (metalake && catalog && schema && fileset && currentLocation && storageLocations?.[currentLocation]) {
       dispatch(
         getFilesetFiles({
           metalake,
@@ -124,7 +85,7 @@ const ListFiles = ({ metalake, catalog, schema, fileset, storageLocations, defau
         })
       )
     }
-  }, [dispatch, metalake, catalog, schema, fileset, sub_path, currentLocation, storageLocationsIsStale])
+  }, [dispatch, metalake, catalog, schema, fileset, sub_path, currentLocation])
 
   const handleLocationChange = value => {
     setCurrentLocation(value)
@@ -205,8 +166,12 @@ const ListFiles = ({ metalake, catalog, schema, fileset, storageLocations, defau
     return { columns, minWidth: 100 }
   }, [columns])
 
-  if (!storageLocations || Object.keys(storageLocations).length === 0 || storageLocationsIsStale) {
+  if (!storageLocations) {
     return <Spin />
+  }
+
+  if (Object.keys(storageLocations).length === 0) {
+    return <Text type='secondary'>No storage locations configured</Text>
   }
 
   if (!currentLocation || !storageLocations[currentLocation]) {

--- a/web-v2/web/src/app/catalogs/rightContent/entitiesContent/ListFiles.js
+++ b/web-v2/web/src/app/catalogs/rightContent/entitiesContent/ListFiles.js
@@ -19,7 +19,7 @@
 
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useRef } from 'react'
 
 import { ArrowLeftOutlined, CopyOutlined, FileOutlined, FolderOutlined } from '@ant-design/icons'
 import { App, Button, Select, Space, Spin, Table, Typography } from 'antd'
@@ -41,11 +41,59 @@ const ListFiles = ({ metalake, catalog, schema, fileset, storageLocations, defau
   const store = useAppSelector(state => state.metalakes)
   const dispatch = useAppDispatch()
 
-  useEffect(() => {
-    if (defaultLocationName) {
-      setCurrentLocation(defaultLocationName)
+  // Track the current fileset identity to detect switches.
+  // Reset navigation state immediately during render (before useEffects run)
+  // so that no stale state can trigger API calls with wrong parameters.
+  const filesetIdentity = `${catalog}.${schema}.${fileset}`
+  const prevFilesetIdentityRef = useRef(filesetIdentity)
+
+  // Track which filesetIdentity the storageLocations prop belongs to.
+  // We record the identity when storageLocations reference changes,
+  // so we can detect when storageLocations is stale (from a previous fileset).
+  const prevStorageLocationsRef = useRef(storageLocations)
+  const storageLocationsIdentityRef = useRef(filesetIdentity)
+  if (prevStorageLocationsRef.current !== storageLocations) {
+    prevStorageLocationsRef.current = storageLocations
+
+    // storageLocations reference changed — record which fileset it belongs to
+    if (storageLocations && Object.keys(storageLocations).length > 0) {
+      storageLocationsIdentityRef.current = filesetIdentity
     }
-  }, [defaultLocationName])
+  }
+
+  const filesetSwitched = prevFilesetIdentityRef.current !== filesetIdentity
+  if (filesetSwitched) {
+    prevFilesetIdentityRef.current = filesetIdentity
+    setSubPath('')
+    setPathSegments([])
+    setCurrentLocation(undefined)
+  }
+
+  // Whether storageLocations matches the current fileset (not stale)
+  const storageLocationsIsStale = storageLocationsIdentityRef.current !== filesetIdentity
+
+  // Sync currentLocation with storageLocations/defaultLocationName.
+  // When currentLocation is undefined (after fileset switch) or no longer
+  // exists in storageLocations, derive the correct value from props.
+  useEffect(() => {
+    if (!storageLocations || Object.keys(storageLocations).length === 0) {
+      setCurrentLocation(undefined)
+
+      return
+    }
+
+    // If currentLocation is valid in current storageLocations, keep it
+    if (currentLocation && storageLocations[currentLocation]) {
+      return
+    }
+
+    // Otherwise, derive from props
+    if (defaultLocationName && storageLocations[defaultLocationName]) {
+      setCurrentLocation(defaultLocationName)
+    } else {
+      setCurrentLocation(Object.keys(storageLocations)[0])
+    }
+  }, [currentLocation, defaultLocationName, storageLocations])
 
   useEffect(() => {
     if (sub_path) {
@@ -56,7 +104,15 @@ const ListFiles = ({ metalake, catalog, schema, fileset, storageLocations, defau
   }, [sub_path])
 
   useEffect(() => {
-    if (metalake && catalog && schema && fileset) {
+    if (
+      metalake &&
+      catalog &&
+      schema &&
+      fileset &&
+      currentLocation &&
+      storageLocations?.[currentLocation] &&
+      !storageLocationsIsStale
+    ) {
       dispatch(
         getFilesetFiles({
           metalake,
@@ -68,7 +124,7 @@ const ListFiles = ({ metalake, catalog, schema, fileset, storageLocations, defau
         })
       )
     }
-  }, [dispatch, metalake, catalog, schema, fileset, sub_path, currentLocation])
+  }, [dispatch, metalake, catalog, schema, fileset, sub_path, currentLocation, storageLocationsIsStale])
 
   const handleLocationChange = value => {
     setCurrentLocation(value)
@@ -149,25 +205,12 @@ const ListFiles = ({ metalake, catalog, schema, fileset, storageLocations, defau
     return { columns, minWidth: 100 }
   }, [columns])
 
-  if (!storageLocations || Object.keys(storageLocations).length === 0) {
-    return <p>No storage locations configured</p>
-  }
-
-  if (!currentLocation && defaultLocationName) {
-    setCurrentLocation(defaultLocationName)
-
+  if (!storageLocations || Object.keys(storageLocations).length === 0 || storageLocationsIsStale) {
     return <Spin />
   }
 
-  if (!currentLocation && Object.keys(storageLocations).length > 0) {
-    const firstLocation = Object.keys(storageLocations)[0]
-    setCurrentLocation(firstLocation)
-
+  if (!currentLocation || !storageLocations[currentLocation]) {
     return <Spin />
-  }
-
-  if (!currentLocation) {
-    return <p>Please select a storage location</p>
   }
 
   const displayedFiles = [...store.tableData] || []


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. page.js — Add resetActivatedDetails() for the fileset branch (consistent with the table branch), clearing stale activatedDetails before loading new data.

2. FilesetDetailsPage.js — Guard ListFiles rendering with !store.activatedDetailsLoading to prevent mounting before new details are ready.
 
3. ListFiles.js — Three fixes:
    - Render-time reset: Detect filesetIdentity change via useRef and reset sub_path/currentLocation immediately during render (before useEffects run).
    - Stale props detection: Track which fileset the storageLocations prop belongs to. Block API calls and show loading spinner when storageLocations is stale.
    - currentLocation sync: Derive currentLocation from storageLocations/defaultLocationName when it's undefined or invalid, instead of blindly trusting the previous value.


### Why are the changes needed?


Fix: #12289

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?
munaully