### PR TITLE
[#12297] feat(secret): Add SecretManager and typed SecretBinding/SecretReference

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
   implementation(libs.commons.lang3)
   implementation(libs.commons.collections4)
   implementation(libs.guava)
-  implementation(libs.jackson.annotations)
-  implementation(libs.jackson.databind)
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)

--- a/api/src/main/java/org/apache/gravitino/secret/SecretBinding.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SecretBinding.java
@@ -43,8 +43,6 @@ public final class SecretBinding {
   public SecretBinding(String provider, String plaintext) {
     Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
     Preconditions.checkArgument(plaintext != null, "plaintext must not be null");
-    Preconditions.checkArgument(
-        !"******".equals(plaintext), "plaintext must not be the masked placeholder");
     this.provider = provider;
     this.plaintext = plaintext;
   }

--- a/api/src/main/java/org/apache/gravitino/secret/SecretBinding.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SecretBinding.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.secret;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Write-through secret binding for create/alter requests: a registered provider instance name plus
+ * plaintext to store.
+ */
+@DeveloperApi
+public final class SecretBinding {
+
+  private final String provider;
+  private final String value;
+
+  /**
+   * Creates a write-through binding.
+   *
+   * @param provider registered provider instance name
+   * @param value plaintext secret value
+   */
+  @JsonCreator
+  public SecretBinding(
+      @JsonProperty("provider") String provider, @JsonProperty("value") String value) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
+    Preconditions.checkArgument(value != null, "value must not be null");
+    Preconditions.checkArgument(
+        !"******".equals(value), "value must not be the masked placeholder");
+    this.provider = provider;
+    this.value = value;
+  }
+
+  /**
+   * Returns the registered provider instance name.
+   *
+   * @return the provider name
+   */
+  @JsonProperty("provider")
+  public String provider() {
+    return provider;
+  }
+
+  /**
+   * Returns the plaintext secret value.
+   *
+   * @return the plaintext value
+   */
+  @JsonProperty("value")
+  public String value() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SecretBinding)) {
+      return false;
+    }
+    SecretBinding that = (SecretBinding) o;
+    return Objects.equals(provider, that.provider) && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(provider, value);
+  }
+
+  @Override
+  public String toString() {
+    return "SecretBinding{provider='" + provider + "', value=***}";
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/secret/SecretBinding.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SecretBinding.java
@@ -19,38 +19,34 @@
 
 package org.apache.gravitino.secret;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.annotation.Evolving;
 
 /**
  * Write-through secret binding for create/alter requests: a registered provider instance name plus
  * plaintext to store.
  */
-@DeveloperApi
+@Evolving
 public final class SecretBinding {
 
   private final String provider;
-  private final String value;
+  private final String plaintext;
 
   /**
    * Creates a write-through binding.
    *
    * @param provider registered provider instance name
-   * @param value plaintext secret value
+   * @param plaintext plaintext secret to write through
    */
-  @JsonCreator
-  public SecretBinding(
-      @JsonProperty("provider") String provider, @JsonProperty("value") String value) {
+  public SecretBinding(String provider, String plaintext) {
     Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
-    Preconditions.checkArgument(value != null, "value must not be null");
+    Preconditions.checkArgument(plaintext != null, "plaintext must not be null");
     Preconditions.checkArgument(
-        !"******".equals(value), "value must not be the masked placeholder");
+        !"******".equals(plaintext), "plaintext must not be the masked placeholder");
     this.provider = provider;
-    this.value = value;
+    this.plaintext = plaintext;
   }
 
   /**
@@ -58,19 +54,17 @@ public final class SecretBinding {
    *
    * @return the provider name
    */
-  @JsonProperty("provider")
   public String provider() {
     return provider;
   }
 
   /**
-   * Returns the plaintext secret value.
+   * Returns the plaintext secret to write through.
    *
-   * @return the plaintext value
+   * @return the plaintext secret
    */
-  @JsonProperty("value")
-  public String value() {
-    return value;
+  public String plaintext() {
+    return plaintext;
   }
 
   @Override
@@ -82,16 +76,16 @@ public final class SecretBinding {
       return false;
     }
     SecretBinding that = (SecretBinding) o;
-    return Objects.equals(provider, that.provider) && Objects.equals(value, that.value);
+    return Objects.equals(provider, that.provider) && Objects.equals(plaintext, that.plaintext);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(provider, value);
+    return Objects.hash(provider, plaintext);
   }
 
   @Override
   public String toString() {
-    return "SecretBinding{provider='" + provider + "', value=***}";
+    return "SecretBinding{provider='" + provider + "', plaintext=***}";
   }
 }

--- a/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.secret;
 
 import static org.apache.gravitino.secret.SecretConstants.URN_PREFIX;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
@@ -31,13 +29,13 @@ import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.annotation.Evolving;
 
 /**
  * External secret locator for create/alter requests: a registered provider instance name plus
  * provider-specific attributes. The server builds the URN; clients must not send a raw URN.
  */
-@DeveloperApi
+@Evolving
 public final class SecretReference {
 
   private final String provider;
@@ -49,10 +47,7 @@ public final class SecretReference {
    * @param provider registered provider instance name
    * @param attributes provider-specific locator keys; {@code null} or empty means no attributes
    */
-  @JsonCreator
-  public SecretReference(
-      @JsonProperty("provider") String provider,
-      @JsonProperty("attributes") @Nullable Map<String, String> attributes) {
+  public SecretReference(String provider, @Nullable Map<String, String> attributes) {
     Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
     this.provider = provider;
     if (attributes == null || attributes.isEmpty()) {
@@ -73,7 +68,6 @@ public final class SecretReference {
    *
    * @return the provider name
    */
-  @JsonProperty("provider")
   public String provider() {
     return provider;
   }
@@ -83,7 +77,6 @@ public final class SecretReference {
    *
    * @return an unmodifiable attributes map
    */
-  @JsonProperty("attributes")
   public Map<String, String> attributes() {
     return attributes;
   }

--- a/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
@@ -19,11 +19,8 @@
 
 package org.apache.gravitino.secret;
 
-import static org.apache.gravitino.secret.SecretConstants.URN_PREFIX;
-
 import com.google.common.base.Preconditions;
-import java.util.Collections;
-import java.util.LinkedHashMap;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
@@ -50,13 +47,7 @@ public final class SecretReference {
     Preconditions.checkArgument(
         attributes != null && !attributes.isEmpty(), "attributes must not be null or empty");
     this.provider = provider;
-    Map<String, String> copy = new LinkedHashMap<>(attributes);
-    for (Map.Entry<String, String> entry : copy.entrySet()) {
-      Preconditions.checkArgument(
-          entry.getValue() == null || !entry.getValue().startsWith(URN_PREFIX),
-          "attributes must not contain a raw gravitino secret URN");
-    }
-    this.attributes = Collections.unmodifiableMap(copy);
+    this.attributes = ImmutableMap.copyOf(attributes);
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
@@ -22,7 +22,6 @@ package org.apache.gravitino.secret;
 import static org.apache.gravitino.secret.SecretConstants.URN_PREFIX;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -44,23 +43,20 @@ public final class SecretReference {
    * Creates an external secret reference.
    *
    * @param provider registered provider instance name
-   * @param attributes provider-specific locator keys; empty means no attributes
+   * @param attributes provider-specific locator keys; must be non-null and non-empty
    */
   public SecretReference(String provider, Map<String, String> attributes) {
     Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
-    Preconditions.checkArgument(attributes != null, "attributes must not be null");
+    Preconditions.checkArgument(
+        attributes != null && !attributes.isEmpty(), "attributes must not be null or empty");
     this.provider = provider;
-    if (attributes.isEmpty()) {
-      this.attributes = ImmutableMap.of();
-    } else {
-      Map<String, String> copy = new LinkedHashMap<>(attributes);
-      for (Map.Entry<String, String> entry : copy.entrySet()) {
-        Preconditions.checkArgument(
-            entry.getValue() == null || !entry.getValue().startsWith(URN_PREFIX),
-            "attributes must not contain a raw gravitino secret URN");
-      }
-      this.attributes = Collections.unmodifiableMap(copy);
+    Map<String, String> copy = new LinkedHashMap<>(attributes);
+    for (Map.Entry<String, String> entry : copy.entrySet()) {
+      Preconditions.checkArgument(
+          entry.getValue() == null || !entry.getValue().startsWith(URN_PREFIX),
+          "attributes must not contain a raw gravitino secret URN");
     }
+    this.attributes = Collections.unmodifiableMap(copy);
   }
 
   /**
@@ -73,7 +69,7 @@ public final class SecretReference {
   }
 
   /**
-   * Returns provider-specific locator attributes (never {@code null}).
+   * Returns provider-specific locator attributes (never {@code null} or empty).
    *
    * @return an unmodifiable attributes map
    */

--- a/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.secret;
+
+import static org.apache.gravitino.secret.SecretConstants.URN_PREFIX;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * External secret locator for create/alter requests: a registered provider instance name plus
+ * provider-specific attributes. The server builds the URN; clients must not send a raw URN.
+ */
+@DeveloperApi
+public final class SecretReference {
+
+  private final String provider;
+  private final Map<String, String> attributes;
+
+  /**
+   * Creates an external secret reference.
+   *
+   * @param provider registered provider instance name
+   * @param attributes provider-specific locator keys; {@code null} or empty means no attributes
+   */
+  @JsonCreator
+  public SecretReference(
+      @JsonProperty("provider") String provider,
+      @JsonProperty("attributes") @Nullable Map<String, String> attributes) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
+    this.provider = provider;
+    if (attributes == null || attributes.isEmpty()) {
+      this.attributes = ImmutableMap.of();
+    } else {
+      Map<String, String> copy = new LinkedHashMap<>(attributes);
+      for (Map.Entry<String, String> entry : copy.entrySet()) {
+        Preconditions.checkArgument(
+            entry.getValue() == null || !entry.getValue().startsWith(URN_PREFIX),
+            "attributes must not contain a raw gravitino secret URN");
+      }
+      this.attributes = Collections.unmodifiableMap(copy);
+    }
+  }
+
+  /**
+   * Returns the registered provider instance name.
+   *
+   * @return the provider name
+   */
+  @JsonProperty("provider")
+  public String provider() {
+    return provider;
+  }
+
+  /**
+   * Returns provider-specific locator attributes (never {@code null}).
+   *
+   * @return an unmodifiable attributes map
+   */
+  @JsonProperty("attributes")
+  public Map<String, String> attributes() {
+    return attributes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SecretReference)) {
+      return false;
+    }
+    SecretReference that = (SecretReference) o;
+    return Objects.equals(provider, that.provider) && Objects.equals(attributes, that.attributes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(provider, attributes);
+  }
+
+  @Override
+  public String toString() {
+    return "SecretReference{provider='" + provider + "', attributes=" + attributes + "}";
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SecretReference.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.annotation.Evolving;
 
@@ -45,12 +44,13 @@ public final class SecretReference {
    * Creates an external secret reference.
    *
    * @param provider registered provider instance name
-   * @param attributes provider-specific locator keys; {@code null} or empty means no attributes
+   * @param attributes provider-specific locator keys; empty means no attributes
    */
-  public SecretReference(String provider, @Nullable Map<String, String> attributes) {
+  public SecretReference(String provider, Map<String, String> attributes) {
     Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
+    Preconditions.checkArgument(attributes != null, "attributes must not be null");
     this.provider = provider;
-    if (attributes == null || attributes.isEmpty()) {
+    if (attributes.isEmpty()) {
       this.attributes = ImmutableMap.of();
     } else {
       Map<String, String> copy = new LinkedHashMap<>(attributes);

--- a/api/src/test/java/org/apache/gravitino/secret/TestSecretBinding.java
+++ b/api/src/test/java/org/apache/gravitino/secret/TestSecretBinding.java
@@ -31,8 +31,8 @@ public class TestSecretBinding {
     Assertions.assertEquals("s3cr3t", binding.plaintext());
     Assertions.assertFalse(binding.toString().contains("s3cr3t"));
 
-    Assertions.assertThrows(
-        IllegalArgumentException.class, () -> new SecretBinding("memory", "******"));
     Assertions.assertThrows(IllegalArgumentException.class, () -> new SecretBinding("", "x"));
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> new SecretBinding("memory", null));
   }
 }

--- a/api/src/test/java/org/apache/gravitino/secret/TestSecretBinding.java
+++ b/api/src/test/java/org/apache/gravitino/secret/TestSecretBinding.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.secret;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestSecretBinding {
+
+  @Test
+  void testSecretBinding() {
+    SecretBinding binding = new SecretBinding("memory", "s3cr3t");
+    Assertions.assertEquals("memory", binding.provider());
+    Assertions.assertEquals("s3cr3t", binding.plaintext());
+    Assertions.assertFalse(binding.toString().contains("s3cr3t"));
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> new SecretBinding("memory", "******"));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new SecretBinding("", "x"));
+  }
+}

--- a/api/src/test/java/org/apache/gravitino/secret/TestSecretBindingAndReference.java
+++ b/api/src/test/java/org/apache/gravitino/secret/TestSecretBindingAndReference.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.secret;
+
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestSecretBindingAndReference {
+
+  @Test
+  void testSecretBinding() {
+    SecretBinding binding = new SecretBinding("memory", "s3cr3t");
+    Assertions.assertEquals("memory", binding.provider());
+    Assertions.assertEquals("s3cr3t", binding.value());
+    Assertions.assertFalse(binding.toString().contains("s3cr3t"));
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> new SecretBinding("memory", "******"));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new SecretBinding("", "x"));
+  }
+
+  @Test
+  void testSecretReference() {
+    SecretReference reference =
+        new SecretReference("vault", Map.of("path", "secret/data/x", "key", "password"));
+    Assertions.assertEquals("vault", reference.provider());
+    Assertions.assertEquals("secret/data/x", reference.attributes().get("path"));
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new SecretReference(
+                "vault", Map.of("path", "urn:gravitino-secret:memory:catalog:1:jdbc-password")));
+
+    SecretReference emptyAttrs = new SecretReference("vault", null);
+    Assertions.assertTrue(emptyAttrs.attributes().isEmpty());
+  }
+}

--- a/api/src/test/java/org/apache/gravitino/secret/TestSecretBindingAndReference.java
+++ b/api/src/test/java/org/apache/gravitino/secret/TestSecretBindingAndReference.java
@@ -29,7 +29,7 @@ public class TestSecretBindingAndReference {
   void testSecretBinding() {
     SecretBinding binding = new SecretBinding("memory", "s3cr3t");
     Assertions.assertEquals("memory", binding.provider());
-    Assertions.assertEquals("s3cr3t", binding.value());
+    Assertions.assertEquals("s3cr3t", binding.plaintext());
     Assertions.assertFalse(binding.toString().contains("s3cr3t"));
 
     Assertions.assertThrows(

--- a/api/src/test/java/org/apache/gravitino/secret/TestSecretReference.java
+++ b/api/src/test/java/org/apache/gravitino/secret/TestSecretReference.java
@@ -38,7 +38,10 @@ public class TestSecretReference {
             new SecretReference(
                 "vault", Map.of("path", "urn:gravitino-secret:memory:catalog:1:jdbc-password")));
 
-    SecretReference emptyAttrs = new SecretReference("vault", null);
+    SecretReference emptyAttrs = new SecretReference("vault", Map.of());
     Assertions.assertTrue(emptyAttrs.attributes().isEmpty());
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> new SecretReference("vault", null));
   }
 }

--- a/api/src/test/java/org/apache/gravitino/secret/TestSecretReference.java
+++ b/api/src/test/java/org/apache/gravitino/secret/TestSecretReference.java
@@ -23,19 +23,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestSecretBindingAndReference {
-
-  @Test
-  void testSecretBinding() {
-    SecretBinding binding = new SecretBinding("memory", "s3cr3t");
-    Assertions.assertEquals("memory", binding.provider());
-    Assertions.assertEquals("s3cr3t", binding.plaintext());
-    Assertions.assertFalse(binding.toString().contains("s3cr3t"));
-
-    Assertions.assertThrows(
-        IllegalArgumentException.class, () -> new SecretBinding("memory", "******"));
-    Assertions.assertThrows(IllegalArgumentException.class, () -> new SecretBinding("", "x"));
-  }
+public class TestSecretReference {
 
   @Test
   void testSecretReference() {

--- a/api/src/test/java/org/apache/gravitino/secret/TestSecretReference.java
+++ b/api/src/test/java/org/apache/gravitino/secret/TestSecretReference.java
@@ -33,12 +33,6 @@ public class TestSecretReference {
     Assertions.assertEquals("secret/data/x", reference.attributes().get("path"));
 
     Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new SecretReference(
-                "vault", Map.of("path", "urn:gravitino-secret:memory:catalog:1:jdbc-password")));
-
-    Assertions.assertThrows(
         IllegalArgumentException.class, () -> new SecretReference("vault", null));
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> new SecretReference("vault", Map.of()));

--- a/api/src/test/java/org/apache/gravitino/secret/TestSecretReference.java
+++ b/api/src/test/java/org/apache/gravitino/secret/TestSecretReference.java
@@ -38,10 +38,9 @@ public class TestSecretReference {
             new SecretReference(
                 "vault", Map.of("path", "urn:gravitino-secret:memory:catalog:1:jdbc-password")));
 
-    SecretReference emptyAttrs = new SecretReference("vault", Map.of());
-    Assertions.assertTrue(emptyAttrs.attributes().isEmpty());
-
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> new SecretReference("vault", null));
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> new SecretReference("vault", Map.of()));
   }
 }

--- a/common/src/main/java/org/apache/gravitino/secret/SecretProvider.java
+++ b/common/src/main/java/org/apache/gravitino/secret/SecretProvider.java
@@ -75,6 +75,23 @@ public interface SecretProvider {
   void deleteSecret(SecretUrn urn);
 
   /**
+   * Builds a URN for an external secret reference without writing secret material.
+   *
+   * <p>Providers that only support write-through must leave the default implementation, which
+   * rejects external references.
+   *
+   * @param propertyKey the entity property key that will store the URN
+   * @param attributes provider-specific locator attributes
+   * @return the external-reference secret URN (must end with {@code propertyKey})
+   * @throws UnsupportedOperationException if this provider does not support external references
+   * @throws IllegalArgumentException if attributes are invalid for this provider
+   */
+  default SecretUrn bindExternalReference(String propertyKey, Map<String, String> attributes) {
+    throw new UnsupportedOperationException(
+        type() + " does not support external secret references");
+  }
+
+  /**
    * Releases resources owned by this provider.
    *
    * <p>Implementations must override this method and explicitly release any held resources. An

--- a/common/src/main/java/org/apache/gravitino/secret/SecretProvider.java
+++ b/common/src/main/java/org/apache/gravitino/secret/SecretProvider.java
@@ -86,7 +86,7 @@ public interface SecretProvider {
    * @throws UnsupportedOperationException if this provider does not support external references
    * @throws IllegalArgumentException if attributes are invalid for this provider
    */
-  default SecretUrn bindExternalReference(String propertyKey, Map<String, String> attributes) {
+  default SecretUrn buildReferenceUrn(String propertyKey, Map<String, String> attributes) {
     throw new UnsupportedOperationException(
         type() + " does not support external secret references");
   }

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -743,10 +743,10 @@ public class GravitinoEnv {
     this.catalogDispatcher = new CatalogHookDispatcher(catalogEventDispatcher);
 
     this.credentialOperationDispatcher =
-        new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new CredentialOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
 
     SchemaOperationDispatcher schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     this.internalSchemaDispatcher = schemaOperationDispatcher;
     SchemaNormalizeDispatcher schemaNormalizeDispatcher =
         new SchemaNormalizeDispatcher(schemaOperationDispatcher, catalogManager);
@@ -756,16 +756,16 @@ public class GravitinoEnv {
     this.schemaDispatcher = new SchemaHookDispatcher(schemaEventDispatcher);
 
     TableOperationDispatcher tableOperationDispatcher =
-        new TableOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new TableOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     this.internalTableDispatcher = tableOperationDispatcher;
     TableNormalizeDispatcher tableNormalizeDispatcher =
         new TableNormalizeDispatcher(tableOperationDispatcher, catalogManager);
     TableOperationDispatcher internalTableOperationDispatcher =
         new TableOperationDispatcher(
             catalogManager,
+            secretManager,
             entityStore,
             idGenerator,
-            secretManager,
             () -> internalSchemaDispatcher);
     this.internalTableDispatcher =
         new TableNormalizeDispatcher(internalTableOperationDispatcher, catalogManager);
@@ -777,13 +777,13 @@ public class GravitinoEnv {
     // TODO: We can install hooks when we need, we only supports ownership post hook,
     //  partition doesn't have ownership, so we don't need it now.
     PartitionOperationDispatcher partitionOperationDispatcher =
-        new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new PartitionOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     PartitionNormalizeDispatcher partitionNormalizeDispatcher =
         new PartitionNormalizeDispatcher(partitionOperationDispatcher, catalogManager);
     this.partitionDispatcher = new PartitionEventDispatcher(eventBus, partitionNormalizeDispatcher);
 
     FilesetOperationDispatcher filesetOperationDispatcher =
-        new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new FilesetOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     FilesetNormalizeDispatcher filesetNormalizeDispatcher =
         new FilesetNormalizeDispatcher(filesetOperationDispatcher, catalogManager);
     this.internalFilesetDispatcher = filesetNormalizeDispatcher;
@@ -792,7 +792,7 @@ public class GravitinoEnv {
     this.filesetDispatcher = new FilesetHookDispatcher(filesetEventDispatcher);
 
     TopicOperationDispatcher topicOperationDispatcher =
-        new TopicOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new TopicOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     TopicNormalizeDispatcher topicNormalizeDispatcher =
         new TopicNormalizeDispatcher(topicOperationDispatcher, catalogManager);
     this.internalTopicDispatcher = topicNormalizeDispatcher;
@@ -801,7 +801,7 @@ public class GravitinoEnv {
     this.topicDispatcher = new TopicHookDispatcher(topicEventDispatcher);
 
     ModelOperationDispatcher modelOperationDispatcher =
-        new ModelOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new ModelOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     ModelNormalizeDispatcher modelNormalizeDispatcher =
         new ModelNormalizeDispatcher(modelOperationDispatcher, catalogManager);
     ModelEventDispatcher modelEventDispatcher =
@@ -813,7 +813,7 @@ public class GravitinoEnv {
     // FunctionOperationDispatcher
     FunctionOperationDispatcher functionOperationDispatcher =
         new FunctionOperationDispatcher(
-            catalogManager, schemaOperationDispatcher, entityStore, idGenerator, secretManager);
+            catalogManager, secretManager, schemaOperationDispatcher, entityStore, idGenerator);
     FunctionNormalizeDispatcher functionNormalizeDispatcher =
         new FunctionNormalizeDispatcher(functionOperationDispatcher, catalogManager);
     FunctionEventDispatcher functionEventDispatcher =
@@ -825,16 +825,16 @@ public class GravitinoEnv {
     // TODO(#11007): Add ViewHookDispatcher for view ownership and privilege hooks when view
     // privilege support is finalized.
     ViewOperationDispatcher viewOperationDispatcher =
-        new ViewOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new ViewOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     this.internalViewDispatcher = viewOperationDispatcher;
     ViewNormalizeDispatcher viewNormalizeDispatcher =
         new ViewNormalizeDispatcher(viewOperationDispatcher, catalogManager);
     ViewOperationDispatcher internalViewOperationDispatcher =
         new ViewOperationDispatcher(
             catalogManager,
+            secretManager,
             entityStore,
             idGenerator,
-            secretManager,
             () -> internalSchemaDispatcher);
     this.internalViewDispatcher =
         new ViewNormalizeDispatcher(internalViewOperationDispatcher, catalogManager);

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -743,10 +743,10 @@ public class GravitinoEnv {
     this.catalogDispatcher = new CatalogHookDispatcher(catalogEventDispatcher);
 
     this.credentialOperationDispatcher =
-        new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     SchemaOperationDispatcher schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     this.internalSchemaDispatcher = schemaOperationDispatcher;
     SchemaNormalizeDispatcher schemaNormalizeDispatcher =
         new SchemaNormalizeDispatcher(schemaOperationDispatcher, catalogManager);
@@ -756,13 +756,17 @@ public class GravitinoEnv {
     this.schemaDispatcher = new SchemaHookDispatcher(schemaEventDispatcher);
 
     TableOperationDispatcher tableOperationDispatcher =
-        new TableOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new TableOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     this.internalTableDispatcher = tableOperationDispatcher;
     TableNormalizeDispatcher tableNormalizeDispatcher =
         new TableNormalizeDispatcher(tableOperationDispatcher, catalogManager);
     TableOperationDispatcher internalTableOperationDispatcher =
         new TableOperationDispatcher(
-            catalogManager, entityStore, idGenerator, () -> internalSchemaDispatcher);
+            catalogManager,
+            entityStore,
+            idGenerator,
+            secretManager,
+            () -> internalSchemaDispatcher);
     this.internalTableDispatcher =
         new TableNormalizeDispatcher(internalTableOperationDispatcher, catalogManager);
     TableEventDispatcher tableEventDispatcher =
@@ -773,13 +777,13 @@ public class GravitinoEnv {
     // TODO: We can install hooks when we need, we only supports ownership post hook,
     //  partition doesn't have ownership, so we don't need it now.
     PartitionOperationDispatcher partitionOperationDispatcher =
-        new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     PartitionNormalizeDispatcher partitionNormalizeDispatcher =
         new PartitionNormalizeDispatcher(partitionOperationDispatcher, catalogManager);
     this.partitionDispatcher = new PartitionEventDispatcher(eventBus, partitionNormalizeDispatcher);
 
     FilesetOperationDispatcher filesetOperationDispatcher =
-        new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     FilesetNormalizeDispatcher filesetNormalizeDispatcher =
         new FilesetNormalizeDispatcher(filesetOperationDispatcher, catalogManager);
     this.internalFilesetDispatcher = filesetNormalizeDispatcher;
@@ -788,7 +792,7 @@ public class GravitinoEnv {
     this.filesetDispatcher = new FilesetHookDispatcher(filesetEventDispatcher);
 
     TopicOperationDispatcher topicOperationDispatcher =
-        new TopicOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new TopicOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     TopicNormalizeDispatcher topicNormalizeDispatcher =
         new TopicNormalizeDispatcher(topicOperationDispatcher, catalogManager);
     this.internalTopicDispatcher = topicNormalizeDispatcher;
@@ -797,7 +801,7 @@ public class GravitinoEnv {
     this.topicDispatcher = new TopicHookDispatcher(topicEventDispatcher);
 
     ModelOperationDispatcher modelOperationDispatcher =
-        new ModelOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new ModelOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     ModelNormalizeDispatcher modelNormalizeDispatcher =
         new ModelNormalizeDispatcher(modelOperationDispatcher, catalogManager);
     ModelEventDispatcher modelEventDispatcher =
@@ -809,7 +813,7 @@ public class GravitinoEnv {
     // FunctionOperationDispatcher
     FunctionOperationDispatcher functionOperationDispatcher =
         new FunctionOperationDispatcher(
-            catalogManager, schemaOperationDispatcher, entityStore, idGenerator);
+            catalogManager, schemaOperationDispatcher, entityStore, idGenerator, secretManager);
     FunctionNormalizeDispatcher functionNormalizeDispatcher =
         new FunctionNormalizeDispatcher(functionOperationDispatcher, catalogManager);
     FunctionEventDispatcher functionEventDispatcher =
@@ -821,13 +825,17 @@ public class GravitinoEnv {
     // TODO(#11007): Add ViewHookDispatcher for view ownership and privilege hooks when view
     // privilege support is finalized.
     ViewOperationDispatcher viewOperationDispatcher =
-        new ViewOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new ViewOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     this.internalViewDispatcher = viewOperationDispatcher;
     ViewNormalizeDispatcher viewNormalizeDispatcher =
         new ViewNormalizeDispatcher(viewOperationDispatcher, catalogManager);
     ViewOperationDispatcher internalViewOperationDispatcher =
         new ViewOperationDispatcher(
-            catalogManager, entityStore, idGenerator, () -> internalSchemaDispatcher);
+            catalogManager,
+            entityStore,
+            idGenerator,
+            secretManager,
+            () -> internalSchemaDispatcher);
     this.internalViewDispatcher =
         new ViewNormalizeDispatcher(internalViewOperationDispatcher, catalogManager);
     ViewEventDispatcher viewEventDispatcher =

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -743,10 +743,10 @@ public class GravitinoEnv {
     this.catalogDispatcher = new CatalogHookDispatcher(catalogEventDispatcher);
 
     this.credentialOperationDispatcher =
-        new CredentialOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     SchemaOperationDispatcher schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     this.internalSchemaDispatcher = schemaOperationDispatcher;
     SchemaNormalizeDispatcher schemaNormalizeDispatcher =
         new SchemaNormalizeDispatcher(schemaOperationDispatcher, catalogManager);
@@ -756,17 +756,17 @@ public class GravitinoEnv {
     this.schemaDispatcher = new SchemaHookDispatcher(schemaEventDispatcher);
 
     TableOperationDispatcher tableOperationDispatcher =
-        new TableOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new TableOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     this.internalTableDispatcher = tableOperationDispatcher;
     TableNormalizeDispatcher tableNormalizeDispatcher =
         new TableNormalizeDispatcher(tableOperationDispatcher, catalogManager);
     TableOperationDispatcher internalTableOperationDispatcher =
         new TableOperationDispatcher(
             catalogManager,
-            secretManager,
             entityStore,
             idGenerator,
-            () -> internalSchemaDispatcher);
+            () -> internalSchemaDispatcher,
+            secretManager);
     this.internalTableDispatcher =
         new TableNormalizeDispatcher(internalTableOperationDispatcher, catalogManager);
     TableEventDispatcher tableEventDispatcher =
@@ -777,13 +777,13 @@ public class GravitinoEnv {
     // TODO: We can install hooks when we need, we only supports ownership post hook,
     //  partition doesn't have ownership, so we don't need it now.
     PartitionOperationDispatcher partitionOperationDispatcher =
-        new PartitionOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     PartitionNormalizeDispatcher partitionNormalizeDispatcher =
         new PartitionNormalizeDispatcher(partitionOperationDispatcher, catalogManager);
     this.partitionDispatcher = new PartitionEventDispatcher(eventBus, partitionNormalizeDispatcher);
 
     FilesetOperationDispatcher filesetOperationDispatcher =
-        new FilesetOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     FilesetNormalizeDispatcher filesetNormalizeDispatcher =
         new FilesetNormalizeDispatcher(filesetOperationDispatcher, catalogManager);
     this.internalFilesetDispatcher = filesetNormalizeDispatcher;
@@ -792,7 +792,7 @@ public class GravitinoEnv {
     this.filesetDispatcher = new FilesetHookDispatcher(filesetEventDispatcher);
 
     TopicOperationDispatcher topicOperationDispatcher =
-        new TopicOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new TopicOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     TopicNormalizeDispatcher topicNormalizeDispatcher =
         new TopicNormalizeDispatcher(topicOperationDispatcher, catalogManager);
     this.internalTopicDispatcher = topicNormalizeDispatcher;
@@ -801,7 +801,7 @@ public class GravitinoEnv {
     this.topicDispatcher = new TopicHookDispatcher(topicEventDispatcher);
 
     ModelOperationDispatcher modelOperationDispatcher =
-        new ModelOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new ModelOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     ModelNormalizeDispatcher modelNormalizeDispatcher =
         new ModelNormalizeDispatcher(modelOperationDispatcher, catalogManager);
     ModelEventDispatcher modelEventDispatcher =
@@ -813,7 +813,7 @@ public class GravitinoEnv {
     // FunctionOperationDispatcher
     FunctionOperationDispatcher functionOperationDispatcher =
         new FunctionOperationDispatcher(
-            catalogManager, secretManager, schemaOperationDispatcher, entityStore, idGenerator);
+            catalogManager, schemaOperationDispatcher, entityStore, idGenerator, secretManager);
     FunctionNormalizeDispatcher functionNormalizeDispatcher =
         new FunctionNormalizeDispatcher(functionOperationDispatcher, catalogManager);
     FunctionEventDispatcher functionEventDispatcher =
@@ -825,17 +825,17 @@ public class GravitinoEnv {
     // TODO(#11007): Add ViewHookDispatcher for view ownership and privilege hooks when view
     // privilege support is finalized.
     ViewOperationDispatcher viewOperationDispatcher =
-        new ViewOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new ViewOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     this.internalViewDispatcher = viewOperationDispatcher;
     ViewNormalizeDispatcher viewNormalizeDispatcher =
         new ViewNormalizeDispatcher(viewOperationDispatcher, catalogManager);
     ViewOperationDispatcher internalViewOperationDispatcher =
         new ViewOperationDispatcher(
             catalogManager,
-            secretManager,
             entityStore,
             idGenerator,
-            () -> internalSchemaDispatcher);
+            () -> internalSchemaDispatcher,
+            secretManager);
     this.internalViewDispatcher =
         new ViewNormalizeDispatcher(internalViewOperationDispatcher, catalogManager);
     ViewEventDispatcher viewEventDispatcher =

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -98,6 +98,7 @@ import org.apache.gravitino.metrics.MetricsSystem;
 import org.apache.gravitino.metrics.source.JVMMetricsSource;
 import org.apache.gravitino.policy.PolicyDispatcher;
 import org.apache.gravitino.policy.PolicyManager;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.secret.SecretProviderRegistry;
 import org.apache.gravitino.stats.StatisticDispatcher;
 import org.apache.gravitino.stats.StatisticManager;
@@ -158,7 +159,7 @@ public class GravitinoEnv {
 
   private KmsClientRegistry kmsClientRegistry;
 
-  private SecretProviderRegistry secretProviderRegistry;
+  private SecretManager secretManager;
 
   private TagDispatcher tagDispatcher;
 
@@ -440,18 +441,26 @@ public class GravitinoEnv {
   }
 
   /**
+   * Get the {@link SecretManager} associated with the Gravitino environment.
+   *
+   * @return The SecretManager instance.
+   * @throws IllegalStateException if the environment has not been initialized
+   */
+  public SecretManager secretManager() {
+    Preconditions.checkState(secretManager != null, "GravitinoEnv components are not initialized.");
+    return secretManager;
+  }
+
+  /**
    * Get the secrets-provider registry associated with the Gravitino environment.
    *
-   * <p>The environment owns this registry. Callers may inject it into dependent components but must
-   * not close it.
+   * <p>Owned by {@link #secretManager()}. Callers may use it for discovery but must not close it.
    *
    * @return The secrets-provider registry instance.
    * @throws IllegalStateException if the environment has not been initialized
    */
   public SecretProviderRegistry secretProviderRegistry() {
-    Preconditions.checkState(
-        secretProviderRegistry != null, "GravitinoEnv components are not initialized.");
-    return secretProviderRegistry;
+    return secretManager().getRegistry();
   }
 
   /**
@@ -675,8 +684,8 @@ public class GravitinoEnv {
       kmsClientRegistry.close();
     }
 
-    if (secretProviderRegistry != null) {
-      secretProviderRegistry.close();
+    if (secretManager != null) {
+      secretManager.close();
     }
 
     LOG.info("Gravitino Environment is shut down.");
@@ -684,7 +693,7 @@ public class GravitinoEnv {
 
   private void initBaseComponents() {
     this.kmsClientRegistry = new KmsClientRegistry(config);
-    this.secretProviderRegistry = new SecretProviderRegistry(config);
+    this.secretManager = new SecretManager(config);
 
     this.metricsSystem = new MetricsSystem();
     metricsSystem.register(new JVMMetricsSource());
@@ -724,7 +733,7 @@ public class GravitinoEnv {
     // CatalogManager
     // CatalogManager registers its own change-log listener with the entity store (when the store
     // supports it), so no poller wiring is needed here.
-    this.catalogManager = new CatalogManager(config, entityStore, idGenerator);
+    this.catalogManager = new CatalogManager(config, entityStore, idGenerator, secretManager);
     this.internalCatalogDispatcher = catalogManager;
     CatalogNormalizeDispatcher catalogNormalizeDispatcher =
         new CatalogNormalizeDispatcher(catalogManager);

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -106,6 +106,7 @@ import org.apache.gravitino.rel.SupportsPartitions;
 import org.apache.gravitino.rel.Table;
 import org.apache.gravitino.rel.TableCatalog;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.storage.relational.SupportsEntityChangeLog;
 import org.apache.gravitino.utils.ClassLoaderKey;
@@ -358,6 +359,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   @Nullable private final CatalogChangeLogListener catalogChangeLogListener;
 
   private final IdGenerator idGenerator;
+  private final SecretManager secretManager;
   private final List<Consumer<NameIdentifier>> removalListeners = Lists.newArrayList();
   private final ConcurrentHashMap<NameIdentifier, AtomicInteger> localMutationCounts =
       new ConcurrentHashMap<>();
@@ -373,11 +375,14 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    * @param config The configuration for the manager.
    * @param store The entity store to use.
    * @param idGenerator The id generator to use.
+   * @param secretManager The secret manager used by catalog operations.
    */
-  public CatalogManager(Config config, EntityStore store, IdGenerator idGenerator) {
+  public CatalogManager(
+      Config config, EntityStore store, IdGenerator idGenerator, SecretManager secretManager) {
     this.config = config;
     this.store = store;
     this.idGenerator = idGenerator;
+    this.secretManager = secretManager;
     this.classLoaderSharingEnabled = config.get(Configs.CATALOG_CLASSLOADER_SHARING_ENABLED);
 
     long cacheEvictionIntervalInMs = config.get(Configs.CATALOG_CACHE_EVICTION_INTERVAL_MS);
@@ -433,6 +438,15 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     }
     catalogCache.invalidateAll();
     classLoaderPool.close();
+  }
+
+  /**
+   * Returns the secret manager used by this catalog manager.
+   *
+   * @return the secret manager
+   */
+  public SecretManager secretManager() {
+    return secretManager;
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -359,7 +359,11 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   @Nullable private final CatalogChangeLogListener catalogChangeLogListener;
 
   private final IdGenerator idGenerator;
+
+  // Held for create-time secret writes; consumed by the entity-secrets create follow-up.
+  @SuppressWarnings("UnusedVariable")
   private final SecretManager secretManager;
+
   private final List<Consumer<NameIdentifier>> removalListeners = Lists.newArrayList();
   private final ConcurrentHashMap<NameIdentifier, AtomicInteger> localMutationCounts =
       new ConcurrentHashMap<>();
@@ -438,15 +442,6 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     }
     catalogCache.invalidateAll();
     classLoaderPool.close();
-  }
-
-  /**
-   * Returns the secret manager used by this catalog manager.
-   *
-   * @return the secret manager
-   */
-  public SecretManager secretManager() {
-    return secretManager;
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -38,6 +38,7 @@ import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.lock.LockType;
 import org.apache.gravitino.lock.TreeLockUtils;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 
 public class FilesetOperationDispatcher extends OperationDispatcher implements FilesetDispatcher {
@@ -47,10 +48,14 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
    * @param catalogManager The CatalogManager instance to be used for fileset operations.
    * @param store The EntityStore instance to be used for fileset operations.
    * @param idGenerator The IdGenerator instance to be used for fileset operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public FilesetOperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
-    super(catalogManager, store, idGenerator);
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -46,16 +46,16 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
    * Creates a new FilesetOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for fileset operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for fileset operations.
    * @param idGenerator The IdGenerator instance to be used for fileset operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public FilesetOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
-    super(catalogManager, store, idGenerator, secretManager);
+      IdGenerator idGenerator) {
+    super(catalogManager, secretManager, store, idGenerator);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -46,16 +46,16 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
    * Creates a new FilesetOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for fileset operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for fileset operations.
    * @param idGenerator The IdGenerator instance to be used for fileset operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public FilesetOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
-    super(catalogManager, secretManager, store, idGenerator);
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/FunctionOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FunctionOperationDispatcher.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.function.FunctionDefinition;
 import org.apache.gravitino.function.FunctionType;
 import org.apache.gravitino.lock.LockType;
 import org.apache.gravitino.lock.TreeLockUtils;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 
 /**
@@ -56,15 +57,18 @@ public class FunctionOperationDispatcher extends OperationDispatcher implements 
    * Creates a new FunctionOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for function operations.
+   * @param schemaOps The SchemaOperationDispatcher used to validate schema existence.
    * @param store The EntityStore instance to be used for function operations.
    * @param idGenerator The IdGenerator instance to be used for function operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public FunctionOperationDispatcher(
       CatalogManager catalogManager,
       SchemaOperationDispatcher schemaOps,
       EntityStore store,
-      IdGenerator idGenerator) {
-    super(catalogManager, store, idGenerator);
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
     this.schemaOps = schemaOps;
     this.managedFunctionOps = new ManagedFunctionOperations(store, idGenerator);
   }

--- a/core/src/main/java/org/apache/gravitino/catalog/FunctionOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FunctionOperationDispatcher.java
@@ -57,18 +57,18 @@ public class FunctionOperationDispatcher extends OperationDispatcher implements 
    * Creates a new FunctionOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for function operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param schemaOps The SchemaOperationDispatcher used to validate schema existence.
    * @param store The EntityStore instance to be used for function operations.
    * @param idGenerator The IdGenerator instance to be used for function operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public FunctionOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       SchemaOperationDispatcher schemaOps,
       EntityStore store,
-      IdGenerator idGenerator) {
-    super(catalogManager, secretManager, store, idGenerator);
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
     this.schemaOps = schemaOps;
     this.managedFunctionOps = new ManagedFunctionOperations(store, idGenerator);
   }

--- a/core/src/main/java/org/apache/gravitino/catalog/FunctionOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FunctionOperationDispatcher.java
@@ -57,18 +57,18 @@ public class FunctionOperationDispatcher extends OperationDispatcher implements 
    * Creates a new FunctionOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for function operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param schemaOps The SchemaOperationDispatcher used to validate schema existence.
    * @param store The EntityStore instance to be used for function operations.
    * @param idGenerator The IdGenerator instance to be used for function operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public FunctionOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       SchemaOperationDispatcher schemaOps,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
-    super(catalogManager, store, idGenerator, secretManager);
+      IdGenerator idGenerator) {
+    super(catalogManager, secretManager, store, idGenerator);
     this.schemaOps = schemaOps;
     this.managedFunctionOps = new ManagedFunctionOperations(store, idGenerator);
   }

--- a/core/src/main/java/org/apache/gravitino/catalog/ModelOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ModelOperationDispatcher.java
@@ -44,14 +44,18 @@ import org.apache.gravitino.model.ModelCatalog;
 import org.apache.gravitino.model.ModelChange;
 import org.apache.gravitino.model.ModelVersion;
 import org.apache.gravitino.model.ModelVersionChange;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.ThrowableFunction;
 
 public class ModelOperationDispatcher extends OperationDispatcher implements ModelDispatcher {
 
   public ModelOperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
-    super(catalogManager, store, idGenerator);
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/ModelOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ModelOperationDispatcher.java
@@ -52,10 +52,10 @@ public class ModelOperationDispatcher extends OperationDispatcher implements Mod
 
   public ModelOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
-    super(catalogManager, secretManager, store, idGenerator);
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/ModelOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ModelOperationDispatcher.java
@@ -52,10 +52,10 @@ public class ModelOperationDispatcher extends OperationDispatcher implements Mod
 
   public ModelOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
-    super(catalogManager, store, idGenerator, secretManager);
+      IdGenerator idGenerator) {
+    super(catalogManager, secretManager, store, idGenerator);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -56,29 +56,29 @@ public abstract class OperationDispatcher {
 
   private final CatalogManager catalogManager;
 
-  protected final SecretManager secretManager;
-
   protected final EntityStore store;
 
   protected final IdGenerator idGenerator;
+
+  protected final SecretManager secretManager;
 
   /**
    * Creates a new CatalogOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for catalog operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for catalog operations.
    * @param idGenerator The IdGenerator instance to be used for catalog operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   protected OperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
     this.catalogManager = catalogManager;
-    this.secretManager = secretManager;
     this.store = store;
     this.idGenerator = idGenerator;
+    this.secretManager = secretManager;
   }
 
   protected <R, E extends Throwable> R doWithTable(

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.catalog;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForAlter;
 import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.Set;
@@ -68,13 +69,17 @@ public abstract class OperationDispatcher {
    * @param catalogManager The CatalogManager instance to be used for catalog operations.
    * @param store The EntityStore instance to be used for catalog operations.
    * @param idGenerator The IdGenerator instance to be used for catalog operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   protected OperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
     this.catalogManager = catalogManager;
     this.store = store;
     this.idGenerator = idGenerator;
-    this.secretManager = catalogManager.secretManager();
+    this.secretManager = Preconditions.checkNotNull(secretManager, "secretManager cannot be null");
   }
 
   protected <R, E extends Throwable> R doWithTable(

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -56,29 +56,29 @@ public abstract class OperationDispatcher {
 
   private final CatalogManager catalogManager;
 
+  protected final SecretManager secretManager;
+
   protected final EntityStore store;
 
   protected final IdGenerator idGenerator;
-
-  protected final SecretManager secretManager;
 
   /**
    * Creates a new CatalogOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for catalog operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for catalog operations.
    * @param idGenerator The IdGenerator instance to be used for catalog operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   protected OperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
+      IdGenerator idGenerator) {
     this.catalogManager = catalogManager;
+    this.secretManager = secretManager;
     this.store = store;
     this.idGenerator = idGenerator;
-    this.secretManager = secretManager;
   }
 
   protected <R, E extends Throwable> R doWithTable(

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -40,6 +40,8 @@ import org.apache.gravitino.messaging.TopicChange;
 import org.apache.gravitino.rel.SupportsPartitions;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.ViewChange;
+import org.apache.gravitino.secret.SecretManager;
+import org.apache.gravitino.secret.SecretPropertyUtils;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.ThrowableFunction;
 import org.slf4j.Logger;
@@ -58,6 +60,8 @@ public abstract class OperationDispatcher {
 
   protected final IdGenerator idGenerator;
 
+  protected final SecretManager secretManager;
+
   /**
    * Creates a new CatalogOperationDispatcher instance.
    *
@@ -70,6 +74,7 @@ public abstract class OperationDispatcher {
     this.catalogManager = catalogManager;
     this.store = store;
     this.idGenerator = idGenerator;
+    this.secretManager = catalogManager.secretManager();
   }
 
   protected <R, E extends Throwable> R doWithTable(
@@ -140,8 +145,12 @@ public abstract class OperationDispatcher {
             c.doWithPropertiesMeta(
                 p -> {
                   PropertiesMetadata propertiesMetadata = provider.apply(p);
-                  return properties.keySet().stream()
-                      .filter(propertiesMetadata::isHiddenProperty)
+                  return properties.entrySet().stream()
+                      .filter(
+                          e ->
+                              propertiesMetadata.isHiddenProperty(e.getKey())
+                                  || SecretPropertyUtils.isSecretProperty(e.getKey(), e.getValue()))
+                      .map(Map.Entry::getKey)
                       .collect(Collectors.toSet());
                 }),
         IllegalArgumentException.class);

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -21,7 +21,6 @@ package org.apache.gravitino.catalog;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForAlter;
 import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.Set;
@@ -79,7 +78,7 @@ public abstract class OperationDispatcher {
     this.catalogManager = catalogManager;
     this.store = store;
     this.idGenerator = idGenerator;
-    this.secretManager = Preconditions.checkNotNull(secretManager, "secretManager cannot be null");
+    this.secretManager = secretManager;
   }
 
   protected <R, E extends Throwable> R doWithTable(

--- a/core/src/main/java/org/apache/gravitino/catalog/PartitionOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PartitionOperationDispatcher.java
@@ -27,6 +27,7 @@ import org.apache.gravitino.lock.LockType;
 import org.apache.gravitino.lock.TreeLockUtils;
 import org.apache.gravitino.rel.SupportsPartitions;
 import org.apache.gravitino.rel.partitions.Partition;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 
 public class PartitionOperationDispatcher extends OperationDispatcher
@@ -38,10 +39,14 @@ public class PartitionOperationDispatcher extends OperationDispatcher
    * @param catalogManager The CatalogManager instance to be used for partition operations.
    * @param store The EntityStore instance to be used for partition operations.
    * @param idGenerator The IdGenerator instance to be used for partition operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public PartitionOperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
-    super(catalogManager, store, idGenerator);
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/PartitionOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PartitionOperationDispatcher.java
@@ -37,16 +37,16 @@ public class PartitionOperationDispatcher extends OperationDispatcher
    * Creates a new PartitionOperationDispatcher.
    *
    * @param catalogManager The CatalogManager instance to be used for partition operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for partition operations.
    * @param idGenerator The IdGenerator instance to be used for partition operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public PartitionOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
-    super(catalogManager, store, idGenerator, secretManager);
+      IdGenerator idGenerator) {
+    super(catalogManager, secretManager, store, idGenerator);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/PartitionOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PartitionOperationDispatcher.java
@@ -37,16 +37,16 @@ public class PartitionOperationDispatcher extends OperationDispatcher
    * Creates a new PartitionOperationDispatcher.
    *
    * @param catalogManager The CatalogManager instance to be used for partition operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for partition operations.
    * @param idGenerator The IdGenerator instance to be used for partition operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public PartitionOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
-    super(catalogManager, secretManager, store, idGenerator);
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -42,6 +42,7 @@ import org.apache.gravitino.lock.LockType;
 import org.apache.gravitino.lock.TreeLockUtils;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.SchemaEntity;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.apache.gravitino.utils.SchemaEntityCleaner;
@@ -58,10 +59,14 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
    * @param catalogManager The CatalogManager instance to be used for schema operations.
    * @param store The EntityStore instance to be used for schema operations.
    * @param idGenerator The IdGenerator instance to be used for schema operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public SchemaOperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
-    super(catalogManager, store, idGenerator);
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -57,16 +57,16 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
    * Creates a new SchemaOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for schema operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for schema operations.
    * @param idGenerator The IdGenerator instance to be used for schema operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public SchemaOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
-    super(catalogManager, secretManager, store, idGenerator);
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -57,16 +57,16 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
    * Creates a new SchemaOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for schema operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for schema operations.
    * @param idGenerator The IdGenerator instance to be used for schema operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public SchemaOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
-    super(catalogManager, store, idGenerator, secretManager);
+      IdGenerator idGenerator) {
+    super(catalogManager, secretManager, store, idGenerator);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -64,6 +64,7 @@ import org.apache.gravitino.rel.expressions.sorts.SortOrder;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
@@ -82,10 +83,19 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
    * @param catalogManager The CatalogManager instance to be used for table operations.
    * @param store The EntityStore instance to be used for table operations.
    * @param idGenerator The IdGenerator instance to be used for table operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public TableOperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
-    this(catalogManager, store, idGenerator, () -> GravitinoEnv.getInstance().schemaDispatcher());
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    this(
+        catalogManager,
+        store,
+        idGenerator,
+        secretManager,
+        () -> GravitinoEnv.getInstance().schemaDispatcher());
   }
 
   /**
@@ -94,14 +104,16 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
    * @param catalogManager The CatalogManager instance to be used for table operations.
    * @param store The EntityStore instance to be used for table operations.
    * @param idGenerator The IdGenerator instance to be used for table operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param schemaDispatcherSupplier The SchemaDispatcher supplier to ensure schemas are imported.
    */
   public TableOperationDispatcher(
       CatalogManager catalogManager,
       EntityStore store,
       IdGenerator idGenerator,
+      SecretManager secretManager,
       Supplier<SchemaDispatcher> schemaDispatcherSupplier) {
-    super(catalogManager, store, idGenerator);
+    super(catalogManager, store, idGenerator, secretManager);
     this.schemaDispatcherSupplier =
         Preconditions.checkNotNull(
             schemaDispatcherSupplier, "schemaDispatcherSupplier must not be null");

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -81,39 +81,39 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
    * Creates a new TableOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for table operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for table operations.
    * @param idGenerator The IdGenerator instance to be used for table operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public TableOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
     this(
         catalogManager,
-        secretManager,
         store,
         idGenerator,
-        () -> GravitinoEnv.getInstance().schemaDispatcher());
+        () -> GravitinoEnv.getInstance().schemaDispatcher(),
+        secretManager);
   }
 
   /**
    * Creates a new TableOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for table operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for table operations.
    * @param idGenerator The IdGenerator instance to be used for table operations.
    * @param schemaDispatcherSupplier The SchemaDispatcher supplier to ensure schemas are imported.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public TableOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
       IdGenerator idGenerator,
-      Supplier<SchemaDispatcher> schemaDispatcherSupplier) {
-    super(catalogManager, secretManager, store, idGenerator);
+      Supplier<SchemaDispatcher> schemaDispatcherSupplier,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
     this.schemaDispatcherSupplier =
         Preconditions.checkNotNull(
             schemaDispatcherSupplier, "schemaDispatcherSupplier must not be null");

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -81,20 +81,20 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
    * Creates a new TableOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for table operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for table operations.
    * @param idGenerator The IdGenerator instance to be used for table operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public TableOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
+      IdGenerator idGenerator) {
     this(
         catalogManager,
+        secretManager,
         store,
         idGenerator,
-        secretManager,
         () -> GravitinoEnv.getInstance().schemaDispatcher());
   }
 
@@ -102,18 +102,18 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
    * Creates a new TableOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for table operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for table operations.
    * @param idGenerator The IdGenerator instance to be used for table operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param schemaDispatcherSupplier The SchemaDispatcher supplier to ensure schemas are imported.
    */
   public TableOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
       IdGenerator idGenerator,
-      SecretManager secretManager,
       Supplier<SchemaDispatcher> schemaDispatcherSupplier) {
-    super(catalogManager, store, idGenerator, secretManager);
+    super(catalogManager, secretManager, store, idGenerator);
     this.schemaDispatcherSupplier =
         Preconditions.checkNotNull(
             schemaDispatcherSupplier, "schemaDispatcherSupplier must not be null");

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.messaging.Topic;
 import org.apache.gravitino.messaging.TopicChange;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TopicEntity;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.slf4j.Logger;
@@ -58,10 +59,14 @@ public class TopicOperationDispatcher extends OperationDispatcher implements Top
    * @param catalogManager The CatalogManager instance to be used for catalog operations.
    * @param store The EntityStore instance to be used for catalog operations.
    * @param idGenerator The IdGenerator instance to be used for catalog operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public TopicOperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
-    super(catalogManager, store, idGenerator);
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
@@ -57,16 +57,16 @@ public class TopicOperationDispatcher extends OperationDispatcher implements Top
    * Creates a new TopicOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for catalog operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for catalog operations.
    * @param idGenerator The IdGenerator instance to be used for catalog operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public TopicOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
-    super(catalogManager, store, idGenerator, secretManager);
+      IdGenerator idGenerator) {
+    super(catalogManager, secretManager, store, idGenerator);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
@@ -57,16 +57,16 @@ public class TopicOperationDispatcher extends OperationDispatcher implements Top
    * Creates a new TopicOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for catalog operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for catalog operations.
    * @param idGenerator The IdGenerator instance to be used for catalog operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public TopicOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
-    super(catalogManager, secretManager, store, idGenerator);
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
@@ -51,6 +51,7 @@ import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewChange;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.slf4j.Logger;
@@ -69,10 +70,19 @@ public class ViewOperationDispatcher extends OperationDispatcher implements View
    * @param catalogManager The CatalogManager instance to be used for view operations.
    * @param store The EntityStore instance to be used for view operations.
    * @param idGenerator The IdGenerator instance to be used for view operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public ViewOperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
-    this(catalogManager, store, idGenerator, () -> GravitinoEnv.getInstance().schemaDispatcher());
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    this(
+        catalogManager,
+        store,
+        idGenerator,
+        secretManager,
+        () -> GravitinoEnv.getInstance().schemaDispatcher());
   }
 
   /**
@@ -81,14 +91,16 @@ public class ViewOperationDispatcher extends OperationDispatcher implements View
    * @param catalogManager The CatalogManager instance to be used for view operations.
    * @param store The EntityStore instance to be used for view operations.
    * @param idGenerator The IdGenerator instance to be used for view operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param schemaDispatcherSupplier The SchemaDispatcher supplier to ensure schemas are imported.
    */
   public ViewOperationDispatcher(
       CatalogManager catalogManager,
       EntityStore store,
       IdGenerator idGenerator,
+      SecretManager secretManager,
       Supplier<SchemaDispatcher> schemaDispatcherSupplier) {
-    super(catalogManager, store, idGenerator);
+    super(catalogManager, store, idGenerator, secretManager);
     this.schemaDispatcherSupplier =
         Preconditions.checkNotNull(
             schemaDispatcherSupplier, "schemaDispatcherSupplier must not be null");

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
@@ -68,39 +68,39 @@ public class ViewOperationDispatcher extends OperationDispatcher implements View
    * Creates a new ViewOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for view operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for view operations.
    * @param idGenerator The IdGenerator instance to be used for view operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public ViewOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
     this(
         catalogManager,
-        secretManager,
         store,
         idGenerator,
-        () -> GravitinoEnv.getInstance().schemaDispatcher());
+        () -> GravitinoEnv.getInstance().schemaDispatcher(),
+        secretManager);
   }
 
   /**
    * Creates a new ViewOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for view operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for view operations.
    * @param idGenerator The IdGenerator instance to be used for view operations.
    * @param schemaDispatcherSupplier The SchemaDispatcher supplier to ensure schemas are imported.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public ViewOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
       IdGenerator idGenerator,
-      Supplier<SchemaDispatcher> schemaDispatcherSupplier) {
-    super(catalogManager, secretManager, store, idGenerator);
+      Supplier<SchemaDispatcher> schemaDispatcherSupplier,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
     this.schemaDispatcherSupplier =
         Preconditions.checkNotNull(
             schemaDispatcherSupplier, "schemaDispatcherSupplier must not be null");

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
@@ -68,20 +68,20 @@ public class ViewOperationDispatcher extends OperationDispatcher implements View
    * Creates a new ViewOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for view operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for view operations.
    * @param idGenerator The IdGenerator instance to be used for view operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    */
   public ViewOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
+      IdGenerator idGenerator) {
     this(
         catalogManager,
+        secretManager,
         store,
         idGenerator,
-        secretManager,
         () -> GravitinoEnv.getInstance().schemaDispatcher());
   }
 
@@ -89,18 +89,18 @@ public class ViewOperationDispatcher extends OperationDispatcher implements View
    * Creates a new ViewOperationDispatcher instance.
    *
    * @param catalogManager The CatalogManager instance to be used for view operations.
+   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param store The EntityStore instance to be used for view operations.
    * @param idGenerator The IdGenerator instance to be used for view operations.
-   * @param secretManager The SecretManager instance to be used for secret operations.
    * @param schemaDispatcherSupplier The SchemaDispatcher supplier to ensure schemas are imported.
    */
   public ViewOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
       IdGenerator idGenerator,
-      SecretManager secretManager,
       Supplier<SchemaDispatcher> schemaDispatcherSupplier) {
-    super(catalogManager, store, idGenerator, secretManager);
+    super(catalogManager, secretManager, store, idGenerator);
     this.schemaDispatcherSupplier =
         Preconditions.checkNotNull(
             schemaDispatcherSupplier, "schemaDispatcherSupplier must not be null");

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialOperationDispatcher.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.connector.credential.PathContext;
 import org.apache.gravitino.connector.credential.SupportsPathBasedCredentials;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
@@ -45,8 +46,11 @@ import org.apache.gravitino.utils.PrincipalUtils;
 public class CredentialOperationDispatcher extends OperationDispatcher {
 
   public CredentialOperationDispatcher(
-      CatalogManager catalogManager, EntityStore store, IdGenerator idGenerator) {
-    super(catalogManager, store, idGenerator);
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   public List<Credential> getCredentials(NameIdentifier identifier, CredentialPrivilege privilege) {

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialOperationDispatcher.java
@@ -47,10 +47,10 @@ public class CredentialOperationDispatcher extends OperationDispatcher {
 
   public CredentialOperationDispatcher(
       CatalogManager catalogManager,
+      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator,
-      SecretManager secretManager) {
-    super(catalogManager, store, idGenerator, secretManager);
+      IdGenerator idGenerator) {
+    super(catalogManager, secretManager, store, idGenerator);
   }
 
   public List<Credential> getCredentials(NameIdentifier identifier, CredentialPrivilege privilege) {

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialOperationDispatcher.java
@@ -47,10 +47,10 @@ public class CredentialOperationDispatcher extends OperationDispatcher {
 
   public CredentialOperationDispatcher(
       CatalogManager catalogManager,
-      SecretManager secretManager,
       EntityStore store,
-      IdGenerator idGenerator) {
-    super(catalogManager, secretManager, store, idGenerator);
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
   }
 
   public List<Credential> getCredentials(NameIdentifier identifier, CredentialPrivilege privilege) {

--- a/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
+++ b/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
@@ -86,7 +86,7 @@ public class SecretManager implements Closeable {
       String providerName = locator.provider();
       SecretProvider provider = registry.getProvider(providerName);
       try {
-        SecretUrn urn = provider.bindExternalReference(key, locator.attributes());
+        SecretUrn urn = provider.buildReferenceUrn(key, locator.attributes());
         validateUrnEndsWithPropertyKey(urn, key);
         urns.add(urn);
       } catch (UnsupportedOperationException e) {

--- a/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
+++ b/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
@@ -173,7 +173,7 @@ public class SecretManager implements Closeable {
         SecretBinding binding = secretBindings.get(propertyKey);
         Preconditions.checkArgument(
             binding != null, "No secretBindings entry for property key \"%s\"", propertyKey);
-        String plaintext = binding.value();
+        String plaintext = binding.plaintext();
         Map<String, String> attributes =
             ImmutableMap.of(
                 ATTR_ENTITY_TYPE, entityType,

--- a/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
+++ b/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import static org.apache.gravitino.secret.SecretConstants.ATTR_ENTITY_ID;
+import static org.apache.gravitino.secret.SecretConstants.ATTR_ENTITY_TYPE;
+import static org.apache.gravitino.secret.SecretConstants.ATTR_PROPERTY_KEY;
+import static org.apache.gravitino.secret.SecretPropertyUtils.validateSecretBindings;
+import static org.apache.gravitino.secret.SecretPropertyUtils.validateSecretReferences;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SecretManager owns write-through / external-reference secret lifecycle against configured
+ * providers, and rolls back write-through secrets when entity create fails.
+ */
+public class SecretManager implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SecretManager.class);
+
+  private final SecretProviderRegistry registry;
+
+  public SecretManager(Config config) {
+    this.registry = new SecretProviderRegistry(config);
+  }
+
+  public SecretManager(SecretProviderRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Returns the secrets-provider registry owned by this manager.
+   *
+   * @return the registry
+   */
+  public SecretProviderRegistry getRegistry() {
+    return registry;
+  }
+
+  /**
+   * Builds external-reference URNs from {@code secretReferences} without writing secret material.
+   *
+   * <p>Callers must put the returned URN strings into properties themselves (e.g. via {@link
+   * SecretPropertyUtils#applySecretUrns}). External-ref URNs are owned outside Gravitino and must
+   * not be passed to {@link #rollbackWritten}.
+   *
+   * @param secretReferences property key → secret locator
+   * @return external-reference URNs (insertion order)
+   */
+  public List<SecretUrn> getSecretReferenceUrns(Map<String, SecretReference> secretReferences) {
+    Preconditions.checkArgument(
+        secretReferences != null && !secretReferences.isEmpty(),
+        "secretReferences must not be null or empty");
+    validateSecretReferences(secretReferences);
+
+    List<SecretUrn> urns = new ArrayList<>(secretReferences.size());
+    for (Map.Entry<String, SecretReference> entry : secretReferences.entrySet()) {
+      String key = entry.getKey();
+      SecretReference locator = entry.getValue();
+      String providerName = locator.provider();
+      SecretProvider provider = registry.getProvider(providerName);
+      try {
+        SecretUrn urn = provider.bindExternalReference(key, locator.attributes());
+        validateUrnEndsWithPropertyKey(urn, key);
+        urns.add(urn);
+      } catch (UnsupportedOperationException e) {
+        throw new IllegalArgumentException(
+            "Provider \""
+                + providerName
+                + "\" does not support secretReferences for key \""
+                + key
+                + "\"",
+            e);
+      }
+    }
+    return List.copyOf(urns);
+  }
+
+  /**
+   * Builds write-through URNs from {@code secretBindings} without writing secret material.
+   *
+   * <p>Callers should pass the returned URNs to {@link #writeSecrets} to persist plaintext from
+   * each binding's value, then put URNs into properties (e.g. via {@link
+   * SecretPropertyUtils#applySecretUrns}).
+   *
+   * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
+   * @param entityId stable numeric entity id
+   * @param secretBindings property key → write-through binding
+   * @return write-through URNs (insertion order)
+   */
+  public List<SecretUrn> getSecretBindingUrns(
+      String entityType, long entityId, Map<String, SecretBinding> secretBindings) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(entityType), "entityType must not be blank");
+    Preconditions.checkArgument(
+        secretBindings != null && !secretBindings.isEmpty(),
+        "secretBindings must not be null or empty");
+    validateSecretBindings(secretBindings);
+
+    List<SecretUrn> urns = new ArrayList<>(secretBindings.size());
+    for (Map.Entry<String, SecretBinding> entry : secretBindings.entrySet()) {
+      String key = entry.getKey();
+      String providerName = entry.getValue().provider();
+      // Ensure the provider is registered before building the URN.
+      registry.getProvider(providerName);
+      Map<String, String> attributes =
+          ImmutableMap.of(
+              ATTR_ENTITY_TYPE, entityType,
+              ATTR_ENTITY_ID, String.valueOf(entityId),
+              ATTR_PROPERTY_KEY, key);
+      SecretUrn urn = SecretUrn.buildWriteThrough(providerName, attributes);
+      validateUrnEndsWithPropertyKey(urn, key);
+      urns.add(urn);
+    }
+    return List.copyOf(urns);
+  }
+
+  /**
+   * Writes plaintext secrets from {@code secretBindings} values into the write-through providers
+   * for {@code secretUrns} (e.g. Vault).
+   *
+   * <p>{@code secretUrns} must come from {@link #getSecretBindingUrns}. On failure, already-written
+   * URNs are rolled back. Callers must put URN strings into properties themselves (e.g. via {@link
+   * SecretPropertyUtils#applySecretUrns}).
+   *
+   * @param secretBindings property key → write-through binding
+   * @param secretUrns write-through URNs from {@link #getSecretBindingUrns}
+   */
+  public void writeSecrets(Map<String, SecretBinding> secretBindings, List<SecretUrn> secretUrns) {
+    Preconditions.checkArgument(
+        secretBindings != null && !secretBindings.isEmpty(),
+        "secretBindings must not be null or empty");
+    Preconditions.checkArgument(
+        secretUrns != null && !secretUrns.isEmpty(), "secretUrns must not be null or empty");
+    validateSecretBindings(secretBindings);
+
+    List<SecretUrn> written = new ArrayList<>(secretUrns.size());
+    try {
+      for (SecretUrn urn : secretUrns) {
+        List<String> segments = urn.identifierSegments();
+        Preconditions.checkArgument(
+            segments.size() == 3,
+            "Write-through secret URN must have entityType, entityId, propertyKey segments: %s",
+            urn);
+        String entityType = segments.get(0);
+        String entityId = segments.get(1);
+        String propertyKey = segments.get(2);
+        SecretBinding binding = secretBindings.get(propertyKey);
+        Preconditions.checkArgument(
+            binding != null, "No secretBindings entry for property key \"%s\"", propertyKey);
+        String plaintext = binding.value();
+        Map<String, String> attributes =
+            ImmutableMap.of(
+                ATTR_ENTITY_TYPE, entityType,
+                ATTR_ENTITY_ID, entityId,
+                ATTR_PROPERTY_KEY, propertyKey);
+        SecretUrn writtenUrn =
+            registry.getProvider(urn.providerName()).writeSecret(plaintext, attributes);
+        Preconditions.checkArgument(
+            urn.equals(writtenUrn),
+            "Provider returned unexpected URN: expected %s, got %s",
+            urn,
+            writtenUrn);
+        written.add(writtenUrn);
+      }
+    } catch (RuntimeException e) {
+      rollbackWritten(written);
+      throw e;
+    }
+  }
+
+  /**
+   * Best-effort delete of write-through secrets after a failed create.
+   *
+   * <p>Only write-through URNs that were persisted by {@link #writeSecrets} may be passed. Do not
+   * roll back external reference URNs from {@link #getSecretReferenceUrns}.
+   *
+   * @param secretUrns write-through URNs from {@link #getSecretBindingUrns}
+   */
+  public void rollbackWritten(@Nullable List<SecretUrn> secretUrns) {
+    if (secretUrns == null || secretUrns.isEmpty()) {
+      return;
+    }
+    for (SecretUrn urn : secretUrns) {
+      try {
+        registry.getProvider(urn.providerName()).deleteSecret(urn);
+      } catch (Exception e) {
+        LOG.warn("Failed to roll back written secret {}", urn, e);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    registry.close();
+  }
+
+  private static void validateUrnEndsWithPropertyKey(SecretUrn urn, String propertyKey) {
+    Preconditions.checkArgument(
+        urn.toString().endsWith(propertyKey),
+        "Built secret URN must end with property key \"%s\": %s",
+        propertyKey,
+        urn);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/secret/SecretPropertyUtils.java
+++ b/core/src/main/java/org/apache/gravitino/secret/SecretPropertyUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import static org.apache.gravitino.secret.SecretConstants.URN_PREFIX;
+
+import com.google.common.base.Preconditions;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Helpers for secret-related entity property handling and request validation.
+ *
+ * <p>This is intentionally separate from {@link SecretManager}, which owns secret lifecycle
+ * (build/write/rollback) rather than property assembly and request-shape checks.
+ */
+public final class SecretPropertyUtils {
+
+  private SecretPropertyUtils() {}
+
+  /**
+   * Returns whether a property value is a Gravitino secret URN for the given key.
+   *
+   * @param key the property key
+   * @param value the property value
+   * @return true when value starts with the secret URN prefix and ends with the key
+   */
+  public static boolean isSecretProperty(@Nullable String key, @Nullable String value) {
+    return key != null && value != null && value.startsWith(URN_PREFIX) && value.endsWith(key);
+  }
+
+  /**
+   * Rejects property keys that appear in both {@code secretBindings} and {@code secretReferences}.
+   *
+   * @param secretBindings property key → write-through binding (may be null)
+   * @param secretReferences property key → secret locator (may be null)
+   */
+  public static void checkNoOverlap(
+      @Nullable Map<String, SecretBinding> secretBindings,
+      @Nullable Map<String, SecretReference> secretReferences) {
+    Set<String> bindingKeys = secretBindings == null ? Set.of() : secretBindings.keySet();
+    Set<String> referenceKeys = secretReferences == null ? Set.of() : secretReferences.keySet();
+    Set<String> overlap = new HashSet<>(bindingKeys);
+    overlap.retainAll(referenceKeys);
+    Preconditions.checkArgument(
+        overlap.isEmpty(),
+        "Property keys cannot appear in both secretBindings and secretReferences: %s",
+        overlap);
+  }
+
+  /**
+   * Applies each URN string into {@code properties} under the property key encoded in the URN (last
+   * identifier segment).
+   *
+   * @param properties mutable entity properties
+   * @param secretUrns secret URNs whose last identifier segment is the property key
+   */
+  public static void applySecretUrns(Map<String, String> properties, List<SecretUrn> secretUrns) {
+    Preconditions.checkArgument(properties != null, "properties must not be null");
+    Preconditions.checkArgument(secretUrns != null, "secretUrns must not be null");
+    for (SecretUrn urn : secretUrns) {
+      List<String> segments = urn.identifierSegments();
+      Preconditions.checkArgument(
+          !segments.isEmpty(), "Secret URN must contain at least one identifier segment: %s", urn);
+      properties.put(segments.get(segments.size() - 1), urn.toString());
+    }
+  }
+
+  /**
+   * Validates create-time {@code secretBindings} request shape.
+   *
+   * @param bindings property key → write-through binding
+   */
+  static void validateSecretBindings(Map<String, SecretBinding> bindings) {
+    for (Map.Entry<String, SecretBinding> entry : bindings.entrySet()) {
+      String key = entry.getKey();
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(key), "secretBindings keys must not be blank");
+      Preconditions.checkArgument(
+          entry.getValue() != null, "secretBindings[%s] must not be null", key);
+    }
+  }
+
+  /**
+   * Validates create-time {@code secretReferences} request shape.
+   *
+   * @param references property key → secret locator
+   */
+  static void validateSecretReferences(Map<String, SecretReference> references) {
+    for (Map.Entry<String, SecretReference> entry : references.entrySet()) {
+      String key = entry.getKey();
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(key), "secretReferences keys must not be blank");
+      Preconditions.checkArgument(
+          entry.getValue() != null, "secretReferences[%s] must not be null", key);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/TestGravitinoEnvSecretProviderRegistry.java
+++ b/core/src/test/java/org/apache/gravitino/TestGravitinoEnvSecretProviderRegistry.java
@@ -7,10 +7,10 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
@@ -20,6 +20,7 @@ package org.apache.gravitino;
 
 import java.util.Properties;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.secret.SecretProviderRegistry;
 import org.apache.gravitino.secret.memory.InMemorySecretsProvider;
 import org.junit.jupiter.api.Assertions;
@@ -31,17 +32,20 @@ public class TestGravitinoEnvSecretProviderRegistry {
   void testEmptyRegistryIsOptionalAndClosedWithEnvironment() throws IllegalAccessException {
     TestGravitinoEnv env = new TestGravitinoEnv();
     Assertions.assertThrows(IllegalStateException.class, env::secretProviderRegistry);
+    Assertions.assertThrows(IllegalStateException.class, env::secretManager);
 
-    SecretProviderRegistry registry = new SecretProviderRegistry(new Config(false) {});
-    FieldUtils.writeField(env, "secretProviderRegistry", registry, true);
+    SecretManager secretManager = new SecretManager(new Config(false) {});
+    FieldUtils.writeField(env, "secretManager", secretManager, true);
 
-    Assertions.assertSame(registry, env.secretProviderRegistry());
-    Assertions.assertTrue(registry.listProviders().isEmpty());
+    Assertions.assertSame(secretManager, env.secretManager());
+    Assertions.assertSame(secretManager.getRegistry(), env.secretProviderRegistry());
+    Assertions.assertTrue(secretManager.getRegistry().listProviders().isEmpty());
 
     env.shutdown();
 
-    Assertions.assertSame(registry, env.secretProviderRegistry());
-    Assertions.assertThrows(IllegalStateException.class, registry::listProviders);
+    Assertions.assertSame(secretManager, env.secretManager());
+    Assertions.assertThrows(
+        IllegalStateException.class, () -> secretManager.getRegistry().listProviders());
   }
 
   @Test
@@ -58,13 +62,15 @@ public class TestGravitinoEnvSecretProviderRegistry {
     config.loadFromProperties(properties);
 
     env.initializeBaseComponents(config);
+    SecretManager secretManager = env.secretManager();
     SecretProviderRegistry registry = env.secretProviderRegistry();
+    Assertions.assertSame(secretManager.getRegistry(), registry);
     Assertions.assertEquals(1, registry.listProviders().size());
     Assertions.assertEquals("memory", registry.getProvider("memory").type());
 
     env.shutdown();
 
-    Assertions.assertSame(registry, env.secretProviderRegistry());
+    Assertions.assertSame(secretManager, env.secretManager());
     Assertions.assertThrows(IllegalStateException.class, registry::listProviders);
   }
 

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -65,6 +65,7 @@ import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.meta.SchemaVersion;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore.InMemoryEntityStore;
@@ -113,7 +114,8 @@ public class TestCatalogManager {
 
     entityStore.put(metalakeEntity, true);
 
-    catalogManager = new CatalogManager(config, entityStore, new RandomIdGenerator());
+    catalogManager =
+        new CatalogManager(config, entityStore, new RandomIdGenerator(), new SecretManager(config));
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     catalogManager = Mockito.spy(catalogManager);
   }
@@ -793,7 +795,8 @@ public class TestCatalogManager {
   @Test
   void testCloseUnregistersCatalogChangeLogListener() {
     ChangeLogAwareEntityStore store = new ChangeLogAwareEntityStore();
-    CatalogManager manager = new CatalogManager(config, store, new RandomIdGenerator());
+    CatalogManager manager =
+        new CatalogManager(config, store, new RandomIdGenerator(), new SecretManager(config));
 
     EntityChangeLogListener registeredListener = store.listener.get();
     Assertions.assertNotNull(registeredListener);
@@ -809,7 +812,8 @@ public class TestCatalogManager {
     store.initialize(config);
     store.put(metalakeEntity, true);
 
-    CatalogManager manager = new CatalogManager(config, store, new RandomIdGenerator());
+    CatalogManager manager =
+        new CatalogManager(config, store, new RandomIdGenerator(), new SecretManager(config));
     NameIdentifier ident = NameIdentifier.of("metalake", "delete_returns_false");
     Map<String, String> props =
         ImmutableMap.of(
@@ -852,7 +856,8 @@ public class TestCatalogManager {
     store.initialize(config);
     store.put(metalakeEntity, true);
 
-    CatalogManager manager = new CatalogManager(config, store, new RandomIdGenerator());
+    CatalogManager manager =
+        new CatalogManager(config, store, new RandomIdGenerator(), new SecretManager(config));
     NameIdentifier ident = NameIdentifier.of("metalake", "failed_create_cleanup");
 
     // A creation that fails validation (key1 is required but missing) stores the entity and then

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogNormalizeDispatcher.java
@@ -27,15 +27,19 @@ import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.Configs;
 import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.SchemaVersion;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore;
 import org.junit.jupiter.api.AfterAll;
@@ -61,7 +65,7 @@ public class TestCatalogNormalizeDispatcher {
           .build();
 
   @BeforeAll
-  public static void setUp() throws IOException {
+  public static void setUp() throws IOException, IllegalAccessException {
     Config config = new Config(false) {};
     config.set(Configs.CATALOG_LOAD_ISOLATED, false);
 
@@ -70,7 +74,9 @@ public class TestCatalogNormalizeDispatcher {
 
     entityStore.put(metalakeEntity, true);
 
-    catalogManager = new CatalogManager(config, entityStore, new RandomIdGenerator());
+    catalogManager =
+        new CatalogManager(config, entityStore, new RandomIdGenerator(), new SecretManager(config));
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     catalogManager = Mockito.spy(catalogManager);
     catalogNormalizeDispatcher = new CatalogNormalizeDispatcher(catalogManager);
   }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestClassLoaderPoolIntegration.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestClassLoaderPoolIntegration.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.SchemaVersion;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore.InMemoryEntityStore;
@@ -90,7 +91,8 @@ public class TestClassLoaderPoolIntegration {
 
   @BeforeEach
   public void beforeEach() throws IOException {
-    catalogManager = new CatalogManager(config, entityStore, new RandomIdGenerator());
+    catalogManager =
+        new CatalogManager(config, entityStore, new RandomIdGenerator(), new SecretManager(config));
   }
 
   @AfterEach
@@ -243,7 +245,11 @@ public class TestClassLoaderPoolIntegration {
     noSharingConfig.set(Configs.CATALOG_CLASSLOADER_SHARING_ENABLED, false);
 
     CatalogManager noSharingManager =
-        new CatalogManager(noSharingConfig, entityStore, new RandomIdGenerator());
+        new CatalogManager(
+            noSharingConfig,
+            entityStore,
+            new RandomIdGenerator(),
+            new SecretManager(noSharingConfig));
     try {
       Map<String, String> props =
           ImmutableMap.of("key1", "value1", "key2", "value2", "key5-1", "value3");
@@ -292,7 +298,11 @@ public class TestClassLoaderPoolIntegration {
     noSharingConfig.set(Configs.CATALOG_CLASSLOADER_SHARING_ENABLED, false);
 
     CatalogManager noSharingManager =
-        new CatalogManager(noSharingConfig, entityStore, new RandomIdGenerator());
+        new CatalogManager(
+            noSharingConfig,
+            entityStore,
+            new RandomIdGenerator(),
+            new SecretManager(noSharingConfig));
     try {
       Map<String, String> props =
           ImmutableMap.of("key1", "value1", "key2", "value2", "key5-1", "value3");

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
@@ -45,9 +45,9 @@ public class TestFilesetOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     filesetOperationDispatcher =
-        new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new FilesetOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
   }
 
   public static FilesetOperationDispatcher getFilesetOperationDispatcher() {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
@@ -45,9 +45,9 @@ public class TestFilesetOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     filesetOperationDispatcher =
-        new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
   }
 
   public static FilesetOperationDispatcher getFilesetOperationDispatcher() {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
@@ -45,9 +45,9 @@ public class TestFilesetOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     filesetOperationDispatcher =
-        new FilesetOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
   }
 
   public static FilesetOperationDispatcher getFilesetOperationDispatcher() {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFunctionOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFunctionOperationDispatcher.java
@@ -28,6 +28,7 @@ import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.function.FunctionChange;
 import org.apache.gravitino.function.FunctionDefinition;
 import org.apache.gravitino.function.FunctionType;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.junit.jupiter.api.Assertions;
@@ -61,7 +62,9 @@ public class TestFunctionOperationDispatcher {
     when(catalogManager.loadCatalogAndWrap(NameIdentifier.of(METALAKE, HIVE_CATALOG)))
         .thenReturn(hiveWrapper);
 
-    dispatcher = new FunctionOperationDispatcher(catalogManager, schemaOps, store, idGenerator);
+    dispatcher =
+        new FunctionOperationDispatcher(
+            catalogManager, schemaOps, store, idGenerator, mock(SecretManager.class));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFunctionOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFunctionOperationDispatcher.java
@@ -64,7 +64,7 @@ public class TestFunctionOperationDispatcher {
 
     dispatcher =
         new FunctionOperationDispatcher(
-            catalogManager, schemaOps, store, idGenerator, mock(SecretManager.class));
+            catalogManager, mock(SecretManager.class), schemaOps, store, idGenerator);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFunctionOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFunctionOperationDispatcher.java
@@ -64,7 +64,7 @@ public class TestFunctionOperationDispatcher {
 
     dispatcher =
         new FunctionOperationDispatcher(
-            catalogManager, mock(SecretManager.class), schemaOps, store, idGenerator);
+            catalogManager, schemaOps, store, idGenerator, mock(SecretManager.class));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -65,9 +65,9 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
 
     modelOperationDispatcher =
-        new ModelOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new ModelOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -65,9 +65,9 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
 
     modelOperationDispatcher =
-        new ModelOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new ModelOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -65,9 +65,9 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
 
     modelOperationDispatcher =
-        new ModelOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new ModelOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
@@ -78,6 +78,8 @@ public abstract class TestOperationDispatcher {
 
   protected static CatalogManager catalogManager;
 
+  protected static SecretManager secretManager;
+
   private static Config config;
 
   @BeforeAll
@@ -98,8 +100,8 @@ public abstract class TestOperationDispatcher {
             .build();
     entityStore.put(metalakeEntity, true);
 
-    catalogManager =
-        new CatalogManager(config, entityStore, idGenerator, new SecretManager(config));
+    secretManager = new SecretManager(config);
+    catalogManager = new CatalogManager(config, entityStore, idGenerator, secretManager);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogManager", catalogManager, true);
 
     Config config = mock(Config.class);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
@@ -53,6 +53,7 @@ import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.SchemaVersion;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore;
@@ -97,7 +98,8 @@ public abstract class TestOperationDispatcher {
             .build();
     entityStore.put(metalakeEntity, true);
 
-    catalogManager = new CatalogManager(config, entityStore, idGenerator);
+    catalogManager =
+        new CatalogManager(config, entityStore, idGenerator, new SecretManager(config));
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogManager", catalogManager, true);
 
     Config config = mock(Config.class);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPartitionOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPartitionOperationDispatcher.java
@@ -78,11 +78,11 @@ public class TestPartitionOperationDispatcher extends TestOperationDispatcher {
 
   protected static void prepareTable() throws IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     tableOperationDispatcher =
-        new TableOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new TableOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     partitionOperationDispatcher =
-        new PartitionOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPartitionOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPartitionOperationDispatcher.java
@@ -78,11 +78,11 @@ public class TestPartitionOperationDispatcher extends TestOperationDispatcher {
 
   protected static void prepareTable() throws IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     tableOperationDispatcher =
-        new TableOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new TableOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     partitionOperationDispatcher =
-        new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPartitionOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPartitionOperationDispatcher.java
@@ -78,11 +78,11 @@ public class TestPartitionOperationDispatcher extends TestOperationDispatcher {
 
   protected static void prepareTable() throws IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     tableOperationDispatcher =
-        new TableOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new TableOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     partitionOperationDispatcher =
-        new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new PartitionOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -61,7 +61,8 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
 
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
-    dispatcher = new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+    dispatcher =
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(Configs.TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -62,7 +62,7 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     dispatcher =
-        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(Configs.TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -62,7 +62,7 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     dispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(Configs.TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -80,13 +80,13 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     tableOperationDispatcher =
         new TableOperationDispatcher(
             catalogManager,
+            secretManager,
             entityStore,
             idGenerator,
-            secretManager,
             () -> schemaOperationDispatcher);
 
     Config config = mock(Config.class);
@@ -271,7 +271,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
         NullPointerException.class,
         () ->
             new TableOperationDispatcher(
-                catalogManager, entityStore, idGenerator, secretManager, null));
+                catalogManager, secretManager, entityStore, idGenerator, null));
   }
 
   @Test
@@ -283,7 +283,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Supplier<SchemaDispatcher> nullSchemaDispatcherSupplier = () -> null;
     TableOperationDispatcher dispatcher =
         new TableOperationDispatcher(
-            catalogManager, entityStore, idGenerator, secretManager, nullSchemaDispatcherSupplier);
+            catalogManager, secretManager, entityStore, idGenerator, nullSchemaDispatcherSupplier);
     NameIdentifier tableIdent = NameIdentifier.of(tableNs, "table_null_dispatcher");
     Column[] columns =
         new Column[] {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -80,14 +80,14 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     tableOperationDispatcher =
         new TableOperationDispatcher(
             catalogManager,
-            secretManager,
             entityStore,
             idGenerator,
-            () -> schemaOperationDispatcher);
+            () -> schemaOperationDispatcher,
+            secretManager);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
@@ -271,7 +271,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
         NullPointerException.class,
         () ->
             new TableOperationDispatcher(
-                catalogManager, secretManager, entityStore, idGenerator, null));
+                catalogManager, entityStore, idGenerator, null, secretManager));
   }
 
   @Test
@@ -283,7 +283,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Supplier<SchemaDispatcher> nullSchemaDispatcherSupplier = () -> null;
     TableOperationDispatcher dispatcher =
         new TableOperationDispatcher(
-            catalogManager, secretManager, entityStore, idGenerator, nullSchemaDispatcherSupplier);
+            catalogManager, entityStore, idGenerator, nullSchemaDispatcherSupplier, secretManager);
     NameIdentifier tableIdent = NameIdentifier.of(tableNs, "table_null_dispatcher");
     Column[] columns =
         new Column[] {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -80,10 +80,14 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     tableOperationDispatcher =
         new TableOperationDispatcher(
-            catalogManager, entityStore, idGenerator, () -> schemaOperationDispatcher);
+            catalogManager,
+            entityStore,
+            idGenerator,
+            secretManager,
+            () -> schemaOperationDispatcher);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
@@ -265,7 +269,9 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
   public void testTableOperationDispatcherRejectsNullSchemaDispatcherSupplier() {
     Assertions.assertThrows(
         NullPointerException.class,
-        () -> new TableOperationDispatcher(catalogManager, entityStore, idGenerator, null));
+        () ->
+            new TableOperationDispatcher(
+                catalogManager, entityStore, idGenerator, secretManager, null));
   }
 
   @Test
@@ -277,7 +283,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Supplier<SchemaDispatcher> nullSchemaDispatcherSupplier = () -> null;
     TableOperationDispatcher dispatcher =
         new TableOperationDispatcher(
-            catalogManager, entityStore, idGenerator, nullSchemaDispatcherSupplier);
+            catalogManager, entityStore, idGenerator, secretManager, nullSchemaDispatcherSupplier);
     NameIdentifier tableIdent = NameIdentifier.of(tableNs, "table_null_dispatcher");
     Column[] columns =
         new Column[] {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
@@ -66,9 +66,9 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     topicOperationDispatcher =
-        new TopicOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new TopicOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
@@ -66,9 +66,9 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     topicOperationDispatcher =
-        new TopicOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new TopicOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
@@ -66,9 +66,9 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     topicOperationDispatcher =
-        new TopicOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new TopicOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -72,14 +72,14 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     viewOperationDispatcher =
         new ViewOperationDispatcher(
             catalogManager,
-            secretManager,
             entityStore,
             idGenerator,
-            () -> schemaOperationDispatcher);
+            () -> schemaOperationDispatcher,
+            secretManager);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
@@ -213,7 +213,7 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
         NullPointerException.class,
         () ->
             new ViewOperationDispatcher(
-                catalogManager, secretManager, entityStore, idGenerator, null));
+                catalogManager, entityStore, idGenerator, null, secretManager));
   }
 
   @Test
@@ -225,7 +225,7 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
     Supplier<SchemaDispatcher> nullSchemaDispatcherSupplier = () -> null;
     ViewOperationDispatcher dispatcher =
         new ViewOperationDispatcher(
-            catalogManager, secretManager, entityStore, idGenerator, nullSchemaDispatcherSupplier);
+            catalogManager, entityStore, idGenerator, nullSchemaDispatcherSupplier, secretManager);
     NameIdentifier viewIdent = NameIdentifier.of(viewNs, "view_null_dispatcher");
     Representation[] representations =
         new Representation[] {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -72,13 +72,13 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new SchemaOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
     viewOperationDispatcher =
         new ViewOperationDispatcher(
             catalogManager,
+            secretManager,
             entityStore,
             idGenerator,
-            secretManager,
             () -> schemaOperationDispatcher);
 
     Config config = mock(Config.class);
@@ -213,7 +213,7 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
         NullPointerException.class,
         () ->
             new ViewOperationDispatcher(
-                catalogManager, entityStore, idGenerator, secretManager, null));
+                catalogManager, secretManager, entityStore, idGenerator, null));
   }
 
   @Test
@@ -225,7 +225,7 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
     Supplier<SchemaDispatcher> nullSchemaDispatcherSupplier = () -> null;
     ViewOperationDispatcher dispatcher =
         new ViewOperationDispatcher(
-            catalogManager, entityStore, idGenerator, secretManager, nullSchemaDispatcherSupplier);
+            catalogManager, secretManager, entityStore, idGenerator, nullSchemaDispatcherSupplier);
     NameIdentifier viewIdent = NameIdentifier.of(viewNs, "view_null_dispatcher");
     Representation[] representations =
         new Representation[] {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -72,10 +72,14 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
   @BeforeAll
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
-        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     viewOperationDispatcher =
         new ViewOperationDispatcher(
-            catalogManager, entityStore, idGenerator, () -> schemaOperationDispatcher);
+            catalogManager,
+            entityStore,
+            idGenerator,
+            secretManager,
+            () -> schemaOperationDispatcher);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
@@ -207,7 +211,9 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
   public void testViewOperationDispatcherRejectsNullSchemaDispatcherSupplier() {
     Assertions.assertThrows(
         NullPointerException.class,
-        () -> new ViewOperationDispatcher(catalogManager, entityStore, idGenerator, null));
+        () ->
+            new ViewOperationDispatcher(
+                catalogManager, entityStore, idGenerator, secretManager, null));
   }
 
   @Test
@@ -219,7 +225,7 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
     Supplier<SchemaDispatcher> nullSchemaDispatcherSupplier = () -> null;
     ViewOperationDispatcher dispatcher =
         new ViewOperationDispatcher(
-            catalogManager, entityStore, idGenerator, nullSchemaDispatcherSupplier);
+            catalogManager, entityStore, idGenerator, secretManager, nullSchemaDispatcherSupplier);
     NameIdentifier viewIdent = NameIdentifier.of(viewNs, "view_null_dispatcher");
     Representation[] representations =
         new Representation[] {

--- a/core/src/test/java/org/apache/gravitino/credential/TestCredentialOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestCredentialOperationDispatcher.java
@@ -143,7 +143,7 @@ public class TestCredentialOperationDispatcher extends TestOperationDispatcher {
     Mockito.when(baseCatalog.ops()).thenReturn(ops);
 
     CredentialOperationDispatcher dispatcher =
-        new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     List<Credential> credentials =
         dispatcher.getCredentials(

--- a/core/src/test/java/org/apache/gravitino/credential/TestCredentialOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestCredentialOperationDispatcher.java
@@ -143,7 +143,7 @@ public class TestCredentialOperationDispatcher extends TestOperationDispatcher {
     Mockito.when(baseCatalog.ops()).thenReturn(ops);
 
     CredentialOperationDispatcher dispatcher =
-        new CredentialOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
+        new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
 
     List<Credential> credentials =
         dispatcher.getCredentials(

--- a/core/src/test/java/org/apache/gravitino/credential/TestCredentialOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestCredentialOperationDispatcher.java
@@ -143,7 +143,7 @@ public class TestCredentialOperationDispatcher extends TestOperationDispatcher {
     Mockito.when(baseCatalog.ops()).thenReturn(ops);
 
     CredentialOperationDispatcher dispatcher =
-        new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+        new CredentialOperationDispatcher(catalogManager, secretManager, entityStore, idGenerator);
 
     List<Credential> credentials =
         dispatcher.getCredentials(

--- a/core/src/test/java/org/apache/gravitino/secret/TestSecretManager.java
+++ b/core/src/test/java/org/apache/gravitino/secret/TestSecretManager.java
@@ -91,7 +91,7 @@ public class TestSecretManager {
   }
 
   @Test
-  void testSecretBindingToStringRedactsValue() {
+  void testSecretBindingToStringRedactsPlaintext() {
     SecretBinding binding = new SecretBinding("memory", "s3cr3t");
     Assertions.assertFalse(binding.toString().contains("s3cr3t"));
     Assertions.assertTrue(binding.toString().contains("***"));

--- a/core/src/test/java/org/apache/gravitino/secret/TestSecretManager.java
+++ b/core/src/test/java/org/apache/gravitino/secret/TestSecretManager.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.secret.memory.InMemorySecretsProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestSecretManager {
+
+  @Test
+  void testWriteSecrets() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      Map<String, String> properties = new HashMap<>(Map.of("jdbc-user", "root"));
+      Map<String, SecretBinding> secretBindings =
+          Map.of("jdbc-password", new SecretBinding("memory", "s3cr3t"));
+      List<SecretUrn> secretUrns =
+          secretManager.getSecretBindingUrns("catalog", 42L, secretBindings);
+      secretManager.writeSecrets(secretBindings, secretUrns);
+      SecretPropertyUtils.applySecretUrns(properties, secretUrns);
+
+      String urn = properties.get("jdbc-password");
+      Assertions.assertTrue(SecretPropertyUtils.isSecretProperty("jdbc-password", urn));
+      Assertions.assertEquals("root", properties.get("jdbc-user"));
+      Assertions.assertEquals(1, secretUrns.size());
+      Assertions.assertEquals(
+          "s3cr3t",
+          secretManager.getRegistry().getProvider("memory").readSecret(secretUrns.get(0)));
+    }
+  }
+
+  @Test
+  void testGetSecretReferenceUrnsRejectedByMemoryProvider() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              secretManager.getSecretReferenceUrns(
+                  Map.of("jdbc-password", new SecretReference("memory", Map.of()))));
+    }
+  }
+
+  @Test
+  void testRejectOverlapAndInvalidBinding() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              SecretPropertyUtils.checkNoOverlap(
+                  Map.of("jdbc-password", new SecretBinding("memory", "s3cr3t")),
+                  Map.of("jdbc-password", new SecretReference("memory", Map.of()))));
+
+      Assertions.assertThrows(
+          IllegalArgumentException.class, () -> new SecretBinding(" ", "s3cr3t"));
+
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              new SecretReference(
+                  "memory", Map.of("path", "urn:gravitino-secret:memory:catalog:1:x")));
+
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              secretManager.getSecretReferenceUrns(
+                  Map.of(
+                      "jdbc-password",
+                      new SecretReference("memory", Map.of("path", "secret/data/x")))));
+    }
+  }
+
+  @Test
+  void testSecretBindingToStringRedactsValue() {
+    SecretBinding binding = new SecretBinding("memory", "s3cr3t");
+    Assertions.assertFalse(binding.toString().contains("s3cr3t"));
+    Assertions.assertTrue(binding.toString().contains("***"));
+  }
+
+  private static SecretManager memorySecretManager() {
+    Config config = new Config(false) {};
+    Properties properties = new Properties();
+    properties.setProperty(SecretProviderRegistry.GRAVITINO_SECRET_PROVIDERS, "memory");
+    properties.setProperty(
+        SecretProviderRegistry.GRAVITINO_SECRET_PROVIDER_PREFIX
+            + "memory."
+            + SecretProviderRegistry.CLASS_NAME,
+        InMemorySecretsProvider.class.getName());
+    config.loadFromProperties(properties);
+    return new SecretManager(config);
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/secret/TestSecretManager.java
+++ b/core/src/test/java/org/apache/gravitino/secret/TestSecretManager.java
@@ -57,7 +57,9 @@ public class TestSecretManager {
           IllegalArgumentException.class,
           () ->
               secretManager.getSecretReferenceUrns(
-                  Map.of("jdbc-password", new SecretReference("memory", Map.of()))));
+                  Map.of(
+                      "jdbc-password",
+                      new SecretReference("memory", Map.of("path", "secret/data/x")))));
     }
   }
 
@@ -69,7 +71,9 @@ public class TestSecretManager {
           () ->
               SecretPropertyUtils.checkNoOverlap(
                   Map.of("jdbc-password", new SecretBinding("memory", "s3cr3t")),
-                  Map.of("jdbc-password", new SecretReference("memory", Map.of()))));
+                  Map.of(
+                      "jdbc-password",
+                      new SecretReference("memory", Map.of("path", "secret/data/x")))));
 
       Assertions.assertThrows(
           IllegalArgumentException.class, () -> new SecretBinding(" ", "s3cr3t"));

--- a/core/src/test/java/org/apache/gravitino/secret/TestSecretManager.java
+++ b/core/src/test/java/org/apache/gravitino/secret/TestSecretManager.java
@@ -81,12 +81,6 @@ public class TestSecretManager {
       Assertions.assertThrows(
           IllegalArgumentException.class,
           () ->
-              new SecretReference(
-                  "memory", Map.of("path", "urn:gravitino-secret:memory:catalog:1:x")));
-
-      Assertions.assertThrows(
-          IllegalArgumentException.class,
-          () ->
               secretManager.getSecretReferenceUrns(
                   Map.of(
                       "jdbc-password",


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add `SecretManager` for write-through / external-ref lifecycle (`getSecretBindingUrns`, `getSecretReferenceUrns`, `writeSecrets`, `rollbackWritten`).
- Add `SecretPropertyUtils` for request checks, URN recognition, and applying URNs into properties.
- Add typed `@Evolving` API models: `SecretBinding` (`provider` + `plaintext`) and `SecretReference` (`provider` + non-null `attributes`).
- Extend `SecretProvider` with optional `bindExternalReference` (default rejects; write-through-only providers need not override).
- Wire `SecretManager` into `GravitinoEnv` / `CatalogManager` / `OperationDispatcher` (including hidden-property detection for secret URNs).
- Create APIs / REST request shapes are **unchanged** in this PR

### Why are the changes needed?

Entity create needs a shared secret lifecycle layer and typed models before public create APIs can accept `secretBindings` / `secretReferences`.

Fix: #12297

### Does this PR introduce _any_ user-facing change?

- No create API / REST request shape change yet.
- Adds typed secret models in the public API module for follow-up create wiring.

### How was this patch tested?

- `./gradlew :api:test --tests org.apache.gravitino.secret.TestSecretBinding --tests org.apache.gravitino.secret.TestSecretReference :core:test --tests org.apache.gravitino.secret.TestSecretManager --tests org.apache.gravitino.TestGravitinoEnvSecretProviderRegistry -PskipITs`