### PR TITLE
[#12344] improvement(core): add OCC for roles

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/ManagedSchemaOperations.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ManagedSchemaOperations.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -116,9 +117,11 @@ public abstract class ManagedSchemaOperations implements SupportsSchemas {
                     .build())
             .build();
     try {
-      store().put(schemaEntity, true /* overwrite */);
+      store().put(schemaEntity, false /* overwrite */);
     } catch (IOException ioe) {
       throw new RuntimeException("Failed to create schema " + ident, ioe);
+    } catch (EntityAlreadyExistsException e) {
+      throw new SchemaAlreadyExistsException(e, "Schema %s already exists", ident);
     } catch (NoSuchEntityException e) {
       throw new NoSuchCatalogException(e, "Catalog %s does not exist", ident.namespace());
     }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/CatalogMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/CatalogMetaMapper.java
@@ -89,7 +89,8 @@ public interface CatalogMetaMapper {
   @UpdateProvider(
       type = CatalogMetaSQLProviderFactory.class,
       method = "softDeleteCatalogMetasByCatalogId")
-  Integer softDeleteCatalogMetasByCatalogId(@Param("catalogId") Long catalogId);
+  Integer softDeleteCatalogMetasByCatalogId(
+      @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion);
 
   @UpdateProvider(
       type = CatalogMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/CatalogMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/CatalogMetaMapper.java
@@ -86,11 +86,30 @@ public interface CatalogMetaMapper {
       @Param("newCatalogMeta") CatalogPO newCatalogPO,
       @Param("oldCatalogMeta") CatalogPO oldCatalogPO);
 
+  /**
+   * Advances the catalog version when the expected OCC version still matches.
+   *
+   * @return the number of updated rows
+   */
+  @UpdateProvider(type = CatalogMetaSQLProviderFactory.class, method = "fenceCatalogMeta")
+  Integer fenceCatalogMeta(
+      @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion);
+
   @UpdateProvider(
       type = CatalogMetaSQLProviderFactory.class,
       method = "softDeleteCatalogMetasByCatalogId")
   Integer softDeleteCatalogMetasByCatalogId(
       @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion);
+
+  /**
+   * Soft-deletes catalogs whose identifiers and OCC versions still match.
+   *
+   * @return the number of deleted rows
+   */
+  @UpdateProvider(
+      type = CatalogMetaSQLProviderFactory.class,
+      method = "softDeleteCatalogMetasWithVersion")
+  Integer softDeleteCatalogMetasWithVersion(@Param("catalogMetas") List<CatalogPO> catalogPOs);
 
   @UpdateProvider(
       type = CatalogMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/CatalogMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/CatalogMetaSQLProviderFactory.java
@@ -109,8 +109,9 @@ public class CatalogMetaSQLProviderFactory {
     return getProvider().updateCatalogMeta(newCatalogPO, oldCatalogPO);
   }
 
-  public static String softDeleteCatalogMetasByCatalogId(@Param("catalogId") Long catalogId) {
-    return getProvider().softDeleteCatalogMetasByCatalogId(catalogId);
+  public static String softDeleteCatalogMetasByCatalogId(
+      @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion) {
+    return getProvider().softDeleteCatalogMetasByCatalogId(catalogId, currentVersion);
   }
 
   public static String softDeleteCatalogMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/CatalogMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/CatalogMetaSQLProviderFactory.java
@@ -109,9 +109,21 @@ public class CatalogMetaSQLProviderFactory {
     return getProvider().updateCatalogMeta(newCatalogPO, oldCatalogPO);
   }
 
+  /** Returns SQL that advances a catalog OCC version conditionally. */
+  public static String fenceCatalogMeta(
+      @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion) {
+    return getProvider().fenceCatalogMeta(catalogId, currentVersion);
+  }
+
   public static String softDeleteCatalogMetasByCatalogId(
       @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion) {
     return getProvider().softDeleteCatalogMetasByCatalogId(catalogId, currentVersion);
+  }
+
+  /** Returns SQL that soft-deletes catalogs using identifier-and-version pairs. */
+  public static String softDeleteCatalogMetasWithVersion(
+      @Param("catalogMetas") List<CatalogPO> catalogPOs) {
+    return getProvider().softDeleteCatalogMetasWithVersion(catalogPOs);
   }
 
   public static String softDeleteCatalogMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/MetalakeMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/MetalakeMetaMapper.java
@@ -73,7 +73,8 @@ public interface MetalakeMetaMapper {
   @UpdateProvider(
       type = MetalakeMetaSQLProviderFactory.class,
       method = "softDeleteMetalakeMetaByMetalakeId")
-  Integer softDeleteMetalakeMetaByMetalakeId(@Param("metalakeId") Long metalakeId);
+  Integer softDeleteMetalakeMetaByMetalakeId(
+      @Param("metalakeId") Long metalakeId, @Param("currentVersion") Long currentVersion);
 
   @DeleteProvider(
       type = MetalakeMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/MetalakeMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/MetalakeMetaMapper.java
@@ -70,6 +70,15 @@ public interface MetalakeMetaMapper {
       @Param("newMetalakeMeta") MetalakePO newMetalakePO,
       @Param("oldMetalakeMeta") MetalakePO oldMetalakePO);
 
+  /**
+   * Advances the metalake version when the expected OCC version still matches.
+   *
+   * @return the number of updated rows
+   */
+  @UpdateProvider(type = MetalakeMetaSQLProviderFactory.class, method = "fenceMetalakeMeta")
+  Integer fenceMetalakeMeta(
+      @Param("metalakeId") Long metalakeId, @Param("currentVersion") Long currentVersion);
+
   @UpdateProvider(
       type = MetalakeMetaSQLProviderFactory.class,
       method = "softDeleteMetalakeMetaByMetalakeId")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/MetalakeMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/MetalakeMetaSQLProviderFactory.java
@@ -88,8 +88,9 @@ public class MetalakeMetaSQLProviderFactory {
     return getProvider().updateMetalakeMeta(newMetalakePO, oldMetalakePO);
   }
 
-  public static String softDeleteMetalakeMetaByMetalakeId(@Param("metalakeId") Long metalakeId) {
-    return getProvider().softDeleteMetalakeMetaByMetalakeId(metalakeId);
+  public static String softDeleteMetalakeMetaByMetalakeId(
+      @Param("metalakeId") Long metalakeId, @Param("currentVersion") Long currentVersion) {
+    return getProvider().softDeleteMetalakeMetaByMetalakeId(metalakeId, currentVersion);
   }
 
   public static String deleteMetalakeMetasByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/MetalakeMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/MetalakeMetaSQLProviderFactory.java
@@ -88,6 +88,12 @@ public class MetalakeMetaSQLProviderFactory {
     return getProvider().updateMetalakeMeta(newMetalakePO, oldMetalakePO);
   }
 
+  /** Returns SQL that advances a metalake OCC version conditionally. */
+  public static String fenceMetalakeMeta(
+      @Param("metalakeId") Long metalakeId, @Param("currentVersion") Long currentVersion) {
+    return getProvider().fenceMetalakeMeta(metalakeId, currentVersion);
+  }
+
   public static String softDeleteMetalakeMetaByMetalakeId(
       @Param("metalakeId") Long metalakeId, @Param("currentVersion") Long currentVersion) {
     return getProvider().softDeleteMetalakeMetaByMetalakeId(metalakeId, currentVersion);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
@@ -82,7 +82,8 @@ public interface RoleMetaMapper {
       @Param("newRoleMeta") RolePO newRolePO, @Param("oldRoleMeta") RolePO oldRolePO);
 
   @UpdateProvider(type = RoleMetaSQLProviderFactory.class, method = "softDeleteRoleMetaByRoleId")
-  void softDeleteRoleMetaByRoleId(@Param("roleId") Long roleId);
+  Integer softDeleteRoleMetaByRoleId(
+      @Param("roleId") Long roleId, @Param("currentVersion") Long currentVersion);
 
   @UpdateProvider(
       type = RoleMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
@@ -90,8 +90,9 @@ public class RoleMetaSQLProviderFactory {
     return getProvider().updateRoleMeta(newRolePO, oldRolePO);
   }
 
-  public static String softDeleteRoleMetaByRoleId(@Param("roleId") Long roleId) {
-    return getProvider().softDeleteRoleMetaByRoleId(roleId);
+  public static String softDeleteRoleMetaByRoleId(
+      @Param("roleId") Long roleId, @Param("currentVersion") Long currentVersion) {
+    return getProvider().softDeleteRoleMetaByRoleId(roleId, currentVersion);
   }
 
   public static String softDeleteRoleMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaMapper.java
@@ -109,6 +109,12 @@ public interface SchemaMetaMapper {
 
   @UpdateProvider(
       type = SchemaMetaSQLProviderFactory.class,
+      method = "softDeleteSchemaMetaBySchemaIdAndVersion")
+  Integer softDeleteSchemaMetaBySchemaIdAndVersion(
+      @Param("schemaId") Long schemaId, @Param("currentVersion") Long currentVersion);
+
+  @UpdateProvider(
+      type = SchemaMetaSQLProviderFactory.class,
       method = "softDeleteSchemaMetasByMetalakeId")
   Integer softDeleteSchemaMetasByMetalakeId(@Param("metalakeId") Long metalakeId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaMapper.java
@@ -102,6 +102,15 @@ public interface SchemaMetaMapper {
   Integer updateSchemaMeta(
       @Param("newSchemaMeta") SchemaPO newSchemaPO, @Param("oldSchemaMeta") SchemaPO oldSchemaPO);
 
+  /**
+   * Advances the schema version when the expected OCC version still matches.
+   *
+   * @return the number of updated rows
+   */
+  @UpdateProvider(type = SchemaMetaSQLProviderFactory.class, method = "fenceSchemaMeta")
+  Integer fenceSchemaMeta(
+      @Param("schemaId") Long schemaId, @Param("currentVersion") Long currentVersion);
+
   @UpdateProvider(
       type = SchemaMetaSQLProviderFactory.class,
       method = "softDeleteSchemaMetasBySchemaIds")
@@ -112,6 +121,16 @@ public interface SchemaMetaMapper {
       method = "softDeleteSchemaMetaBySchemaIdAndVersion")
   Integer softDeleteSchemaMetaBySchemaIdAndVersion(
       @Param("schemaId") Long schemaId, @Param("currentVersion") Long currentVersion);
+
+  /**
+   * Soft-deletes schemas whose identifiers and OCC versions still match.
+   *
+   * @return the number of deleted rows
+   */
+  @UpdateProvider(
+      type = SchemaMetaSQLProviderFactory.class,
+      method = "softDeleteSchemaMetasWithVersion")
+  Integer softDeleteSchemaMetasWithVersion(@Param("schemaMetas") List<SchemaPO> schemaPOs);
 
   @UpdateProvider(
       type = SchemaMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaSQLProviderFactory.java
@@ -120,6 +120,11 @@ public class SchemaMetaSQLProviderFactory {
     return getProvider().softDeleteSchemaMetasBySchemaIds(schemaIds);
   }
 
+  public static String softDeleteSchemaMetaBySchemaIdAndVersion(
+      @Param("schemaId") Long schemaId, @Param("currentVersion") Long currentVersion) {
+    return getProvider().softDeleteSchemaMetaBySchemaIdAndVersion(schemaId, currentVersion);
+  }
+
   public static String softDeleteSchemaMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {
     return getProvider().softDeleteSchemaMetasByMetalakeId(metalakeId);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaSQLProviderFactory.java
@@ -116,6 +116,12 @@ public class SchemaMetaSQLProviderFactory {
     return getProvider().updateSchemaMeta(newSchemaPO, oldSchemaPO);
   }
 
+  /** Returns SQL that advances a schema OCC version conditionally. */
+  public static String fenceSchemaMeta(
+      @Param("schemaId") Long schemaId, @Param("currentVersion") Long currentVersion) {
+    return getProvider().fenceSchemaMeta(schemaId, currentVersion);
+  }
+
   public static String softDeleteSchemaMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteSchemaMetasBySchemaIds(schemaIds);
   }
@@ -123,6 +129,12 @@ public class SchemaMetaSQLProviderFactory {
   public static String softDeleteSchemaMetaBySchemaIdAndVersion(
       @Param("schemaId") Long schemaId, @Param("currentVersion") Long currentVersion) {
     return getProvider().softDeleteSchemaMetaBySchemaIdAndVersion(schemaId, currentVersion);
+  }
+
+  /** Returns SQL that soft-deletes schemas using identifier-and-version pairs. */
+  public static String softDeleteSchemaMetasWithVersion(
+      @Param("schemaMetas") List<SchemaPO> schemaPOs) {
+    return getProvider().softDeleteSchemaMetasWithVersion(schemaPOs);
   }
 
   public static String softDeleteSchemaMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/CatalogMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/CatalogMetaBaseSQLProvider.java
@@ -210,6 +210,16 @@ public class CatalogMetaBaseSQLProvider {
         + " AND deleted_at = 0";
   }
 
+  /** Returns SQL that advances a catalog OCC version conditionally. */
+  public String fenceCatalogMeta(
+      @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET last_version = current_version + 1, current_version = current_version + 1"
+        + " WHERE catalog_id = #{catalogId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
+  }
+
   public String softDeleteCatalogMetasByCatalogId(
       @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion) {
     return "UPDATE "
@@ -218,6 +228,21 @@ public class CatalogMetaBaseSQLProvider {
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
         + " WHERE catalog_id = #{catalogId}"
         + " AND current_version = #{currentVersion} AND deleted_at = 0";
+  }
+
+  /** Returns SQL that soft-deletes catalogs using identifier-and-version pairs. */
+  public String softDeleteCatalogMetasWithVersion(
+      @Param("catalogMetas") List<CatalogPO> catalogPOs) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE deleted_at = 0 AND "
+        + "<foreach collection='catalogMetas' item='item' separator=' OR ' open='(' close=')'>"
+        + "(catalog_id = #{item.catalogId} AND current_version = #{item.currentVersion})"
+        + "</foreach>"
+        + "</script>";
   }
 
   public String softDeleteCatalogMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/CatalogMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/CatalogMetaBaseSQLProvider.java
@@ -206,25 +206,18 @@ public class CatalogMetaBaseSQLProvider {
         + " last_version = #{newCatalogMeta.lastVersion},"
         + " deleted_at = #{newCatalogMeta.deletedAt}"
         + " WHERE catalog_id = #{oldCatalogMeta.catalogId}"
-        + " AND catalog_name = #{oldCatalogMeta.catalogName}"
-        + " AND metalake_id = #{oldCatalogMeta.metalakeId}"
-        + " AND type = #{oldCatalogMeta.type}"
-        + " AND provider = #{oldCatalogMeta.provider}"
-        + " AND (catalog_comment = #{oldCatalogMeta.catalogComment} "
-        + "   OR (catalog_comment IS NULL and #{oldCatalogMeta.catalogComment} IS NULL))"
-        + " AND properties = #{oldCatalogMeta.properties}"
-        + " AND audit_info = #{oldCatalogMeta.auditInfo}"
         + " AND current_version = #{oldCatalogMeta.currentVersion}"
-        + " AND last_version = #{oldCatalogMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 
-  public String softDeleteCatalogMetasByCatalogId(@Param("catalogId") Long catalogId) {
+  public String softDeleteCatalogMetasByCatalogId(
+      @Param("catalogId") Long catalogId, @Param("currentVersion") Long currentVersion) {
     return "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
+        + " WHERE catalog_id = #{catalogId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   public String softDeleteCatalogMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/MetalakeMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/MetalakeMetaBaseSQLProvider.java
@@ -143,23 +143,18 @@ public class MetalakeMetaBaseSQLProvider {
         + " current_version = #{newMetalakeMeta.currentVersion},"
         + " last_version = #{newMetalakeMeta.lastVersion}"
         + " WHERE metalake_id = #{oldMetalakeMeta.metalakeId}"
-        + " AND metalake_name = #{oldMetalakeMeta.metalakeName}"
-        + " AND (metalake_comment = #{oldMetalakeMeta.metalakeComment} "
-        + "  OR (metalake_comment IS NULL and #{oldMetalakeMeta.metalakeComment} IS NULL))"
-        + " AND properties = #{oldMetalakeMeta.properties}"
-        + " AND audit_info = #{oldMetalakeMeta.auditInfo}"
-        + " AND schema_version = #{oldMetalakeMeta.schemaVersion}"
         + " AND current_version = #{oldMetalakeMeta.currentVersion}"
-        + " AND last_version = #{oldMetalakeMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 
-  public String softDeleteMetalakeMetaByMetalakeId(@Param("metalakeId") Long metalakeId) {
+  public String softDeleteMetalakeMetaByMetalakeId(
+      @Param("metalakeId") Long metalakeId, @Param("currentVersion") Long currentVersion) {
     return "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
+        + " WHERE metalake_id = #{metalakeId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   public String deleteMetalakeMetasByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/MetalakeMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/MetalakeMetaBaseSQLProvider.java
@@ -147,6 +147,16 @@ public class MetalakeMetaBaseSQLProvider {
         + " AND deleted_at = 0";
   }
 
+  /** Returns SQL that advances a metalake OCC version conditionally. */
+  public String fenceMetalakeMeta(
+      @Param("metalakeId") Long metalakeId, @Param("currentVersion") Long currentVersion) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET last_version = current_version + 1, current_version = current_version + 1"
+        + " WHERE metalake_id = #{metalakeId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
+  }
+
   public String softDeleteMetalakeMetaByMetalakeId(
       @Param("metalakeId") Long metalakeId, @Param("currentVersion") Long currentVersion) {
     return "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
@@ -164,19 +164,18 @@ public class RoleMetaBaseSQLProvider {
         + " last_version = #{newRoleMeta.lastVersion},"
         + " deleted_at = #{newRoleMeta.deletedAt}"
         + " WHERE role_id = #{oldRoleMeta.roleId}"
-        + " AND role_name = #{oldRoleMeta.roleName}"
-        + " AND metalake_id = #{oldRoleMeta.metalakeId}"
         + " AND current_version = #{oldRoleMeta.currentVersion}"
-        + " AND last_version = #{oldRoleMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 
-  public String softDeleteRoleMetaByRoleId(@Param("roleId") Long roleId) {
+  public String softDeleteRoleMetaByRoleId(
+      @Param("roleId") Long roleId, @Param("currentVersion") Long currentVersion) {
     return "UPDATE "
         + ROLE_TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE role_id = #{roleId} AND deleted_at = 0";
+        + " WHERE role_id = #{roleId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   public String softDeleteRoleMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
@@ -273,15 +273,7 @@ public class SchemaMetaBaseSQLProvider {
         + " last_version = #{newSchemaMeta.lastVersion},"
         + " deleted_at = #{newSchemaMeta.deletedAt}"
         + " WHERE schema_id = #{oldSchemaMeta.schemaId}"
-        + " AND schema_name = #{oldSchemaMeta.schemaName}"
-        + " AND metalake_id = #{oldSchemaMeta.metalakeId}"
-        + " AND catalog_id = #{oldSchemaMeta.catalogId}"
-        + " AND (schema_comment = #{oldSchemaMeta.schemaComment}"
-        + "   OR (schema_comment IS NULL and #{oldSchemaMeta.schemaComment} IS NULL))"
-        + " AND properties = #{oldSchemaMeta.properties}"
-        + " AND audit_info = #{oldSchemaMeta.auditInfo}"
         + " AND current_version = #{oldSchemaMeta.currentVersion}"
-        + " AND last_version = #{oldSchemaMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 
@@ -297,6 +289,16 @@ public class SchemaMetaBaseSQLProvider {
         + "</foreach>"
         + ") AND deleted_at = 0"
         + "</script>";
+  }
+
+  public String softDeleteSchemaMetaBySchemaIdAndVersion(
+      @Param("schemaId") Long schemaId, @Param("currentVersion") Long currentVersion) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id = #{schemaId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   public String softDeleteSchemaMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
@@ -277,6 +277,16 @@ public class SchemaMetaBaseSQLProvider {
         + " AND deleted_at = 0";
   }
 
+  /** Returns SQL that advances a schema OCC version conditionally. */
+  public String fenceSchemaMeta(
+      @Param("schemaId") Long schemaId, @Param("currentVersion") Long currentVersion) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET last_version = current_version + 1, current_version = current_version + 1"
+        + " WHERE schema_id = #{schemaId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
+  }
+
   public String softDeleteSchemaMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "
@@ -299,6 +309,20 @@ public class SchemaMetaBaseSQLProvider {
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
         + " WHERE schema_id = #{schemaId}"
         + " AND current_version = #{currentVersion} AND deleted_at = 0";
+  }
+
+  /** Returns SQL that soft-deletes schemas using identifier-and-version pairs. */
+  public String softDeleteSchemaMetasWithVersion(@Param("schemaMetas") List<SchemaPO> schemaPOs) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE deleted_at = 0 AND "
+        + "<foreach collection='schemaMetas' item='item' separator=' OR ' open='(' close=')'>"
+        + "(schema_id = #{item.schemaId} AND current_version = #{item.currentVersion})"
+        + "</foreach>"
+        + "</script>";
   }
 
   public String softDeleteSchemaMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
@@ -26,11 +26,12 @@ import org.apache.ibatis.annotations.Param;
 
 public class CatalogMetaPostgreSQLProvider extends CatalogMetaBaseSQLProvider {
   @Override
-  public String softDeleteCatalogMetasByCatalogId(Long catalogId) {
+  public String softDeleteCatalogMetasByCatalogId(Long catalogId, Long currentVersion) {
     return "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
+        + " WHERE catalog_id = #{catalogId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   @Override
@@ -101,17 +102,7 @@ public class CatalogMetaPostgreSQLProvider extends CatalogMetaBaseSQLProvider {
         + " last_version = #{newCatalogMeta.lastVersion},"
         + " deleted_at = #{newCatalogMeta.deletedAt}"
         + " WHERE catalog_id = #{oldCatalogMeta.catalogId}"
-        + " AND catalog_name = #{oldCatalogMeta.catalogName}"
-        + " AND metalake_id = #{oldCatalogMeta.metalakeId}"
-        + " AND type = #{oldCatalogMeta.type}"
-        + " AND provider = #{oldCatalogMeta.provider}"
-        + " AND (catalog_comment = #{oldCatalogMeta.catalogComment} "
-        + "   OR (CAST(catalog_comment AS VARCHAR) IS NULL AND "
-        + "   CAST(#{oldCatalogMeta.catalogComment} AS VARCHAR) IS NULL))"
-        + " AND properties = #{oldCatalogMeta.properties}"
-        + " AND audit_info = #{oldCatalogMeta.auditInfo}"
         + " AND current_version = #{oldCatalogMeta.currentVersion}"
-        + " AND last_version = #{oldCatalogMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/CatalogMetaPostgreSQLProvider.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
 import static org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper.TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.provider.base.CatalogMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.CatalogPO;
 import org.apache.ibatis.annotations.Param;
@@ -32,6 +33,20 @@ public class CatalogMetaPostgreSQLProvider extends CatalogMetaBaseSQLProvider {
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
         + " WHERE catalog_id = #{catalogId}"
         + " AND current_version = #{currentVersion} AND deleted_at = 0";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String softDeleteCatalogMetasWithVersion(List<CatalogPO> catalogPOs) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE deleted_at = 0 AND "
+        + "<foreach collection='catalogMetas' item='item' separator=' OR ' open='(' close=')'>"
+        + "(catalog_id = #{item.catalogId} AND current_version = #{item.currentVersion})"
+        + "</foreach>"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/MetalakeMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/MetalakeMetaPostgreSQLProvider.java
@@ -26,11 +26,12 @@ import org.apache.ibatis.annotations.Param;
 
 public class MetalakeMetaPostgreSQLProvider extends MetalakeMetaBaseSQLProvider {
   @Override
-  public String softDeleteMetalakeMetaByMetalakeId(Long metalakeId) {
+  public String softDeleteMetalakeMetaByMetalakeId(Long metalakeId, Long currentVersion) {
     return "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
+        + " WHERE metalake_id = #{metalakeId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   @Override
@@ -75,15 +76,7 @@ public class MetalakeMetaPostgreSQLProvider extends MetalakeMetaBaseSQLProvider 
         + " current_version = #{newMetalakeMeta.currentVersion},"
         + " last_version = #{newMetalakeMeta.lastVersion}"
         + " WHERE metalake_id = #{oldMetalakeMeta.metalakeId}"
-        + " AND metalake_name = #{oldMetalakeMeta.metalakeName}"
-        + " AND (metalake_comment = #{oldMetalakeMeta.metalakeComment} "
-        + "  OR (CAST(metalake_comment AS VARCHAR) IS NULL AND "
-        + "  CAST(#{oldMetalakeMeta.metalakeComment} AS VARCHAR) IS NULL))"
-        + " AND properties = #{oldMetalakeMeta.properties}"
-        + " AND audit_info = #{oldMetalakeMeta.auditInfo}"
-        + " AND schema_version = #{oldMetalakeMeta.schemaVersion}"
         + " AND current_version = #{oldMetalakeMeta.currentVersion}"
-        + " AND last_version = #{oldMetalakeMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/RoleMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/RoleMetaPostgreSQLProvider.java
@@ -26,11 +26,13 @@ import org.apache.ibatis.annotations.Param;
 
 public class RoleMetaPostgreSQLProvider extends RoleMetaBaseSQLProvider {
   @Override
-  public String softDeleteRoleMetaByRoleId(@Param("roleId") Long roleId) {
+  public String softDeleteRoleMetaByRoleId(
+      @Param("roleId") Long roleId, @Param("currentVersion") Long currentVersion) {
     return "UPDATE "
         + ROLE_TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE role_id = #{roleId} AND deleted_at = 0";
+        + " WHERE role_id = #{roleId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
@@ -98,16 +98,7 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + " last_version = #{newSchemaMeta.lastVersion},"
         + " deleted_at = #{newSchemaMeta.deletedAt}"
         + " WHERE schema_id = #{oldSchemaMeta.schemaId}"
-        + " AND schema_name = #{oldSchemaMeta.schemaName}"
-        + " AND metalake_id = #{oldSchemaMeta.metalakeId}"
-        + " AND catalog_id = #{oldSchemaMeta.catalogId}"
-        + " AND (schema_comment = #{oldSchemaMeta.schemaComment}"
-        + "   OR (CAST(schema_comment AS VARCHAR) IS NULL"
-        + "   AND CAST(#{oldSchemaMeta.schemaComment} AS VARCHAR) IS NULL))"
-        + " AND properties = #{oldSchemaMeta.properties}"
-        + " AND audit_info = #{oldSchemaMeta.auditInfo}"
         + " AND current_version = #{oldSchemaMeta.currentVersion}"
-        + " AND last_version = #{oldSchemaMeta.lastVersion}"
         + " AND deleted_at = 0";
   }
 
@@ -123,6 +114,15 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + "</foreach>"
         + ") AND deleted_at = 0"
         + "</script>";
+  }
+
+  @Override
+  public String softDeleteSchemaMetaBySchemaIdAndVersion(Long schemaId, Long currentVersion) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id = #{schemaId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
@@ -125,6 +125,20 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public String softDeleteSchemaMetasWithVersion(List<SchemaPO> schemaPOs) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE deleted_at = 0 AND "
+        + "<foreach collection='schemaMetas' item='item' separator=' OR ' open='(' close=')'>"
+        + "(schema_id = #{item.schemaId} AND current_version = #{item.currentVersion})"
+        + "</foreach>"
+        + "</script>";
+  }
+
   @Override
   public String softDeleteSchemaMetasByMetalakeId(Long metalakeId) {
     return "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -229,15 +230,19 @@ public class CatalogMetaService {
     AtomicInteger updateResult = new AtomicInteger(0);
     try {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              updateResult.set(
-                  SessionUtils.getWithoutCommit(
-                      CatalogMetaMapper.class,
-                      mapper ->
-                          mapper.updateCatalogMeta(
-                              POConverters.updateCatalogPOWithVersion(
-                                  oldCatalogPO, newEntity, oldCatalogPO.getMetalakeId()),
-                              oldCatalogPO))),
+          () -> {
+            updateResult.set(
+                SessionUtils.getWithoutCommit(
+                    CatalogMetaMapper.class,
+                    mapper ->
+                        mapper.updateCatalogMeta(
+                            POConverters.updateCatalogPOWithVersion(
+                                oldCatalogPO, newEntity, oldCatalogPO.getMetalakeId()),
+                            oldCatalogPO)));
+            if (updateResult.get() == 0) {
+              throw optimisticLockException(identifier);
+            }
+          },
           () -> {
             if (updateResult.get() > 0) {
               SessionUtils.doWithoutCommit(
@@ -256,11 +261,7 @@ public class CatalogMetaService {
       throw re;
     }
 
-    if (updateResult.get() > 0) {
-      return newEntity;
-    } else {
-      throw new IOException("Failed to update the entity: " + identifier);
-    }
+    return newEntity;
   }
 
   @Monitored(
@@ -270,15 +271,14 @@ public class CatalogMetaService {
     NameIdentifierUtil.checkCatalog(identifier);
 
     String catalogName = identifier.name();
-    long catalogId = EntityIdService.getEntityId(identifier, Entity.EntityType.CATALOG);
+    CatalogPO catalogPO = getCatalogPOByName(identifier.namespace().level(0), catalogName);
+    long catalogId = catalogPO.getCatalogId();
+    long currentVersion = catalogPO.getCurrentVersion();
     String metalakeName = identifier.namespace().level(0);
 
     if (cascade) {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              SessionUtils.doWithoutCommit(
-                  CatalogMetaMapper.class,
-                  mapper -> mapper.softDeleteCatalogMetasByCatalogId(catalogId)),
+          () -> deleteCatalogWithVersion(identifier, catalogId, currentVersion),
           () ->
               SessionUtils.doWithoutCommit(
                   SchemaMetaMapper.class,
@@ -368,10 +368,7 @@ public class CatalogMetaService {
             "Entity %s has sub-entities, you should remove sub-entities first", identifier);
       }
       SessionUtils.doMultipleWithCommit(
-          () ->
-              SessionUtils.doWithoutCommit(
-                  CatalogMetaMapper.class,
-                  mapper -> mapper.softDeleteCatalogMetasByCatalogId(catalogId)),
+          () -> deleteCatalogWithVersion(identifier, catalogId, currentVersion),
           () ->
               SessionUtils.doWithoutCommit(
                   OwnerMetaMapper.class,
@@ -413,6 +410,22 @@ public class CatalogMetaService {
     }
 
     return true;
+  }
+
+  private void deleteCatalogWithVersion(
+      NameIdentifier identifier, Long catalogId, Long currentVersion) {
+    int deleted =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class,
+            mapper -> mapper.softDeleteCatalogMetasByCatalogId(catalogId, currentVersion));
+    if (deleted == 0) {
+      throw optimisticLockException(identifier);
+    }
+  }
+
+  private OptimisticLockException optimisticLockException(NameIdentifier identifier) {
+    return new OptimisticLockException(
+        "The catalog %s was modified concurrently; retry the operation", identifier);
   }
 
   @Monitored(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
@@ -36,7 +36,6 @@ import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.CatalogEntity;
-import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.helper.CatalogIds;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
@@ -45,6 +44,7 @@ import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionAliasRelMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionMetaMapper;
@@ -59,6 +59,8 @@ import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper
 import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
 import org.apache.gravitino.storage.relational.po.CatalogPO;
+import org.apache.gravitino.storage.relational.po.MetalakePO;
+import org.apache.gravitino.storage.relational.po.SchemaPO;
 import org.apache.gravitino.storage.relational.po.cache.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
@@ -182,20 +184,32 @@ public class CatalogMetaService {
     try {
       NameIdentifierUtil.checkCatalog(catalogEntity.nameIdentifier());
 
-      String metalake = NameIdentifierUtil.getMetalake(catalogEntity.nameIdentifier());
-      Long metalakeId =
-          EntityIdService.getEntityId(NameIdentifier.of(metalake), Entity.EntityType.METALAKE);
+      String metalakeName = NameIdentifierUtil.getMetalake(catalogEntity.nameIdentifier());
+      MetalakePO metalakePO =
+          SessionUtils.getWithoutCommit(
+              MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalakeName));
+      if (metalakePO == null) {
+        throw new NoSuchEntityException(
+            NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+            Entity.EntityType.METALAKE.name().toLowerCase(),
+            metalakeName);
+      }
 
-      SessionUtils.doWithCommit(
-          CatalogMetaMapper.class,
-          mapper -> {
-            CatalogPO po = POConverters.initializeCatalogPOWithVersion(catalogEntity, metalakeId);
-            if (overwrite) {
-              mapper.insertCatalogMetaOnDuplicateKeyUpdate(po);
-            } else {
-              mapper.insertCatalogMeta(po);
-            }
-          });
+      SessionUtils.doMultipleWithCommit(
+          () -> fenceMetalakeForCatalogCreate(metalakePO),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  CatalogMetaMapper.class,
+                  mapper -> {
+                    CatalogPO po =
+                        POConverters.initializeCatalogPOWithVersion(
+                            catalogEntity, metalakePO.getMetalakeId());
+                    if (overwrite) {
+                      mapper.insertCatalogMetaOnDuplicateKeyUpdate(po);
+                    } else {
+                      mapper.insertCatalogMeta(po);
+                    }
+                  }));
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.CATALOG, catalogEntity.nameIdentifier().toString());
@@ -278,11 +292,10 @@ public class CatalogMetaService {
 
     if (cascade) {
       SessionUtils.doMultipleWithCommit(
-          () -> deleteCatalogWithVersion(identifier, catalogId, currentVersion),
-          () ->
-              SessionUtils.doWithoutCommit(
-                  SchemaMetaMapper.class,
-                  mapper -> mapper.softDeleteSchemaMetasByCatalogId(catalogId)),
+          () -> {
+            deleteCatalogWithVersion(identifier, catalogId, currentVersion);
+            deleteSchemasWithVersions(identifier, catalogId);
+          },
           () ->
               SessionUtils.doWithoutCommit(
                   TableMetaMapper.class,
@@ -359,16 +372,17 @@ public class CatalogMetaService {
                         OperateType.DROP));
           });
     } else {
-      List<SchemaEntity> schemaEntities =
-          SchemaMetaService.getInstance()
-              .listSchemasByNamespace(
-                  NamespaceUtil.ofSchema(identifier.namespace().level(0), catalogName));
-      if (!schemaEntities.isEmpty()) {
-        throw new NonEmptyEntityException(
-            "Entity %s has sub-entities, you should remove sub-entities first", identifier);
-      }
       SessionUtils.doMultipleWithCommit(
-          () -> deleteCatalogWithVersion(identifier, catalogId, currentVersion),
+          () -> {
+            deleteCatalogWithVersion(identifier, catalogId, currentVersion);
+            List<SchemaPO> schemaPOs =
+                SessionUtils.getWithoutCommit(
+                    SchemaMetaMapper.class, mapper -> mapper.listSchemaPOsByCatalogId(catalogId));
+            if (!schemaPOs.isEmpty()) {
+              throw new NonEmptyEntityException(
+                  "Entity %s has sub-entities, you should remove sub-entities first", identifier);
+            }
+          },
           () ->
               SessionUtils.doWithoutCommit(
                   OwnerMetaMapper.class,
@@ -420,6 +434,37 @@ public class CatalogMetaService {
             mapper -> mapper.softDeleteCatalogMetasByCatalogId(catalogId, currentVersion));
     if (deleted == 0) {
       throw optimisticLockException(identifier);
+    }
+  }
+
+  private void fenceMetalakeForCatalogCreate(MetalakePO metalakePO) {
+    int fenced =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class,
+            mapper ->
+                mapper.fenceMetalakeMeta(
+                    metalakePO.getMetalakeId(), metalakePO.getCurrentVersion()));
+    if (fenced == 0) {
+      throw new OptimisticLockException(
+          "The parent metalake %s was modified concurrently; retry the operation",
+          metalakePO.getMetalakeName());
+    }
+  }
+
+  private void deleteSchemasWithVersions(NameIdentifier catalogIdentifier, Long catalogId) {
+    List<SchemaPO> schemaPOs =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class, mapper -> mapper.listSchemaPOsByCatalogId(catalogId));
+    if (schemaPOs.isEmpty()) {
+      return;
+    }
+    int deleted =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class, mapper -> mapper.softDeleteSchemaMetasWithVersion(schemaPOs));
+    if (deleted != schemaPOs.size()) {
+      throw new OptimisticLockException(
+          "A schema under catalog %s was modified concurrently; retry the operation",
+          catalogIdentifier);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
@@ -33,6 +33,7 @@ import org.apache.gravitino.HasIdentifier;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -183,11 +184,15 @@ public class MetalakeMetaService {
     AtomicInteger updateResult = new AtomicInteger(0);
     try {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              updateResult.set(
-                  SessionUtils.getWithoutCommit(
-                      MetalakeMetaMapper.class,
-                      mapper -> mapper.updateMetalakeMeta(newMetalakePO, oldMetalakePO))),
+          () -> {
+            updateResult.set(
+                SessionUtils.getWithoutCommit(
+                    MetalakeMetaMapper.class,
+                    mapper -> mapper.updateMetalakeMeta(newMetalakePO, oldMetalakePO)));
+            if (updateResult.get() == 0) {
+              throw optimisticLockException(ident);
+            }
+          },
           () -> {
             if (isRenamed && updateResult.get() > 0) {
               SessionUtils.doWithoutCommit(
@@ -206,11 +211,7 @@ public class MetalakeMetaService {
       throw re;
     }
 
-    if (updateResult.get() > 0) {
-      return newMetalakeEntity;
-    } else {
-      throw new IOException("Failed to update the entity: " + ident);
-    }
+    return newMetalakeEntity;
   }
 
   @Monitored(
@@ -218,14 +219,21 @@ public class MetalakeMetaService {
       baseMetricName = "deleteMetalake")
   public boolean deleteMetalake(NameIdentifier ident, boolean cascade) {
     NameIdentifierUtil.checkMetalake(ident);
-    Long metalakeId = getMetalakeIdByName(ident.name());
+    MetalakePO metalakePO =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(ident.name()));
+    if (metalakePO == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.METALAKE.name().toLowerCase(),
+          ident.toString());
+    }
+    Long metalakeId = metalakePO.getMetalakeId();
+    Long currentVersion = metalakePO.getCurrentVersion();
     if (metalakeId != null) {
       if (cascade) {
         SessionUtils.doMultipleWithCommit(
-            () ->
-                SessionUtils.doWithoutCommit(
-                    MetalakeMetaMapper.class,
-                    mapper -> mapper.softDeleteMetalakeMetaByMetalakeId(metalakeId)),
+            () -> deleteMetalakeWithVersion(ident, metalakeId, currentVersion),
             () ->
                 SessionUtils.doWithoutCommit(
                     CatalogMetaMapper.class,
@@ -353,10 +361,7 @@ public class MetalakeMetaService {
               "Entity %s has sub-entities, you should remove sub-entities first", ident);
         }
         SessionUtils.doMultipleWithCommit(
-            () ->
-                SessionUtils.doWithoutCommit(
-                    MetalakeMetaMapper.class,
-                    mapper -> mapper.softDeleteMetalakeMetaByMetalakeId(metalakeId)),
+            () -> deleteMetalakeWithVersion(ident, metalakeId, currentVersion),
             () ->
                 SessionUtils.doWithoutCommit(
                     UserRoleRelMapper.class,
@@ -418,6 +423,22 @@ public class MetalakeMetaService {
       }
     }
     return true;
+  }
+
+  private void deleteMetalakeWithVersion(
+      NameIdentifier identifier, Long metalakeId, Long currentVersion) {
+    int deleted =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class,
+            mapper -> mapper.softDeleteMetalakeMetaByMetalakeId(metalakeId, currentVersion));
+    if (deleted == 0) {
+      throw optimisticLockException(identifier);
+    }
+  }
+
+  private OptimisticLockException optimisticLockException(NameIdentifier identifier) {
+    return new OptimisticLockException(
+        "The metalake %s was modified concurrently; retry the operation", identifier);
   }
 
   @Monitored(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
@@ -35,7 +35,6 @@ import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.BaseMetalake;
-import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
@@ -66,13 +65,13 @@ import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.UserRoleRelMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
+import org.apache.gravitino.storage.relational.po.CatalogPO;
 import org.apache.gravitino.storage.relational.po.MetalakePO;
 import org.apache.gravitino.storage.relational.po.cache.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
-import org.apache.gravitino.utils.NamespaceUtil;
 
 /**
  * The service class for metalake metadata. It provides the basic database operations for metalake.
@@ -233,11 +232,10 @@ public class MetalakeMetaService {
     if (metalakeId != null) {
       if (cascade) {
         SessionUtils.doMultipleWithCommit(
-            () -> deleteMetalakeWithVersion(ident, metalakeId, currentVersion),
-            () ->
-                SessionUtils.doWithoutCommit(
-                    CatalogMetaMapper.class,
-                    mapper -> mapper.softDeleteCatalogMetasByMetalakeId(metalakeId)),
+            () -> {
+              deleteMetalakeWithVersion(ident, metalakeId, currentVersion);
+              deleteCatalogsWithVersions(ident, metalakeId);
+            },
             () ->
                 SessionUtils.doWithoutCommit(
                     SchemaMetaMapper.class,
@@ -353,15 +351,18 @@ public class MetalakeMetaService {
                           OperateType.DROP));
             });
       } else {
-        List<CatalogEntity> catalogEntities =
-            CatalogMetaService.getInstance()
-                .listCatalogsByNamespace(NamespaceUtil.ofCatalog(ident.name()));
-        if (!catalogEntities.isEmpty()) {
-          throw new NonEmptyEntityException(
-              "Entity %s has sub-entities, you should remove sub-entities first", ident);
-        }
         SessionUtils.doMultipleWithCommit(
-            () -> deleteMetalakeWithVersion(ident, metalakeId, currentVersion),
+            () -> {
+              deleteMetalakeWithVersion(ident, metalakeId, currentVersion);
+              List<CatalogPO> catalogPOs =
+                  SessionUtils.getWithoutCommit(
+                      CatalogMetaMapper.class,
+                      mapper -> mapper.listCatalogPOsByMetalakeId(metalakeId));
+              if (!catalogPOs.isEmpty()) {
+                throw new NonEmptyEntityException(
+                    "Entity %s has sub-entities, you should remove sub-entities first", ident);
+              }
+            },
             () ->
                 SessionUtils.doWithoutCommit(
                     UserRoleRelMapper.class,
@@ -425,14 +426,31 @@ public class MetalakeMetaService {
     return true;
   }
 
-  private void deleteMetalakeWithVersion(
-      NameIdentifier identifier, Long metalakeId, Long currentVersion) {
+  void deleteMetalakeWithVersion(NameIdentifier identifier, Long metalakeId, Long currentVersion) {
     int deleted =
         SessionUtils.getWithoutCommit(
             MetalakeMetaMapper.class,
             mapper -> mapper.softDeleteMetalakeMetaByMetalakeId(metalakeId, currentVersion));
     if (deleted == 0) {
       throw optimisticLockException(identifier);
+    }
+  }
+
+  private void deleteCatalogsWithVersions(NameIdentifier metalakeIdentifier, Long metalakeId) {
+    List<CatalogPO> catalogPOs =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class, mapper -> mapper.listCatalogPOsByMetalakeId(metalakeId));
+    if (catalogPOs.isEmpty()) {
+      return;
+    }
+    int deleted =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class,
+            mapper -> mapper.softDeleteCatalogMetasWithVersion(catalogPOs));
+    if (deleted != catalogPOs.size()) {
+      throw new OptimisticLockException(
+          "A catalog under metalake %s was modified concurrently; retry the operation",
+          metalakeIdentifier);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -46,10 +46,12 @@ import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.mapper.GroupRoleRelMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.mapper.UserRoleRelMapper;
+import org.apache.gravitino.storage.relational.po.MetalakePO;
 import org.apache.gravitino.storage.relational.po.RolePO;
 import org.apache.gravitino.storage.relational.po.SecurableObjectPO;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
@@ -155,8 +157,17 @@ public class RoleMetaService {
       AuthorizationUtils.checkRole(roleEntity.nameIdentifier());
 
       String metalake = NameIdentifierUtil.getMetalake(roleEntity.nameIdentifier());
-      Long metalakeId = MetalakeMetaService.getInstance().getMetalakeIdByName(metalake);
-      RolePO.Builder builder = RolePO.builder().withMetalakeId(metalakeId);
+      MetalakePO metalakePO =
+          SessionUtils.getWithoutCommit(
+              MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalake));
+      if (metalakePO == null) {
+        throw new NoSuchEntityException(
+            NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+            Entity.EntityType.METALAKE.name().toLowerCase(),
+            metalake);
+      }
+
+      RolePO.Builder builder = RolePO.builder().withMetalakeId(metalakePO.getMetalakeId());
       RolePO rolePO = POConverters.initializeRolePOWithVersion(roleEntity, builder);
       List<SecurableObjectPO> securableObjectPOs = Lists.newArrayList();
       for (SecurableObject object : roleEntity.securableObjects()) {
@@ -170,6 +181,17 @@ public class RoleMetaService {
       }
 
       SessionUtils.doMultipleWithCommit(
+          () -> fenceMetalakeForRoleCreate(metalakePO),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  RoleMetaMapper.class,
+                  mapper -> {
+                    if (overwritten) {
+                      mapper.insertRoleMetaOnDuplicateKeyUpdate(rolePO);
+                    } else {
+                      mapper.insertRoleMeta(rolePO);
+                    }
+                  }),
           () ->
               SessionUtils.doWithoutCommit(
                   SecurableObjectMapper.class,
@@ -179,16 +201,6 @@ public class RoleMetaService {
                     }
                     if (!securableObjectPOs.isEmpty()) {
                       mapper.batchInsertSecurableObjects(securableObjectPOs);
-                    }
-                  }),
-          () ->
-              SessionUtils.doWithoutCommit(
-                  RoleMetaMapper.class,
-                  mapper -> {
-                    if (overwritten) {
-                      mapper.insertRoleMetaOnDuplicateKeyUpdate(rolePO);
-                    } else {
-                      mapper.insertRoleMeta(rolePO);
                     }
                   }));
 
@@ -225,10 +237,6 @@ public class RoleMetaService {
       Set<SecurableObject> newObjects = new HashSet<>(newRoleEntity.securableObjects());
       Set<SecurableObject> insertObjects = Sets.difference(newObjects, oldObjects);
       Set<SecurableObject> deleteObjects = Sets.difference(oldObjects, newObjects);
-
-      if (insertObjects.isEmpty() && deleteObjects.isEmpty()) {
-        return newRoleEntity;
-      }
 
       List<SecurableObjectPO> deleteSecurableObjectPOs =
           toSecurableObjectPOs(deleteObjects, oldRoleEntity, metalake);
@@ -471,6 +479,20 @@ public class RoleMetaService {
   private OptimisticLockException optimisticLockException(NameIdentifier identifier) {
     return new OptimisticLockException(
         "The role %s was modified concurrently; retry the operation", identifier);
+  }
+
+  private void fenceMetalakeForRoleCreate(MetalakePO metalakePO) {
+    int fenced =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class,
+            mapper ->
+                mapper.fenceMetalakeMeta(
+                    metalakePO.getMetalakeId(), metalakePO.getCurrentVersion()));
+    if (fenced == 0) {
+      throw new OptimisticLockException(
+          "The parent metalake %s was modified concurrently; retry the operation",
+          metalakePO.getMetalakeName());
+    }
   }
 
   private static MetadataObject.Type getType(String type) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -41,6 +41,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.metrics.Monitored;
@@ -236,12 +237,17 @@ public class RoleMetaService {
           toSecurableObjectPOs(insertObjects, oldRoleEntity, metalake);
 
       SessionUtils.doMultipleWithCommit(
-          () ->
-              SessionUtils.doWithoutCommit(
-                  RoleMetaMapper.class,
-                  mapper ->
-                      mapper.updateRoleMeta(
-                          POConverters.updateRolePOWithVersion(rolePO, newRoleEntity), rolePO)),
+          () -> {
+            int updated =
+                SessionUtils.getWithoutCommit(
+                    RoleMetaMapper.class,
+                    mapper ->
+                        mapper.updateRoleMeta(
+                            POConverters.updateRolePOWithVersion(rolePO, newRoleEntity), rolePO));
+            if (updated == 0) {
+              throw optimisticLockException(identifier);
+            }
+          },
           () -> {
             if (deleteSecurableObjectPOs.isEmpty()) {
               return;
@@ -308,12 +314,19 @@ public class RoleMetaService {
 
     Long metalakeId =
         MetalakeMetaService.getInstance().getMetalakeIdByName(identifier.namespace().level(0));
-    Long roleId = getRoleIdByMetalakeIdAndName(metalakeId, identifier.name());
+    RolePO rolePO = getRolePOByMetalakeIdAndName(metalakeId, identifier.name());
+    Long roleId = rolePO.getRoleId();
 
     SessionUtils.doMultipleWithCommit(
-        () ->
-            SessionUtils.doWithoutCommit(
-                RoleMetaMapper.class, mapper -> mapper.softDeleteRoleMetaByRoleId(roleId)),
+        () -> {
+          int deleted =
+              SessionUtils.getWithoutCommit(
+                  RoleMetaMapper.class,
+                  mapper -> mapper.softDeleteRoleMetaByRoleId(roleId, rolePO.getCurrentVersion()));
+          if (deleted == 0) {
+            throw optimisticLockException(identifier);
+          }
+        },
         () ->
             SessionUtils.doWithoutCommit(
                 UserRoleRelMapper.class, mapper -> mapper.softDeleteUserRoleRelByRoleId(roleId)),
@@ -453,6 +466,11 @@ public class RoleMetaService {
           roleName);
     }
     return rolePO;
+  }
+
+  private OptimisticLockException optimisticLockException(NameIdentifier identifier) {
+    return new OptimisticLockException(
+        "The role %s was modified concurrently; retry the operation", identifier);
   }
 
   private static MetadataObject.Type getType(String type) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.NamespacedEntityId;
@@ -230,15 +231,19 @@ public class SchemaMetaService {
     AtomicInteger updateResult = new AtomicInteger(0);
     try {
       SessionUtils.doMultipleWithCommit(
-          () ->
-              updateResult.set(
-                  SessionUtils.getWithoutCommit(
-                      SchemaMetaMapper.class,
-                      mapper ->
-                          ops.updatePO(
-                              mapper,
-                              POConverters.updateSchemaPOWithVersion(oldSchemaPO, newEntity),
-                              oldSchemaPO))),
+          () -> {
+            updateResult.set(
+                SessionUtils.getWithoutCommit(
+                    SchemaMetaMapper.class,
+                    mapper ->
+                        ops.updatePO(
+                            mapper,
+                            POConverters.updateSchemaPOWithVersion(oldSchemaPO, newEntity),
+                            oldSchemaPO)));
+            if (updateResult.get() == 0) {
+              throw optimisticLockException(identifier);
+            }
+          },
           () -> {
             if (isRenamed && updateResult.get() > 0) {
               SessionUtils.doWithoutCommit(
@@ -257,11 +262,7 @@ public class SchemaMetaService {
       throw re;
     }
 
-    if (updateResult.get() > 0) {
-      return newEntity;
-    } else {
-      throw new IOException("Failed to update the entity: " + identifier);
-    }
+    return newEntity;
   }
 
   @Monitored(
@@ -287,11 +288,17 @@ public class SchemaMetaService {
       if (schemaIds.isEmpty()) {
         return false;
       }
+      List<Long> descendantSchemaIds =
+          schemaIds.stream().filter(id -> !id.equals(schemaId)).collect(Collectors.toList());
       SessionUtils.doMultipleWithCommit(
-          () ->
+          () -> deleteSchemaWithVersion(identifier, schemaId, schemaPO.getCurrentVersion()),
+          () -> {
+            if (!descendantSchemaIds.isEmpty()) {
               SessionUtils.doWithoutCommit(
                   SchemaMetaMapper.class,
-                  mapper -> mapper.softDeleteSchemaMetasBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteSchemaMetasBySchemaIds(descendantSchemaIds));
+            }
+          },
           () ->
               SessionUtils.doWithoutCommit(
                   TableMetaMapper.class,
@@ -411,12 +418,8 @@ public class SchemaMetaService {
             "Entity %s has sub-entities, you should remove sub-entities first", identifier);
       }
 
-      List<Long> singleSchemaId = Collections.singletonList(schemaId);
       SessionUtils.doMultipleWithCommit(
-          () ->
-              SessionUtils.doWithoutCommit(
-                  SchemaMetaMapper.class,
-                  mapper -> mapper.softDeleteSchemaMetasBySchemaIds(singleSchemaId)),
+          () -> deleteSchemaWithVersion(identifier, schemaId, schemaPO.getCurrentVersion()),
           () ->
               SessionUtils.doWithoutCommit(
                   OwnerMetaMapper.class,
@@ -457,6 +460,22 @@ public class SchemaMetaService {
           });
     }
     return true;
+  }
+
+  private void deleteSchemaWithVersion(
+      NameIdentifier identifier, Long schemaId, Long currentVersion) {
+    int deleted =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class,
+            mapper -> mapper.softDeleteSchemaMetaBySchemaIdAndVersion(schemaId, currentVersion));
+    if (deleted == 0) {
+      throw optimisticLockException(identifier);
+    }
+  }
+
+  private OptimisticLockException optimisticLockException(NameIdentifier identifier) {
+    return new OptimisticLockException(
+        "The schema %s was modified concurrently; retry the operation", identifier);
   }
 
   @Monitored(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -26,9 +26,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -41,15 +42,11 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.OptimisticLockException;
-import org.apache.gravitino.meta.FilesetEntity;
-import org.apache.gravitino.meta.ModelEntity;
-import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.meta.SchemaEntity;
-import org.apache.gravitino.meta.TableEntity;
-import org.apache.gravitino.meta.TopicEntity;
 import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.storage.relational.helper.SchemaIds;
+import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
@@ -68,6 +65,7 @@ import org.apache.gravitino.storage.relational.mapper.TableMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
+import org.apache.gravitino.storage.relational.po.CatalogPO;
 import org.apache.gravitino.storage.relational.po.SchemaPO;
 import org.apache.gravitino.storage.relational.po.cache.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
@@ -146,6 +144,10 @@ public class SchemaMetaService {
       // rewriter to translate each PO's name to storage form before SQL execution.
       String logicalSep = HierarchicalSchemaUtil.schemaSeparator();
       String schemaName = schemaEntity.name();
+      String metalakeName = schemaEntity.namespace().level(0);
+      String catalogName = schemaEntity.namespace().level(1);
+      CatalogPO catalogPO =
+          CatalogMetaService.getInstance().getCatalogPOByName(metalakeName, catalogName);
       List<SchemaEntity> rowsToInsert = new ArrayList<>();
       if (schemaName == null || !schemaName.contains(logicalSep)) {
         rowsToInsert.add(schemaEntity);
@@ -168,39 +170,46 @@ public class SchemaMetaService {
         rowsToInsert.add(schemaEntity);
       }
 
-      SessionUtils.doWithCommit(
-          SchemaMetaMapper.class,
-          mapper -> {
-            int n = rowsToInsert.size();
-            List<SchemaPO> missingAncestorPOs = new ArrayList<>();
-            if (n > 1) {
-              SchemaEntity firstAncestor = rowsToInsert.get(0);
-              Namespace ancestorNs = firstAncestor.namespace();
-              List<String> ancestorNames =
-                  rowsToInsert.subList(0, n - 1).stream()
-                      .map(SchemaEntity::name)
-                      .collect(Collectors.toList());
-              Set<String> existingLogicalNames =
-                  ops.listPOs(mapper, ancestorNs, ancestorNames).stream()
-                      .map(SchemaPO::getSchemaName)
-                      .collect(Collectors.toSet());
-              for (SchemaEntity row : rowsToInsert.subList(0, n - 1)) {
-                if (existingLogicalNames.contains(row.name())) {
-                  continue;
-                }
-                SchemaPO.Builder builder = SchemaPO.builder();
-                fillSchemaPOBuilderParentEntityId(builder, row.namespace());
-                missingAncestorPOs.add(POConverters.initializeSchemaPOWithVersion(row, builder));
-              }
-            }
-            SchemaEntity leafRow = rowsToInsert.get(n - 1);
-            SchemaPO.Builder leafBuilder = SchemaPO.builder();
-            fillSchemaPOBuilderParentEntityId(leafBuilder, leafRow.namespace());
-            SchemaPO leafPO = POConverters.initializeSchemaPOWithVersion(leafRow, leafBuilder);
-            List<SchemaPO> schemaPosToInsert = new ArrayList<>(missingAncestorPOs);
-            schemaPosToInsert.add(leafPO);
-            ops.batchInsertPOs(mapper, schemaPosToInsert, overwrite);
-          });
+      SessionUtils.doMultipleWithCommit(
+          () -> fenceCatalogForSchemaCreate(catalogPO),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  SchemaMetaMapper.class,
+                  mapper -> {
+                    int n = rowsToInsert.size();
+                    List<SchemaPO> missingAncestorPOs = new ArrayList<>();
+                    if (n > 1) {
+                      SchemaEntity firstAncestor = rowsToInsert.get(0);
+                      Namespace ancestorNs = firstAncestor.namespace();
+                      List<String> ancestorNames =
+                          rowsToInsert.subList(0, n - 1).stream()
+                              .map(SchemaEntity::name)
+                              .collect(Collectors.toList());
+                      Map<String, SchemaPO> existingAncestors =
+                          ops.listPOs(mapper, ancestorNs, ancestorNames).stream()
+                              .collect(
+                                  Collectors.toMap(SchemaPO::getSchemaName, Function.identity()));
+                      for (SchemaEntity row : rowsToInsert.subList(0, n - 1)) {
+                        SchemaPO existingAncestor = existingAncestors.get(row.name());
+                        if (existingAncestor != null) {
+                          fenceSchemaAncestor(
+                              mapper, existingAncestor, schemaEntity.nameIdentifier());
+                          continue;
+                        }
+                        SchemaPO.Builder builder = newSchemaPOBuilder(catalogPO);
+                        missingAncestorPOs.add(
+                            POConverters.initializeSchemaPOWithVersion(row, builder));
+                      }
+                    }
+                    if (!missingAncestorPOs.isEmpty()) {
+                      ops.batchInsertPOs(mapper, missingAncestorPOs, false);
+                    }
+                    SchemaEntity leafRow = rowsToInsert.get(n - 1);
+                    SchemaPO leafPO =
+                        POConverters.initializeSchemaPOWithVersion(
+                            leafRow, newSchemaPOBuilder(catalogPO));
+                    ops.batchInsertPOs(mapper, Collections.singletonList(leafPO), overwrite);
+                  }));
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.SCHEMA, schemaEntity.nameIdentifier().toString());
@@ -280,87 +289,81 @@ public class SchemaMetaService {
         NameIdentifierUtil.ofSchema(metalakeName, catalogName, schemaName).toString();
 
     if (cascade) {
-      // For HierarchicalSchema, deleting `A:B` must also cascade into all descendant schemas
-      // such as `A:B:C`, `A:B:C:D`, etc. Collect the descendant schema ids up-front and run a
-      // single batch UPDATE per child table so the total SQL cost stays bounded regardless of
-      // how many descendants exist.
-      List<Long> schemaIds = listSchemaIdsForCascade(schemaPO);
-      if (schemaIds.isEmpty()) {
-        return false;
-      }
-      List<Long> descendantSchemaIds =
-          schemaIds.stream().filter(id -> !id.equals(schemaId)).collect(Collectors.toList());
+      AtomicReference<List<Long>> schemaIds = new AtomicReference<>();
       SessionUtils.doMultipleWithCommit(
-          () -> deleteSchemaWithVersion(identifier, schemaId, schemaPO.getCurrentVersion()),
           () -> {
-            if (!descendantSchemaIds.isEmpty()) {
-              SessionUtils.doWithoutCommit(
-                  SchemaMetaMapper.class,
-                  mapper -> mapper.softDeleteSchemaMetasBySchemaIds(descendantSchemaIds));
-            }
+            deleteSchemaWithVersion(identifier, schemaId, schemaPO.getCurrentVersion());
+            List<SchemaPO> descendants = listDescendantSchemaPOs(schemaPO);
+            deleteDescendantSchemasWithVersions(identifier, descendants);
+            List<Long> ids = new ArrayList<>(descendants.size() + 1);
+            ids.add(schemaId);
+            descendants.stream().map(SchemaPO::getSchemaId).forEach(ids::add);
+            schemaIds.set(ids);
           },
           () ->
               SessionUtils.doWithoutCommit(
                   TableMetaMapper.class,
-                  mapper -> mapper.softDeleteTableMetasBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteTableMetasBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   TableColumnMapper.class,
-                  mapper -> mapper.softDeleteColumnsBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteColumnsBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   FilesetMetaMapper.class,
-                  mapper -> mapper.softDeleteFilesetMetasBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteFilesetMetasBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   FilesetVersionMapper.class,
-                  mapper -> mapper.softDeleteFilesetVersionsBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteFilesetVersionsBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   TopicMetaMapper.class,
-                  mapper -> mapper.softDeleteTopicMetasBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteTopicMetasBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   FunctionMetaMapper.class,
-                  mapper -> mapper.softDeleteFunctionMetasBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteFunctionMetasBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   FunctionVersionMetaMapper.class,
-                  mapper -> mapper.softDeleteFunctionVersionMetasBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteFunctionVersionMetasBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
-                  OwnerMetaMapper.class, mapper -> mapper.softDeleteOwnerRelBySchemaIds(schemaIds)),
+                  OwnerMetaMapper.class,
+                  mapper -> mapper.softDeleteOwnerRelBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   SecurableObjectMapper.class,
-                  mapper -> mapper.softDeleteObjectRelsBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteObjectRelsBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   TagMetadataObjectRelMapper.class,
-                  mapper -> mapper.softDeleteTagMetadataObjectRelsBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteTagMetadataObjectRelsBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   PolicyMetadataObjectRelMapper.class,
-                  mapper -> mapper.softDeletePolicyMetadataObjectRelsBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeletePolicyMetadataObjectRelsBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   ModelVersionAliasRelMapper.class,
-                  mapper -> mapper.softDeleteModelVersionAliasRelsBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteModelVersionAliasRelsBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   ModelVersionMetaMapper.class,
-                  mapper -> mapper.softDeleteModelVersionMetasBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteModelVersionMetasBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   ModelMetaMapper.class,
-                  mapper -> mapper.softDeleteModelMetasBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteModelMetasBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   StatisticMetaMapper.class,
-                  mapper -> mapper.softDeleteStatisticsBySchemaIds(schemaIds)),
+                  mapper -> mapper.softDeleteStatisticsBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
-                  ViewMetaMapper.class, mapper -> mapper.softDeleteViewMetasBySchemaIds(schemaIds)),
+                  ViewMetaMapper.class,
+                  mapper -> mapper.softDeleteViewMetasBySchemaIds(schemaIds.get())),
           () -> {
             SessionUtils.doWithoutCommit(
                 EntityChangeLogMapper.class,
@@ -372,54 +375,11 @@ public class SchemaMetaService {
                         OperateType.DROP));
           });
     } else {
-      List<TableEntity> tableEntities =
-          TableMetaService.getInstance()
-              .listTablesByNamespace(
-                  NamespaceUtil.ofTable(
-                      identifier.namespace().level(0),
-                      identifier.namespace().level(1),
-                      schemaName));
-      if (!tableEntities.isEmpty()) {
-        throw new NonEmptyEntityException(
-            "Entity %s has sub-entities, you should remove sub-entities first", identifier);
-      }
-      List<FilesetEntity> filesetEntities =
-          FilesetMetaService.getInstance()
-              .listFilesetsByNamespace(
-                  NamespaceUtil.ofFileset(
-                      identifier.namespace().level(0),
-                      identifier.namespace().level(1),
-                      schemaName));
-      if (!filesetEntities.isEmpty()) {
-        throw new NonEmptyEntityException(
-            "Entity %s has sub-entities, you should remove sub-entities first", identifier);
-      }
-      List<ModelEntity> modelEntities =
-          ModelMetaService.getInstance()
-              .listModelsByNamespace(
-                  NamespaceUtil.ofModel(
-                      identifier.namespace().level(0),
-                      identifier.namespace().level(1),
-                      schemaName));
-      if (!modelEntities.isEmpty()) {
-        throw new NonEmptyEntityException(
-            "Entity %s has sub-entities, you should remove sub-entities first", identifier);
-      }
-
-      List<TopicEntity> topicEntities =
-          TopicMetaService.getInstance()
-              .listTopicsByNamespace(
-                  NamespaceUtil.ofTopic(
-                      identifier.namespace().level(0),
-                      identifier.namespace().level(1),
-                      schemaName));
-      if (!topicEntities.isEmpty()) {
-        throw new NonEmptyEntityException(
-            "Entity %s has sub-entities, you should remove sub-entities first", identifier);
-      }
-
       SessionUtils.doMultipleWithCommit(
-          () -> deleteSchemaWithVersion(identifier, schemaId, schemaPO.getCurrentVersion()),
+          () -> {
+            deleteSchemaWithVersion(identifier, schemaId, schemaPO.getCurrentVersion());
+            checkSchemaIsEmpty(identifier, schemaPO);
+          },
           () ->
               SessionUtils.doWithoutCommit(
                   OwnerMetaMapper.class,
@@ -511,13 +471,78 @@ public class SchemaMetaService {
         mapper -> POStorageReadRouting.listPOs(mapper, namespace, ops, Entity.EntityType.SCHEMA));
   }
 
+  private void fenceCatalogForSchemaCreate(CatalogPO catalogPO) {
+    int fenced =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class,
+            mapper ->
+                mapper.fenceCatalogMeta(catalogPO.getCatalogId(), catalogPO.getCurrentVersion()));
+    if (fenced == 0) {
+      throw new OptimisticLockException(
+          "The parent catalog %s was modified concurrently; retry the operation",
+          catalogPO.getCatalogName());
+    }
+  }
+
+  private void fenceSchemaAncestor(
+      SchemaMetaMapper mapper, SchemaPO ancestor, NameIdentifier schemaIdentifier) {
+    int fenced = mapper.fenceSchemaMeta(ancestor.getSchemaId(), ancestor.getCurrentVersion());
+    if (fenced == 0) {
+      throw new OptimisticLockException(
+          "An ancestor of schema %s was modified concurrently; retry the operation",
+          schemaIdentifier);
+    }
+  }
+
+  private void deleteDescendantSchemasWithVersions(
+      NameIdentifier schemaIdentifier, List<SchemaPO> descendants) {
+    if (descendants.isEmpty()) {
+      return;
+    }
+    int deleted =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class, mapper -> mapper.softDeleteSchemaMetasWithVersion(descendants));
+    if (deleted != descendants.size()) {
+      throw new OptimisticLockException(
+          "A descendant of schema %s was modified concurrently; retry the operation",
+          schemaIdentifier);
+    }
+  }
+
+  private void checkSchemaIsEmpty(NameIdentifier identifier, SchemaPO schemaPO) {
+    boolean hasDescendantSchemas = !listDescendantSchemaPOs(schemaPO).isEmpty();
+    boolean hasTables =
+        !SessionUtils.getWithoutCommit(
+                TableMetaMapper.class,
+                mapper -> mapper.listTablePOsBySchemaId(schemaPO.getSchemaId()))
+            .isEmpty();
+    boolean hasFilesets =
+        !SessionUtils.getWithoutCommit(
+                FilesetMetaMapper.class,
+                mapper -> mapper.listFilesetPOsBySchemaId(schemaPO.getSchemaId()))
+            .isEmpty();
+    boolean hasModels =
+        !SessionUtils.getWithoutCommit(
+                ModelMetaMapper.class,
+                mapper -> mapper.listModelPOsBySchemaId(schemaPO.getSchemaId()))
+            .isEmpty();
+    boolean hasTopics =
+        !SessionUtils.getWithoutCommit(
+                TopicMetaMapper.class,
+                mapper -> mapper.listTopicPOsBySchemaId(schemaPO.getSchemaId()))
+            .isEmpty();
+    if (hasDescendantSchemas || hasTables || hasFilesets || hasModels || hasTopics) {
+      throw new NonEmptyEntityException(
+          "Entity %s has sub-entities, you should remove sub-entities first", identifier);
+    }
+  }
+
   /**
-   * Collects the schema ids that participate in a cascade delete: the target schema itself plus
-   * every HierarchicalSchema descendant. The {@link SchemaPO} arrives in logical form (e.g. {@code
-   * A:B}); {@link HierarchicalConversionPOStorageOps} translates to storage form before running the
-   * SQL prefix match, so this method only deals in logical names.
+   * Collects every HierarchicalSchema descendant of the target schema. The {@link SchemaPO} arrives
+   * in logical form (e.g. {@code A:B}); {@link HierarchicalConversionPOStorageOps} translates to
+   * storage form before running the SQL prefix match.
    */
-  private List<Long> listSchemaIdsForCascade(SchemaPO schemaPO) {
+  private List<SchemaPO> listDescendantSchemaPOs(SchemaPO schemaPO) {
     List<SchemaPO> matched =
         SessionUtils.getWithoutCommit(
             SchemaMetaMapper.class,
@@ -526,16 +551,15 @@ public class SchemaMetaService {
     if (matched == null || matched.isEmpty()) {
       return Collections.emptyList();
     }
-    return matched.stream().map(SchemaPO::getSchemaId).collect(Collectors.toList());
+    return matched.stream()
+        .filter(po -> !po.getSchemaId().equals(schemaPO.getSchemaId()))
+        .collect(Collectors.toList());
   }
 
-  private void fillSchemaPOBuilderParentEntityId(SchemaPO.Builder builder, Namespace namespace) {
-    NamespaceUtil.checkSchema(namespace);
-    NamespacedEntityId namespacedEntityId =
-        EntityIdService.getEntityIds(
-            NameIdentifier.of(namespace.levels()), Entity.EntityType.CATALOG);
-    builder.withMetalakeId(namespacedEntityId.namespaceIds()[0]);
-    builder.withCatalogId(namespacedEntityId.entityId());
+  private SchemaPO.Builder newSchemaPOBuilder(CatalogPO catalogPO) {
+    return SchemaPO.builder()
+        .withMetalakeId(catalogPO.getMetalakeId())
+        .withCatalogId(catalogPO.getCatalogId());
   }
 
   @Monitored(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -1387,9 +1387,7 @@ public class POConverters {
 
   public static RolePO updateRolePOWithVersion(RolePO oldRolePO, RoleEntity newRole) {
     Long lastVersion = oldRolePO.getLastVersion();
-    // TODO: set the version to the last version + 1 when having some fields need be multiple
-    // version
-    Long nextVersion = lastVersion;
+    Long nextVersion = lastVersion + 1;
     try {
       return RolePO.builder()
           .withRoleId(oldRolePO.getRoleId())

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -136,9 +136,9 @@ public class POConverters {
    */
   public static MetalakePO updateMetalakePOWithVersion(
       MetalakePO oldMetalakePO, BaseMetalake newMetalake) {
-    Long lastVersion = oldMetalakePO.getLastVersion();
-    // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion + 1;
+    // Every metadata update advances the OCC token. Both version columns stay aligned because
+    // metalakes do not retain independently addressable historical versions.
+    Long nextVersion = oldMetalakePO.getCurrentVersion() + 1;
     try {
       return MetalakePO.builder()
           .withMetalakeId(newMetalake.id())
@@ -233,9 +233,9 @@ public class POConverters {
    */
   public static CatalogPO updateCatalogPOWithVersion(
       CatalogPO oldCatalogPO, CatalogEntity newCatalog, Long metalakeId) {
-    Long lastVersion = oldCatalogPO.getLastVersion();
-    // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion + 1;
+    // Every metadata update advances the OCC token. Both version columns stay aligned because
+    // catalogs do not retain independently addressable historical versions.
+    Long nextVersion = oldCatalogPO.getCurrentVersion() + 1;
     try {
       return CatalogPO.builder()
           .withCatalogId(newCatalog.id())
@@ -329,9 +329,9 @@ public class POConverters {
    * @return SchemaPO object with updated version
    */
   public static SchemaPO updateSchemaPOWithVersion(SchemaPO oldSchemaPO, SchemaEntity newSchema) {
-    Long lastVersion = oldSchemaPO.getLastVersion();
-    // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion + 1;
+    // Every metadata update advances the OCC token. Both version columns stay aligned because
+    // schemas do not retain independently addressable historical versions.
+    Long nextVersion = oldSchemaPO.getCurrentVersion() + 1;
     try {
       return SchemaPO.builder()
           .withSchemaId(oldSchemaPO.getSchemaId())

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -138,7 +138,7 @@ public class POConverters {
       MetalakePO oldMetalakePO, BaseMetalake newMetalake) {
     Long lastVersion = oldMetalakePO.getLastVersion();
     // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion;
+    Long nextVersion = lastVersion + 1;
     try {
       return MetalakePO.builder()
           .withMetalakeId(newMetalake.id())
@@ -235,7 +235,7 @@ public class POConverters {
       CatalogPO oldCatalogPO, CatalogEntity newCatalog, Long metalakeId) {
     Long lastVersion = oldCatalogPO.getLastVersion();
     // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion;
+    Long nextVersion = lastVersion + 1;
     try {
       return CatalogPO.builder()
           .withCatalogId(newCatalog.id())
@@ -331,7 +331,7 @@ public class POConverters {
   public static SchemaPO updateSchemaPOWithVersion(SchemaPO oldSchemaPO, SchemaEntity newSchema) {
     Long lastVersion = oldSchemaPO.getLastVersion();
     // Will set the version to the last version + 1 when having some fields need be multiple version
-    Long nextVersion = lastVersion;
+    Long nextVersion = lastVersion + 1;
     try {
       return SchemaPO.builder()
           .withSchemaId(oldSchemaPO.getSchemaId())

--- a/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestAuthMappers.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestAuthMappers.java
@@ -188,13 +188,23 @@ public class TestAuthMappers {
   void testRoleMetaTouchUpdatedAtSkipsSoftDeleted() {
     insertMetalake(1L, "metalake1");
     insertRole(13L, "role13", 1L);
-    roleMetaMapper.softDeleteRoleMetaByRoleId(13L);
+    roleMetaMapper.softDeleteRoleMetaByRoleId(13L, 1L);
 
     long beforeUpdatedAt = queryUpdatedAt("role_meta", "role_id", 13L);
     roleMetaMapper.touchRoleUpdatedAt(13L);
     long afterUpdatedAt = queryUpdatedAt("role_meta", "role_id", 13L);
 
     Assertions.assertEquals(beforeUpdatedAt, afterUpdatedAt);
+  }
+
+  @Test
+  void testRoleDeleteUsesCurrentVersion() {
+    insertMetalake(1L, "metalake1");
+    insertRole(14L, "role14", 1L);
+
+    Assertions.assertEquals(0, roleMetaMapper.softDeleteRoleMetaByRoleId(14L, 2L));
+    Assertions.assertNotNull(roleMetaMapper.selectRoleMetaByMetalakeIdAndName(1L, "role14"));
+    Assertions.assertEquals(1, roleMetaMapper.softDeleteRoleMetaByRoleId(14L, 1L));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestCatalogMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestCatalogMetaService.java
@@ -35,6 +35,8 @@ import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.ColumnEntity;
@@ -50,7 +52,9 @@ import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import org.apache.gravitino.storage.relational.po.CatalogPO;
+import org.apache.gravitino.storage.relational.po.MetalakePO;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -88,6 +92,40 @@ public class TestCatalogMetaService extends TestJDBCBackend {
             auditInfo);
     backend.insert(catalog, false);
     assertThrows(EntityAlreadyExistsException.class, () -> backend.insert(catalogCopy, false));
+  }
+
+  @TestTemplate
+  public void testInsertCatalogFencesMetalakeAndRollsBackFenceOnFailure() throws IOException {
+    MetalakePO beforeInsert =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalakeName));
+    CatalogEntity catalog =
+        createCatalog(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofCatalog(metalakeName),
+            "catalog_fence",
+            auditInfo);
+    backend.insert(catalog, false);
+
+    MetalakePO afterInsert =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalakeName));
+    assertEquals(beforeInsert.getCurrentVersion() + 1, afterInsert.getCurrentVersion());
+    assertEquals(afterInsert.getCurrentVersion(), afterInsert.getLastVersion());
+
+    CatalogEntity duplicate =
+        createCatalog(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofCatalog(metalakeName),
+            catalog.name(),
+            auditInfo);
+    assertThrows(EntityAlreadyExistsException.class, () -> backend.insert(duplicate, false));
+
+    MetalakePO afterFailure =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalakeName));
+    assertEquals(afterInsert.getCurrentVersion(), afterFailure.getCurrentVersion());
+    assertEquals(afterInsert.getLastVersion(), afterFailure.getLastVersion());
   }
 
   @TestTemplate
@@ -198,6 +236,72 @@ public class TestCatalogMetaService extends TestJDBCBackend {
             mapper ->
                 mapper.softDeleteCatalogMetasByCatalogId(catalog.id(), newPO.getCurrentVersion()));
     assertEquals(1, deleted);
+  }
+
+  @TestTemplate
+  public void testAlterReportsOptimisticLockConflict() throws IOException {
+    CatalogEntity catalog =
+        createCatalog(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofCatalog(metalakeName),
+            "catalog_alter_conflict",
+            auditInfo);
+    backend.insert(catalog, false);
+
+    assertThrows(
+        OptimisticLockException.class,
+        () ->
+            CatalogMetaService.getInstance()
+                .updateCatalog(
+                    catalog.nameIdentifier(),
+                    entity -> {
+                      CatalogEntity current = (CatalogEntity) entity;
+                      CatalogPO currentPO =
+                          SessionUtils.getWithoutCommit(
+                              CatalogMetaMapper.class,
+                              mapper -> mapper.selectCatalogMetaById(current.id()));
+                      CatalogEntity competingUpdate =
+                          copyCatalogWithComment(current, "competing update");
+                      CatalogPO competingPO =
+                          POConverters.updateCatalogPOWithVersion(
+                              currentPO, competingUpdate, currentPO.getMetalakeId());
+                      SessionUtils.doWithCommitAndFetchResult(
+                          CatalogMetaMapper.class,
+                          mapper -> mapper.updateCatalogMeta(competingPO, currentPO));
+                      return copyCatalogWithComment(current, "requested update");
+                    }));
+  }
+
+  @TestTemplate
+  public void testNonCascadeDeleteRollsBackCatalogFence() throws IOException {
+    CatalogEntity catalog =
+        createCatalog(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofCatalog(metalakeName),
+            "catalog_non_empty",
+            auditInfo);
+    backend.insert(catalog, false);
+    SchemaEntity schema =
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalog.name()),
+            "schema",
+            auditInfo);
+    backend.insert(schema, false);
+    CatalogPO beforeDelete =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class, mapper -> mapper.selectCatalogMetaById(catalog.id()));
+
+    assertThrows(
+        NonEmptyEntityException.class,
+        () -> CatalogMetaService.getInstance().deleteCatalog(catalog.nameIdentifier(), false));
+
+    CatalogPO afterDelete =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class, mapper -> mapper.selectCatalogMetaById(catalog.id()));
+    assertEquals(beforeDelete.getCurrentVersion(), afterDelete.getCurrentVersion());
+    assertTrue(backend.exists(catalog.nameIdentifier(), Entity.EntityType.CATALOG));
+    assertTrue(backend.exists(schema.nameIdentifier(), Entity.EntityType.SCHEMA));
   }
 
   @TestTemplate
@@ -352,6 +456,19 @@ public class TestCatalogMetaService extends TestJDBCBackend {
     assertEquals(0, countActiveTagRelForMetadataObject(model.id(), "MODEL"));
     assertEquals(0, countActiveTagRelForMetadataObject(view.id(), "VIEW"));
     assertEquals(0, countActiveTagRelForMetadataObject(function.id(), "FUNCTION"));
+  }
+
+  private CatalogEntity copyCatalogWithComment(CatalogEntity catalog, String comment) {
+    return CatalogEntity.builder()
+        .withId(catalog.id())
+        .withName(catalog.name())
+        .withNamespace(catalog.namespace())
+        .withType(catalog.getType())
+        .withProvider(catalog.getProvider())
+        .withComment(comment)
+        .withProperties(catalog.getProperties())
+        .withAuditInfo(auditInfo)
+        .build();
   }
 
   private void associateTag(TagEntity tag, NameIdentifier ident, Entity.EntityType type)

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestCatalogMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestCatalogMetaService.java
@@ -50,7 +50,9 @@ import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.po.CatalogPO;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
@@ -147,6 +149,55 @@ public class TestCatalogMetaService extends TestJDBCBackend {
 
     CatalogEntity updatedCatalog = backend.get(catalog.nameIdentifier(), Entity.EntityType.CATALOG);
     Assertions.assertNotNull(updatedCatalog.getComment());
+  }
+
+  @TestTemplate
+  public void testAlterAndDeleteUseCurrentVersion() throws IOException {
+    CatalogEntity catalog =
+        createCatalog(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofCatalog(metalakeName),
+            "catalog_occ",
+            auditInfo);
+    backend.insert(catalog, false);
+    CatalogPO oldPO =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class, mapper -> mapper.selectCatalogMetaById(catalog.id()));
+    CatalogEntity updatedCatalog =
+        CatalogEntity.builder()
+            .withId(catalog.id())
+            .withName(catalog.name())
+            .withNamespace(catalog.namespace())
+            .withAuditInfo(auditInfo)
+            .withComment("updated")
+            .withProperties(catalog.getProperties())
+            .withType(catalog.getType())
+            .withProvider(catalog.getProvider())
+            .build();
+    CatalogPO newPO =
+        POConverters.updateCatalogPOWithVersion(oldPO, updatedCatalog, oldPO.getMetalakeId());
+
+    int updated =
+        SessionUtils.doWithCommitAndFetchResult(
+            CatalogMetaMapper.class, mapper -> mapper.updateCatalogMeta(newPO, oldPO));
+    int staleUpdate =
+        SessionUtils.doWithCommitAndFetchResult(
+            CatalogMetaMapper.class, mapper -> mapper.updateCatalogMeta(newPO, oldPO));
+    int staleDelete =
+        SessionUtils.doWithCommitAndFetchResult(
+            CatalogMetaMapper.class,
+            mapper ->
+                mapper.softDeleteCatalogMetasByCatalogId(catalog.id(), oldPO.getCurrentVersion()));
+    assertEquals(1, updated);
+    assertEquals(0, staleUpdate);
+    assertEquals(0, staleDelete);
+    assertTrue(backend.exists(catalog.nameIdentifier(), Entity.EntityType.CATALOG));
+    int deleted =
+        SessionUtils.doWithCommitAndFetchResult(
+            CatalogMetaMapper.class,
+            mapper ->
+                mapper.softDeleteCatalogMetasByCatalogId(catalog.id(), newPO.getCurrentVersion()));
+    assertEquals(1, deleted);
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestMetalakeMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestMetalakeMetaService.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.util.List;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.SchemaVersion;
@@ -178,6 +179,57 @@ public class TestMetalakeMetaService extends TestJDBCBackend {
                           .withVersion(current.getVersion())
                           .build();
                     }));
+  }
+
+  @TestTemplate
+  public void testDeleteReportsOptimisticLockConflict() throws IOException {
+    BaseMetalake metalake = createAndInsertMakeLake(METALAKE_NAME);
+    MetalakePO stalePO =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalake.name()));
+    BaseMetalake competingUpdate =
+        BaseMetalake.builder()
+            .withId(metalake.id())
+            .withName(metalake.name())
+            .withAuditInfo(metalake.auditInfo())
+            .withComment("competing update")
+            .withProperties(metalake.properties())
+            .withVersion(metalake.getVersion())
+            .build();
+    MetalakePO competingPO = POConverters.updateMetalakePOWithVersion(stalePO, competingUpdate);
+    SessionUtils.doWithCommitAndFetchResult(
+        MetalakeMetaMapper.class, mapper -> mapper.updateMetalakeMeta(competingPO, stalePO));
+
+    assertThrows(
+        OptimisticLockException.class,
+        () ->
+            SessionUtils.doMultipleWithCommit(
+                () ->
+                    MetalakeMetaService.getInstance()
+                        .deleteMetalakeWithVersion(
+                            metalake.nameIdentifier(),
+                            metalake.id(),
+                            stalePO.getCurrentVersion())));
+    assertTrue(backend.exists(metalake.nameIdentifier(), Entity.EntityType.METALAKE));
+  }
+
+  @TestTemplate
+  public void testNonCascadeDeleteRollsBackMetalakeFence() throws IOException {
+    BaseMetalake metalake = createAndInsertMakeLake(METALAKE_NAME);
+    createAndInsertCatalog(METALAKE_NAME, "catalog");
+    MetalakePO beforeDelete =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalake.name()));
+
+    assertThrows(
+        NonEmptyEntityException.class,
+        () -> MetalakeMetaService.getInstance().deleteMetalake(metalake.nameIdentifier(), false));
+
+    MetalakePO afterDelete =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalake.name()));
+    Assertions.assertEquals(beforeDelete.getCurrentVersion(), afterDelete.getCurrentVersion());
+    assertTrue(backend.exists(metalake.nameIdentifier(), Entity.EntityType.METALAKE));
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestMetalakeMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestMetalakeMetaService.java
@@ -27,10 +27,15 @@ import java.time.Instant;
 import java.util.List;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
+import org.apache.gravitino.storage.relational.po.MetalakePO;
+import org.apache.gravitino.storage.relational.utils.POConverters;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
 
@@ -90,6 +95,89 @@ public class TestMetalakeMetaService extends TestJDBCBackend {
     Assertions.assertNotNull(updatedMetalake.comment());
 
     backend.delete(metalake.nameIdentifier(), Entity.EntityType.METALAKE, false);
+  }
+
+  @TestTemplate
+  public void testAlterAndDeleteUseCurrentVersion() throws IOException {
+    BaseMetalake metalake = createAndInsertMakeLake(METALAKE_NAME);
+    MetalakePO oldPO =
+        SessionUtils.getWithoutCommit(
+            MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(metalake.name()));
+    BaseMetalake updatedMetalake =
+        BaseMetalake.builder()
+            .withId(metalake.id())
+            .withName(metalake.name())
+            .withAuditInfo(metalake.auditInfo())
+            .withComment("updated")
+            .withProperties(metalake.properties())
+            .withVersion(metalake.getVersion())
+            .build();
+    MetalakePO newPO = POConverters.updateMetalakePOWithVersion(oldPO, updatedMetalake);
+
+    int updated =
+        SessionUtils.doWithCommitAndFetchResult(
+            MetalakeMetaMapper.class, mapper -> mapper.updateMetalakeMeta(newPO, oldPO));
+    int staleUpdate =
+        SessionUtils.doWithCommitAndFetchResult(
+            MetalakeMetaMapper.class, mapper -> mapper.updateMetalakeMeta(newPO, oldPO));
+    int staleDelete =
+        SessionUtils.doWithCommitAndFetchResult(
+            MetalakeMetaMapper.class,
+            mapper ->
+                mapper.softDeleteMetalakeMetaByMetalakeId(
+                    metalake.id(), oldPO.getCurrentVersion()));
+    Assertions.assertEquals(1, updated);
+    Assertions.assertEquals(0, staleUpdate);
+    Assertions.assertEquals(0, staleDelete);
+    assertTrue(backend.exists(metalake.nameIdentifier(), Entity.EntityType.METALAKE));
+    int deleted =
+        SessionUtils.doWithCommitAndFetchResult(
+            MetalakeMetaMapper.class,
+            mapper ->
+                mapper.softDeleteMetalakeMetaByMetalakeId(
+                    metalake.id(), newPO.getCurrentVersion()));
+    Assertions.assertEquals(1, deleted);
+  }
+
+  @TestTemplate
+  public void testAlterReportsOptimisticLockConflict() throws IOException {
+    BaseMetalake metalake = createAndInsertMakeLake(METALAKE_NAME);
+
+    assertThrows(
+        OptimisticLockException.class,
+        () ->
+            MetalakeMetaService.getInstance()
+                .updateMetalake(
+                    metalake.nameIdentifier(),
+                    entity -> {
+                      BaseMetalake current = (BaseMetalake) entity;
+                      MetalakePO currentPO =
+                          SessionUtils.getWithoutCommit(
+                              MetalakeMetaMapper.class,
+                              mapper -> mapper.selectMetalakeMetaByName(current.name()));
+                      BaseMetalake competingUpdate =
+                          BaseMetalake.builder()
+                              .withId(current.id())
+                              .withName(current.name())
+                              .withAuditInfo(current.auditInfo())
+                              .withComment("competing update")
+                              .withProperties(current.properties())
+                              .withVersion(current.getVersion())
+                              .build();
+                      MetalakePO competingPO =
+                          POConverters.updateMetalakePOWithVersion(currentPO, competingUpdate);
+                      SessionUtils.doWithCommitAndFetchResult(
+                          MetalakeMetaMapper.class,
+                          mapper -> mapper.updateMetalakeMeta(competingPO, currentPO));
+                      return BaseMetalake.builder()
+                          .withId(current.id())
+                          .withName(current.name())
+                          .withAuditInfo(current.auditInfo())
+                          .withComment("requested update")
+                          .withProperties(current.properties())
+                          .withVersion(current.getVersion())
+                          .build();
+                    }));
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestRoleMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestRoleMetaService.java
@@ -59,8 +59,12 @@ import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
 import org.apache.gravitino.storage.relational.mapper.GroupMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
 import org.apache.gravitino.storage.relational.po.GroupPO;
+import org.apache.gravitino.storage.relational.po.MetalakePO;
+import org.apache.gravitino.storage.relational.po.RolePO;
 import org.apache.gravitino.storage.relational.po.UserPO;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -883,6 +887,76 @@ class TestRoleMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  void testCreateFencesMetalakeAndRollsBackFenceOnFailure() throws IOException {
+    createAndInsertMakeLake(METALAKE_NAME);
+    createAndInsertCatalog(METALAKE_NAME, "catalog");
+    RoleMetaService service = RoleMetaService.getInstance();
+    MetalakePO beforeCreate = getMetalakePO();
+    RoleEntity role =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(METALAKE_NAME),
+            "fenced-role",
+            AUDIT_INFO,
+            "catalog");
+
+    service.insertRole(role, false);
+
+    MetalakePO afterCreate = getMetalakePO();
+    assertEquals(beforeCreate.getCurrentVersion() + 1, afterCreate.getCurrentVersion());
+    assertEquals(afterCreate.getCurrentVersion(), afterCreate.getLastVersion());
+
+    RoleEntity duplicate =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(METALAKE_NAME),
+            role.name(),
+            AUDIT_INFO,
+            "catalog");
+    Assertions.assertThrows(
+        EntityAlreadyExistsException.class, () -> service.insertRole(duplicate, false));
+
+    MetalakePO afterFailedCreate = getMetalakePO();
+    assertEquals(afterCreate.getCurrentVersion(), afterFailedCreate.getCurrentVersion());
+    assertEquals(afterCreate.getLastVersion(), afterFailedCreate.getLastVersion());
+  }
+
+  @TestTemplate
+  void testMetadataOnlyUpdateUsesOcc() throws IOException {
+    createAndInsertMakeLake(METALAKE_NAME);
+    createAndInsertCatalog(METALAKE_NAME, "catalog");
+    RoleMetaService service = RoleMetaService.getInstance();
+    RoleEntity role =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(METALAKE_NAME),
+            "metadata-only-role",
+            AUDIT_INFO,
+            "catalog");
+    service.insertRole(role, false);
+    RolePO beforeUpdate = getRolePO(role.name());
+
+    service.updateRole(role.nameIdentifier(), (RoleEntity oldRole) -> copyRole(oldRole, "value-1"));
+
+    RolePO afterUpdate = getRolePO(role.name());
+    assertEquals(beforeUpdate.getCurrentVersion() + 1, afterUpdate.getCurrentVersion());
+    assertEquals(
+        "value-1", service.getRoleByIdentifier(role.nameIdentifier()).properties().get("key"));
+
+    Assertions.assertThrows(
+        OptimisticLockException.class,
+        () ->
+            service.updateRole(
+                role.nameIdentifier(),
+                (RoleEntity oldRole) -> {
+                  advanceRoleVersion(role.id());
+                  return copyRole(oldRole, "value-2");
+                }));
+    assertEquals(
+        "value-1", service.getRoleByIdentifier(role.nameIdentifier()).properties().get("key"));
+  }
+
+  @TestTemplate
   void testDeleteMetalakeCascade() throws IOException {
     BaseMetalake metalake = createAndInsertMakeLake(METALAKE_NAME);
     createAndInsertCatalog(METALAKE_NAME, "catalog");
@@ -1104,6 +1178,29 @@ class TestRoleMetaService extends TestJDBCBackend {
       throw new RuntimeException("SQL execution failed", e);
     }
     return count;
+  }
+
+  private MetalakePO getMetalakePO() {
+    return SessionUtils.getWithoutCommit(
+        MetalakeMetaMapper.class, mapper -> mapper.selectMetalakeMetaByName(METALAKE_NAME));
+  }
+
+  private RolePO getRolePO(String roleName) {
+    MetalakePO metalakePO = getMetalakePO();
+    return SessionUtils.getWithoutCommit(
+        RoleMetaMapper.class,
+        mapper -> mapper.selectRoleMetaByMetalakeIdAndName(metalakePO.getMetalakeId(), roleName));
+  }
+
+  private RoleEntity copyRole(RoleEntity role, String propertyValue) {
+    return RoleEntity.builder()
+        .withId(role.id())
+        .withName(role.name())
+        .withNamespace(role.namespace())
+        .withProperties(ImmutableMap.of("key", propertyValue))
+        .withSecurableObjects(role.securableObjects())
+        .withAuditInfo(role.auditInfo())
+        .build();
   }
 
   private Integer countUserRoleRels() {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestRoleMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestRoleMetaService.java
@@ -46,6 +46,7 @@ import org.apache.gravitino.authorization.Privileges;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
@@ -836,6 +837,52 @@ class TestRoleMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  void testConcurrentUpdateDoesNotChangeSecurableObjectsOnConflict() throws IOException {
+    createAndInsertMakeLake(METALAKE_NAME);
+    createAndInsertCatalog(METALAKE_NAME, "catalog");
+    RoleEntity role =
+        createRoleEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofRoleNamespace(METALAKE_NAME),
+            "concurrent-role",
+            AUDIT_INFO,
+            "catalog");
+    RoleMetaService.getInstance().insertRole(role, false);
+
+    Assertions.assertThrows(
+        OptimisticLockException.class,
+        () ->
+            RoleMetaService.getInstance()
+                .updateRole(
+                    role.nameIdentifier(),
+                    (RoleEntity oldRole) -> {
+                      advanceRoleVersion(role.id());
+                      List<SecurableObject> securableObjects =
+                          Lists.newArrayList(oldRole.securableObjects());
+                      securableObjects.add(
+                          SecurableObjects.ofMetalake(
+                              METALAKE_NAME, Lists.newArrayList(Privileges.CreateTable.allow())));
+                      return RoleEntity.builder()
+                          .withId(oldRole.id())
+                          .withName(oldRole.name())
+                          .withNamespace(oldRole.namespace())
+                          .withProperties(oldRole.properties())
+                          .withSecurableObjects(securableObjects)
+                          .withAuditInfo(oldRole.auditInfo())
+                          .build();
+                    }));
+
+    RoleEntity storedRole =
+        RoleMetaService.getInstance().getRoleByIdentifier(role.nameIdentifier());
+    assertTrue(
+        CollectionUtils.isEqualCollection(
+            Lists.newArrayList(
+                SecurableObjects.ofCatalog(
+                    "catalog", Lists.newArrayList(Privileges.UseCatalog.allow()))),
+            storedRole.securableObjects()));
+  }
+
+  @TestTemplate
   void testDeleteMetalakeCascade() throws IOException {
     BaseMetalake metalake = createAndInsertMakeLake(METALAKE_NAME);
     createAndInsertCatalog(METALAKE_NAME, "catalog");
@@ -1126,5 +1173,20 @@ class TestRoleMetaService extends TestJDBCBackend {
       throw new RuntimeException("SQL execution failed", e);
     }
     return count;
+  }
+
+  private void advanceRoleVersion(long roleId) {
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        Statement statement = connection.createStatement()) {
+      assertEquals(
+          1,
+          statement.executeUpdate(
+              "UPDATE role_meta SET current_version = current_version + 1 WHERE role_id = "
+                  + roleId));
+    } catch (SQLException e) {
+      throw new RuntimeException("Advance role version failed", e);
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
@@ -37,6 +37,8 @@ import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
+import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.ColumnEntity;
 import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.meta.FunctionEntity;
@@ -49,7 +51,9 @@ import org.apache.gravitino.meta.ViewEntity;
 import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
+import org.apache.gravitino.storage.relational.po.CatalogPO;
 import org.apache.gravitino.storage.relational.po.SchemaPO;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
 import org.apache.gravitino.storage.relational.utils.POConverters;
@@ -83,6 +87,42 @@ public class TestSchemaMetaService extends TestJDBCBackend {
             AUDIT_INFO);
     backend.insert(schema, false);
     assertThrows(EntityAlreadyExistsException.class, () -> backend.insert(schemaCopy, false));
+  }
+
+  @TestTemplate
+  public void testInsertSchemaFencesCatalogAndRollsBackFenceOnFailure() throws IOException {
+    createAndInsertMakeLake(metalakeName);
+    CatalogEntity catalog = createAndInsertCatalog(metalakeName, catalogName);
+    CatalogPO beforeInsert =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class, mapper -> mapper.selectCatalogMetaById(catalog.id()));
+    SchemaEntity schema =
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            "schema_fence",
+            AUDIT_INFO);
+    backend.insert(schema, false);
+
+    CatalogPO afterInsert =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class, mapper -> mapper.selectCatalogMetaById(catalog.id()));
+    Assertions.assertEquals(beforeInsert.getCurrentVersion() + 1, afterInsert.getCurrentVersion());
+    Assertions.assertEquals(afterInsert.getCurrentVersion(), afterInsert.getLastVersion());
+
+    SchemaEntity duplicate =
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            schema.name(),
+            AUDIT_INFO);
+    assertThrows(EntityAlreadyExistsException.class, () -> backend.insert(duplicate, false));
+
+    CatalogPO afterFailure =
+        SessionUtils.getWithoutCommit(
+            CatalogMetaMapper.class, mapper -> mapper.selectCatalogMetaById(catalog.id()));
+    Assertions.assertEquals(afterInsert.getCurrentVersion(), afterFailure.getCurrentVersion());
+    Assertions.assertEquals(afterInsert.getLastVersion(), afterFailure.getLastVersion());
   }
 
   @TestTemplate
@@ -200,6 +240,41 @@ public class TestSchemaMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  public void testAlterReportsOptimisticLockConflict() throws IOException {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+    SchemaEntity schema =
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            "schema_alter_conflict",
+            AUDIT_INFO);
+    backend.insert(schema, false);
+
+    assertThrows(
+        OptimisticLockException.class,
+        () ->
+            SchemaMetaService.getInstance()
+                .updateSchema(
+                    schema.nameIdentifier(),
+                    entity -> {
+                      SchemaEntity current = (SchemaEntity) entity;
+                      SchemaPO currentPO =
+                          SessionUtils.getWithoutCommit(
+                              SchemaMetaMapper.class,
+                              mapper -> mapper.selectSchemaMetaById(current.id()));
+                      SchemaEntity competingUpdate =
+                          copySchemaWithComment(current, "competing update");
+                      SchemaPO competingPO =
+                          POConverters.updateSchemaPOWithVersion(currentPO, competingUpdate);
+                      SessionUtils.doWithCommitAndFetchResult(
+                          SchemaMetaMapper.class,
+                          mapper -> mapper.updateSchemaMeta(competingPO, currentPO));
+                      return copySchemaWithComment(current, "requested update");
+                    }));
+  }
+
+  @TestTemplate
   public void testMetaLifeCycleFromCreationToDeletion() throws IOException {
     createAndInsertMakeLake(metalakeName);
     createAndInsertCatalog(metalakeName, catalogName);
@@ -269,11 +344,21 @@ public class TestSchemaMetaService extends TestJDBCBackend {
             topicName,
             AUDIT_INFO);
     topicMetaService.insertTopic(topic, false);
+    SchemaPO beforeDelete =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class, mapper -> mapper.selectSchemaMetaById(schema.id()));
 
     Assertions.assertThrows(
         NonEmptyEntityException.class,
         () -> schemaMetaService.deleteSchema(schema.nameIdentifier(), false),
         "Non-cascading delete must fail when dependent topics exist.");
+
+    SchemaPO afterDelete =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class, mapper -> mapper.selectSchemaMetaById(schema.id()));
+    Assertions.assertEquals(beforeDelete.getCurrentVersion(), afterDelete.getCurrentVersion());
+    assertTrue(backend.exists(schema.nameIdentifier(), Entity.EntityType.SCHEMA));
+    assertTrue(backend.exists(topic.nameIdentifier(), Entity.EntityType.TOPIC));
 
     topicMetaService.deleteTopic(topic.nameIdentifier());
     schemaMetaService.deleteSchema(schema.nameIdentifier(), false);
@@ -561,14 +646,24 @@ public class TestSchemaMetaService extends TestJDBCBackend {
             .build();
     schemaMetaService.insertSchema(first, false);
 
-    long idA =
-        schemaMetaService
-            .getSchemaByIdentifier(NameIdentifier.of(metalakeName, catalogName, ancestorA))
-            .id();
-    long idAB =
-        schemaMetaService
-            .getSchemaByIdentifier(NameIdentifier.of(metalakeName, catalogName, ancestorAB))
-            .id();
+    SchemaPO ancestorAPOBefore =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class,
+            mapper ->
+                mapper.selectSchemaMetaById(
+                    schemaMetaService
+                        .getSchemaByIdentifier(
+                            NameIdentifier.of(metalakeName, catalogName, ancestorA))
+                        .id()));
+    SchemaPO ancestorABPOBefore =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class,
+            mapper ->
+                mapper.selectSchemaMetaById(
+                    schemaMetaService
+                        .getSchemaByIdentifier(
+                            NameIdentifier.of(metalakeName, catalogName, ancestorAB))
+                        .id()));
 
     SchemaEntity second =
         SchemaEntity.builder()
@@ -581,16 +676,41 @@ public class TestSchemaMetaService extends TestJDBCBackend {
             .build();
     schemaMetaService.insertSchema(second, false);
 
+    SchemaPO ancestorAPOAfter =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class,
+            mapper ->
+                mapper.selectSchemaMetaById(
+                    schemaMetaService
+                        .getSchemaByIdentifier(
+                            NameIdentifier.of(metalakeName, catalogName, ancestorA))
+                        .id()));
+    SchemaPO ancestorABPOAfter =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class,
+            mapper ->
+                mapper.selectSchemaMetaById(
+                    schemaMetaService
+                        .getSchemaByIdentifier(
+                            NameIdentifier.of(metalakeName, catalogName, ancestorAB))
+                        .id()));
+    Assertions.assertEquals(ancestorAPOBefore.getSchemaId(), ancestorAPOAfter.getSchemaId());
+    Assertions.assertEquals(ancestorABPOBefore.getSchemaId(), ancestorABPOAfter.getSchemaId());
     Assertions.assertEquals(
-        idA,
-        schemaMetaService
-            .getSchemaByIdentifier(NameIdentifier.of(metalakeName, catalogName, ancestorA))
-            .id());
+        ancestorAPOBefore.getCurrentVersion() + 1, ancestorAPOAfter.getCurrentVersion());
     Assertions.assertEquals(
-        idAB,
-        schemaMetaService
-            .getSchemaByIdentifier(NameIdentifier.of(metalakeName, catalogName, ancestorAB))
-            .id());
+        ancestorABPOBefore.getCurrentVersion() + 1, ancestorABPOAfter.getCurrentVersion());
+  }
+
+  private SchemaEntity copySchemaWithComment(SchemaEntity schema, String comment) {
+    return SchemaEntity.builder()
+        .withId(schema.id())
+        .withName(schema.name())
+        .withNamespace(schema.namespace())
+        .withComment(comment)
+        .withProperties(schema.properties())
+        .withAuditInfo(schema.auditInfo())
+        .build();
   }
 
   private void associateTag(TagEntity tag, NameIdentifier ident, Entity.EntityType type)

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
@@ -49,7 +49,11 @@ import org.apache.gravitino.meta.ViewEntity;
 import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
+import org.apache.gravitino.storage.relational.po.SchemaPO;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.gravitino.storage.relational.utils.POConverters;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.apache.ibatis.session.SqlSession;
@@ -143,6 +147,56 @@ public class TestSchemaMetaService extends TestJDBCBackend {
     SchemaEntity updatedSchema =
         schemaMetaService.getSchemaByIdentifier(schemaEntity.nameIdentifier());
     Assertions.assertEquals("schema comment updated", updatedSchema.comment());
+  }
+
+  @TestTemplate
+  public void testAlterAndDeleteUseCurrentVersion() throws IOException {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+    SchemaEntity schema =
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            "schema_occ",
+            AUDIT_INFO);
+    backend.insert(schema, false);
+    SchemaPO oldPO =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class, mapper -> mapper.selectSchemaMetaById(schema.id()));
+    SchemaEntity updatedSchema =
+        SchemaEntity.builder()
+            .withId(schema.id())
+            .withName(schema.name())
+            .withNamespace(schema.namespace())
+            .withAuditInfo(schema.auditInfo())
+            .withComment("updated")
+            .withProperties(schema.properties())
+            .build();
+    SchemaPO newPO = POConverters.updateSchemaPOWithVersion(oldPO, updatedSchema);
+
+    int updated =
+        SessionUtils.doWithCommitAndFetchResult(
+            SchemaMetaMapper.class, mapper -> mapper.updateSchemaMeta(newPO, oldPO));
+    int staleUpdate =
+        SessionUtils.doWithCommitAndFetchResult(
+            SchemaMetaMapper.class, mapper -> mapper.updateSchemaMeta(newPO, oldPO));
+    int staleDelete =
+        SessionUtils.doWithCommitAndFetchResult(
+            SchemaMetaMapper.class,
+            mapper ->
+                mapper.softDeleteSchemaMetaBySchemaIdAndVersion(
+                    schema.id(), oldPO.getCurrentVersion()));
+    Assertions.assertEquals(1, updated);
+    Assertions.assertEquals(0, staleUpdate);
+    Assertions.assertEquals(0, staleDelete);
+    assertTrue(backend.exists(schema.nameIdentifier(), Entity.EntityType.SCHEMA));
+    int deleted =
+        SessionUtils.doWithCommitAndFetchResult(
+            SchemaMetaMapper.class,
+            mapper ->
+                mapper.softDeleteSchemaMetaBySchemaIdAndVersion(
+                    schema.id(), newPO.getCurrentVersion()));
+    Assertions.assertEquals(1, deleted);
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
@@ -54,6 +54,7 @@ import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.meta.PolicyEntity;
+import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.meta.StatisticEntity;
@@ -86,6 +87,7 @@ import org.apache.gravitino.storage.relational.po.ModelVersionPO;
 import org.apache.gravitino.storage.relational.po.OwnerRelPO;
 import org.apache.gravitino.storage.relational.po.PolicyPO;
 import org.apache.gravitino.storage.relational.po.PolicyVersionPO;
+import org.apache.gravitino.storage.relational.po.RolePO;
 import org.apache.gravitino.storage.relational.po.SchemaPO;
 import org.apache.gravitino.storage.relational.po.SecurableObjectPO;
 import org.apache.gravitino.storage.relational.po.StatisticPO;
@@ -721,6 +723,21 @@ public class TestPOConverters {
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
     assertEquals("test", updatePO.getTableName());
+  }
+
+  @Test
+  public void testUpdateRolePOVersion() {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
+    RoleEntity role =
+        RoleEntity.builder().withId(1L).withName("role").withAuditInfo(auditInfo).build();
+    RolePO rolePO =
+        POConverters.initializeRolePOWithVersion(role, RolePO.builder().withMetalakeId(1L));
+
+    RolePO updatedRolePO = POConverters.updateRolePOWithVersion(rolePO, role);
+
+    assertEquals(2, updatedRolePO.getCurrentVersion());
+    assertEquals(2, updatedRolePO.getLastVersion());
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
@@ -665,6 +665,8 @@ public class TestPOConverters {
     assertEquals(1, initPO.getCurrentVersion());
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
     assertEquals("this is test2", updatePO.getMetalakeComment());
   }
 
@@ -679,6 +681,8 @@ public class TestPOConverters {
     assertEquals(1, initPO.getCurrentVersion());
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
     assertEquals("this is test2", updatePO.getCatalogComment());
   }
 
@@ -696,6 +700,8 @@ public class TestPOConverters {
     assertEquals(1, initPO.getCurrentVersion());
     assertEquals(1, initPO.getLastVersion());
     assertEquals(0, initPO.getDeletedAt());
+    assertEquals(2, updatePO.getCurrentVersion());
+    assertEquals(2, updatePO.getLastVersion());
     assertEquals("this is test2", updatePO.getSchemaComment());
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make managed role mutations concurrency-safe with database OCC and one transaction per service operation.

- Fence the active parent metalake by expected version before creating a role.
- Insert the root role before its securable objects, in the same transaction as the parent fence.
- Always advance the role OCC version on alter, including metadata-only changes with no securable-object delta.
- Update and delete the root role by id plus expected version before changing authorization relationships.
- Roll back the complete operation and throw `OptimisticLockException` when a CAS fails.

This PR depends on #12350, which provides the metalake OCC fence.

### Why are the changes needed?

Concurrent managed-role operations must not create roles under a concurrently deleted metalake, overwrite newer role metadata, or partially commit securable-object and authorization relationship changes.

Fix: #12344

### Does this PR introduce _any_ user-facing change?

Concurrent managed role mutations fail atomically and report HTTP 409 through the shared optimistic-lock conflict contract.

### How was this patch tested?

Added tests for parent fencing and rollback, metadata-only OCC updates, stale alter/delete conflicts, and securable-object rollback. Ran:

`./gradlew :core:test --tests 'org.apache.gravitino.storage.relational.service.TestRoleMetaService' -PskipITs`
