### PR TITLE
[#12357] fix: Relocate Jackson in Iceberg Aliyun bundle

### DIFF
--- a/bundles/iceberg-aliyun-bundle/build.gradle.kts
+++ b/bundles/iceberg-aliyun-bundle/build.gradle.kts
@@ -32,10 +32,14 @@ dependencies {
   implementation(libs.sun.activation)
   // Include Gravitino Aliyun credential providers (OSSSecretKeyProvider, etc.) for credential vending
   implementation(project(":bundles:aliyun"))
+
+  testImplementation(libs.junit.jupiter.api)
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 tasks.withType(ShadowJar::class.java) {
   isZip64 = true
+  includeEmptyDirs = false
   configurations = listOf(project.configurations.runtimeClasspath.get())
   archiveClassifier.set("")
 
@@ -48,10 +52,35 @@ tasks.withType(ShadowJar::class.java) {
     exclude(project(":catalogs:hadoop-common"))
   }
 
+  // :bundles:aliyun pulls Jackson into this fat jar. Relocate it so the bundle remains
+  // self-contained without exposing com.fasterxml.jackson classes on the server classpath.
+  relocate(
+    "com.fasterxml.jackson",
+    "org.apache.gravitino.iceberg.aliyun.shaded.com.fasterxml.jackson"
+  )
+
+  // POM metadata is not relocated by shadow and would still advertise the original
+  // Jackson coordinates.
+  exclude("META-INF/maven/com.fasterxml.jackson.core/**")
+  exclude("META-INF/maven/com.fasterxml.jackson.datatype/**")
+  exclude("META-INF/maven/com.fasterxml.jackson.module/**")
+  exclude("META-INF/maven/com.fasterxml.jackson/**")
+
   mergeServiceFiles()
 }
 
 tasks.jar {
   dependsOn(tasks.named("shadowJar"))
   archiveClassifier.set("empty")
+}
+
+tasks.test {
+  val shadowJar = tasks.named<ShadowJar>("shadowJar")
+  dependsOn(shadowJar)
+  doFirst {
+    systemProperty(
+      "shadowJarPath",
+      shadowJar.get().archiveFile.get().asFile.absolutePath
+    )
+  }
 }

--- a/bundles/iceberg-aliyun-bundle/build.gradle.kts
+++ b/bundles/iceberg-aliyun-bundle/build.gradle.kts
@@ -77,6 +77,7 @@ tasks.jar {
 tasks.test {
   val shadowJar = tasks.named<ShadowJar>("shadowJar")
   dependsOn(shadowJar)
+  inputs.file(shadowJar.flatMap { it.archiveFile })
   doFirst {
     systemProperty(
       "shadowJarPath",

--- a/bundles/iceberg-aliyun-bundle/src/test/java/org/apache/gravitino/iceberg/bundle/TestIcebergAliyunBundleShadowJar.java
+++ b/bundles/iceberg-aliyun-bundle/src/test/java/org/apache/gravitino/iceberg/bundle/TestIcebergAliyunBundleShadowJar.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.bundle;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class TestIcebergAliyunBundleShadowJar {
+  private static final String RELOCATED_JACKSON_PREFIX =
+      "org/apache/gravitino/iceberg/aliyun/shaded/com/fasterxml/jackson/";
+
+  @Test
+  void jacksonShouldBeRelocated() throws IOException {
+    String jarPath = System.getProperty("shadowJarPath");
+    assertNotNull(jarPath, "shadowJarPath system property should be provided by the build");
+
+    File shadowJar = new File(jarPath);
+    assertTrue(shadowJar.exists(), "shadow jar does not exist: " + shadowJar);
+
+    try (JarFile jarFile = new JarFile(shadowJar)) {
+      List<String> entries = jarFile.stream().map(JarEntry::getName).collect(Collectors.toList());
+
+      assertTrue(
+          entries.stream().anyMatch(entry -> entry.startsWith(RELOCATED_JACKSON_PREFIX)),
+          "Iceberg Aliyun bundle should keep Jackson under a relocated namespace");
+      assertFalse(
+          entries.stream().anyMatch(TestIcebergAliyunBundleShadowJar::isUnshadedJacksonEntry),
+          "Iceberg Aliyun bundle should not expose unshaded Jackson classes or services");
+    }
+  }
+
+  private static boolean isUnshadedJacksonEntry(String entry) {
+    if (entry.endsWith("/")) {
+      return false;
+    }
+    return entry.startsWith("com/fasterxml/jackson/")
+        || entry.matches("META-INF/versions/[^/]+/com/fasterxml/jackson/.*")
+        || entry.startsWith("META-INF/maven/com.fasterxml.jackson")
+        || entry.startsWith("META-INF/services/com.fasterxml.jackson");
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Relocate `com.fasterxml.jackson` classes in the Iceberg Aliyun bundle to an internal shaded namespace, and exclude the original Jackson Maven metadata from the shadow jar.

This also adds a regression test that inspects the generated shadow jar to ensure Jackson is relocated and no unshaded Jackson classes, services, or metadata are exposed.

### Why are the changes needed?

The Iceberg Aliyun bundle includes Gravitino Aliyun credential providers, which pull Jackson into the fat jar. Leaving those classes unshaded can leak Jackson onto the server classpath and conflict with the Jackson version resolved by Iceberg REST server dependencies.

This change is intentionally limited to the Iceberg Aliyun bundle. The Iceberg AWS bundle also includes `:bundles:aws`, but the AWS provider has no Jackson runtime dependency. Inspection of the generated AWS shadow jar confirms that it contains no unshaded `com/fasterxml/jackson` entries; the AWS SDK uses its isolated `software/amazon/awssdk/thirdparty/jackson` namespace. Therefore, no AWS relocation is required at present.

Fix: #12357

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew :bundles:iceberg-aliyun-bundle:test`
- Built `:bundles:iceberg-aws-bundle:shadowJar` and verified that the generated jar contains no unshaded Jackson entries.