### PR TITLE
[Cherry-pick to branch-1.3] [MINOR] docs: Update server configuration and relational backend storage pages (#12291)

### DIFF
--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -142,9 +142,9 @@ it recognizes.
 
 Servers behind a load balancer share the entity store but keep local caches. Each server polls the
 entity change log and invalidates entries that another server has modified. The defaults are safe:
-a three second poll, and a server that cannot keep its caches current exits rather than serving
-metadata it knows to be stale. Point the load balancer's health check at `GET /health/ready` so a
-server that has lost its database stops receiving traffic.
+a three second poll, with poll failures logged and retried on the next cycle. Point the load
+balancer's health check at `GET /health/ready` so a server that has lost its database stops
+receiving traffic.
 
 ## Server Configuration
 

--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -8,357 +8,218 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Introduction
 
-Apache Gravitino supports several configurations:
+The Apache Gravitino server reads `conf/gravitino.conf` at startup. Almost every property has a
+default, so the server starts with an empty file, and most deployments change only a handful of
+them. The exception is `gravitino.authorization.serviceAdmins`, which you must set once you turn
+authorization on.
 
-1. **Gravitino server configuration**: Used to start up the Gravitino server.
-2. **Gravitino catalog properties configuration**: Used to make default values for different catalogs.
-3. **Some other configurations**: Includes HDFS and other configurations.
+This page covers the server itself. Catalog properties, which configure an individual catalog
+rather than the server, are covered further down. Properties for the auxiliary services live with
+those services: see [Iceberg REST Catalog Service](iceberg-rest-service.md) and
+[Security](security/security.md).
 
-## Gravitino Server Configurations
+## Quick Start
 
-Customize the Gravitino server by editing the configuration file `gravitino.conf` in the `conf` directory. The default values are sufficient for most use cases.
-We strongly recommend that you read the following sections to understand the configuration file, so you can change the default values to suit your specific situation and usage scenario.
+### Development
 
-The `gravitino.conf` file lists the configuration items in the following table. It groups those items into the following categories:
+The defaults are already right for local work. The server listens on `0.0.0.0:8090` and keeps its
+metadata in an embedded H2 database, so no configuration is needed:
 
-### HTTP Server Configuration
-
-| Configuration item                                   | Description                                                                                                                                                                           | Default value                                                                | Required | Since version    |
-|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|----------|------------------|
-| `gravitino.server.webserver.host`                    | The host of the Gravitino server.                                                                                                                                                     | `0.0.0.0`                                                                    | No       | 0.1.0            |
-| `gravitino.server.webserver.httpPort`                | The port on which the Gravitino server listens for incoming connections.                                                                                                              | `8090`                                                                       | No       | 0.1.0            |
-| `gravitino.server.webserver.minThreads`              | The minimum number of threads in the thread pool used by the Jetty webserver. `minThreads` is 8 if the value is less than 8.                                                          | `Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 100), 8)` | No       | 0.2.0            |
-| `gravitino.server.webserver.maxThreads`              | The maximum number of threads in the thread pool used by the Jetty webserver. `maxThreads` is 8 if the value is less than 8, and `maxThreads` must be great or equal to `minThreads`. | `Math.max(Runtime.getRuntime().availableProcessors() * 4, 400)`              | No       | 0.1.0            |
-| `gravitino.server.webserver.threadPoolWorkQueueSize` | The size of the queue in the thread pool used by the Jetty webserver.                                                                                                                 | `100`                                                                        | No       | 0.1.0            |
-| `gravitino.server.webserver.stopTimeout`             | Time in milliseconds to gracefully shut down the Jetty webserver, for more, see `org.eclipse.jetty.server.Server#setStopTimeout`.                                                     | `30000`                                                                      | No       | 0.2.0            |
-| `gravitino.server.webserver.idleTimeout`             | The timeout in milliseconds of idle connections.                                                                                                                                      | `30000`                                                                      | No       | 0.2.0            |
-| `gravitino.server.webserver.requestHeaderSize`       | Maximum size of HTTP requests.                                                                                                                                                        | `131072`                                                                     | No       | 0.1.0            |
-| `gravitino.server.webserver.responseHeaderSize`      | Maximum size of HTTP responses.                                                                                                                                                       | `131072`                                                                     | No       | 0.1.0            |
-| `gravitino.server.shutdown.timeout`                  | Time in milliseconds to gracefully shut down of the Gravitino webserver.                                                                                                              | `3000`                                                                       | No       | 0.2.0            |
-| `gravitino.server.webserver.customFilters`           | Comma-separated list of filter class names to apply to the API.                                                                                                                       | (none)                                                                       | No       | 0.4.0            |
-| `gravitino.server.rest.extensionPackages`            | Comma-separated list of REST API packages to expand                                                                                                                                   | (none)                                                                       | No       | 0.6.0-incubating |
-| `gravitino.server.visibleConfigs`                    | List of configs that are visible in the config servlet                                                                                                                                | (none)                                                                       | No       | 0.9.0-incubating |
-
-The filter in the customFilters should be a standard javax servlet filter.
-Specify filter parameters by setting configuration entries of the form `gravitino.server.webserver.<class name of filter>.param.<param name>=<value>`.
-
-### Storage Configuration
-
-#### Storage Backend Configuration
-
-Gravitino only supports JDBC database backend, and the default implementation is H2 database as it's an embedded database, has no external dependencies and is very suitable for local development or tests.
-If you are going to use H2 in the production environment, Gravitino will not guarantee the data consistency and durability. It's highly recommended using MySQL as the backend database.  
-
-The following table lists the storage configuration items:
-
-| Configuration item                                 | Description                                                                                                                                                                                                                                             | Default value                     | Required                                        | Since version    |
-|----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|-------------------------------------------------|------------------|
-| `gravitino.entity.store`                           | Which entity storage implementation to use. Only`relational` storage is supported.                                                                                                                                                                      | `relational`                      | No                                              | 0.1.0            |
-| `gravitino.entity.store.maxTransactionSkewTimeMs`  | The maximum skew time of transactions in milliseconds.                                                                                                                                                                                                  | `2000`                            | No                                              | 0.3.0            |
-| `gravitino.entity.store.deleteAfterTimeMs`         | The maximum time in milliseconds that deleted and old-version data is kept. Set to at least 10 minutes and no longer than 30 days.                                                                                                                      | `604800000`(7 days)               | No                                              | 0.5.0            |
-| `gravitino.entity.store.versionRetentionCount`     | The Count of versions allowed to be retained, including the current version, used to delete old versions data. Set to at least 1 and no greater than 10.                                                                                                | `1`                               | No                                              | 0.5.0            |
-| `gravitino.entityChangeLog.pollIntervalSecs`       | The interval in seconds for polling the entity change log. The poller invalidates stale local caches (e.g. the catalog cache) across HA nodes by consuming change log records. Must be positive.                                                        | `3`                               | No                                              | 1.3.0            |
-| `gravitino.entityChangeLog.retentionSecs`          | The retention time in seconds for entity change log rows. Expired rows are pruned periodically. Set to `0` to disable automatic cleanup. Must be non-negative.                                                                                          | `86400`(1 day)                    | No                                              | 1.3.0            |
-| `gravitino.entityChangeLog.cleanupIntervalSecs`    | The interval in seconds for pruning expired entity change log rows. Must be positive.                                                                                                                                                                   | `3600`(1 hour)                    | No                                              | 1.3.0            |
-| `gravitino.entity.store.relational`                | Detailed implementation of Relational storage. `H2`, `MySQL` and `PostgreSQL` is supported, and the implementation is `JDBCBackend`.                                                                                                                    | `JDBCBackend`                     | No                                              | 0.5.0            |
-| `gravitino.entity.store.relational.jdbcUrl`        | The database url that the `JDBCBackend` needs to connect to. If you use `MySQL` or `PostgreSQL`, you should firstly initialize the database tables yourself by executing the ddl scripts in the `${GRAVITINO_HOME}/scripts/{DATABASE_TYPE}/` directory. | `jdbc:h2`                         | No                                              | 0.5.0            |
-| `gravitino.entity.store.relational.jdbcDriver`     | The jdbc driver name that the `JDBCBackend` needs to use. You should place the driver Jar package in the `${GRAVITINO_HOME}/libs/` directory.                                                                                                           | `org.h2.Driver`                   | Yes if the jdbc connection url is not `jdbc:h2` | 0.5.0            |
-| `gravitino.entity.store.relational.jdbcUser`       | The username that the `JDBCBackend` needs to use when connecting the database. It is required for `MySQL`.                                                                                                                                              | `gravitino`                       | Yes if the jdbc connection url is not `jdbc:h2` | 0.5.0            |
-| `gravitino.entity.store.relational.jdbcPassword`   | The password that the `JDBCBackend` needs to use when connecting the database. It is required for `MySQL`.                                                                                                                                              | `gravitino`                       | Yes if the jdbc connection url is not `jdbc:h2` | 0.5.0            |
-| `gravitino.entity.store.relational.storagePath`    | The storage path for embedded JDBC storage implementation. It supports both absolute and relative path, if the value is a relative path, the final path is `${GRAVITINO_HOME}/${PATH_YOU_HAVA_SET}`, default value is `${GRAVITINO_HOME}/data/jdbc`     | `${GRAVITINO_HOME}/data/jdbc`     | No                                              | 0.6.0-incubating |
-| `gravitino.entity.store.relational.maxConnections` | The maximum number of connections for the JDBC Backend connection pool                                                                                                                                                                                  | `100`                             | No                                              | 0.9.0-incubating |
-| `gravitino.entity.store.relational.maxWaitMillis`  | The maximum wait time in milliseconds for a connection from the JDBC Backend connection pool                                                                                                                                                            | `1000`                            | No                                              | 0.9.0-incubating |
-
-
-:::caution
-We strongly recommend that you change the default value of `gravitino.entity.store.relational.storagePath`, as it's under the deployment directory and future version upgrades may remove it.
-:::
-
-#### Create JDBC Backend Schema and Table
-
-For H2 database, All tables needed by Gravitino are created automatically when the Gravitino server starts up. For MySQL, you should firstly initialize the database tables yourself by executing the ddl scripts in the `${GRAVITINO_HOME}/scripts/mysql/` directory.
-
-### Storage Cache Configuration
-
-To enable storage caching, modify the following settings in the `${GRAVITINO_HOME}/conf/gravitino.conf` file:
-
-```
-# Whether to enable the cache
-gravitino.cache.enabled=true
-
-# Specify the cache implementation (no need to use the fully qualified class name)
-gravitino.cache.implementation=caffeine
-
-# Number of lock segments for cache concurrency optimization
-gravitino.cache.lockSegments=16
+```shell
+${GRAVITINO_HOME}/bin/gravitino.sh start
 ```
 
-| Configuration Key                | Description                                | Default Value          | Required | Since Version |
-|----------------------------------|--------------------------------------------|------------------------|----------|---------------|
-| `gravitino.cache.enabled`        | Whether to enable caching                  | `true`                 | Yes      | 1.0.0         |
-| `gravitino.cache.implementation` | Specifies the cache implementation         | `caffeine`             | Yes      | 1.0.0         |
-| `gravitino.cache.maxEntries`     | Maximum number of entries allowed in cache | `10000`                | No       | 1.0.0         |
-| `gravitino.cache.expireTimeInMs` | Cache expiration time (in milliseconds)    | `3600000` (about 1 hr) | No       | 1.0.0         |
-| `gravitino.cache.enableStats`    | Whether to enable cache statistics logging | `false`                | No       | 1.0.0         |
-| `gravitino.cache.enableWeigher`  | Whether to enable weight-based eviction    | `true`                 | No       | 1.0.0         |
-| `gravitino.cache.lockSegments`   | Number of lock segments.                   | `16`                   | No       | 1.0.0         |
+One property is still worth setting. By default, H2 writes its database files to
+`${GRAVITINO_HOME}/data/jdbc`, which is inside the unpacked distribution. Upgrading Gravitino
+means unpacking a new distribution, so the metadata sits in the very directory you are about to
+replace or abandon. Move it somewhere the upgrade does not touch:
 
-- `gravitino.cache.enableWeigher`: When enabled, eviction is based on weight and `maxEntries` will be ignored.
-- `gravitino.cache.expireTimeInMs`: Controls the cache TTL in milliseconds.
-- If `gravitino.cache.enableStats` is enabled, Gravitino will log cache statistics (hit count, miss count, load failures, etc.) every 5 minutes at the Info level.
-
-#### Eviction Strategies
-
-Gravitino supports multiple eviction strategies including capacity-based, weight-based, and time-based (TTL) eviction. The following describes how they work with Caffeine:
-
-##### Capacity-based eviction
-
-When `gravitino.cache.enableWeigher` is **disabled**, Gravitino limits the number of cached entries using `gravitino.cache.maxEntries` and employs Caffeine’s W-TinyLFU eviction policy to remove the least-used entries when the cache is full.
-
-##### Weight-based eviction
-
-When `gravitino.cache.enableWeigher` is **enabled**, Gravitino uses a combination of `maximumWeight` and a custom weigher to control the total weight of the cache:
-
-- Each entity type has a default weight (e.g., Metalake > Catalog > Schema);
-- Entries are evicted based on the combined weight limit (`maximumWeight`);
-- If a single cache item exceeds the total weight limit, it will not be cached;
-- When this strategy is active, `maxEntries` will be ignored.
-
-##### Time-based eviction
-
-All cache entries are subject to a TTL (Time-To-Live) expiration policy. By default, the TTL is `3600000ms` (1 hour) and can be adjusted via the `gravitino.cache.expireTimeInMs` setting:
-
-- TTL starts at the time of entry creation; once it exceeds the configured duration, the entry expires automatically;
-- TTL can work in conjunction with both capacity and weight-based eviction;
-- Expired entries will also trigger asynchronous cleanup mechanisms for resource release and logging.
-
-### Job Configuration
-
-The following table lists the job configuration items:
-
-| Configuration Item                     | Description                                                                                                                                                               | Default Value                 | Required | Since Version |
-|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|----------|---------------|
-| `gravitino.job.stagingDir`             | Directory for managing staging files when running jobs.                                                                                                                   | `/tmp/gravitino/jobs/staging` | No       | 1.0.0         |
-| `gravitino.job.executor`               | The executor to run jobs. By default it is `local`; users can implement their own executor and set it here.                                                               | `local`                       | No       | 1.0.0         |
-| `gravitino.job.stagingDirKeepTimeInMs` | The time in milliseconds to keep the staging files of the finished job in the job staging directory. The minimum recommended value is 10 minutes if you are not testing.  | `604800000` (7 days)          | No       | 1.0.0         |
-| `gravitino.job.statusPullIntervalInMs` | The interval in milliseconds to pull the job status from the job executor. The minimum recommended value is 1 minute if you are not testing.                              | `300000` (5 minutes)          | No       | 1.0.0         |
-
-### Tree Lock Configuration
-
-The Gravitino server uses a tree lock to ensure data consistency. The tree lock is an in-memory lock; Gravitino currently supports only in-memory locks. The configuration items are as follows:
-
-| Configuration item                   | Description                                                   | Default value | Required | Since Version |
-|--------------------------------------|---------------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.lock.maxNodes`            | The maximum number of tree lock nodes to keep in memory       | 100000        | No       | 0.5.0         |
-| `gravitino.lock.minNodes`            | The minimum number of tree lock nodes to keep in memory       | 1000          | No       | 0.5.0         |
-| `gravitino.lock.cleanIntervalInSecs` | The interval in seconds to clean up the stale tree lock nodes | 60            | No       | 0.5.0         |
-
-### Catalog Configuration
-
-| Configuration item                           | Description                                                                                                                                                                                         | Default value | Required | Since version |
-|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.catalog.cache.evictionIntervalMs`           | The interval in milliseconds to evict the catalog cache; default 3600000ms(1h).                                                                                                                                                                                                                                                                                                                          | `3600000` | No | 0.1.0 |
-| `gravitino.catalog.classloader.isolated`               | Whether to use an isolated classloader for catalog. If `true`, an isolated classloader loads all catalog-related libraries and configurations, not the AppClassLoader. The default value is `true`.                                                                                                                                                                                                       | `true`    | No | 0.1.0 |
-| `gravitino.catalog.credential.backfillToProperties`    | For backward compatibility only: if `true`, the server exposes hidden catalog credentials (such as jdbc-user and jdbc-password) in the catalog properties response so that connectors that do not support credential vending can still read them. **Enabling this is a security risk** — credentials are visible to anyone who can read catalog properties. Disable once all connectors are upgraded.       | `false`   | No | 1.3.0 |
-
-### Schema configuration
-
-| Configuration item          | Description                                                                                                                                                                                                                                                                                                                                                                          | Default value | Required | Since version |
-|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.schema.separator` | The separator used to represent a hierarchical (multi-level) schema in schema names at the API boundary, e.g. `:` for `A:B:C`. It only takes effect for catalogs that support hierarchical schemas (currently the Iceberg catalog). The value must not be blank and must not contain `.` or the internal physical separator (ASCII-1, `\u0001`). See [Hierarchical schema](./lakehouse-iceberg-catalog.md#hierarchical-schema). | `:`           | No       | 1.3.0         |
-
-### Auxiliary Service Configuration
-
-| Configuration item            | Description                                                                                                                    | Default value | Since Version |
-|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|---------------|---------------|
-| `gravitino.auxService.names ` | The auxiliary service name of the Gravitino Iceberg REST server. Use **`iceberg-rest`** for the Gravitino Iceberg REST server. | (none)        | 0.2.0         |
-
-Refer to [Iceberg REST catalog service](iceberg-rest-service.md) for configuration details.
-
-### Event Listener Configuration
-
-Gravitino provides event listener mechanism to allow users to capture the events which are provided by Gravitino server to integrate some custom operations.
-
-To leverage the event listener, you must implement the `EventListenerPlugin` interface and place the JAR file in the classpath of the Gravitino server. Then, add configurations to gravitino.conf to enable the event listener.
-
-| Property name                          | Description                                                                                            | Default value | Required | Since Version |
-|----------------------------------------|--------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.eventListener.names`        | The name of the event listener, For multiple listeners, separate names with a comma, like "audit,sync" | (none)        | Yes      | 0.5.0         |
-| `gravitino.eventListener.{name}.class` | The class name of the event listener, replace `{name}` with the actual listener name.                  | (none)        | Yes      | 0.5.0         | 
-| `gravitino.eventListener.{name}.{key}` | Custom properties that will be passed to the event listener plugin.                                    | (none)        | Yes      | 0.5.0         | 
-
-#### Event
-
-Gravitino triggers a pre-event before the operation, a post-event after the completion of the operation and a failure event after the operation failed.
-
-##### Post-event
-
-| Operation type                          | Post-event                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Since Version    |
-|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-| table operation                         | `CreateTableEvent`, `AlterTableEvent`, `DropTableEvent`, `LoadTableEvent`, `ListTableEvent`, `PurgeTableEvent`, `CreateTableFailureEvent`, `AlterTableFailureEvent`, `DropTableFailureEvent`, `LoadTableFailureEvent`, `ListTableFailureEvent`, `PurgeTableFailureEvent`                                                                                                                                                                                                                                                                                                                                                                                         | 0.5.0            |
-| fileset operation                       | `CreateFilesetEvent`, `AlterFilesetEvent`, `DropFilesetEvent`, `LoadFilesetEvent`, `ListFilesetEvent`, `GetFileLocationEvent`, `ListFilesEvent`, `CreateFilesetFailureEvent`, `AlterFilesetFailureEvent`, `DropFilesetFailureEvent`, `LoadFilesetFailureEvent`, `ListFilesetFailureEvent`, `GetFileLocationFailureEvent`, `ListFilesFailureEvent`                                                                                                                                                                                                                                                                                                                 | 0.5.0            |
-| topic operation                         | `CreateTopicEvent`, `AlterTopicEvent`, `DropTopicEvent`, `LoadTopicEvent`, `ListTopicEvent`, `CreateTopicFailureEvent`, `AlterTopicFailureEvent`, `DropTopicFailureEvent`, `LoadTopicFailureEvent`, `ListTopicFailureEvent`                                                                                                                                                                                                                                                                                                                                                                                                                                      | 0.5.0            |
-| schema operation                        | `CreateSchemaEvent`, `AlterSchemaEvent`, `DropSchemaEvent`, `LoadSchemaEvent`, `ListSchemaEvent`, `CreateSchemaFailureEvent`, `AlterSchemaFailureEvent`, `DropSchemaFailureEvent`, `LoadSchemaFailureEvent`, `ListSchemaFailureEvent`                                                                                                                                                                                                                                                                                                                                                                                                                            | 0.5.0            |
-| catalog operation                       | `CreateCatalogEvent`, `AlterCatalogEvent`, `DropCatalogEvent`, `LoadCatalogEvent`, `ListCatalogEvent`, `EnableCatalogEvent`, `DisableCatalogEvent`, `CreateCatalogFailureEvent`, `AlterCatalogFailureEvent`, `DropCatalogFailureEvent`, `LoadCatalogFailureEvent`, `ListCatalogFailureEvent`, `EnableCatalogFailureEvent`, `DisableCatalogFailureEvent`                                                                                                                                                                                                                                                                                                           | 0.5.0            |
-| metalake operation                      | `CreateMetalakeEvent`, `AlterMetalakeEvent`, `DropMetalakeEvent`, `LoadMetalakeEvent`, `ListMetalakeEvent`, `EnableMetalakeEvent`, `DisableMetalakeEvent`, `CreateMetalakeFailureEvent`, `AlterMetalakeFailureEvent`, `DropMetalakeFailureEvent`, `LoadMetalakeFailureEvent`, `ListMetalakeFailureEvent`, `EnableMetalakeFailureEvent`, `DisableMetalakeFailureEvent`                                                                                                                                                                                                                                                                                             | 0.5.0            |
-| partition operation                     | `AddPartitionEvent`, `GetPartitionEvent`, `DropPartitionEvent`, `PurgePartitionEvent`, `ListPartitionEvent`, `ListPartitionNamesEvent`, `PartitionExistsEvent`, `AddPartitionFailureEvent`, `GetPartitionFailureEvent`, `DropPartitionFailureEvent`, `PurgePartitionFailureEvent`, `ListPartitionFailureEvent`, `ListPartitionNamesFailureEvent`, `PartitionExistsFailureEvent`                                                                                                                                                                                                                                                                                   | 0.6.0-incubating |
-| Iceberg REST server table operation     | `IcebergCreateTableEvent`, `IcebergUpdateTableEvent`, `IcebergDropTableEvent`, `IcebergLoadTableEvent`, `IcebergListTableEvent`, `IcebergTableExistsEvent`, `IcebergRenameTableEvent`, `IcebergRegisterTableEvent`, `IcebergLoadTableCredentialEvent`, `IcebergPlanTableScanEvent`, `IcebergCreateTableFailureEvent`, `IcebergUpdateTableFailureEvent`, `IcebergDropTableFailureEvent`, `IcebergLoadTableFailureEvent`, `IcebergListTableFailureEvent`, `IcebergTableExistsFailureEvent`, `IcebergRenameTableFailureEvent`, `IcebergRegisterTableFailureEvent`, `IcebergLoadTableCredentialFailureEvent`, `IcebergPlanTableScanFailureEvent` | 0.7.0-incubating |
-| Iceberg REST server namespace operation | `IcebergCreateNamespaceEvent`, `IcebergUpdateNamespaceEvent`, `IcebergDropNamespaceEvent`, `IcebergLoadNamespaceEvent`, `IcebergListNamespacesEvent`, `IcebergNamespaceExistsEvent`, `IcebergCreateNamespaceFailureEvent`, `IcebergUpdateNamespaceFailureEvent`, `IcebergDropNamespaceFailureEvent`, `IcebergLoadNamespaceFailureEvent`, `IcebergListNamespacesFailureEvent`, `IcebergNamespaceExistsFailureEvent`                                                                                                                                                                                                                                              | 0.8.0-incubating |
-| Iceberg REST server view operation      | `IcebergCreateViewEvent`, `IcebergReplaceViewEvent`, `IcebergDropViewEvent`, `IcebergLoadViewEvent`, `IcebergListViewEvent`, `IcebergViewExistsEvent`, `IcebergRenameViewEvent`, `IcebergCreateViewFailureEvent`, `IcebergReplaceViewFailureEvent`, `IcebergDropViewFailureEvent`, `IcebergLoadViewFailureEvent`, `IcebergListViewFailureEvent`, `IcebergViewExistsFailureEvent`, `IcebergRenameViewFailureEvent`                                                                                                                                                                                                                                                      | 0.8.0-incubating |
-| tag operation                           | `ListTagsEvent`, `ListTagsInfoEvent`, `CreateTagEvent`, `GetTagEvent`, `AlterTagEvent`, `DeleteTagEvent`, `ListMetadataObjectsForTagEvent`, `ListTagsForMetadataObjectEvent`, `ListTagsInfoForMetadataObjectEvent`, `AssociateTagsForMetadataObjectEvent`, `GetTagForMetadataObjectEvent`, `ListTagsFailureEvent`, `ListTagInfoFailureEvent`, `CreateTagFailureEvent`, `GetTagFailureEvent`, `AlterTagFailureEvent`, `DeleteTagFailureEvent`, `ListMetadataObjectsForTagFailureEvent`, `ListTagsForMetadataObjectFailureEvent`, `ListTagsInfoForMetadataObjectFailureEvent`, `AssociateTagsForMetadataObjectFailureEvent`, `GetTagForMetadataObjectFailureEvent` | 0.9.0-incubating |
-| model operation                         | `DeleteModelEvent`, `DeleteModelVersionEvent`, `GetModelEvent`, `GetModelVersionEvent`, `GetModelVersionUriEvent`, `LinkModelVersionEvent`, `ListModelEvent`, `ListModelVersionsEvent`, `ListModelVersionInfosEvent`, `RegisterAndLinkModelEvent`, `RegisterModelEvent`, `AlterModelEvent`, `AlterModelVersionEvent`, `DeleteModelFailureEvent`, `DeleteModelVersionFailureEvent`, `GetModelFailureEvent`, `GetModelVersionFailureEvent`, `GetModelVersionUriFailureEvent`, `LinkModelVersionFailureEvent`, `ListModelFailureEvent`, `ListModelVersionFailureEvent`, `ListModelVersionInfosFailureEvent`, `RegisterAndLinkModelFailureEvent`, `RegisterModelFailureEvent`, `AlterModelFailureEvent`, `AlterModelVersionFailureEvent` | 0.9.0-incubating |
-| user operation                          | `AddUserEvent`, `GetUserEvent`, `ListUserNamesEvent`, `ListUsersEvent`, `RemoveUserEvent`, `GrantUserRolesEvent`, `RevokeUserRolesEvent`, `AddUserFailureEvent`, `GetUserFailureEvent`, `GrantUserRolesFailureEvent`, `ListUserNamesFailureEvent`, `ListUsersFailureEvent`, `RemoveUserFailureEvent`, `RevokeUserRolesFailureEvent`                                                                                                                                                                                                                                                                                                                              | 0.9.0-incubating |
-| group operation                         | `AddGroupEvent`, `GetGroupEvent`, `ListGroupNamesEvent`, `ListGroupsEvent`, `RemoveGroupEvent`, `GrantGroupRolesEvent`, `RevokeGroupRolesEvent`, `AddGroupFailureEvent`, `GetGroupFailureEvent`, `GrantGroupRolesFailureEvent`, `ListGroupNamesFailureEvent`, `ListGroupsFailureEvent`, `RemoveGroupFailureEvent`, `RevokeGroupRolesFailureEvent`                                                                                                                                                                                                                                                                                                                | 0.9.0-incubating |
-| role operation                          | `CreateRoleEvent`, `DeleteRoleEvent`, `GetRoleEvent`, `GrantPrivilegesEvent`, `ListRoleNamesEvent`, `RevokePrivilegesEvent`, `OverridePrivilegesEvent`, `CreateRoleFailureEvent`, `DeleteRoleFailureEvent`, `GetRoleFailureEvent`, `GrantPrivilegesFailureEvent`, `ListRoleNamesFailureEvent`, `RevokePrivilegesFailureEvent`, `OverridePrivilegesFailureEvent`                                                                                                                                                                                                                                                                                                   | 0.9.0-incubating |
-| owner operation                         | `SetOwnerEvent`, `GetOwnerEvent`, `SetOwnerFailureEvent`, `GetOwnerFailureEvent`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 1.0.0            |
-| Gravitino server job template operation | `RegisterJobTemplateEvent`, `GetJobTemplateEvent`, `ListJobTemplatesEvent`, `AlterJobTemplateEvent`, `DeleteJobTemplateEvent`, `RegisterJobTemplateFailureEvent`, `GetJobTemplateFailureEvent`, `ListJobTemplatesFailureEvent`, `AlterJobTemplateFailureEvent`, `DeleteJobTemplateFailureEvent`                                                                                                                                                                                                                                                                                                                                                                  | 1.0.1            |
-| Gravitino server job operation          | `RunJobEvent`, `GetJobEvent`, `ListJobsEvent`, `CancelJobEvent`, `RunJobFailureEvent`, `GetJobFailureEvent`, `ListJobsFailureEvent`, `CancelJobFailureEvent`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1.0.1            |
-| Gravitino server statistics operation   | `ListStatisticsEvent`, `UpdateStatisticsEvent`, `DropStatisticsEvent`, `ListPartitionStatisticsEvent`, `UpdatePartitionStatisticsEvent`, `DropPartitionStatisticsEvent`, `ListStatisticsFailureEvent`, `UpdateStatisticsFailureEvent`, `DropStatisticsFailureEvent`, `ListPartitionStatisticsFailureEvent`, `UpdatePartitionStatisticsFailureEvent`, `DropPartitionStatisticsFailureEvent`                                                                                                                                                                                                                                                                       | 1.1.0            |
-| policy operation                        | `CreatePolicyEvent`, `AlterPolicyEvent`, `DeletePolicyEvent`, `GetPolicyEvent`, `ListPoliciesEvent`, `ListPolicyInfosEvent`, `EnablePolicyEvent`, `DisablePolicyEvent`, `GetPolicyForMetadataObjectEvent`, `AssociatePoliciesForMetadataObjectEvent`, `ListPolicyInfosForMetadataObjectEvent`, `ListMetadataObjectsForPolicyEvent`, `CreatePolicyFailureEvent`, `AlterPolicyFailureEvent`, `DeletePolicyFailureEvent`, `GetPolicyFailureEvent`, `ListPoliciesFailureEvent`, `ListPolicyInfosFailureEvent`, `EnablePolicyFailureEvent`, `DisablePolicyFailureEvent`, `GetPolicyForMetadataObjectFailureEvent`, `AssociatePoliciesForMetadataObjectFailureEvent`, `ListPolicyInfosForMetadataObjectFailureEvent`, `ListMetadataObjectsForPolicyFailureEvent` | 1.1.0            |
-| function operation                      | `RegisterFunctionEvent`, `GetFunctionEvent`, `AlterFunctionEvent`, `DropFunctionEvent`, `ListFunctionEvent`, `ListFunctionInfosEvent`, `RegisterFunctionFailureEvent`, `GetFunctionFailureEvent`, `AlterFunctionFailureEvent`, `DropFunctionFailureEvent`, `ListFunctionFailureEvent`                                                                                                                                                       | 1.3.0            |
-
-##### Pre-event
-
-| Operation type                          | Pre-event                                                                                                                                                                                                                                                                                                                  | Since Version    |
-|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-| Iceberg REST server table operation     | `IcebergCreateTablePreEvent`, `IcebergUpdateTablePreEvent`, `IcebergDropTablePreEvent`, `IcebergLoadTablePreEvent`, `IcebergListTablePreEvent`, `IcebergTableExistsPreEvent`, `IcebergRenameTablePreEvent`, `IcebergRegisterTablePreEvent`, `IcebergLoadTableCredentialPreEvent`, `IcebergPlanTableScanPreEvent`           | 0.7.0-incubating |
-| Iceberg REST server namespace operation | `IcebergCreateNamespacePreEvent`, `IcebergUpdateNamespacePreEvent`, `IcebergDropNamespacePreEvent`, `IcebergLoadNamespacePreEvent`, `IcebergListNamespacesPreEvent`, `IcebergNamespaceExistsPreEvent`                                                                                                                      | 0.8.0-incubating |
-| Iceberg REST server view operation      | `IcebergCreateViewPreEvent`, `IcebergReplaceViewPreEvent`, `IcebergDropViewPreEvent`, `IcebergLoadViewPreEvent`, `IcebergListViewPreEvent`, `IcebergViewExistsPreEvent`, `IcebergRenameViewPreEvent`                                                                                                                       | 0.8.0-incubating |
-| Gravitino server table operation        | `CreateTablePreEvent`, `AlterTablePreEvent`, `DropTablePreEvent`, `PurgeTablePreEvent`, `LoadTablePreEvent`, `ListTablePreEvent`                                                                                                                                                                                           | 0.8.0-incubating |
-| Gravitino server schema operation       | `CreateSchemaPreEvent`, `AlterSchemaPreEvent`, `DropSchemaPreEvent`, `LoadSchemaPreEvent`, `ListSchemaPreEvent`                                                                                                                                                                                                            | 0.8.0-incubating |
-| Gravitino server catalog operation      | `CreateCatalogPreEvent`, `AlterCatalogPreEvent`, `DropCatalogPreEvent`, `LoadCatalogPreEvent`, `ListCatalogPreEvent`, `EnableCatalogPreEvent`, `DisableCatalogPreEvent`                                                                                                                                                     | 0.8.0-incubating |
-| Gravitino server metalake operation     | `CreateMetalakePreEvent`, `AlterMetalakePreEvent`, `DropMetalakePreEvent`, `LoadMetalakePreEvent`, `ListMetalakePreEvent`, `EnableMetalakePreEvent`, `DisableMetalakePreEvent`                                                                                                                                              | 0.8.0-incubating |
-| Gravitino server partition operation    | `AddPartitionPreEvent`, `DropPartitionPreEvent`, `GetPartitionPreEvent`, `PurgePartitionPreEvent`,`ListPartitionPreEvent`,`ListPartitionNamesPreEvent`                                                                                                                                                                     | 0.8.0-incubating |
-| Gravitino server fileset operation      | `CreateFilesetPreEvent`, `AlterFilesetPreEvent`, `DropFilesetPreEvent`, `LoadFilesetPreEvent`,`ListFilesetPreEvent`,`GetFileLocationPreEvent`, `ListFilesPreEvent`                                                                                                                                                         | 0.8.0-incubating |
-| Gravitino server model operation        | `DeleteModelPreEvent`, `DeleteModelVersionPreEvent`, `RegisterAndLinkModelPreEvent`, `GetModelPreEvent`, `GetModelVersionPreEvent`, `GetModelVersionUriPreEvent`, `LinkModelVersionPreEvent`, `ListModelPreEvent`, `ListModelVersionPreEvent`, `ListModelVersionInfosPreEvent`, `RegisterModelPreEvent`, `AlterModelPreEvent`, `AlterModelVersionPreEvent` | 0.9.0-incubating |
-| Gravitino server tag operation          | `ListTagsPreEvent`, `ListTagsInfoPreEvent`, `CreateTagPreEvent`, `GetTagPreEvent`, `AlterTagPreEvent`, `DeleteTagPreEvent`, `ListMetadataObjectsForTagPreEvent`, `ListTagsForMetadataObjectPreEvent`, `ListTagsInfoForMetadataObjectPreEvent`, `AssociateTagsForMetadataObjectPreEvent`, `GetTagForMetadataObjectPreEvent` | 0.9.0-incubating |
-| Gravitino server user operation         | `AddUserPreEvent`, `GetUserPreEvent`, `ListUserNamesPreEvent`, `ListUsersPreEvent`, `RemoveUserPreEvent`, `GrantUserRolesPreEvent`, `RevokeUserRolesPreEvent`                                                                                                                                                              | 0.9.0-incubating |
-| Gravitino server group operation        | `AddGroupPreEvent`, `GetGroupPreEvent`, `ListGroupNamesPreEvent`, `ListGroupsPreEvent`, `RemoveGroupPreEvent`, `GrantGroupRolesPreEvent`, `RevokeGroupRolesPreEvent`                                                                                                                                                       | 0.9.0-incubating |
-| Gravitino server role operation         | `CreateRolePreEvent`, `DeleteRolePreEvent`, `GetRolePreEvent`, `GrantPrivilegesPreEvent`, `ListRoleNamesPreEvent`, `RevokePrivilegesPreEvent`, `OverridePrivilegesPreEvent`                                                                                                                                                 | 0.9.0-incubating |
-| Gravitino server owner operation        | `SetOwnerPreEvent`, `GetOwnerPreEvent`                                                                                                                                                                                                                                                                                     | 1.0.0            |
-| Gravitino server job template operation | `RegisterJobTemplatePreEvent`, `GetJobTemplatePreEvent`, `ListJobTemplatesPreEvent`, `AlterJobTemplatePreEvent`, `DeleteJobTemplatePreEvent`                                                                                                                                                                               | 1.0.1            |
-| Gravitino server job operation          | `RunJobPreEvent`, `GetJobPreEvent`, `ListJobsPreEvent`, `CancelJobPreEvent`                                                                                                                                                                                                                                                | 1.0.1            |
-| Gravitino server statistics operation   | `ListStatisticsPreEvent`, `UpdateStatisticsPreEvent`, `DropStatisticsPreEvent`, `ListPartitionStatisticsPreEvent`, `UpdatePartitionStatisticsPreEvent`, `DropPartitionStatisticsPreEvent`                                                                                                                                  | 1.1.0            |
-| policy operation                        | `CreatePolicyPreEvent`, `AlterPolicyPreEvent`, `DeletePolicyPreEvent`, `GetPolicyPreEvent`, `ListPoliciesPreEvent`, `ListPolicyInfosPreEvent`, `EnablePolicyPreEvent`, `DisablePolicyPreEvent`, `GetPolicyForMetadataObjectPreEvent`, `AssociatePoliciesForMetadataObjectPreEvent`, `ListPolicyInfosForMetadataObjectPreEvent`, `ListMetadataObjectsForPolicyPreEvent` | 1.1.0 |
-| function operation                      | `RegisterFunctionPreEvent`, `GetFunctionPreEvent`, `AlterFunctionPreEvent`, `DropFunctionPreEvent`, `ListFunctionPreEvent`                                                                                                                                                                                                        | 1.3.0 |
-
-#### Event Listener Plugin
-
-The `EventListenerPlugin` defines an interface for event listeners that manage the lifecycle and state of a plugin. This includes handling its initialization, startup, and shutdown processes, as well as handing events triggered by various operations.
-
-The plugin provides several operational modes for how to process event, supporting both synchronous and asynchronous processing approaches.
-
-- **SYNC**: Events are processed synchronously, immediately following the associated operation. This mode ensures events are processed before the operation's result is returned to the client, but it may delay the main process if event processing takes too long.
-
-- **ASYNC_SHARED**: This mode employs a shared queue and dispatcher for asynchronous event processing. It prevents the main process from being blocked, though there's a risk events might be dropped if not promptly consumed. Sharing a dispatcher can lead to poor isolation in case of slow listeners.
- 
-- **ASYNC_ISOLATED**: Events are processed asynchronously, with each listener having its own dedicated queue and dispatcher thread. This approach offers better isolation but at the expense of multiple queues and dispatchers.
-
-When processing pre-event, you could throw a `ForbiddenException` to skip the following executions. For more details, refer to the definition of the plugin.
-
-### Audit Log Configuration
-
-The audit log framework defines how audit logs are formatted and written to various storages. The formatter defines an interface that transforms different `Event` types into a unified `AuditLog`. The writer defines an interface to writing AuditLog to different storages.
-
-Gravitino provides a default implementation to log basic audit information to a file. You can extend the audit system by implementing the corresponding interfaces.
-
-| Property name                         | Description                            | Default value                                   | Required | Since Version     |
-|---------------------------------------|----------------------------------------|-------------------------------------------------|----------|-------------------|
-| `gravitino.audit.enabled`             | The audit log enable flag.             | false                                           | NO       | 0.7.0-incubating  |
-| `gravitino.audit.writer.className`    | The class name of audit log writer.    | org.apache.gravitino.audit.FileAuditWriter      | NO       | 0.7.0-incubating  |
-| `gravitino.audit.formatter.className` | The class name of audit log formatter. | org.apache.gravitino.audit.v2.SimpleFormatterV2 | NO       | 0.7.0-incubating  |
-
-#### Audit Log Formatter
-
-The `Formatter` interface transforms an `Event` into an `AuditLog`. `SimpleFormatterV2` is the default implementation. `JsonAuditFormatter` is also available when structured JSON output is required. It emits one JSON object per line, serializes `customInfo`, and formats `timestamp` as ISO 8601 with millisecond precision and zone offset. Both simple and JSON formatters mask sensitive values such as `Authorization`, `Cookie`, `X-Amz-Security-Token`, `s3.access-key-id`, and `jdbc-password`.
-
-#### Audit Log Writer
-
-The `AuditLogWriter` interface enables writing audit logs to different storage mediums (files, databases, etc.).
-
-`FileAuditWriter` is the default implementation. It delegates all file management — rotation, compression, and retention — to Log4j2 via a dedicated logger named `gravitino.audit`. The appender is configured in `conf/log4j2.properties` (see the `audit_file` appender group). The default configuration rotates daily and on 256 MB, compresses rotated files with gzip, and deletes files older than 30 days.
-
-##### Deprecated FileAuditWriter properties
-
-The following `gravitino.audit.writer.file.*` properties were accepted in earlier versions but are now **deprecated** and have no effect. `FileAuditWriter` emits a `WARN` log at startup if any of them are present. Configure the equivalent behavior directly in `conf/log4j2.properties` instead.
-
-| Deprecated property                             | Migration: configure in `conf/log4j2.properties`                  |
-|-------------------------------------------------|-------------------------------------------------------------------|
-| `gravitino.audit.writer.file.fileName`          | `appender.audit_file.fileName`                                    |
-| `gravitino.audit.writer.file.append`            | `appender.audit_file.append`                                      |
-| `gravitino.audit.writer.file.flushIntervalSecs` | Use `immediateFlush` on the appender or an async appender wrapper |
-
-Example — change the audit log path:
-
-```properties
-# conf/log4j2.properties
-appender.audit_file.fileName = /var/log/gravitino/my_audit.log
-appender.audit_file.filePattern = /var/log/gravitino/my_audit_%d{yyyyMMdd}.%i.log.gz
+```text
+# conf/gravitino.conf
+gravitino.entity.store.relational.storagePath = /var/lib/gravitino/data/jdbc
 ```
 
-Example — adjust retention to 90 days:
+Nothing here is authenticated. The default `simple` authenticator takes whatever username the
+client sends, the server speaks plain HTTP, and authorization is off, so every caller can do
+everything. Together with H2, for which Gravitino makes no consistency or durability guarantee,
+that makes this configuration unfit for anything but local work.
 
-```properties
-appender.audit_file.strategy.delete.ifLastModified.age = 90d
+### Production
+
+A production server keeps metadata in MySQL or PostgreSQL, authenticates its callers, enforces
+authorization, and writes an audit log:
+
+```text
+# conf/gravitino.conf
+# Entity store
+gravitino.entity.store.relational.jdbcUrl      = jdbc:mysql://{db_host}:3306/{database}
+gravitino.entity.store.relational.jdbcDriver   = com.mysql.cj.jdbc.Driver
+gravitino.entity.store.relational.jdbcUser     = {username}
+gravitino.entity.store.relational.jdbcPassword = {password}
+
+# Transport
+gravitino.server.webserver.enableHttps      = true
+gravitino.server.webserver.keyStorePath     = /etc/gravitino/tls/server.jks
+gravitino.server.webserver.keyStorePassword = {keystore_password}
+gravitino.server.webserver.managerPassword  = {manager_password}
+
+# Authentication
+gravitino.authenticators                            = oauth
+gravitino.authenticator.oauth.jwksUri               = {jwks_uri}
+gravitino.authenticator.oauth.tokenValidatorClass   = org.apache.gravitino.server.authentication.JwksTokenValidator
+gravitino.authenticator.oauth.serviceAudience       = {audience}
+gravitino.authenticator.oauth.principalFields       = preferred_username,email,sub
+
+# Authorization
+gravitino.authorization.enable        = true
+gravitino.authorization.serviceAdmins = {admin_user}
+
+# Audit log
+gravitino.audit.enabled = true
+
+# Entity cache
+gravitino.cache.enabled        = true
+gravitino.cache.implementation = caffeine
+gravitino.cache.lockSegments   = 16
+gravitino.cache.enableStats    = true
 ```
 
-### Security Configuration
+Only `gravitino.cache.enableStats` changes behavior here; it logs hit count, miss count, and load
+failures every five minutes, which is what makes a cache problem visible in production. The three
+lines above it restate defaults, and are spelled out so the cache configuration is reviewable in
+one place rather than inferred from its absence. Raise `lockSegments` above the default if the
+server runs hot enough for cache lock contention to show up in profiles.
 
-Refer to [security](security/security.md) for HTTPS and authentication configurations.
+Four things this block depends on:
 
-| Configuration Item                         | Description                                                                                                                                                                                                                                          | Default Value | Required | Since Version |
-|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.fetchFile.blockUnsafeRemoteUri` | Whether to block remote file URIs from resolving to unsafe addresses from the Gravitino server side. This applies to job files and catalog files such as Kerberos keytabs. Disable this only for trusted URIs that require access to such addresses. | `true`        | No       | 1.3.0         |
+**The database schema is not created for you.** Initialize it and put the JDBC driver jar in
+`${GRAVITINO_HOME}/libs/` before the first start. See
+[Relational Backend Storage](how-to-use-relational-backend-storage.md).
 
-### Metrics Configuration
+**HTTPS replaces HTTP rather than joining it.** A server with `enableHttps` set no longer serves
+plain HTTP, so clients and the Web UI must move to `httpsPort`, which defaults to `8433`. See
+[HTTPS](security/how-to-use-https.md).
 
-| Property name                             | Description                                          | Default value | Required | Since Version |
-|-------------------------------------------|------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.metrics.timeSlidingWindowSecs` | The seconds of Gravitino metrics time sliding window | 60            | No       | 0.5.1         |
+**The authenticator is one line, its provider is not.** The block above validates JWTs against a
+JWKS endpoint, which is the common case for an external identity provider. Static sign keys,
+Kerberos, and the OIDC login flow for the Web UI each take a different set of properties. See
+[How to Authenticate](security/how-to-authenticate.md), or
+[How to Use the Built-in IdP](security/how-to-use-built-in-idp.md) to keep users and groups in
+Gravitino's own metadata store instead of an external provider.
 
-### Health Check Endpoints
+**`gravitino.authorization.serviceAdmins` has no default.** It is the one property here that
+Gravitino will not fill in for you, and enabling authorization without it fails at startup. What
+those admins and everyone else may then do is the subject of
+[Access Control](security/access-control.md).
 
-Gravitino exposes three health check endpoints following [MicroProfile Health](https://microprofile.io/project/eclipse/microprofile-health) semantics. All endpoints are exempt from authentication so that Kubernetes probes, load balancers, and global traffic managers can reach them without credentials.
+Give the JVM more than the 1 GB it takes by default:
 
-| Endpoint                | Description                                                                                                                                                                           | HTTP status |
-|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| `GET /api/health/live`  | Liveness probe. Returns 200 as long as the HTTP server thread can respond. Use this to determine whether to restart a pod.                                                            | 200         |
-| `GET /api/health/ready` | Readiness probe. Returns 200 when the entity store is reachable within the configured timeout; 503 when the entity store is unavailable or slow. Use this to control traffic routing. | 200 / 503   |
-| `GET /api/health`       | Aggregate check. Returns 200 when both liveness and readiness pass; 503 when any check fails.                                                                                         | 200 / 503   |
-
-Root-level aliases are also available for global traffic managers that require probes at well-known root paths:
-
-| Alias               | Forwards to             |
-|---------------------|-------------------------|
-| `GET /health`       | `GET /api/health`       |
-| `GET /health/live`  | `GET /api/health/live`  |
-| `GET /health/ready` | `GET /api/health/ready` |
-| `GET /health.html`  | `GET /api/health`       |
-
-**Configuration:**
-
-| Property name                                        | Description                                                                               | Default value | Required | Since version |
-|------------------------------------------------------|-------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.server.health.entityStore.probeTimeoutMs` | Timeout in milliseconds for the entity-store readiness probe used by `/api/health/ready`. | `2000`        | No       | 1.3.0         |
-
-**Response format:**
-
-All endpoints return a JSON body with the same shape. The `code` field is always `0`. `status` is `UP` or `DOWN`. `checks` lists per-component results; liveness reports `httpServer` and readiness reports `entityStore`.
-
-Healthy response (HTTP 200):
-
-```json
-{
-  "code": 0,
-  "status": "UP",
-  "checks": [
-    { "name": "httpServer", "status": "UP", "details": {} },
-    { "name": "entityStore", "status": "UP", "details": {} }
-  ]
-}
+```shell
+export GRAVITINO_MEM="-Xms4g -Xmx4g -XX:MaxMetaspaceSize=1g"
 ```
 
-Unhealthy response (HTTP 503):
+### Docker
+
+The Gravitino image does not simply run the server against the configuration file you give it. At
+startup the entrypoint rewrites `conf/gravitino.conf`, applying its own defaults over roughly two
+dozen properties and then applying any supported environment variables. Configure the container
+through environment variables:
+
+```shell
+docker run --rm -d \
+  -p 8090:8090 \
+  -e GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_URL="jdbc:postgresql://{db_host}:5432/{database}" \
+  -e GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_DRIVER="org.postgresql.Driver" \
+  apache/gravitino:{tag}
+```
+
+To supply a configuration file instead, for example from a Kubernetes ConfigMap, disable the
+rewrite with `SKIP_CONFIG_REWRITE=true`. See
+[Container Configuration](#container-configuration) for what the rewrite does and which variables
+it recognizes.
+
+### Running More Than One Server
+
+Servers behind a load balancer share the entity store but keep local caches. Each server polls the
+entity change log and invalidates entries that another server has modified. The defaults are safe:
+a three second poll, and a server that cannot keep its caches current exits rather than serving
+metadata it knows to be stale. Point the load balancer's health check at `GET /health/ready` so a
+server that has lost its database stops receiving traffic.
+
+## Server Configuration
+
+Every property in this section belongs in `${GRAVITINO_HOME}/conf/gravitino.conf`, one
+`property = value` pair per line. The server reads the file once, at startup, so a change
+takes effect on the next restart. A Default Value of `(empty)` means the property exists with an
+empty string or list; `(none)` means it has no default at all.
+
+### Serving Requests
+
+#### HTTP Server
+
+| Configuration Item                                   | Description                                                                                                                                                                                  | Default Value                           |
+|------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| `gravitino.server.webserver.host`                    | The address the server binds to.                                                                                                                                                             | `0.0.0.0`                               |
+| `gravitino.server.webserver.httpPort`                | The port the server listens on.                                                                                                                                                              | `8090`                                  |
+| `gravitino.server.webserver.minThreads`              | Minimum threads in the Jetty thread pool. Values below 8 are raised to 8.                                                                                                                    | Twice the processor count, 8 to 100     |
+| `gravitino.server.webserver.maxThreads`              | Maximum threads in the Jetty thread pool. Values below 8 are raised to 8, and the value must be at least `minThreads`.                                                                       | Four times the processor count, min 400 |
+| `gravitino.server.webserver.threadPoolWorkQueueSize` | Size of the Jetty thread pool work queue.                                                                                                                                                    | `100`                                   |
+| `gravitino.server.webserver.idleTimeout`             | Timeout in milliseconds for idle connections.                                                                                                                                                | `30000`                                 |
+| `gravitino.server.webserver.stopTimeout`             | Time in milliseconds Jetty waits for a graceful shutdown. See `org.eclipse.jetty.server.Server#setStopTimeout`.                                                                              | `30000`                                 |
+| `gravitino.server.shutdown.timeout`                  | Time in milliseconds for the Gravitino server itself to shut down gracefully.                                                                                                                | `3000`                                  |
+| `gravitino.server.webserver.requestHeaderSize`       | Maximum size in bytes of an HTTP request header.                                                                                                                                             | `131072`                                |
+| `gravitino.server.webserver.responseHeaderSize`      | Maximum size in bytes of an HTTP response header.                                                                                                                                            | `131072`                                |
+| `gravitino.server.webserver.customFilters`           | Comma-separated list of servlet filter class names to apply to the API.                                                                                                                      | (empty)                                 |
+| `gravitino.server.rest.extensionPackages`            | Comma-separated list of packages to scan for additional REST resources.                                                                                                                      | (empty)                                 |
+| `gravitino.server.visibleConfigs`                    | Comma-separated list of extra properties to expose on the unauthenticated `GET /configs` endpoint, on top of the fixed set it always returns. Additive, so each entry widens what is public. | (empty)                                 |
+
+Filters named in `customFilters` must be standard `javax.servlet` filters. Pass parameters to a
+filter with properties of the form
+`gravitino.server.webserver.{filter_class_name}.param.{param_name} = {value}`.
+
+`GET /configs` backs the Web UI, so it answers without authentication and always returns
+`gravitino.authenticators`, `gravitino.authorization.enable`, and `gravitino.schema.separator`.
+It adds `gravitino.authorization.serviceAdmins` when authorization is on, and the OAuth client
+settings when `oauth` is among the authenticators. Treat anything you add through
+`visibleConfigs` as public.
+
+Two further groups of `gravitino.server.webserver.*` properties are documented elsewhere, because
+they belong to features rather than to the web server itself. TLS, key stores, trust stores, and
+client certificate authentication are in [HTTPS](security/how-to-use-https.md). The CORS filter
+and its allowed origins, methods, and headers, needed when a browser client runs on a different
+origin than the server, are in [CORS](security/how-to-use-cors.md).
+
+#### Schema Names
+
+Catalogs that support hierarchical schemas expose the hierarchy as a single delimited name at
+the API boundary. Internally the levels are stored with ASCII-1 as the physical separator, so
+the configured separator is an external representation only, and it may be neither blank, nor
+`.`, nor ASCII-1.
+
+| Configuration Item           | Description                                                                                                                                                       | Default Value |
+|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `gravitino.schema.separator` | Separator representing a multi-level schema name at the API boundary, as in `A:B:C`. See [Hierarchical schema](lakehouse-iceberg-catalog.md#hierarchical-schema). | `:`           |
+
+#### Health Check Endpoints
+
+Gravitino exposes three health endpoints following
+[MicroProfile Health](https://microprofile.io/project/eclipse/microprofile-health) semantics. All
+of them are exempt from authentication, so Kubernetes probes, load balancers, and traffic managers
+reach them without credentials.
+
+| Endpoint                | Root Alias          | Description                                                                                                                                 | HTTP Status |
+|-------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| `GET /api/health/live`  | `GET /health/live`  | Liveness. Returns 200 as long as an HTTP server thread can respond. Use it to decide whether to restart a pod.                              | 200         |
+| `GET /api/health/ready` | `GET /health/ready` | Readiness. Returns 200 when the entity store answers within the probe timeout, 503 when it is unavailable or slow. Use it to route traffic. | 200 or 503  |
+| `GET /api/health`       | `GET /health`       | Aggregate. Returns 200 when both of the above pass. Also aliased as `GET /health.html`.                                                     | 200 or 503  |
+
+| Configuration Item                                   | Description                                                         | Default Value |
+|------------------------------------------------------|---------------------------------------------------------------------|---------------|
+| `gravitino.server.health.entityStore.probeTimeoutMs` | Timeout in milliseconds for the entity store probe behind `/ready`. | `2000`        |
+
+Every endpoint returns the same JSON shape, but not the same checks. `code` is always `0`,
+`status` is `UP` or `DOWN`, and `checks` carries one entry per component probed. `/live` reports
+`httpServer` alone, `/ready` reports `entityStore` alone, and the aggregate endpoint reports both:
 
 ```json
 {
@@ -371,213 +232,435 @@ Unhealthy response (HTTP 503):
 }
 ```
 
-Possible `reason` values in the `entityStore` DOWN check: `timeout`, `interrupted`, `probe-rejected`, or the class name of an unexpected exception.
+A failing `entityStore` check reports `timeout`, `interrupted`, `probe-rejected`,
+`entity store not initialized`, or the simple class name of an unexpected exception.
 
-### Memory Settings
+#### JVM Memory
 
-`GRAVITINO_MEM` sets JVM heap/metaspace flags for the Gravitino server and is also read by the Iceberg REST server and Lance REST server launchers.
+`GRAVITINO_MEM` sets the heap and metaspace flags. The launch scripts append it to `JAVA_OPTS`, and
+the Iceberg REST server and Lance REST server launchers read the same variable. Set it in
+`conf/gravitino-env.sh` or in the environment before starting the server.
 
-Default: `-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=512m` (see `bin/common.sh`). Launch scripts append this to `JAVA_OPTS`; override `GRAVITINO_MEM` when you need different heap/metaspace sizes.
+The default, from `bin/common.sh`, is `-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=512m`. Raise it in
+line with catalog count, plugin count, and query concurrency: `-Xms4g -Xmx4g
+-XX:MaxMetaspaceSize=1g` suits a moderate production server, and larger deployments go beyond that.
 
-Typical values:
-- Development: `-Xms1g -Xmx1g -XX:MaxMetaspaceSize=512m`
-- Moderate production: `-Xms4g -Xmx4g -XX:MaxMetaspaceSize=1g`
-- Larger deployments: `-Xms8g -Xmx8g -XX:MaxMetaspaceSize=1g` or higher depending on catalog count, plugins, and query concurrency
+#### Metrics
 
-## Catalog Properties Configuration
+| Configuration Item                        | Description                                          | Default Value |
+|-------------------------------------------|------------------------------------------------------|---------------|
+| `gravitino.metrics.timeSlidingWindowSecs` | Width in seconds of the metrics time sliding window. | `60`          |
 
-There are three types of catalog properties:
+### Storing Metadata
 
-1. **Gravitino defined properties**: Gravitino defines these properties as the necessary
-   configurations for the catalog to work properly.
-2. **Properties with the `gravitino.bypass.` prefix**: These properties are not managed by
-   Gravitino and pass directly to the underlying system for advanced usage.
-3. **Other properties**: Gravitino doesn't leverage these properties, just store them. Users
-   can use them for their own purposes.
+#### Storage Backend
 
-Catalog properties are either defined in catalog configuration files as default values or
-specified as `properties` explicitly when creating a catalog.
+Gravitino stores metadata over JDBC. H2 is the default because it is embedded and needs nothing
+external, which makes it right for local development and wrong for anything else: Gravitino makes
+no consistency or durability guarantee for metadata held in H2. Production deployments use MySQL or
+PostgreSQL, and the setup procedure for both is in
+[Relational Backend Storage](how-to-use-relational-backend-storage.md).
 
-:::info
-The catalog properties explicitly specified in the `properties` field take precedence over the
-default values in the catalog configuration file.
+The driver, user, and password properties are required whenever the URL is not `jdbc:h2`.
 
-These rules only apply to the catalog properties and don't affect the schema or table properties.
-:::
+| Configuration Item                                 | Description                                                                                                                                                                                                          | Default Value                 |
+|----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `gravitino.entity.store`                           | Entity storage implementation. `relational` is the only supported value.                                                                                                                                             | `relational`                  |
+| `gravitino.entity.store.relational`                | Relational storage implementation. `JDBCBackend` is the only supported value, and it covers H2, MySQL, and PostgreSQL.                                                                                               | `JDBCBackend`                 |
+| `gravitino.entity.store.relational.jdbcUrl`        | Database URL the backend connects to.                                                                                                                                                                                | `jdbc:h2`                     |
+| `gravitino.entity.store.relational.jdbcDriver`     | Driver class name. Place the driver jar in `${GRAVITINO_HOME}/libs/`.                                                                                                                                                | `org.h2.Driver`               |
+| `gravitino.entity.store.relational.jdbcUser`       | Database username.                                                                                                                                                                                                   | `gravitino`                   |
+| `gravitino.entity.store.relational.jdbcPassword`   | Database password.                                                                                                                                                                                                   | `gravitino`                   |
+| `gravitino.entity.store.relational.storagePath`    | Where embedded H2 keeps its files. A relative value resolves against `${GRAVITINO_HOME}`. The default sits inside the deployment directory, so an upgrade that replaces that directory discards the data. Change it. | `${GRAVITINO_HOME}/data/jdbc` |
+| `gravitino.entity.store.relational.maxConnections` | Maximum size of the JDBC connection pool.                                                                                                                                                                            | `100`                         |
+| `gravitino.entity.store.relational.maxWaitMillis`  | Maximum wait in milliseconds for a connection from the pool.                                                                                                                                                         | `1000`                        |
+| `gravitino.entity.store.maxTransactionSkewTimeMs`  | Maximum transaction skew in milliseconds.                                                                                                                                                                            | `2000`                        |
+| `gravitino.entity.store.deleteAfterTimeMs`         | How long in milliseconds deleted and superseded rows are kept. Accepts 10 minutes to 30 days.                                                                                                                        | `604800000` (7 days)          |
+| `gravitino.entity.store.versionRetentionCount`     | Number of entity versions kept, including the current one. Accepts 1 to 10.                                                                                                                                          | `1`                           |
 
-Below is a list of catalog properties that will be used by all Gravitino catalogs:
+#### Caching
 
-| Configuration item  | Description                                                                                                                                                                                                                                                | Default value | Required | Since version    |
-|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|------------------|
-| `package`           | The path of the catalog package, Gravitino leverages this path to load the related catalog libs and configurations. The package should consist two folders, `conf` (for catalog related configurations) and `libs` (for catalog related dependencies/jars) | (none)        | No       | 0.5.0            |
-| `cloud.name`        | The property to specify the cloud that the catalog is running on. The valid values are `aws`, `azure`, `gcp`, `on_premise` and `other`.                                                                                                                    | (none)        | No       | 0.6.0-incubating |
-| `cloud.region-code` | The property to specify the region code of the cloud that the catalog is running on.                                                                                                                                                                       | (none)        | No       | 0.6.0-incubating |
+The server caches entities in memory to avoid reading the backend on every request. Caching is on
+by default, and the properties below tune what it holds and how it evicts.
 
+| Configuration Item               | Description                                                                         | Default Value      |
+|----------------------------------|-------------------------------------------------------------------------------------|--------------------|
+| `gravitino.cache.enabled`        | Whether to cache entities at all.                                                   | `true`             |
+| `gravitino.cache.implementation` | Cache implementation. Use the short name, not a fully qualified class name.         | `caffeine`         |
+| `gravitino.cache.maxEntries`     | Maximum number of cached entries. Ignored when `enableWeigher` is `true`.           | `10000`            |
+| `gravitino.cache.expireTimeInMs` | Time to live in milliseconds, measured from entry creation.                         | `3600000` (1 hour) |
+| `gravitino.cache.enableWeigher`  | Whether to evict by weight rather than by entry count.                              | `true`             |
+| `gravitino.cache.enableStats`    | Whether to log hit count, miss count, and load failures every five minutes at INFO. | `false`            |
+| `gravitino.cache.lockSegments`   | Number of lock segments used to reduce contention.                                  | `16`               |
 
-The following table lists the catalog specific properties and their default paths:
+Two eviction limits apply at once. Time to live always applies: an entry older than
+`expireTimeInMs` expires and is cleaned up asynchronously. Alongside it, the cache bounds its size
+either by count or by weight. With `enableWeigher` disabled, Caffeine's W-TinyLFU policy evicts the
+least-used entries once `maxEntries` is reached. With `enableWeigher` enabled, each entity type
+carries a weight, larger for entities higher in the hierarchy, and eviction targets a total weight
+budget instead; `maxEntries` is ignored, and a single entry heavier than the whole budget is never
+cached.
 
-| catalog provider    | catalog properties                                                                      | catalog properties configuration file path               |
+#### Change Log Propagation
+
+Caches are local to each server, so a metalake modified on one server would otherwise stay stale on
+its neighbors. Every server writes its changes to an entity change log table and polls that table
+to invalidate what other servers have touched. A separate cleaner trims old rows.
+
+| Configuration Item                              | Description                                                              | Default Value   |
+|--------------------------------------------------|---------------------------------------------------------------------------|-----------------|
+| `gravitino.entityChangeLog.pollIntervalSecs`    | Interval in seconds between polls. Must be positive.                    | `3`             |
+| `gravitino.entityChangeLog.retentionSecs`       | How long in seconds change log rows are kept before being pruned. `0` disables cleanup. Must be non-negative. | `86400` (1 day) |
+| `gravitino.entityChangeLog.cleanupIntervalSecs` | Interval in seconds between cleanup runs that prune expired change log rows. Must be positive. | `3600` (1 hour) |
+
+#### Tree Lock
+
+Gravitino serializes conflicting metadata operations with an in-memory tree lock. It is the only
+lock implementation available, and it is per-server.
+
+| Configuration Item                   | Description                                          | Default Value |
+|--------------------------------------|------------------------------------------------------|---------------|
+| `gravitino.lock.maxNodes`            | Maximum tree lock nodes held in memory.              | `100000`      |
+| `gravitino.lock.minNodes`            | Minimum tree lock nodes held in memory.              | `1000`        |
+| `gravitino.lock.cleanIntervalInSecs` | Interval in seconds for reclaiming stale lock nodes. | `60`          |
+
+### Loading Catalogs
+
+These properties govern how the server loads and isolates catalogs. The properties that configure
+an individual catalog are covered under [Catalog Properties](#catalog-properties).
+
+`credential.backfillToProperties` below is the escape hatch for connectors that cannot consume
+vended credentials; the mechanism it opts out of is described in
+[Credential Vending](security/credential-vending.md).
+
+| Configuration Item                                  | Description                                                                                                                                                                                                                                                                                            | Default Value |
+|-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `gravitino.catalog.cache.evictionIntervalMs`        | Interval in milliseconds before an idle catalog is evicted from the catalog cache.                                                                                                                                                                                                                     | `3600000`     |
+| `gravitino.catalog.classloader.isolated`            | Whether to load each catalog's libraries and configuration in an isolated classloader rather than the application classloader.                                                                                                                                                                         | `true`        |
+| `gravitino.catalog.credential.backfillToProperties` | Whether to return hidden catalog credentials such as `jdbc-user` and `jdbc-password` in the catalog properties response, for connectors that cannot consume vended credentials. Anyone who can read catalog properties can then read those credentials. Turn it off once your connectors are upgraded. | `false`       |
+
+### Securing the Server
+
+#### Authentication
+
+Authentication decides who a caller is. It is off by default: an unconfigured server trusts
+whatever username the client sends.
+
+| Configuration Item         | Description                                                                                                    | Default Value |
+|----------------------------|----------------------------------------------------------------------------------------------------------------|---------------|
+| `gravitino.authenticators` | Comma-separated authenticators to enable. Valid values are `simple`, `oauth`, `kerberos`, `basic`, and `none`. | `simple`      |
+
+Naming an authenticator is one line; configuring it is not. Each value reads its own family of
+`gravitino.authenticator.*` properties, covered in
+[How to Authenticate](security/how-to-authenticate.md). To hold users, password hashes, and group
+membership in Gravitino's own relational store rather than an external provider, see
+[How to Use the Built-in IdP](security/how-to-use-built-in-idp.md).
+
+`gravitino.authenticator`, in the singular, is a deprecated spelling that still works.
+
+#### Authorization
+
+Authorization decides what an authenticated caller may do. It is also off by default, and turning
+it on requires naming the service admins, since that property has no default of its own.
+
+| Configuration Item                       | Description                                                                                | Default Value                                                         |
+|------------------------------------------|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| `gravitino.authorization.enable`         | Whether to enforce privileges on metadata operations.                                      | `false`                                                               |
+| `gravitino.authorization.serviceAdmins`  | Comma-separated users who administer the service. Metalake creation is restricted to them. | (none)                                                                |
+| `gravitino.authorization.impl`           | Authorizer implementation.                                                                 | `org.apache.gravitino.server.authorization.jcasbin.JcasbinAuthorizer` |
+| `gravitino.authorization.threadPoolSize` | Threads serving authorization checks.                                                      | `100`                                                                 |
+
+The privilege model these properties switch on, roles, grants, ownership, and the
+`gravitino.authorization.jcasbin.*` tuning of the default authorizer, is described in
+[Access Control](security/access-control.md). To push enforcement down into the underlying systems
+through Apache Ranger or a native permission model, see
+[Authorization Pushdown](security/authorization-pushdown.md).
+
+#### Remote File Fetching
+
+The server fetches files by URI in two situations: staging a job's files, and loading catalog files
+such as a Kerberos keytab. Both accept remote URIs, so both are a path by which a caller who can
+create a catalog or submit a job could make the server issue requests of its own.
+
+| Configuration Item                         | Description                                                                                                   | Default Value |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------|---------------|
+| `gravitino.fetchFile.blockUnsafeRemoteUri` | Whether to refuse remote URIs that resolve to unsafe addresses. Disable only for trusted URIs that need them. | `true`        |
+
+#### Audit Logging
+
+The audit log framework has two halves. A formatter turns an `Event` into an `AuditLog`, and a
+writer puts that `AuditLog` somewhere. Both are interfaces, so a deployment with its own log
+pipeline can replace either.
+
+| Configuration Item                    | Description                    | Default Value                                     |
+|---------------------------------------|--------------------------------|---------------------------------------------------|
+| `gravitino.audit.enabled`             | Whether to write an audit log. | `false`                                           |
+| `gravitino.audit.formatter.className` | Formatter class name.          | `org.apache.gravitino.audit.v2.SimpleFormatterV2` |
+| `gravitino.audit.writer.className`    | Writer class name.             | `org.apache.gravitino.audit.FileAuditWriter`      |
+
+`SimpleFormatterV2` is the default formatter. `JsonAuditFormatter` is available where structured
+output is wanted: it emits one JSON object per line, serializes `customInfo`, and writes timestamps
+as ISO 8601 with millisecond precision and a zone offset. Both formatters replace the value of a
+sensitive `customInfo` key with `***`. The masked keys are `authorization`, `cookie`,
+`x-amz-security-token`, `s3.access-key-id`, and `jdbc-password`.
+
+`FileAuditWriter` is the default writer, and it manages no files itself. Rotation, compression, and
+retention are delegated to Log4j2 through a logger named `gravitino.audit`, configured by the
+`audit_file` appender group in `conf/log4j2.properties`. Out of the box it writes
+`gravitino_audit.log` under the log directory, rotates daily and at 256 MB, gzips what it rotates,
+and deletes anything older than 30 days. Change the path or the retention there:
+
+```properties
+# conf/log4j2.properties
+appender.audit_file.fileName    = /var/log/gravitino/my_audit.log
+appender.audit_file.filePattern = /var/log/gravitino/my_audit_%d{yyyyMMdd}.%i.log.gz
+
+appender.audit_file.strategy.delete.ifAll.ifLastModified.age = 90d
+```
+
+Earlier releases configured the writer directly through `gravitino.audit.writer.file.*`. Those
+properties now do nothing, and `FileAuditWriter` logs a warning at startup if it finds any of them.
+
+| Removed Property                                | Configure Instead In `conf/log4j2.properties`                     |
+|-------------------------------------------------|-------------------------------------------------------------------|
+| `gravitino.audit.writer.file.fileName`          | `appender.audit_file.fileName`                                    |
+| `gravitino.audit.writer.file.append`            | `appender.audit_file.append`                                      |
+| `gravitino.audit.writer.file.flushIntervalSecs` | `immediateFlush` on the appender, or wrap it in an async appender |
+
+### Extending the Server
+
+#### Event Listeners
+
+An event listener receives the events Gravitino emits around metadata operations, which is how
+external systems observe the catalog without polling it. To use one, implement
+`EventListenerPlugin`, put the jar on the server classpath, and name it in `gravitino.conf`.
+
+| Configuration Item                     | Description                                                                            | Default Value |
+|----------------------------------------|----------------------------------------------------------------------------------------|---------------|
+| `gravitino.eventListener.names`        | Comma-separated listener names, as in `audit,sync`.                                    | (empty)       |
+| `gravitino.eventListener.{name}.class` | Class name of the listener registered under `{name}`.                                  | (none)        |
+| `gravitino.eventListener.{name}.{key}` | Any other property under a listener's name is passed through to that plugin unchanged. | (none)        |
+
+Every name in `names` needs a matching `{name}.class`, or the server fails to build that listener.
+
+Each operation emits up to three events: a pre-event before it runs, a post-event after it
+succeeds, and a failure event after it throws. The names follow the operation, so `createTable`
+produces `CreateTablePreEvent`, `CreateTableEvent`, and `CreateTableFailureEvent`. Operations
+served by the Gravitino IRC endpoint carry an `Iceberg` prefix, as in `IcebergCreateTableEvent`.
+Not every operation defines all three. The full set of classes lives in the
+[`org.apache.gravitino.listener.api.event`](https://github.com/apache/gravitino/tree/main/core/src/main/java/org/apache/gravitino/listener/api/event)
+package.
+
+Throwing a `ForbiddenException` from a pre-event handler stops the operation before it runs, which
+makes pre-events a veto point rather than a notification.
+
+A plugin declares how its events are dispatched:
+
+| Mode             | Behavior                                                                                                                         |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `SYNC`           | Processed inline, before the operation's result reaches the client. A slow listener slows the request.                           |
+| `ASYNC_SHARED`   | Processed on a queue and dispatcher shared with other listeners. One slow listener degrades the rest, and events can be dropped. |
+| `ASYNC_ISOLATED` | Processed on a queue and dispatcher of its own. Better isolation, at the cost of a queue and thread per listener.                |
+
+#### Auxiliary Services
+
+An auxiliary service runs inside the Gravitino server process on its own port. The property has
+no default, but the `gravitino.conf` shipped in the distribution sets it to
+`iceberg-rest,lance-rest`, so both start unless you change the line.
+
+| Configuration Item           | Description                                                                                                                  | Default Value |
+|------------------------------|------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `gravitino.auxService.names` | Comma-separated auxiliary services to start. `iceberg-rest` is the Gravitino IRC server, `lance-rest` the Lance REST server. | (empty)       |
+
+The rest of the IRC configuration, and the `gravitino.lance-rest.*` properties of the Lance REST
+server, are documented with those services. See
+[Iceberg REST Catalog Service](iceberg-rest-service.md).
+
+#### Jobs
+
+| Configuration Item                     | Description                                                                                                | Default Value                 |
+|----------------------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `gravitino.job.executor`               | Executor that runs jobs. Implement your own and name it here to replace the built-in one.                  | `local`                       |
+| `gravitino.job.stagingDir`             | Directory holding staging files for running jobs.                                                          | `/tmp/gravitino/jobs/staging` |
+| `gravitino.job.stagingDirKeepTimeInMs` | How long in milliseconds a finished job's staging files are kept. Use at least 10 minutes outside testing. | `604800000` (7 days)          |
+| `gravitino.job.statusPullIntervalInMs` | Interval in milliseconds between job status polls. Use at least 1 minute outside testing.                  | `300000` (5 minutes)          |
+
+## Catalog Properties
+
+Catalog properties configure one catalog rather than the server. They come from two places: a
+catalog configuration file supplies defaults for every catalog of that provider, and the
+`properties` field on a create-catalog request supplies values for that catalog alone. The request
+wins. Neither affects schema or table properties.
+
+A catalog property is one of three kinds. Gravitino defines some itself, as the settings a catalog
+needs to work. Anything prefixed `gravitino.bypass.` passes straight through to the underlying
+system untouched. Anything else Gravitino simply stores for you to use as you like.
+
+Passing credentials, tokens, or access keys through `gravitino.bypass.` exposes them: bypassed
+properties are not managed by Gravitino and can come back in plaintext from the REST API. Where an
+underlying system leaves no alternative, restrict access to the catalog APIs accordingly.
+
+These properties apply to every catalog:
+
+| Configuration Item  | Description                                                                                                                                            | Default Value |
+|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `package`           | Path to the catalog package, from which Gravitino loads the catalog's libraries and configuration. It holds a `conf` directory and a `libs` directory. | (none)        |
+| `cloud.name`        | Cloud the catalog runs on. One of `aws`, `azure`, `gcp`, `on_premise`, or `other`.                                                                     | (none)        |
+| `cloud.region-code` | Region code within that cloud.                                                                                                                         | (none)        |
+
+Everything else is per provider. The server adds each configuration directory below to the
+classpath automatically, which is also where provider-specific files such as `hdfs-site.xml` go.
+
+| Catalog Provider    | Catalog Properties                                                                      | Configuration File Path                                  |
 |---------------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------|
 | `hive`              | [Hive catalog properties](apache-hive-catalog.md#catalog-properties)                    | `catalogs/hive/conf/hive.conf`                           |
+| `glue`              | [AWS Glue catalog properties](aws-glue-catalog.md#catalog-properties)                   | `catalogs/glue/conf/glue.conf`                           |
 | `lakehouse-iceberg` | [Lakehouse Iceberg catalog properties](lakehouse-iceberg-catalog.md#catalog-properties) | `catalogs/lakehouse-iceberg/conf/lakehouse-iceberg.conf` |
 | `lakehouse-paimon`  | [Lakehouse Paimon catalog properties](lakehouse-paimon-catalog.md#catalog-properties)   | `catalogs/lakehouse-paimon/conf/lakehouse-paimon.conf`   |
 | `lakehouse-hudi`    | [Lakehouse Hudi catalog properties](lakehouse-hudi-catalog.md#catalog-properties)       | `catalogs/lakehouse-hudi/conf/lakehouse-hudi.conf`       |
+| `lakehouse-generic` | [Lakehouse Generic catalog properties](lakehouse-generic-catalog.md#catalog-properties) | `catalogs/lakehouse-generic/conf/lakehouse-generic.conf` |
 | `jdbc-mysql`        | [MySQL catalog properties](jdbc-mysql-catalog.md#catalog-properties)                    | `catalogs/jdbc-mysql/conf/jdbc-mysql.conf`               |
 | `jdbc-postgresql`   | [PostgreSQL catalog properties](jdbc-postgresql-catalog.md#catalog-properties)          | `catalogs/jdbc-postgresql/conf/jdbc-postgresql.conf`     |
 | `jdbc-doris`        | [Doris catalog properties](jdbc-doris-catalog.md#catalog-properties)                    | `catalogs/jdbc-doris/conf/jdbc-doris.conf`               |
-| `jdbc-oceanbase`    | [OceanBase catalog properties](jdbc-oceanbase-catalog.md#catalog-properties)            | `catalogs/jdbc-oceanbase/conf/jdbc-oceanbase.conf`       |
+| `jdbc-starrocks`    | [StarRocks catalog properties](jdbc-starrocks-catalog.md#catalog-properties)            | `catalogs/jdbc-starrocks/conf/jdbc-starrocks.conf`       |
+| `jdbc-clickhouse` ‡ | [ClickHouse catalog properties](jdbc-clickhouse-catalog.md#catalog-properties)          | `catalogs/jdbc-clickhouse/conf/jdbc-clickhouse.conf`     |
+| `jdbc-hologres` ‡   | [Hologres catalog properties](jdbc-hologres-catalog.md#catalog-properties)              | `catalogs/jdbc-hologres/conf/jdbc-hologres.conf`         |
+| `jdbc-oceanbase` ‡  | [OceanBase catalog properties](jdbc-oceanbase-catalog.md#catalog-properties)            | `catalogs/jdbc-oceanbase/conf/jdbc-oceanbase.conf`       |
 | `kafka`             | [Kafka catalog properties](kafka-catalog.md#catalog-properties)                         | `catalogs/kafka/conf/kafka.conf`                         |
-| `fileset`           | [Fileset catalog properties](fileset-catalog#catalog-properties)                        | `catalogs/fileset/conf/fileset.conf`                     |
-| `model`             | [Fileset catalog properties](model-catalog#catalog-properties)                          | `catalogs/model/conf/model.conf`                         |
+| `fileset`           | [Fileset catalog properties](fileset-catalog.md#catalog-properties)                     | `catalogs/fileset/conf/fileset.conf`                     |
+| `model`             | [Model catalog properties](model-catalog.md#catalog-properties)                         | `catalogs/model/conf/model.conf`                         |
 
-:::info
-The Gravitino server automatically adds the catalog properties configuration directory to classpath.
-:::
+‡ Contributed catalogs, shipped only in the `-all` distribution package. The standard package
+does not contain their directories.
 
-## Some Other Configurations
-
-You could put HDFS configuration file to the catalog properties configuration dir, like `catalogs/lakehouse-iceberg/conf/`.
-
-## Docker Instructions
-
-Run the Gravitino server in a Docker container:
+## Container Configuration
 
 ```shell
-docker run -d -p 8090:8090 apache/gravitino:latest
+docker run --rm -d -p 8090:8090 apache/gravitino:{tag}
 ```
 
-The Gravitino Docker image supports injecting configuration values via environment variables by translating them to corresponding entries in `gravitino.conf` at container startup.
+### How the Container Builds Its Configuration
 
-This is done using a startup script that parses environment variables prefixed with `GRAVITINO_` and rewrites the configuration file accordingly.
+The container entrypoint rewrites `conf/gravitino.conf` before the JVM starts. It works in two
+passes. First it writes its own defaults, unconditionally, over every property it knows a default
+for, discarding whatever the file said. Then it applies each supported environment variable that is
+set. The result is written back over the original file.
 
-These variables override the corresponding entries in `gravitino.conf` at startup.
+Two consequences worth internalizing. A property you baked into `conf/gravitino.conf` survives only
+if the container has no default for it, so a value like a custom `httpPort` in a mounted file is
+silently replaced. And the container's defaults are not the server's defaults: the container pins
+`minThreads` to 24 and `maxThreads` to 200, where a server started outside a container computes both
+from the processor count.
 
-| Environment Variable                                     | Configuration Key                                    | Default Value                                        | Since Version |
-|----------------------------------------------------------|------------------------------------------------------|------------------------------------------------------|---------------|
-| `GRAVITINO_SERVER_SHUTDOWN_TIMEOUT`                      | `gravitino.server.shutdown.timeout`                  | `3000`                                               | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_HOST`                        | `gravitino.server.webserver.host`                    | `0.0.0.0`                                            | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_HTTP_PORT`                   | `gravitino.server.webserver.httpPort`                | `8090`                                               | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_MIN_THREADS`                 | `gravitino.server.webserver.minThreads`              | `24`                                                 | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_MAX_THREADS`                 | `gravitino.server.webserver.maxThreads`              | `200`                                                | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_STOP_TIMEOUT`                | `gravitino.server.webserver.stopTimeout`             | `30000`                                              | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_IDLE_TIMEOUT`                | `gravitino.server.webserver.idleTimeout`             | `30000`                                              | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_THREAD_POOL_WORK_QUEUE_SIZE` | `gravitino.server.webserver.threadPoolWorkQueueSize` | `100`                                                | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_REQUEST_HEADER_SIZE`         | `gravitino.server.webserver.requestHeaderSize`       | `131072`                                             | 1.0.0         |
-| `GRAVITINO_SERVER_WEBSERVER_RESPONSE_HEADER_SIZE`        | `gravitino.server.webserver.responseHeaderSize`      | `131072`                                             | 1.0.0         |
-| `GRAVITINO_ENTITY_STORE`                                 | `gravitino.entity.store`                             | `relational`                                         | 1.0.0         |
-| `GRAVITINO_ENTITY_STORE_RELATIONAL`                      | `gravitino.entity.store.relational`                  | `JDBCBackend`                                        | 1.0.0         |
-| `GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_URL`             | `gravitino.entity.store.relational.jdbcUrl`          | `jdbc:h2`                                            | 1.0.0         |
-| `GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_DRIVER`          | `gravitino.entity.store.relational.jdbcDriver`       | `org.h2.Driver`                                      | 1.0.0         |
-| `GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_USER`            | `gravitino.entity.store.relational.jdbcUser`         | `gravitino`                                          | 1.0.0         |
-| `GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_PASSWORD`        | `gravitino.entity.store.relational.jdbcPassword`     | `gravitino`                                          | 1.0.0         |
-| `GRAVITINO_CATALOG_CACHE_EVICTION_INTERVAL_MS`           | `gravitino.catalog.cache.evictionIntervalMs`         | `3600000`                                            | 1.0.0         |
-| `GRAVITINO_AUTHORIZATION_ENABLE`                         | `gravitino.authorization.enable`                     | `false`                                              | 1.0.0         |
-| `GRAVITINO_AUTHORIZATION_THREAD_POOL_SIZE`               | `gravitino.authorization.threadPoolSize`             | `100`                                                | 1.0.0         |
-| `GRAVITINO_AUTHORIZATION_SERVICE_ADMINS`                 | `gravitino.authorization.serviceAdmins`              | `anonymous`                                          | 1.0.0         |
-| `GRAVITINO_AUX_SERVICE_NAMES`                            | `gravitino.auxService.names`                         | `iceberg-rest`                                       | 1.0.0         |
-| `GRAVITINO_ICEBERG_REST_CLASSPATH`                       | `gravitino.iceberg-rest.classpath`                   | `iceberg-rest-server/libs, iceberg-rest-server/conf` | 1.0.0         |
-| `GRAVITINO_ICEBERG_REST_HOST`                            | `gravitino.iceberg-rest.host`                        | `0.0.0.0`                                            | 1.0.0         |
-| `GRAVITINO_ICEBERG_REST_HTTP_PORT`                       | `gravitino.iceberg-rest.httpPort`                    | `9001`                                               | 1.0.0         |
-| `GRAVITINO_ICEBERG_REST_URI`                             | `gravitino.iceberg-rest.uri`                         | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_IO_IMPL`                         | `gravitino.iceberg-rest.io-impl`                     | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_CATALOG_BACKEND`                 | `gravitino.iceberg-rest.catalog-backend`             | `memory`                                             | 1.0.0         |
-| `GRAVITINO_ICEBERG_REST_JDBC_DRIVER`                     | `gravitino.iceberg-rest.jdbc-driver`                 | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_JDBC_USER`                       | `gravitino.iceberg-rest.jdbc-user`                   | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_JDBC_PASSWORD`                   | `gravitino.iceberg-rest.jdbc-password`               | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_WAREHOUSE`                       | `gravitino.iceberg-rest.warehouse`                   | `/tmp/`                                              | 1.0.0         |
-| `GRAVITINO_ICEBERG_REST_CREDENTIAL_PROVIDERS`            | `gravitino.iceberg-rest.credential-providers`        | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_GCS_SERVICE_ACCOUNT_FILE`        | `gravitino.iceberg-rest.gcs-service-account-file`    | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_S3_ACCESS_KEY`                   | `gravitino.iceberg-rest.s3-access-key-id`            | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_S3_SECRET_KEY`                   | `gravitino.iceberg-rest.s3-secret-access-key`        | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_S3_ENDPOINT`                     | `gravitino.iceberg-rest.s3-endpoint`                 | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_S3_REGION`                       | `gravitino.iceberg-rest.s3-region`                   | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_S3_PATH_STYLE_ACCESS`            | `gravitino.iceberg-rest.s3-path-style-access`        | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_S3_ROLE_ARN`                     | `gravitino.iceberg-rest.s3-role-arn`                 | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_S3_EXTERNAL_ID`                  | `gravitino.iceberg-rest.s3-external-id`              | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_S3_TOKEN_SERVICE_ENDPOINT`       | `gravitino.iceberg-rest.s3-token-service-endpoint`   | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_AZURE_STORAGE_ACCOUNT_NAME`      | `gravitino.iceberg-rest.azure-storage-account-name`  | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_AZURE_STORAGE_ACCOUNT_KEY`       | `gravitino.iceberg-rest.azure-storage-account-key`   | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_AZURE_TENANT_ID`                 | `gravitino.iceberg-rest.azure-tenant-id`             | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_AZURE_CLIENT_ID`                 | `gravitino.iceberg-rest.azure-client-id`             | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_AZURE_CLIENT_SECRET`             | `gravitino.iceberg-rest.azure-client-secret`         | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_OSS_ACCESS_KEY`                  | `gravitino.iceberg-rest.oss-access-key-id`           | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_OSS_SECRET_KEY`                  | `gravitino.iceberg-rest.oss-secret-access-key`       | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_OSS_ENDPOINT`                    | `gravitino.iceberg-rest.oss-endpoint`                | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_OSS_REGION`                      | `gravitino.iceberg-rest.oss-region`                  | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_OSS_ROLE_ARN`                    | `gravitino.iceberg-rest.oss-role-arn`                | (none)                                               | 1.3.0         |
-| `GRAVITINO_ICEBERG_REST_OSS_EXTERNAL_ID`                 | `gravitino.iceberg-rest.oss-external-id`             | (none)                                               | 1.3.0         |
+Set `SKIP_CONFIG_REWRITE=true` to disable both passes and run the configuration file exactly as
+written. Use this when the file comes from a Kubernetes ConfigMap.
 
-:::note
-The Gravitino server Docker image bundles MySQL and PostgreSQL JDBC drivers under
-`jdbc-drivers/`. The container startup script links them into `libs/` and
-`iceberg-rest-server/libs/` for the auxiliary Iceberg REST service.
+### Supported Environment Variables
 
-For cloud storage backends such as S3, OSS, Azure, or GCS, place the corresponding Iceberg
-bundle jars under `iceberg-bundles/`. The startup script links them into
-`iceberg-rest-server/libs/` at container startup.
-:::
+The entrypoint recognizes the variables below and ignores every other `GRAVITINO_` variable. The
+Container Default column gives the value the first pass writes when the variable is unset; `(none)`
+means the property is left alone.
 
-### Usage examples
+| Environment Variable                                     | Configuration Key                                    | Container Default                                    |
+|----------------------------------------------------------|------------------------------------------------------|------------------------------------------------------|
+| `GRAVITINO_SERVER_SHUTDOWN_TIMEOUT`                      | `gravitino.server.shutdown.timeout`                  | `3000`                                               |
+| `GRAVITINO_SERVER_WEBSERVER_HOST`                        | `gravitino.server.webserver.host`                    | `0.0.0.0`                                            |
+| `GRAVITINO_SERVER_WEBSERVER_HTTP_PORT`                   | `gravitino.server.webserver.httpPort`                | `8090`                                               |
+| `GRAVITINO_SERVER_WEBSERVER_MIN_THREADS`                 | `gravitino.server.webserver.minThreads`              | `24`                                                 |
+| `GRAVITINO_SERVER_WEBSERVER_MAX_THREADS`                 | `gravitino.server.webserver.maxThreads`              | `200`                                                |
+| `GRAVITINO_SERVER_WEBSERVER_STOP_TIMEOUT`                | `gravitino.server.webserver.stopTimeout`             | `30000`                                              |
+| `GRAVITINO_SERVER_WEBSERVER_IDLE_TIMEOUT`                | `gravitino.server.webserver.idleTimeout`             | `30000`                                              |
+| `GRAVITINO_SERVER_WEBSERVER_THREAD_POOL_WORK_QUEUE_SIZE` | `gravitino.server.webserver.threadPoolWorkQueueSize` | `100`                                                |
+| `GRAVITINO_SERVER_WEBSERVER_REQUEST_HEADER_SIZE`         | `gravitino.server.webserver.requestHeaderSize`       | `131072`                                             |
+| `GRAVITINO_SERVER_WEBSERVER_RESPONSE_HEADER_SIZE`        | `gravitino.server.webserver.responseHeaderSize`      | `131072`                                             |
+| `GRAVITINO_ENTITY_STORE`                                 | `gravitino.entity.store`                             | `relational`                                         |
+| `GRAVITINO_ENTITY_STORE_RELATIONAL`                      | `gravitino.entity.store.relational`                  | `JDBCBackend`                                        |
+| `GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_URL`             | `gravitino.entity.store.relational.jdbcUrl`          | `jdbc:h2`                                            |
+| `GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_DRIVER`          | `gravitino.entity.store.relational.jdbcDriver`       | `org.h2.Driver`                                      |
+| `GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_USER`            | `gravitino.entity.store.relational.jdbcUser`         | `gravitino`                                          |
+| `GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_PASSWORD`        | `gravitino.entity.store.relational.jdbcPassword`     | `gravitino`                                          |
+| `GRAVITINO_CATALOG_CACHE_EVICTION_INTERVAL_MS`           | `gravitino.catalog.cache.evictionIntervalMs`         | `3600000`                                            |
+| `GRAVITINO_AUTHORIZATION_ENABLE`                         | `gravitino.authorization.enable`                     | `false`                                              |
+| `GRAVITINO_AUTHORIZATION_SERVICE_ADMINS`                 | `gravitino.authorization.serviceAdmins`              | `anonymous`                                          |
+| `GRAVITINO_AUX_SERVICE_NAMES`                            | `gravitino.auxService.names`                         | `iceberg-rest`                                       |
+| `GRAVITINO_ICEBERG_REST_HOST`                            | `gravitino.iceberg-rest.host`                        | `0.0.0.0`                                            |
+| `GRAVITINO_ICEBERG_REST_HTTP_PORT`                       | `gravitino.iceberg-rest.httpPort`                    | `9001`                                               |
+| `GRAVITINO_ICEBERG_REST_URI`                             | `gravitino.iceberg-rest.uri`                         | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_CLASSPATH`                       | `gravitino.iceberg-rest.classpath`                   | `iceberg-rest-server/libs, iceberg-rest-server/conf` |
+| `GRAVITINO_ICEBERG_REST_IO_IMPL`                         | `gravitino.iceberg-rest.io-impl`                     | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_CATALOG_BACKEND`                 | `gravitino.iceberg-rest.catalog-backend`             | `memory`                                             |
+| `GRAVITINO_ICEBERG_REST_JDBC_DRIVER`                     | `gravitino.iceberg-rest.jdbc-driver`                 | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_JDBC_USER`                       | `gravitino.iceberg-rest.jdbc-user`                   | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_JDBC_PASSWORD`                   | `gravitino.iceberg-rest.jdbc-password`               | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_WAREHOUSE`                       | `gravitino.iceberg-rest.warehouse`                   | `/tmp/`                                              |
+| `GRAVITINO_ICEBERG_REST_CREDENTIAL_PROVIDERS`            | `gravitino.iceberg-rest.credential-providers`        | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_GCS_SERVICE_ACCOUNT_FILE`        | `gravitino.iceberg-rest.gcs-service-account-file`    | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_S3_ACCESS_KEY`                   | `gravitino.iceberg-rest.s3-access-key-id`            | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_S3_SECRET_KEY`                   | `gravitino.iceberg-rest.s3-secret-access-key`        | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_S3_ENDPOINT`                     | `gravitino.iceberg-rest.s3-endpoint`                 | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_S3_REGION`                       | `gravitino.iceberg-rest.s3-region`                   | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_S3_PATH_STYLE_ACCESS`            | `gravitino.iceberg-rest.s3-path-style-access`        | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_S3_ROLE_ARN`                     | `gravitino.iceberg-rest.s3-role-arn`                 | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_S3_EXTERNAL_ID`                  | `gravitino.iceberg-rest.s3-external-id`              | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_S3_TOKEN_SERVICE_ENDPOINT`       | `gravitino.iceberg-rest.s3-token-service-endpoint`   | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_AZURE_STORAGE_ACCOUNT_NAME`      | `gravitino.iceberg-rest.azure-storage-account-name`  | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_AZURE_STORAGE_ACCOUNT_KEY`       | `gravitino.iceberg-rest.azure-storage-account-key`   | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_AZURE_TENANT_ID`                 | `gravitino.iceberg-rest.azure-tenant-id`             | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_AZURE_CLIENT_ID`                 | `gravitino.iceberg-rest.azure-client-id`             | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_AZURE_CLIENT_SECRET`             | `gravitino.iceberg-rest.azure-client-secret`         | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_OSS_ACCESS_KEY`                  | `gravitino.iceberg-rest.oss-access-key-id`           | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_OSS_SECRET_KEY`                  | `gravitino.iceberg-rest.oss-secret-access-key`       | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_OSS_ENDPOINT`                    | `gravitino.iceberg-rest.oss-endpoint`                | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_OSS_REGION`                      | `gravitino.iceberg-rest.oss-region`                  | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_OSS_ROLE_ARN`                    | `gravitino.iceberg-rest.oss-role-arn`                | (none)                                               |
+| `GRAVITINO_ICEBERG_REST_OSS_EXTERNAL_ID`                 | `gravitino.iceberg-rest.oss-external-id`             | (none)                                               |
 
-To start a container and override the default HTTP port:
+The image bundles MySQL and PostgreSQL JDBC drivers in `jdbc-drivers/` and links them into `libs/`
+and `iceberg-rest-server/libs/` at startup. For cloud storage backends, put the matching Iceberg
+bundle jars in `iceberg-bundles/` and they are linked into
+`catalogs/lakehouse-iceberg/libs/` and `iceberg-rest-server/libs/` the same way.
+
+### Checking What the Container Did
+
+Read back the rewritten file:
 
 ```shell
-docker run --rm -d \
-  -e GRAVITINO_SERVER_WEBSERVER_HTTP_PORT=8080 \
-  -p 8080:8080 \
-  apache/gravitino:<tag>
+docker exec -it {container_id} cat /opt/gravitino/conf/gravitino.conf
 ```
 
-To configure the relational entity store with PostgreSQL:
+Then confirm the server, and the auxiliary IRC service if you started one:
 
 ```shell
-docker run --rm -d \
-  -e GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_URL="jdbc:postgresql://localhost:5432/database1" \
-  -e GRAVITINO_ENTITY_STORE_RELATIONAL_JDBC_DRIVER="org.postgresql.Driver" \
-  -p 8090:8090 \
-  apache/gravitino:<tag>
-```
-
-To configure the auxiliary Iceberg REST service with local storage:
-
-```shell
-docker run --rm -d \
-  -p 8090:8090 \
-  -p 9001:9001 \
-  -e GRAVITINO_ICEBERG_REST_WAREHOUSE=/tmp/warehouse/ \
-  -e GRAVITINO_ICEBERG_REST_HTTP_PORT=9001 \
-  apache/gravitino:<tag>
-```
-
-Verify that the configuration was applied correctly by inspecting the container's `gravitino.conf`:
-
-```shell
-docker exec -it <container_id> cat /opt/gravitino/conf/gravitino.conf
-```
-
-To verify that the auxiliary Iceberg REST service is running:
-
-```shell
+curl http://127.0.0.1:8090/health/ready
 curl http://127.0.0.1:9001/iceberg/v1/config
 ```
 
-:::note
-If both `gravitino.conf` and environment variable exist, the container’s startup script will overwrite the config file value with the environment variable.
-:::
+## Accessing Apache Hadoop
 
+Gravitino reaches Hadoop as a single operating system user, so that user needs the HDFS and YARN
+permissions for everything the server will touch. Without them, operations fail with
+`Permission denied`. Either grant the user that starts the server the permissions it needs, or set
+`HADOOP_USER_NAME` to a user that already has them before starting. For a local deployment, set it
+in `conf/gravitino-env.sh`.
 
-## Set Up Runtime Environment Variables
+## Related
 
-The Gravitino server supports configuring runtime environment variables in two ways:
-
-1. **Local deployment:** Modify `gravitino-env.sh` located in the `conf` directory.
-2. **Docker container deployment:** Use environment variable injection during container startup. *(Since 1.0.0)*
-
-### Access Apache Hadoop
-
-Due to the absence of a comprehensive user permission system, Gravitino can only use a single username for
-Apache Hadoop access. Ensure that the user starting the Gravitino server has Hadoop (HDFS, YARN, etc.) access
-permissions; otherwise, you may encounter a `Permission denied` error. There are two ways to resolve this error:
-
-* Grant Gravitino startup user permissions in Hadoop
-* Specify the authorized Hadoop username in the environment variables `HADOOP_USER_NAME` before starting the Gravitino server.
+- [Relational Backend Storage](how-to-use-relational-backend-storage.md), for pointing the entity
+  store at MySQL or PostgreSQL, including schema initialization and driver installation
+- [Iceberg REST Catalog Service](iceberg-rest-service.md), for the `gravitino.iceberg-rest.*`
+  properties of the auxiliary service named by `gravitino.auxService.names`
+- [How to Authenticate](security/how-to-authenticate.md), for the `gravitino.authenticator.*`
+  properties behind each value of `gravitino.authenticators`
+- [How to Use the Built-in IdP](security/how-to-use-built-in-idp.md), for holding users, password
+  hashes, and group membership in Gravitino's own relational store
+- [Access Control](security/access-control.md), for the privilege model the authorizer enforces once
+  `gravitino.authorization.enable` is set: roles, grants, ownership, and metalake administration
+- [Authorization Pushdown](security/authorization-pushdown.md), for propagating those privileges
+  into the underlying systems through Apache Ranger or a native permission model
+- [Credential Vending](security/credential-vending.md), for issuing temporary storage credentials to
+  engines instead of distributing long-lived keys
+- [HTTPS](security/how-to-use-https.md), for the `gravitino.server.webserver.*` key store, trust
+  store, and client certificate properties
+- [CORS](security/how-to-use-cors.md), for letting browser clients served from another origin call
+  the API
+- [Security](security/security.md)

--- a/docs/how-to-use-relational-backend-storage.md
+++ b/docs/how-to-use-relational-backend-storage.md
@@ -6,171 +6,146 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Introduction
 
-Before the version `0.6.0-incubating`, Apache Gravitino supports KV and Relational backend storage to store metadata.
-Since 0.6.0-incubating, Gravitino only supports using RDBMS as relational backend storage to store metadata. This doc will guide you on how to use the
-relational backend storage in Gravitino.
+Apache Gravitino stores its metadata in a relational database through a JDBC backend. H2 is the
+default and needs no configuration, but Gravitino makes no consistency or durability guarantee for
+metadata held in H2. Use it for local development and tests only. A server that holds metadata you
+care about should use MySQL or PostgreSQL.
 
-Relational backend storage mainly aims to the users who are accustomed to using RDBMS to
-store data or lack available a KV storage, and want to use Gravitino.
+This page covers pointing a Gravitino server at MySQL or PostgreSQL. For the connection pool and
+version retention properties that apply whichever database you use, and for the H2 storage path,
+see [Gravitino Server Configuration](gravitino-server-config.md#storage-backend).
 
-With relational backend storage, you can quickly deploy Gravitino in a production environment and
-take advantage of relational storage to manage metadata.
+## Quick Start
 
-### What Kind of Backend Storage Is Supported
-
-Relational backend storage supports the `JDBCBackend`, and `H2`, `MySQL` and `PostgreSQL` are supported for `JDBCBackend`, `H2` is the
-default storage for `JDBCBackend`.
-
-## H2
-
-As mentioned above, `H2` is the default storage for `JDBCBackend`, so you can use `H2` directly without any additional configuration.
-
-## MySQL
-
-### Prerequisites
-
-+ MySQL 5.7 or 8.0.
-+ Gravitino distribution package.
-+ MySQL connector Jar (Should be compatible with the version of MySQL instance).
-
-### Step 1: Get the Initialization Script
-
-You need to `download` and `unzip` the distribution package first; see
-[How to install Gravitino](how-to-install.md).
-
-Then you can get the initialization script in the directory:
+Setting up MySQL or PostgreSQL comes down to four properties in the server configuration file,
+`${GRAVITINO_HOME}/conf/gravitino.conf`:
 
 ```text
-${GRAVITINO_HOME}/scripts/mysql/
+# conf/gravitino.conf
+gravitino.entity.store.relational.jdbcUrl      = {jdbc_url}
+gravitino.entity.store.relational.jdbcDriver   = {driver_class}
+gravitino.entity.store.relational.jdbcUser     = {username}
+gravitino.entity.store.relational.jdbcPassword = {password}
 ```
 
-The script name is like `schema-{version}-mysql.sql`, and the `version` depends on your Gravitino version.
-For example, if your Gravitino version is `0.6.0-incubating`, then you can choose the **latest version** script.
-If you used a legacy script, you can use `upgrade-{old version}-to-{new version}-mysql.sql` to upgrade the schema.
+`gravitino.entity.store` and `gravitino.entity.store.relational` already default to `relational`
+and `JDBCBackend`. Leave them alone.
 
-### Step 2: Initialize the Database
+The values to use, and the driver each one needs:
 
-Please create a database in MySQL in advance, and execute the initialization script obtained above in the database.
+| Database            | JDBC URL                                                          | Driver Class               | Driver Jar                    |
+|---------------------|-------------------------------------------------------------------|----------------------------|-------------------------------|
+| H2 (default)        | `jdbc:h2`                                                         | `org.h2.Driver`            | Bundled with the distribution |
+| MySQL 5.7 or 8.0    | `jdbc:mysql://{host}:3306/{database}`                             | `com.mysql.cj.jdbc.Driver` | `com.mysql:mysql-connector-j` |
+| PostgreSQL 12 to 16 | `jdbc:postgresql://{host}:5432/{database}?currentSchema={schema}` | `org.postgresql.Driver`    | `org.postgresql:postgresql`   |
 
-### Step 3: Place the MySQL Connector Jar
+Other PostgreSQL versions have not been tested by the community and may not work.
 
-You should **download** the MySQL connector Jar for the corresponding version of MySQL you use
-(You can download it from the [maven-central-repo](https://repo1.maven.org/maven2/mysql/mysql-connector-java/)),
-which is name like `mysql-connector-java-{version}.jar`.
+Gravitino initializes its schema automatically on H2 only, by running
+`scripts/h2/schema-{version}-h2.sql` at startup. For MySQL and PostgreSQL you create the database
+and run the script yourself, before starting the server for the first time. Work through the
+steps below.
 
-Then place it in the distribution package directory:
+## Setting Up MySQL
 
-```text
-${GRAVITINO_HOME}/libs/
+**1. Create the database.** Gravitino will not create it for you.
+
+```sql
+CREATE DATABASE {database};
 ```
 
-### Step 4: Set Up the Apache Gravitino Server Configs
-
-Find the server configuration file which name is `gravitino.conf` in the distribution package directory:
-
-```text
-${GRAVITINO_HOME}/conf/
-```
-
-Then set up the following server configs:
-
-```text
-gravitino.entity.store = relational
-gravitino.entity.store.relational = JDBCBackend
-gravitino.entity.store.relational.jdbcUrl = ${your_jdbc_url}
-gravitino.entity.store.relational.jdbcDriver = ${your_driver_name}
-gravitino.entity.store.relational.jdbcUser = ${your_username}
-gravitino.entity.store.relational.jdbcPassword = ${your_password}
-```
-
-### Step 5: Start the Server
-
-Finally, you can run the script in the distribution package directory to start the server:
+**2. Run the schema script.** Download and unpack the Gravitino distribution package if you have
+not already; see [How to Install Gravitino](how-to-install.md). The MySQL scripts are in
+`${GRAVITINO_HOME}/scripts/mysql/`. Run the `schema-*-mysql.sql` file matching your Gravitino
+version against the database you just created:
 
 ```shell
-./${GRAVITINO_HOME}/bin/gravitino.sh start
+mysql -h {host} -u {username} -p {database} < ${GRAVITINO_HOME}/scripts/mysql/schema-{version}-mysql.sql
 ```
 
-## PostgreSQL
+If you are moving an existing deployment forward rather than starting fresh, run the
+`upgrade-{old_version}-to-{new_version}-mysql.sql` scripts in order instead, one per version step.
 
-### Prerequisites
+**3. Install the driver.** Download the MySQL Connector/J jar matching your MySQL version from
+[Maven Central](https://central.sonatype.com/artifact/com.mysql/mysql-connector-j) and place it in
+`${GRAVITINO_HOME}/libs/`. The artifact was renamed from `mysql:mysql-connector-java` to
+`com.mysql:mysql-connector-j`, so the jar is named `mysql-connector-j-{version}.jar`. Older
+`mysql-connector-java-{version}.jar` builds still work but no longer receive fixes.
 
-- PostgreSQL 12 ~ 16. For other versions, the community has not tested fully and may not be compatible.
-- Gravitino distribution package with version `0.7.0` or above.
-- PostgreSQL connector Jar (Should be compatible with the version of PostgreSQL instance).
-
-### Step 1: Get the Initialization Script
-
-You need to `download` and `unzip` the distribution package first; see
-[How to install Gravitino](how-to-install.md).
-
-Then you can get the initialization script in the directory:
+**4. Configure the server.** In `${GRAVITINO_HOME}/conf/gravitino.conf`:
 
 ```text
-${GRAVITINO_HOME}/scripts/postgresql/
+# conf/gravitino.conf
+gravitino.entity.store.relational.jdbcUrl      = jdbc:mysql://{host}:3306/{database}
+gravitino.entity.store.relational.jdbcDriver   = com.mysql.cj.jdbc.Driver
+gravitino.entity.store.relational.jdbcUser     = {username}
+gravitino.entity.store.relational.jdbcPassword = {password}
 ```
 
-The script name is like `schema-{version}-postgresql.sql`, and the `version` depends on your Gravitino version.
-For example, if your Gravitino version is the latest release version, then you can choose the **latest version** script.
-If you used a legacy script, you can use `upgrade-{old version}-to-{new version}-postgresql.sql` to upgrade the schema.
+**5. Start the server.**
 
-### Step 2: Initialize the Database
+```shell
+${GRAVITINO_HOME}/bin/gravitino.sh start
+```
 
-Please create a database and schema in PostgreSQL in advance, and execute the initialization script obtained above in the database.
+## Setting Up PostgreSQL
+
+PostgreSQL follows the same five steps, with one difference: Gravitino addresses a schema inside
+the database, so you create both, and the JDBC URL names both. Neither is optional.
+
+**1. Create the database and schema.**
 
 ```postgresql
-psql --username=postgres --password 
-password:
+psql --username=postgres --password
 
-create database your_database;
-\c your_database
-create schema your_schema;
-set search_path to your_schema;
-\i schema-{version}-postgresql.sql
+CREATE DATABASE {database};
+\c {database}
+CREATE SCHEMA {schema};
 ```
 
-:::note
-Database and schema are required parameters in the Gravitino PostgreSQL JDBC URL, Users should
-create them in advance and set the database and schema in the JDBC URL.
-:::
+**2. Run the schema script.** The PostgreSQL scripts are in `${GRAVITINO_HOME}/scripts/postgresql/`.
+Set the search path first so the tables land in your schema rather than `public`:
 
+```postgresql
+\c {database}
+SET search_path TO {schema};
+\i ${GRAVITINO_HOME}/scripts/postgresql/schema-{version}-postgresql.sql
+```
 
-### Step 3: Place the PostgreSQL Connector Jar
+To move an existing deployment forward, run the
+`upgrade-{old_version}-to-{new_version}-postgresql.sql` scripts in order instead.
 
-You should **download** the PostgreSQL connector Jar for the corresponding version of PostgreSQL you use
-(You can download it from the [PostgreSQL-driver-jar](https://jdbc.postgresql.org/download/postgresql-42.7.0.jar)),
-which is name like `postgresql-{version}.jar`.
+**3. Install the driver.** Download the current pgJDBC driver from
+[jdbc.postgresql.org](https://jdbc.postgresql.org/download/) and place `postgresql-{version}.jar`
+in `${GRAVITINO_HOME}/libs/`. Take the latest release rather than pinning an old one; several
+earlier versions carry published CVEs.
 
-Then place it in the distribution package directory:
+**4. Configure the server.** Note the `currentSchema` parameter:
 
 ```text
-${GRAVITINO_HOME}/libs/
+# conf/gravitino.conf
+gravitino.entity.store.relational.jdbcUrl      = jdbc:postgresql://{host}:5432/{database}?currentSchema={schema}
+gravitino.entity.store.relational.jdbcDriver   = org.postgresql.Driver
+gravitino.entity.store.relational.jdbcUser     = {username}
+gravitino.entity.store.relational.jdbcPassword = {password}
 ```
 
-### Step 4: Set Up the Apache Gravitino Server Configs
+**5. Start the server.**
 
-Find the server configuration file which name is `gravitino.conf` in the distribution package directory:
-
-```text
-${GRAVITINO_HOME}/conf/
+```shell
+${GRAVITINO_HOME}/bin/gravitino.sh start
 ```
 
-Then set up the following server configs:
+## Verifying the Connection
 
-```text
-gravitino.entity.store = relational
-gravitino.entity.store.relational = JDBCBackend
+The readiness endpoint probes the entity store, so it answers the question directly. A server that
+reached its database returns `UP`:
 
-## JDBC URL such as: jdbc:postgresql://localhost:5432/your_database?currentSchema=your_schema
-gravitino.entity.store.relational.jdbcUrl = ${your_jdbc_url}
-
-## JDBC driver name such as: org.postgresql.Driver
-gravitino.entity.store.relational.jdbcDriver = ${your_driver_name}
-
-gravitino.entity.store.relational.jdbcUser = ${your_username}
-gravitino.entity.store.relational.jdbcPassword = ${your_password}
+```shell
+curl http://{host}:8090/health/ready
 ```
 
-### Step 5: Start the Server
-
-Please see the above steps in the MySQL section.
+If the backend is unreachable or slow the endpoint returns 503 with an `entityStore` check in the
+`DOWN` state. See
+[Health Check Endpoints](gravitino-server-config.md#health-check-endpoints) for the response
+format and the probe timeout.


### PR DESCRIPTION
**Cherry-pick Information:**
- Original commit: f1e0a2599a3f0daf4c86e3f28fbbf6a6a7db2b3c
- Target branch: `branch-1.3`
- Status: ⚠️ Conflicts manually resolved

**Conflict resolution notes:**
`docs/gravitino-server-config.md` and `docs/how-to-use-relational-backend-storage.md` conflicted
because the original commit fully restructured `gravitino-server-config.md`, and main's version of
that page had already picked up a few 2.0.0-only config properties that don't exist on
`branch-1.3`. Resolved by taking the rewritten content and adjusting it for branch-1.3's actual
feature set:
- Removed the `gravitino.entityChangeLog.listenerMaxRetries` / `listenerFailureAction` rows
  (not present in branch-1.3's `Configs.java`)
- Restored branch-1.3's actual `entityChangeLog.retentionSecs` (`86400`, 1 day) /
  `cleanupIntervalSecs` (`3600`, 1 hour) defaults, in place of main's 2.0.0-era values
- Removed the `gravitino.catalog.classloader.sharing.enabled` row (not present in branch-1.3's
  `Configs.java`)

Every other config key, default value, and catalog/doc reference in the ported content was
cross-checked against branch-1.3 source (`Configs.java`, `ServerConfig.java`, `JettyServerConfig.java`,
`ConfigServlet.java`, `rewrite_gravitino_server_config.py`, `bin/common.sh`, and the `catalogs/`
module list).