### PR TITLE
[#12254] improvement(iceberg): Enable the Iceberg REST scan plan cache by default

### DIFF
--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -699,13 +699,15 @@ Gravitino caches scan plan results to speed up repeated queries with identical p
 
 Plan scan responses follow the Iceberg 1.11 REST API: completed plans return structured `file-scan-tasks` only. Legacy `plan-tasks` JSON strings (used by some Iceberg 1.9.x–1.10.x clients) are not emitted.
 
-| Configuration item                                         | Description                                              | Default value | Required | Since Version |
-|------------------------------------------------------------|----------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.iceberg-rest.scan-plan-cache-impl`              | The implementation of the scan plan cache.               | (none)        | No       | 1.2.0         |
-| `gravitino.iceberg-rest.scan-plan-cache-capacity`          | The capacity of the scan plan cache.                     | 200           | No       | 1.2.0         |
-| `gravitino.iceberg-rest.scan-plan-cache-expire-minutes`    | The expiration time (in minutes) of the scan plan cache. | 60            | No       | 1.2.0         |
+| Configuration item                                      | Description                                                                                      | Default value                                                   | Required | Since Version |
+|---------------------------------------------------------|--------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|----------|---------------|
+| `gravitino.iceberg-rest.scan-plan-cache-impl`           | The implementation of the scan plan cache. Set to empty string("") to disable scan plan caching. | `org.apache.gravitino.iceberg.service.cache.LocalScanPlanCache` | No       | 1.2.0         |
+| `gravitino.iceberg-rest.scan-plan-cache-capacity`       | The capacity of the scan plan cache.                                                             | 200                                                             | No       | 1.2.0         |
+| `gravitino.iceberg-rest.scan-plan-cache-expire-minutes` | The expiration time (in minutes) of the scan plan cache.                                         | 60                                                              | No       | 1.2.0         |
 
 The scan plan cache uses snapshot ID as part of the cache key, ensuring automatic invalidation when table data changes. This can provide significant speedup for repeated queries like dashboard refreshes or BI tool queries.
+
+The cache is enabled by default and is held per catalog in the server process. Each entry holds a whole plan response, so a server that plans very large scans keeps up to `scan-plan-cache-capacity` plan responses on the heap per catalog; lower the capacity, or set `scan-plan-cache-impl` to an empty string to turn caching off, when that footprint matters more than the replanning it saves. Catalogs with `catalog-backend` set to `rest` delegate scan planning to the upstream REST catalog, so the cache does not apply to them.
 
 Gravitino provides the built-in `org.apache.gravitino.iceberg.service.cache.LocalScanPlanCache` to store the cached data in memory. Also implement your custom scan plan cache by implementing the `org.apache.gravitino.iceberg.service.cache.ScanPlanCache` interface.
 

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -319,10 +319,15 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
 
   public static final ConfigEntry<String> SCAN_PLAN_CACHE_IMPL =
       new ConfigBuilder(IcebergConstants.SCAN_PLAN_CACHE_IMPL)
-          .doc("The implementation of the scan plan cache")
+          .doc(
+              "The implementation of the scan plan cache. Set to empty string(\"\") to disable "
+                  + "scan plan caching.")
           .version(ConfigConstants.VERSION_1_2_0)
           .stringConf()
-          .create();
+          // The default implementation lives in the Iceberg REST server module, which
+          // iceberg-common does not depend on, so it is referenced by name. The name is pinned by
+          // TestCatalogWrapperForREST#testScanPlanCacheDefaultImpl.
+          .createWithDefault("org.apache.gravitino.iceberg.service.cache.LocalScanPlanCache");
 
   public static final ConfigEntry<Integer> SCAN_PLAN_CACHE_CAPACITY =
       new ConfigBuilder(IcebergConstants.SCAN_PLAN_CACHE_CAPACITY)

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestCatalogWrapperForREST.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestCatalogWrapperForREST.java
@@ -469,6 +469,72 @@ public class TestCatalogWrapperForREST {
         "Vended request on cache hit should return fresh credentials");
   }
 
+  @Test
+  void testScanPlanCacheDefaultImpl() {
+    Assertions.assertEquals(
+        LocalScanPlanCache.class.getName(),
+        IcebergConfig.SCAN_PLAN_CACHE_IMPL.getDefaultValue(),
+        "The default scan plan cache impl is configured by class name, keep it in sync");
+    Assertions.assertEquals(
+        LocalScanPlanCache.class.getName(),
+        new IcebergConfig(ImmutableMap.of()).get(IcebergConfig.SCAN_PLAN_CACHE_IMPL));
+  }
+
+  @Test
+  void testPlanTableScanCachedByDefault() {
+    CatalogWrapperForREST wrapper =
+        newWrapperForScanPlanCache("scan-plan-cache-default", ImmutableMap.of());
+    TableIdentifier tableId = createScanPlanCacheTable(wrapper, "default_tbl");
+    PlanTableScanRequest request = PlanTableScanRequest.builder().build();
+
+    PlanTableScanResponse first =
+        wrapper.planTableScan(tableId, request, false, CredentialPrivilege.READ);
+    PlanTableScanResponse second =
+        wrapper.planTableScan(tableId, request, false, CredentialPrivilege.READ);
+
+    Assertions.assertSame(
+        first, second, "An identical scan of the same snapshot should be served from the cache");
+  }
+
+  @Test
+  void testPlanTableScanCacheDisabledByEmptyImpl() {
+    CatalogWrapperForREST wrapper =
+        newWrapperForScanPlanCache(
+            "scan-plan-cache-disabled", ImmutableMap.of(IcebergConstants.SCAN_PLAN_CACHE_IMPL, ""));
+    TableIdentifier tableId = createScanPlanCacheTable(wrapper, "disabled_tbl");
+    PlanTableScanRequest request = PlanTableScanRequest.builder().build();
+
+    PlanTableScanResponse first =
+        wrapper.planTableScan(tableId, request, false, CredentialPrivilege.READ);
+    PlanTableScanResponse second =
+        wrapper.planTableScan(tableId, request, false, CredentialPrivilege.READ);
+
+    Assertions.assertNotSame(
+        first, second, "An empty scan plan cache impl should disable caching, replanning instead");
+  }
+
+  private static CatalogWrapperForREST newWrapperForScanPlanCache(
+      String catalogName, Map<String, String> extraProperties) {
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put(IcebergConstants.CATALOG_BACKEND, "memory")
+            .put(IcebergConstants.WAREHOUSE, "/tmp/warehouse")
+            .putAll(extraProperties)
+            .build();
+    return new CatalogWrapperForREST(catalogName, new IcebergConfig(properties));
+  }
+
+  private static TableIdentifier createScanPlanCacheTable(
+      CatalogWrapperForREST wrapper, String tableName) {
+    Namespace namespace = Namespace.of("db");
+    Catalog catalog = wrapper.getCatalog();
+    ((SupportsNamespaces) catalog).createNamespace(namespace);
+    TableIdentifier tableId = TableIdentifier.of(namespace, tableName);
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    catalog.createTable(tableId, schema, PartitionSpec.unpartitioned());
+    return tableId;
+  }
+
   @SuppressWarnings("deprecation")
   @Test
   void testFederatedPlanTableScanDelegatesToRemote() throws Exception {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `LocalScanPlanCache` the default `gravitino.iceberg-rest.scan-plan-cache-impl`, in the same way `LocalTableMetadataCache` is already the default `table-metadata-cache-impl`.

- `IcebergConfig.SCAN_PLAN_CACHE_IMPL` now defaults to `org.apache.gravitino.iceberg.service.cache.LocalScanPlanCache`. The class lives in the Iceberg REST server module, which `iceberg-common` does not depend on, so it is referenced by name and pinned by a test.
- Setting the property to an empty string (`""`) remains the way to turn caching off; `CatalogWrapperForREST#loadScanPlanCache` already falls back to `ScanPlanCache.DUMMY` for a blank value, so no server-side change was needed.
- Capacity (200) and expiry (60 minutes) defaults are unchanged.
- Docs updated with the new default, how to disable it, the per-catalog heap footprint, and a note that `rest`-backed catalogs delegate planning upstream and so do not use the cache.

### Why are the changes needed?

With the cache off by default, every scan planning request plans from scratch, including the repeated identical scans from BI tools and dashboard refreshes the cache was built for. It also becomes the dominant cost once scan planning hands results out in batches (#11284, #12194), where redeeming a `plan-task` replans the pinned snapshot: a plan spanning N batches costs N plans with the cache off and one with it on.

Correctness is unaffected: `ScanPlanCacheKey` includes the resolved snapshot id plus every scan parameter Gravitino acts on, so a cached plan is only served to an identical scan of the same snapshot.

The wider cache design questions raised in the issue (size-aware bounding instead of an entry count, separate tiers, multi-replica/distributed caching) are deliberately left out of this PR and remain open in #12254.

Fix: #12254

### Does this PR introduce _any_ user-facing change?

Yes. `gravitino.iceberg-rest.scan-plan-cache-impl` changes from no default to `org.apache.gravitino.iceberg.service.cache.LocalScanPlanCache`, so scan plan caching is on out of the box. A server that plans scans now holds up to `scan-plan-cache-capacity` (200) plan responses per catalog on the heap for `scan-plan-cache-expire-minutes` (60) after last access. Operators who do not want that can set `scan-plan-cache-impl` to an empty string. No property keys were added or removed.

### How was this patch tested?

New unit tests in `TestCatalogWrapperForREST`:

- `testScanPlanCacheDefaultImpl` - the config default resolves to `LocalScanPlanCache` (pins the class name used in `IcebergConfig`).
- `testPlanTableScanCachedByDefault` - with no cache configuration, two identical scans of the same snapshot return the same response instance, i.e. the second is served from the cache.
- `testPlanTableScanCacheDisabledByEmptyImpl` - with `scan-plan-cache-impl=""`, the same two scans replan.

Existing suites pass: `./gradlew :iceberg:iceberg-rest-server:test :iceberg:iceberg-common:test :catalogs:catalog-lakehouse-iceberg:test -PskipITs`, plus `spotlessCheck`.
