### PR TITLE
[Cherry-pick to branch-1.3] [MINOR] Split the metalake, partition, model, statistics, job, and view pages (#12328)

### DIFF
--- a/docs/development/custom-job-executor.md
+++ b/docs/development/custom-job-executor.md
@@ -1,0 +1,37 @@
+---
+title: "Custom Job Executor"
+slug: "/development/custom-job-executor"
+keyword: "job executor, job system, extension, JobExecutor, Gravitino"
+license: "This software is licensed under the Apache License version 2."
+---
+
+## Introduction
+
+The `local` job executor that ships with Gravitino runs jobs as a process on the Gravitino server
+and is intended for testing. Running jobs anywhere else, such as against a distributed scheduler,
+means implementing your own job executor.
+
+## Implement a Custom Job Executor
+
+Gravitino's job system is extensible: you can implement your own job executor
+to run jobs in a distributed environment. Refer to the interface `JobExecutor` in the
+code [here](https://github.com/apache/gravitino/blob/main/core/src/main/java/org/apache/gravitino/connector/job/JobExecutor.java).
+
+After you implement your own job executor, you need to register it in the Gravitino server by
+using the `gravitino.conf` file. For example, if you have implemented a job executor named
+`airflow`, you need to configure it as follows:
+
+```
+gravitino.job.executor = airflow
+gravitino.jobExecutor.airflow.class = com.example.MyAirflowJobExecutor
+```
+
+Configure the job executor with additional properties, like:
+
+```
+gravitino.jobExecutor.airflow.host = http://localhost:8080
+gravitino.jobExecutor.airflow.username = myuser
+gravitino.jobExecutor.airflow.password = mypassword
+```
+
+These properties will be passed to the airflow job executor when it is instantiated.

--- a/docs/development/custom-partition-storage.md
+++ b/docs/development/custom-partition-storage.md
@@ -1,0 +1,60 @@
+---
+title: "Custom Partition Storage"
+slug: "/development/custom-partition-storage"
+keyword: "partition statistics, storage, extension, PartitionStatisticStorageFactory, Gravitino"
+license: "This software is licensed under the Apache License version 2."
+---
+
+## Introduction
+
+Partition statistics use a pluggable storage backend, set with
+`gravitino.stats.partition.storageFactoryClass`. Gravitino ships JDBC and Lance backends; writing
+your own backend means implementing the storage factory interface.
+
+## Implement a Custom Partition Storage
+
+Implement a custom partition storage by implementing the interface `org.apache.gravitino.stats.storage.PartitionStatisticStorageFactory` and
+setting the configuration item `gravitino.stats.partition.storageFactoryClass` to your class name.
+
+For example:
+
+```java
+public class MyPartitionStatsStorageFactory implements PartitionStatisticStorageFactory {
+    @Override
+    public PartitionStatisticStorage create(Map<String, String> options) {
+        // Create your custom PartitionStatsStorage here
+        return new MyPartitionStatsStorage(...);
+    }
+}
+```
+
+```java
+public class MyPartitionStatsStorage implements PartitionStatisticStorage {
+
+    @Override
+    public void close() throws IOException {
+        // Close your storage here
+    }
+
+    @Override
+    public void updateStatistics(String metalake, List<MetadataObjectStatisticsUpdate> updates)
+            throws IOException {
+        // Update partition statistics in your storage here
+    }
+
+    @Override
+    public List<PersistedPartitionStatistics> listStatistics(
+            String metalake, MetadataObject metadataObject, PartitionRange range)
+            throws IOException {
+        // List partition statistics from your storage here
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public int dropStatistics(String metalake, List<MetadataObjectStatisticsDrop> drops)
+            throws IOException {
+        // Drop partition statistics from your storage here, returning the number actually dropped
+        return drops.size();
+    }
+}
+```

--- a/docs/manage-jobs-in-gravitino.md
+++ b/docs/manage-jobs-in-gravitino.md
@@ -1,11 +1,7 @@
 ---
 title: "Manage Jobs"
 slug: "/manage-jobs-in-gravitino"
-date: 2025-08-13
-keywords:
-  - job
-  - job template
-  - gravitino
+keyword: "job management, job template, shell job, spark job, Gravitino"
 license: "This software is licensed under the Apache License version 2."
 ---
 
@@ -14,18 +10,13 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-Apache Gravitino provides a submodule called the job system for users to
-register, run, and manage jobs. This job system integrates with the existing metadata
-management, enabling users to execute the jobs or actions based on the metadata,
-known as metadata-driven actions. For instance, this allows users to run jobs for tasks such as
-compacting Iceberg tables or cleaning old data based on TTL properties.
+This page covers the Gravitino API for job templates and jobs. For what a template is, how it
+relates to a run, and what the job statuses mean, see [Jobs](./jobs.md).
 
-The aim of the job system is to provide a unified way to manage job templates and jobs,
-including registering job templates, running jobs based on the job templates, and other related
-tasks. The job system itself is a unified job submitter that allows users to run jobs through it,
-but it doesn't provide the actual job execution capabilities. Instead, it relies on the
-existing job executors (schedulers), such as Apache Airflow, Apache Livy, to execute the jobs.
-Gravitino's job system provides an extensible way to connect to different job executors.
+Jobs run through a job executor, set with `gravitino.job.executor`. The default, `local`, launches
+the job as a process on the Gravitino server and is intended for testing. Running jobs anywhere else
+means implementing an executor. See
+[Custom job executor](./development/custom-job-executor.md).
 
 :::note
 1. The job system is still under development, so some features may not be fully
@@ -34,580 +25,203 @@ Gravitino's job system provides an extensible way to connect to different job ex
    support running a single job at a time, and it doesn't support job scheduling for now.
    :::
 
+## Job Template Operations
+
+### Register a Shell Template
+
+A shell template runs an executable. Placeholders in `arguments`, `environments`, and `customFields`
+are filled in when a job runs.
+
+```json
+{
+  "name": "nightly_export",
+  "jobType": "shell",
+  "comment": "Exports a table to a drop location",
+  "executable": "/opt/jobs/export.sh",
+  "arguments": ["{{table}}", "{{target}}"],
+  "environments": {"REGION": "{{region}}"},
+  "scripts": ["/opt/jobs/lib/common.sh"]
+}
+```
+
+`executable` and `scripts` must be reachable by the Gravitino server, which accepts local paths and
+HTTP, HTTPS, FTP, and FTPS URLs.
+
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
+
+```shell
+curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" -d '{
+  "jobTemplate": {
+    "name": "nightly_export",
+    "jobType": "shell",
+    "comment": "Exports a table to a drop location",
+    "executable": "/opt/jobs/export.sh",
+    "arguments": ["{{table}}", "{{target}}"]
+  }
+}' http://localhost:8090/api/metalakes/example/jobs/templates
+```
+
+</TabItem>
+</Tabs>
+
+### Register a Spark Template
+
+A Spark template submits an application. Running one with the local executor needs either
+`gravitino.jobExecutor.local.sparkHome` or `SPARK_HOME` set before the server starts, or the job
+fails to launch.
+
+```json
+{
+  "name": "nightly_rollup",
+  "jobType": "spark",
+  "comment": "Rolls up daily aggregates",
+  "executable": "/opt/jobs/rollup.jar",
+  "className": "com.example.Rollup",
+  "arguments": ["{{date}}"],
+  "configs": {"spark.executor.memory": "4g"}
+}
+```
+
+### List, Get, and Delete Templates
+
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
+
+```shell
+curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
+  http://localhost:8090/api/metalakes/example/jobs/templates
+
+curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
+  http://localhost:8090/api/metalakes/example/jobs/templates/nightly_export
+
+curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
+  http://localhost:8090/api/metalakes/example/jobs/templates/nightly_export
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+List<JobTemplate> templates = client.listJobTemplates();
+JobTemplate template = client.getJobTemplate("nightly_export");
+boolean deleted = client.deleteJobTemplate("nightly_export");
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+templates = client.list_job_templates()
+template = client.get_job_template("nightly_export")
+deleted = client.delete_job_template("nightly_export")
+```
+
+</TabItem>
+</Tabs>
+
+A template cannot be deleted while jobs from it are queued or running.
+
+### Alter a Template
+
+| Change             | JSON                                                     | Java                                                |
+|--------------------|----------------------------------------------------------|-----------------------------------------------------|
+| Rename             | `{"@type":"rename","newName":"nightly_export_v2"}`       | `JobTemplateChange.rename("nightly_export_v2")`     |
+| Update the comment | `{"@type":"updateComment","newComment":"new_comment"}`   | `JobTemplateChange.updateComment("new_comment")`    |
+| Update the template| `{"@type":"updateTemplate","newTemplate":{...}}`         | `JobTemplateChange.updateTemplate(...)`             |
+
 ## Job Operations
 
-### Register a New Job Template
+### Run a Job
 
-Before running a job, the first step is to register a job template. Gravitino
-supports two types of job templates: `shell` and `spark` (we will add more job templates in the
-future).
+Running names a template and supplies values for its placeholders.
 
-#### Shell Job Template
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
-The `shell` job template is used to run scripts, it can be a shell script, or any executable
-script. The template is defined as follows:
-
-```json
-{
-  "name": "my_shell_job_template",
-  "jobType": "shell",
-  "comment": "A shell job template to run a script",
-  "executable": "/path/to/my_script.sh",
-  "arguments": ["{{arg1}}", "{{arg2}}"],
-  "environments": {
-    "ENV_VAR1": "{{value1}}",
-    "ENV_VAR2": "{{value2}}"
-  },
-  "customFields": {
-    "field1": "{{value1}}",
-    "field2": "{{value2}}"
-  },
-  "scripts": ["/path/to/script1.sh", "/path/to/script2.sh"]
-}
-```
-
-Here is a brief description of the fields in the job template:
-
-- `name`: The name of the job template, must be unique.
-- `jobType`: The type of the job template, use `shell` for a shell job template.
-- `comment`: A comment for the job template, which can be used to describe the job template.
-- `executable`: The path to the executable script, which can be a shell script or any executable script.
-- `arguments`: The arguments to pass to the executable script.
-- `environments`: The environment variables to set when running the jo.
-- `customFields`: Custom fields for the job template, which can be used to store additional
-  information.
-- `scripts`: A list of scripts that the main executable script can use.
-
-Please note that:
-
-1. The `executable` and `scripts` must be accessible by the Gravitino server. Gravitino supports accessing files from the local file system, HTTP(S) URLs, and FTP(S) URLs
-   (more distributed file system support will be added in the future). So the `executable` and
-   `scripts` can be a local file path, or a URL like `http://example.com/my_script.sh`.
-2. The `executable`, `arguments`, `environments`, `customFields` and `scripts` can use placeholders
-   like `{{arg1}}` and `{{value1}}`, the style is `{{foo}}`. They will be replaced with
-   the actual values when running the job, so you can use them to pass dynamic values to the job template.
-3. Gravitino will copy the `executable` and `scripts` files to the job working directory
-   when running the job, so you can use the relative path in the `executable` and `scripts` to
-   refer to other scripts in the job working directory.
-
-#### Spark Job Template
-
-The `spark` job template is used to run Spark jobs, it is a Spark application JAR file for now.
-
-The template is defined as follows:
-
-```json
-{
-  "name": "my_spark_job_template",
-  "jobType": "spark",
-  "comment": "A Spark job template to run a Spark application",
-  "executable": "/path/to/my_spark_app.jar",
-  "arguments": ["{{arg1}}", "{{arg2}}"],
-  "environments": {
-    "ENV_VAR1": "{{value1}}",
-    "ENV_VAR2": "{{value2}}"
-  },
-  "customFields": {
-    "field1": "{{value1}}",
-    "field2": "{{value2}}"
-  },
-  "className": "com.example.MySparkApp",
-  "jars": ["/path/to/dependency1.jar", "/path/to/dependency2.jar"],
-  "files": ["/path/to/file1.txt", "/path/to/file2.txt"],
-  "archives": ["/path/to/archive1.zip", "/path/to/archive2.zip"],
-  "configs": {
-    "spark.executor.memory": "2g",
-    "spark.executor.cores": "2"
+```shell
+curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" -d '{
+  "jobTemplateName": "nightly_export",
+  "jobConf": {
+    "table": "sales.public.orders",
+    "target": "s3a://exports/orders",
+    "region": "us"
   }
-}
-```
-
-Here is a brief description of the fields in the Spark job template:
-
-- `name`: The name of the job template, which must be unique.
-- `jobType`: The type of the job template, use `spark` for Spark job template.
-- `comment`: A comment for the job template, which can be used to describe the job template.
-- `executable`: The path to the Spark application JAR file, which can be a local file path or a URL
-  with a supported scheme.
-- `arguments`: The arguments to pass to the Spark application.
-- `environments`: The environment variables to set when running the job.
-- `customFields`: Custom fields for the job template, which can be used to store additional information.
-- `className`: The main class of the Spark application. It is required for Java/Scala Spark
-  application. For PySpark application, this field can be `null` instead.
-- `jars`: A list of JAR files to add to the Spark job classpath, which can be a local file path or a URL
-  with a supported scheme.
-- `files`: A list of files to be copied to the working directory of the Spark job, which can be a local
-  file path or a URL with a supported scheme.
-- `archives`: A list of archives to be extracted to the working directory of the Spark job, which
-  can be a local file path or a URL with a supported scheme.
-- `configs`: A map of Spark configurations to set when running the Spark job.
-
-Note that:
-
-1. The `executable`, `jars`, `files`, and `archives` must be accessible by the Gravitino server.
-   Gravitino supports accessing files from the local file system, HTTP(S) URLs, and
-   FTP(S) URLs (more distributed file system supports will be added in the future). So the
-   `executable`, `jars`, `files`, and `archives` can be a local file path, or a URL like
-   `http://example.com/my_spark_app.jar`.
-2. The `executable`, `arguments`, `environments`, `customFields`, `className`, `jars`, `files`,
-   `archives`, and `configs` can use placeholders like `{{arg1}}` and `{{value1}}`, the style is
-   `{{foo}}`. They will be replaced with the actual values when running the job, so you can use them
-   to pass dynamic values to the job template.
-3. Gravitino will copy the `executable`, `jars`, `files`, and `archives` files to the job working
-   directory when running the job, so you can use the relative path in the `executable`, `jars`,
-   `files`, and `archives` to refer to other files in the job working directory.
-4. The `className` is required for the Java and Scala Spark job template, it is the main class of
-   the Spark application to be executed. For PySpark job template, this field can be `null` instead.
-
-To register a job template, you can use REST API or the Java and Python SDKs. Here is the
-example to register a shell job template:
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-     -H "Content-Type: application/json" \
-     -d '{
-           "jobTemplate": {
-             "name": "my_shell_job_template",
-             "jobType": "shell",
-             "comment": "A shell job template to run a script",
-             "executable": "/path/to/my_script.sh",
-             "arguments": ["{{arg1}}", "{{arg2}}"],
-             "environments": {
-               "ENV_VAR1": "{{value1}}",
-               "ENV_VAR2": "{{value2}}"
-             },
-             "customFields": {
-               "field1": "{{value1}}",
-               "field2": "{{value2}}"
-             },
-             "scripts": ["/path/to/script1.sh", "/path/to/script2.sh"]
-           }
-        }' \
-     http://localhost:8090/api/metalakes/test/jobs/templates
+}' http://localhost:8090/api/metalakes/example/jobs/runs
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-  ShellJobTemplate jobTemplate = ShellJobTemplate.builder()
-      .name("my_shell_job_template")
-      .comment("A shell job template to run a script")
-      .executable("/path/to/my_script.sh")
-      .arguments(List.of("{{arg1}}", "{{arg2}}"))
-      .environments(Map.of("ENV_VAR1", "{{value1}}", "ENV_VAR2", "{{value2}}"))
-      .customFields(Map.of("field1", "{{value1}}", "field2", "{{value2}}"))
-      .scripts(List.of("/path/to/script1.sh", "/path/to/script2.sh"))
-      .build();
-
-  GravitinoClient client = ...;
-  client.registerJobTemplate(jobTemplate);
+JobHandle job = client.runJob(
+    "nightly_export",
+    ImmutableMap.of(
+        "table", "sales.public.orders",
+        "target", "s3a://exports/orders",
+        "region", "us"));
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-  shell_job_template = (
-      ShellJobTemplate.builder()
-      .with_name("my_shell_job_template")
-      .with_comment("A shell job template to run a script")
-      .with_executable("/path/to/my_script.sh")
-      .with_arguments(["{{arg1}}", "{{arg2}}"])
-      .with_environments({"ENV_VAR1": "{{value1}}", "ENV_VAR2": "{{value2}}"})
-      .with_custom_fields({"field1": "{{value1}}", "field2": "{{value2}}"})
-      .with_scripts(["/path/to/script1.sh", "/path/to/script2.sh"])
-      .build()
-  )
-
-  client = GravitinoClient(...)
-  client.register_job_template(shell_job_template)
-```
-
-</TabItem>
-</Tabs>
-
-### List Registered Job Templates
-
-List all the registered job templates under a metalake by using the REST API or the Java
-and Python SDKs.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-     http://localhost:8090/api/metalakes/test/jobs/templates
-
-Or using query parameter "details=true" to get more details of the job templates:
-
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-     http://localhost:8090/api/metalakes/test/jobs/templates?details=true
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-    GravitinoClient client = ...;
-    List<JobTemplate> detailedJobTemplates = client.listJobTemplates();
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-    client = GravitinoClient(...)
-    detailed_job_templates = client.list_job_templates()
-```
-
-</TabItem>
-</Tabs>
-
-### Get a Registered Job Template by Name
-
-Get a registered job template by its name using the REST API or the Java and Python SDKs.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-     http://localhost:8090/api/metalakes/test/jobs/templates/my_shell_job_template
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-    GravitinoClient client = ...;
-    JobTemplate jobTemplate = client.getJobTemplate("my_shell_job_template");
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-    client = GravitinoClient(...)
-    job_template = client.get_job_template("my_shell_job_template")
-```
-
-</TabItem>
-</Tabs>
-
-### Delete a Registered Job Template by Name
-
-Delete a registered job template by its name using the REST API or the Java and Python SDKs.
-
-Note that deleting a job template will also delete all the jobs that are using this job template.
-If there are queued, started, or to be cancelled jobs that are using this job template, the deletion
-will fail with an `InUseException` error.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
-     http://localhost:8090/api/metalakes/test/jobs/templates/my_shell_job_template
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-    GravitinoClient client = ...;
-    client.deleteJobTemplate("my_shell_job_template");
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-    client = GravitinoClient(...)
-    client.delete_job_template("my_shell_job_template")
-```
-
-</TabItem>
-</Tabs>
-
-### Alter a Registered Job Template
-
-Alter a registered job template by its name using the REST API or the Java and Python
-SDKs. Gravitino supports altering the `name`, `comment` and `template` fields of the job template.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
-    -H "Content-Type: application/json" \
-    -d '{
-        "updates": [
-            {
-                "@type": "rename",
-                "newName": "altered_shell_job_template"
-            },
-            {
-                "@type": "comment",
-                "newComment": "An altered shell job template"
-            },
-            {
-                "@type": "updateTemplate",
-                "newTemplate": {
-                    "@type": "shell",
-                    "newExecutable": "/new/path/to/my_script.sh",
-                    "newArguments": ["{{new_arg1}}", "{{new_arg2}}"],
-                    "newEnvironments": {
-                        "NEW_ENV_VAR1": "{{new_value1}}",
-                        "NEW_ENV_VAR2": "{{new_value2}}"
-                    },
-                    "newCustomFields": {
-                        "new_field1": "{{new_value1}}",
-                        "new_field2": "{{new_value2}}"
-                    },
-                    "newScripts": ["/new/path/to/script1.sh", "/new/path/to/script2.sh"]
-                }
-            }
-        ]
-
-    }' http://localhost:8090/api/metalakes/test/jobs/templates/my_shell_job_template
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-    ShellTemplateUpdate newTemplate = ShellTemplateUpdate.builder()
-        .withNewExecutable("/new/path/to/my_script.sh")
-        .withNewArguments(ImmutableList.of("{{new_arg1}}", "{{new_arg2}}"))
-        .withNewEnvironments(ImmutableMap.of("NEW_ENV_VAR1", "{{new_value1}}", "NEW_ENV_VAR2", "{{new_value2}}"))
-        .withNewCustomFields(ImmutableMap.of("new_field1", "{{new_value1}}", "new_field2", "{{new_value2}}"))
-        .withNewScripts(List.of("/new/path/to/script1.sh", "/new/path/to/script2.sh"))
-        .build();
-
-    List<JobTemplateChange> changes = List.of(
-        JobTemplateChange.rename("altered_shell_job_template"),
-        JobTemplateChange.updateComment("An altered shell job template"),
-        JobTemplateChange.updateTemplateUpdateJobTemplate(newTemplate));
-
-    GravitinoClient client = ...;
-    client.alterJobTemplate("my_shell_job_template", changes);
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-    new_template = ShellTemplateUpdate(
-        new_executable="/new/path/to/my_script.sh",
-        new_arguments=["{{new_arg1}}", "{{new_arg2}}"],
-        new_environments={"NEW_ENV_VAR1": "{{new_value1}}", "NEW_ENV_VAR2": "{{new_value2}}"},
-        new_custom_fields={"new_field1": "{{new_value1}}", "new_field2": "{{new_value2}}"},
-        new_scripts=["/new/path/to/script1.sh", "/new/path/to/script2.sh"]
-    )
-
-    changes = [
-        JobTemplateChange.rename("altered_shell_job_template"),
-        JobTemplateChange.update_comment("An altered shell job template"),
-        JobTemplateChange.update_template(new_template)
-    ]
-
-    client = GravitinoClient(...)
-    client.alter_job_template("my_shell_job_template", changes)
-```
-
-</TabItem>
-</Tabs>
-
-### Run a Job Based on a Job Template
-
-To run a job based on the registered job template, you can use the REST API or the Java and Python SDKs.
-When running a job, you need to provide the job template name and the parameters to replace the
-placeholders in the job template.
-
-Gravitino leverages the job executor to run the job, so you need to specify the job executor
-through configuration `gravitino.job.executor`. By default, it is set to "local", which means
-the job will be launched as a process within the same machine that runs the Gravitino server. Note
-that the local job executor is only for testing. If you want to run the job in a distributed environment,
-you need to implement your own `JobExecutor` and set the configuration; see
-[Implement a custom job executor](#implement-a-custom-job-executor) section below.
-
-When running a Spark job template with the local executor, configure one of:
-
-- `gravitino.jobExecutor.local.sparkHome`
-- `SPARK_HOME`
-
-If neither is set before the Gravitino server starts, Spark jobs may fail to start.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-     -H "Content-Type: application/json" \
-     -d '{
-           "jobTemplateName": "my_shell_job_template",
-           "jobConf": {
-             "arg1": "value1",
-             "arg2": "value2",
-             "value1": "env_value1",
-             "value2": "env_value2"
-           }
-        }' \
-     http://localhost:8090/api/metalakes/test/jobs/runs
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-    GravitinoClient client = ...;
-    JobHandle jobHandle = client.runJob("my_shell_job_template", ImmutableMap.of(
-        "arg1", "value1",
-        "arg2", "value2",
-        "value1", "env_value1",
-        "value2", "env_value2"
-    ));
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-    client = GravitinoClient(...)
-    job_handle = client.run_job("my_shell_job_template", {
-        "arg1": "value1",
-        "arg2": "value2",
-        "value1": "env_value1",
-        "value2": "env_value2"
+job = client.run_job(
+    job_template_name="nightly_export",
+    job_conf={
+        "table": "sales.public.orders",
+        "target": "s3a://exports/orders",
+        "region": "us",
     })
 ```
 
 </TabItem>
 </Tabs>
 
-The returned `JobHandle` contains the job ID and other information about the job. Use the job ID to
-check the job status and cancel the job.
+### List Jobs, Get a Job, and Cancel
 
-The runJob API will return immediately after the job is submitted to the job executor, and the job will be
-executed asynchronously. Check the job status using the job ID returned by the runJob API.
-
-### List All Jobs
-
-List all the jobs under a metalake by using the REST API or the Java and Python SDKs.
+Listing can be filtered to one template. A job is identified by its id, and cancelling is a `POST`
+to the job's own path.
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-     http://localhost:8090/api/metalakes/test/jobs/runs
-
-Or using query parameter "jobTemplateName=my_shell_job_template" to filter jobs by job template name:
+  "http://localhost:8090/api/metalakes/example/jobs/runs?jobTemplateName=nightly_export"
 
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-     http://localhost:8090/api/metalakes/test/jobs/runs?jobTemplateName=my_shell_job_template
-```
+  http://localhost:8090/api/metalakes/example/jobs/runs/{job_id}
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-    GravitinoClient client = ...;
-    List<JobHandle> jobHandles = client.listJobs();
-
-    // To filter jobs by job template name
-    List<JobHandle> filteredJobHandles = client.listJobs("my_shell_job_template");
-
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-    client = GravitinoClient(...)
-    job_handles = client.list_jobs()
-
-    # To filter jobs by job template name
-    filtered_job_handles = client.list_jobs(job_template_name="my_shell_job_template")
-```
-
-</TabItem>
-</Tabs>
-
-### Get a Job by Job ID
-
-Get a job by its job ID using the REST API or the Java and Python SDKs.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-     http://localhost:8090/api/metalakes/test/jobs/runs/job-1234567890
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-    GravitinoClient client = ...;
-    JobHandle jobHandle = client.getJob("job-1234567890");
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-    client = GravitinoClient(...)
-    job_handle = client.get_job("job-1234567890")
-```
-
-</TabItem>
-</Tabs>
-
-### Cancel a Job by Job ID
-
-Cancel a job by its job ID using the REST API or the Java and Python SDKs.
-
-The job will be cancelled asynchronously, and the job status will be updated to `CANCELLING` first,
-then to `CANCELLED` when the cancellation is completed. If the job is already in `SUCCEEDED`,
-`FAILED`, `CANCELLING`, or `CANCELLED` status, the cancellation will be ignored.
-
-The cancellation will be done by the job executor with the best effort, it relies on the job
-executor that supports cancellation. Also, because of the asynchronous nature of the job
-cancellation, the job may not be actually cancelled.
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-     http://localhost:8090/api/metalakes/test/jobs/runs/job-1234567890
+  http://localhost:8090/api/metalakes/example/jobs/runs/{job_id}
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-    GravitinoClient client = ...;
-    client.cancelJob("job-1234567890");
+List<JobHandle> jobs = client.listJobs("nightly_export");
+JobHandle job = client.getJob(jobId);
+JobHandle cancelling = client.cancelJob(jobId);
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-    client = GravitinoClient(...)
-    client.cancel_job("job-1234567890")
+jobs = client.list_jobs(job_template_name="nightly_export")
+job = client.get_job(job_id)
+cancelling = client.cancel_job(job_id)
 ```
 
 </TabItem>
 </Tabs>
+
+Cancelling is a request rather than an instant. The job moves to `CANCELLING` and then to
+`CANCELLED`, and one that finishes first keeps the status it finished with.
 
 ### Job System Configuration
 
@@ -633,31 +247,6 @@ The following are the default configurations for the local job executor:
 | `gravitino.jobExecutor.local.maxRunningJobs`        | The maximum number of running jobs in the local job executor                                                                                      | `max(1, min(available cores / 2, 10))` | No       |
 | `gravitino.jobExecutor.local.jobStatusKeepTimeInMs` | The time in milliseconds to keep the job status in the local job executor                                                                         | `3600000` (1 hour)                     | No       |
 | `gravitino.jobExecutor.local.sparkHome`             | The home directory of Spark, Gravitino checks this configuration firstly and then `SPARK_HOME` env. Either of them should be set to run Spark job | `None`                                 | No       |
-
-### Implement a Custom Job Executor
-
-Gravitino's job system is extensible: you can implement your own job executor
-to run jobs in a distributed environment. Refer to the interface `JobExecutor` in the
-code [here](https://github.com/apache/gravitino/blob/main/core/src/main/java/org/apache/gravitino/connector/job/JobExecutor.java).
-
-After you implement your own job executor, you need to register it in the Gravitino server by
-using the `gravitino.conf` file. For example, if you have implemented a job executor named
-`airflow`, you need to configure it as follows:
-
-```
-gravitino.job.executor = airflow
-gravitino.jobExecutor.airflow.class = com.example.MyAirflowJobExecutor
-```
-
-Configure the job executor with additional properties, like:
-
-```
-gravitino.jobExecutor.airflow.host = http://localhost:8080
-gravitino.jobExecutor.airflow.username = myuser
-gravitino.jobExecutor.airflow.password = mypassword
-```
-
-These properties will be passed to the airflow job executor when it is instantiated.
 
 ## Future Work
 

--- a/docs/manage-metalake-using-gravitino.md
+++ b/docs/manage-metalake-using-gravitino.md
@@ -1,8 +1,7 @@
 ---
 title: "Manage Metalakes"
 slug: "/manage-metalake-using-gravitino"
-date: 2023-12-10
-keyword: "Gravitino metalake manage"
+keyword: "metalake management, metalake, admin client, Gravitino"
 license: "This software is licensed under the Apache License version 2."
 ---
 
@@ -11,310 +10,208 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-This page introduces how to create, modify, view, and delete [metalakes](./glossary.md#metalake) by using Gravitino. 
+This page covers the Gravitino API for metalakes. For what a metalake is, what it isolates, the
+in-use behavior, deletion semantics, and permissions, see [Metalakes](./metalakes.md).
 
-## Prerequisites
+Metalakes sit above any single metalake, so these operations use the admin client rather than the
+client used for everything inside one. Creating a metalake is reserved for service admins,
+configured with `gravitino.authorization.serviceAdmins`.
 
-You have installed and launched Gravitino. For more details, see [Get started](./getting-started/index.md).
+## Metalake Operations
 
-Let's say, the access is [http://localhost:8090](http://localhost:8090).
+### Create a Metalake
 
-## Create a Metalake
-
-To create a metalake, you can send a `POST` request to the `/api/metalakes` endpoint or use the Gravitino Admin client.
-
-The following is an example of creating a metalake:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{"name":"metalake","comment":"This is a new metalake","properties":{}}' \
-http://localhost:8090/api/metalakes
+  -H "Content-Type: application/json" -d '{
+  "name": "production",
+  "comment": "Production estate",
+  "properties": {}
+}' http://localhost:8090/api/metalakes
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoAdminClient gravitinoAdminClient = GravitinoAdminClient
+GravitinoAdminClient adminClient = GravitinoAdminClient
     .builder("http://localhost:8090")
     .build();
 
-GravitinoMetalake newMetalake = gravitinoAdminClient.createMetalake(
-    NameIdentifier.of("metalake"),
-    "This is a new metalake",
-    new HashMap<>());
-  // ...
+GravitinoMetalake metalake = adminClient.createMetalake(
+    "production", "Production estate", new HashMap<>());
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_admin_client: GravitinoAdminClient = GravitinoAdminClient(uri="http://localhost:8090")
-gravitino_admin_client.create_metalake(name="metalake", 
-                                       comment="This is a new metalake", 
-                                       properties={})
+admin_client = GravitinoAdminClient(uri="http://localhost:8090")
+admin_client.create_metalake(
+    name="production", comment="Production estate", properties={})
 ```
 
 </TabItem>
 </Tabs>
 
-## Load a Metalake
+### Load a Metalake
 
-To load a metalake, you can send a `GET` request to the `/api/metalakes/{metalake_name}` endpoint or use the Gravitino Admin client.
-
-The following is an example of loading a metalake:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json"  http://localhost:8090/api/metalakes/metalake
+  http://localhost:8090/api/metalakes/production
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-GravitinoMetalake loaded = gravitinoAdminClient.loadMetalake(
-    NameIdentifier.of("metalake"));
-// ...
+GravitinoMetalake metalake = adminClient.loadMetalake("production");
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_admin_client.load_metalake("metalake")
+metalake = admin_client.load_metalake("production")
 ```
 
 </TabItem>
 </Tabs>
 
-## Alter a Metalake
+### Alter a Metalake
 
-To alter a metalake, you can send a `PUT` request to the `/api/metalakes/{metalake_name}` endpoint or use the Gravitino Admin client.
+Changes are applied as a list in one request.
 
-The following is an example of renaming a metalake:
+| Change             | JSON                                                         | Java                                           | Python                                          |
+|--------------------|--------------------------------------------------------------|------------------------------------------------|-------------------------------------------------|
+| Rename             | `{"@type":"rename","newName":"metalake_renamed"}`            | `MetalakeChange.rename("metalake_renamed")`    | `MetalakeChange.rename("metalake_renamed")`     |
+| Update the comment | `{"@type":"updateComment","newComment":"new_comment"}`       | `MetalakeChange.updateComment("new_comment")`  | `MetalakeChange.update_comment("new_comment")`  |
+| Set a property     | `{"@type":"setProperty","property":"key1","value":"value1"}` | `MetalakeChange.setProperty("key1", "value1")` | `MetalakeChange.set_property("key1", "value1")` |
+| Remove a property  | `{"@type":"removeProperty","property":"key1"}`               | `MetalakeChange.removeProperty("key1")`        | `MetalakeChange.remove_property("key1")`        |
 
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
+  -H "Content-Type: application/json" -d '{
   "updates": [
-    {
-      "@type": "rename",
-      "newName": "metalake_renamed"
-    }
+    {"@type": "updateComment", "newComment": "Production estate, EMEA"}
   ]
-}' http://localhost:8090/api/metalakes/metalake
+}' http://localhost:8090/api/metalakes/production
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-GravitinoMetalake renamed = gravitinoAdminClient.alterMetalake(
-    NameIdentifier.of("metalake"),
-    MetalakeChange.rename("metalake_renamed")
-);
-// ...
+GravitinoMetalake metalake = adminClient.alterMetalake(
+    "production", MetalakeChange.updateComment("Production estate, EMEA"));
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-changes = (
-    MetalakeChange.rename("metalake_renamed"),
-)
-
-metalake = gravitino_admin_client.alter_metalake("metalake", *changes)
+metalake = admin_client.alter_metalake(
+    "production", MetalakeChange.update_comment("Production estate, EMEA"))
 ```
 
 </TabItem>
 </Tabs>
 
+### Enable or Disable a Metalake
 
-The following table outlines the supported modifications that you can make to a metalake:
+A metalake that is not in use can only be listed, loaded, enabled, or dropped. Enabling one that is
+already in use does nothing, and the same is true of disabling one already out of use.
 
-| Supported modification | JSON                                                         | Java                                           | Python                                          |
-|------------------------|--------------------------------------------------------------|------------------------------------------------|-------------------------------------------------|
-| Rename metalake        | `{"@type":"rename","newName":"metalake_renamed"}`            | `MetalakeChange.rename("metalake_renamed")`    | `MetalakeChange.rename("metalake_renamed")`     |
-| Update comment         | `{"@type":"updateComment","newComment":"new_comment"}`       | `MetalakeChange.updateComment("new_comment")`  | `MetalakeChange.update_comment("new_comment")`  |
-| Set property           | `{"@type":"setProperty","property":"key1","value":"value1"}` | `MetalakeChange.setProperty("key1", "value1")` | `MetalakeChange.set_property("key1", "value1")` |
-| Remove property        | `{"@type":"removeProperty","property":"key1"}`               | `MetalakeChange.removeProperty("key1")`        | `MetalakeChange.remove_property("key1")`        |
-
-## Enable a Metalake
-
-Metalake has a reserved property - `in-use`, which indicates whether the metalake is available for use. By default, the `in-use` property is set to `true`.
-To enable a disabled metalake, you can send a `PATCH` request to the `/api/metalakes/{metalake_name}` endpoint or use the Gravitino Admin client.
-
-The following is an example of enabling a metalake:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X PATCH -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{"inUse": true}' \
-http://localhost:8090/api/metalakes/metalake
+  -H "Content-Type: application/json" -d '{"inUse": false}' \
+  http://localhost:8090/api/metalakes/production
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoAdminClient gravitinoAdminClient = GravitinoAdminClient
-    .builder("http://localhost:8090")
-    .build();
-
-gravitinoAdminClient.enableMetalake("metalake");
-  // ...
+adminClient.disableMetalake("production");
+adminClient.enableMetalake("production");
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_admin_client: GravitinoAdminClient = GravitinoAdminClient(uri="http://localhost:8090")
-gravitino_admin_client.enable_metalake("metalake")
+admin_client.disable_metalake("production")
+admin_client.enable_metalake("production")
 ```
 
 </TabItem>
 </Tabs>
 
-:::info
-This operation does nothing if the metalake is already enabled.
-:::
+### Drop a Metalake
 
-## Disable a Metalake
+Without `force`, the metalake must have no catalogs and must not be in use. With `force`, Gravitino
+removes the metalake and everything registered under it, whether or not it is in use. External
+systems are left alone; managed objects are removed with their data.
 
-Once a metalake is disabled:
- - Users can only [list](#list-all-metalakes), [load](#load-a-metalake), [drop](#drop-a-metalake), or [enable](#enable-a-metalake) it.
- - Any other operation on the metalake or its sub-entities will result in an error.
-
-To disable a metalake, you can send a `PATCH` request to the `/api/metalakes/{metalake_name}` endpoint or use the Gravitino Admin client.
-
-The following is an example of disabling a metalake:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X PATCH -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{"inUse": false}' \
-http://localhost:8090/api/metalakes/metalake
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-GravitinoAdminClient gravitinoAdminClient = GravitinoAdminClient
-    .builder("http://localhost:8090")
-    .build();
-
-gravitinoAdminClient.disableMetalake("metalake");
-  // ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_admin_client: GravitinoAdminClient = GravitinoAdminClient(uri="http://localhost:8090")
-gravitino_admin_client.disable_metalake("metalake")
-```
-
-</TabItem>
-</Tabs>
-
-:::info
-This operation does nothing if the metalake is already disabled.
-:::
-
-## Drop a Metalake
-
-Deleting a metalake by "force" is not a default behavior, so make sure:
-
-- There are no catalogs under the metalake. Otherwise, you will get an error.
-- The metalake is [disabled](#disable-a-metalake). Otherwise, you will get an error.
-
-Deleting a metalake by "force" will:
-
-- Delete all sub-entities (tags, catalogs, schemas, etc.) under the metalake.
-- Delete the metalake itself even if it is enabled.
-- Not delete the external resources (such as database, table, etc.) associated with sub-entities unless they are managed (such as managed fileset).
-
-To drop a metalake, you can send a `DELETE` request to the `/api/metalakes/{metalake_name}` endpoint or use the Gravitino Admin client.
-
-The following is an example of dropping a metalake:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" http://localhost:8090/api/metalakes/metalake?force=false
+  "http://localhost:8090/api/metalakes/production?force=false"
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-// force can be true or false
-boolean success = gravitinoAdminClient.dropMetalake("metalake", false);
-// ...
+boolean dropped = adminClient.dropMetalake("production", false);
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_admin_client.drop_metalake("metalake", force=True)
+dropped = admin_client.drop_metalake("production", force=False)
 ```
 
 </TabItem>
 </Tabs>
 
-## List All Metalakes
+### List Metalakes
 
-To view all your metalakes, you can send a `GET` request to the `/api/metalakes` endpoint or use the Gravitino Admin client.
-
-The following is an example of listing all metalakes:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json"  http://localhost:8090/api/metalakes
+  http://localhost:8090/api/metalakes
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-GravitinoMetalake[] allMetalakes = gravitinoAdminClient.listMetalakes();
-// ...
+GravitinoMetalake[] metalakes = adminClient.listMetalakes();
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-metalake_list: List[GravitinoMetalake] = gravitino_admin_client.list_metalakes()
+metalakes = admin_client.list_metalakes()
 ```
 
 </TabItem>

--- a/docs/manage-model-metadata-using-gravitino.md
+++ b/docs/manage-model-metadata-using-gravitino.md
@@ -1,8 +1,7 @@
 ---
 title: "Manage Model Metadata"
 slug: "/manage-model-metadata-using-gravitino"
-date: 2024-12-26
-keyword: "Gravitino model metadata manage"
+keyword: "model management, model version, alias, Gravitino"
 license: "This software is licensed under the Apache License version 2."
 ---
 
@@ -11,256 +10,54 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-This page introduces how to manage model metadata in Apache Gravitino. Gravitino model catalog
-is a kind of model registry, which provides the ability to manage machine learning models'
-versioned metadata. It follows the typical Gravitino 3-level namespace (catalog, schema, and
-model) and supports managing the versions for each model.
-
-It supports model and model version registering, listing, loading, and deleting.
-
-To use the model catalog, make sure that:
-
- - The Gravitino server has started, and is serving at, e.g. [http://localhost:8090](http://localhost:8090).
- - A metalake has been created and [enabled](./manage-metalake-using-gravitino.md#enable-a-metalake)
-
-## Catalog Operations
-
-### Create a Catalog
-
-:::info
-For a model catalog, you must specify the catalog `type` as `MODEL` when creating the catalog.
-Please also be aware that the `provider` is not required for a model catalog.
-:::
-
-Create a catalog by sending a `POST` request to the `/api/metalakes/{metalake_name}/catalogs`
-endpoint or use the Gravitino Java/Python client. The following is an example of creating a
-catalog:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "name": "model_catalog",
-  "type": "MODEL",
-  "comment": "This is a model catalog",
-  "properties": {
-    "k1": "v1"
-  }
-}' http://localhost:8090/api/metalakes/example/catalogs
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://localhost:8090")
-    .withMetalake("example")
-    .build();
-
-Map<String, String> properties = ImmutableMap.<String, String>builder()
-    .put("k1", "v1")
-    .build();
-
-Catalog catalog = gravitinoClient.createCatalog(
-    "model_catalog",
-    Type.MODEL,
-    "This is a model catalog",
-    properties);
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-catalog = gravitino_client.create_catalog(name="model_catalog",
-                                          catalog_type=Catalog.Type.MODEL,
-                                          provider=None,
-                                          comment="This is a model catalog",
-                                          properties={"k1": "v1"})
-```
-
-</TabItem>
-</Tabs>
-
-### Load a Catalog
-
-Refer to [Load a catalog](./manage-relational-metadata-using-gravitino.md#load-a-catalog)
-in relational catalog for more details. For a model catalog, the load operation is the same.
-
-### Alter a Catalog
-
-Refer to [Alter a catalog](./manage-relational-metadata-using-gravitino.md#alter-a-catalog)
-in relational catalog for more details. For a model catalog, the alter operation is the same.
-
-### Drop a Catalog
-
-Refer to [Drop a catalog](./manage-relational-metadata-using-gravitino.md#drop-a-catalog)
-in relational catalog for more details. For a model catalog, the drop operation is the same.
-
-### List All Catalogs in a Metalake
-
-Refer to [List all catalogs in a metalake](./manage-relational-metadata-using-gravitino.md#list-all-catalogs-in-a-metalake)
-in relational catalog for more details. For a model catalog, the list operation is the same.
-
-### List All Catalog Information in a Metalake
-
-Refer to [List all catalog information in a metalake](./manage-relational-metadata-using-gravitino.md#list-all-catalog-information-in-a-metalake)
-in relational catalog for more details. For a model catalog, the list operation is the same.
-
-## Schema Operations
-
-`Schema` is a virtual namespace in a model catalog, which is used to organize the models. It
-is similar to the concept of `schema` in the relational catalog.
-
-:::tip
-Users should create a metalake and a catalog before creating a schema.
-:::
-
-### Create a Schema
-
-Create a schema by sending a `POST` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas`
-endpoint or use the Gravitino Java/Python client. The following is an example of creating a
-schema:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "name": "model_schema",
-  "comment": "This is a model schema",
-  "properties": {
-    "k1": "v1"
-  }
-}' http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://localhost:8090")
-    .withMetalake("example")
-    .build();
-
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-
-SupportsSchemas supportsSchemas = catalog.asSchemas();
-
-Map<String, String> schemaProperties = ImmutableMap.<String, String>builder()
-    .put("k1", "v1")
-    .build();
-Schema schema = supportsSchemas.createSchema(
-    "model_schema",
-    "This is a schema",
-    schemaProperties);
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_schemas().create_schema(name="model_schema",
-                                   comment="This is a schema",
-                                   properties={"k1": "v1"})
-```
-
-</TabItem>
-</Tabs>
-
-### Load a Schema
-
-Refer to [Load a schema](./manage-relational-metadata-using-gravitino.md#load-a-schema)
-in relational catalog for more details. For a model catalog, the schema load operation is the
-same.
-
-### Alter a Schema
-
-Refer to [Alter a schema](./manage-relational-metadata-using-gravitino.md#alter-a-schema)
-in relational catalog for more details. For a model catalog, the schema alter operation is the
-same.
-
-### Drop a Schema
-
-Refer to [Drop a schema](./manage-relational-metadata-using-gravitino.md#drop-a-schema)
-in relational catalog for more details. For a model catalog, the schema drop operation is the
-same.
-
-Note that the drop operation will delete all the model metadata under this schema if `cascade`
-set to `true`.
-
-### List All Schemas Under a Catalog
-
-Refer to [List all schemas under a catalog](./manage-relational-metadata-using-gravitino.md#list-all-schemas-under-a-catalog)
-in relational catalog for more details. For a model catalog, the schema list operation is the
-same.
+This page covers the Gravitino API for models and model versions. For what a model catalog is, how
+versions and aliases work, and how several URIs on one version behave, see
+[Model Catalog](./model-catalog.md). For creating the catalog and schema a model lives in, see
+[Manage Catalogs and Schemas](./manage-catalogs-and-schemas.md).
 
 ## Model Operations
 
-:::tip
- - Users should create a metalake, a catalog, and a schema before creating a model.
-:::
-
 ### Register a Model
 
-Register a model by sending a `POST` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models` endpoint or use the Gravitino
-Java/Python client. The following is an example of creating a model:
+Registering creates the model with no versions. It needs a name, and can carry a comment and
+properties.
 
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "name": "example_model",
-  "comment": "This is an example model",
-  "properties": {
-    "k1": "v1"
-  }
-}' http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models
+  -H "Content-Type: application/json" -d '{
+  "name": "churn_predictor",
+  "comment": "Customer churn model",
+  "properties": {"team": "risk"}
+}' http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://localhost:8090")
-    .withMetalake("example")
-    .build();
+Catalog catalog = client.loadCatalog("models");
+ModelCatalog models = catalog.asModelCatalog();
 
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-Map<String, String> propertiesMap = ImmutableMap.<String, String>builder()
-        .put("k1", "v1")
-        .build();
-
-Model model = catalog.asModelCatalog().registerModel(
-    NameIdentifier.of("model_schema", "example_model"),
-    "This is an example model",
-    propertiesMap);
+Model model = models.registerModel(
+    NameIdentifier.of("customer", "churn_predictor"),
+    "Customer churn model",
+    ImmutableMap.of("team", "risk"));
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
+catalog = client.load_catalog("models")
+models = catalog.as_model_catalog()
 
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-model: Model = catalog.as_model_catalog().register_model(ident=NameIdentifier.of("model_schema", "example_model"),
-                                                         comment="This is an example model",
-                                                         properties={"k1": "v1"})
+model = models.register_model(
+    model_ident=NameIdentifier.of("customer", "churn_predictor"),
+    comment="Customer churn model",
+    properties={"team": "risk"})
 ```
 
 </TabItem>
@@ -268,37 +65,26 @@ model: Model = catalog.as_model_catalog().register_model(ident=NameIdentifier.of
 
 ### Get a Model
 
-Get a model by sending a `GET` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}` endpoint or by using the
-Gravitino Java/Python client. The following is an example of getting a model:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model
+  http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-Model model = catalog.asModelCatalog().getModel(NameIdentifier.of("model_schema", "example_model"));
-// ...
+Model model = models.getModel(NameIdentifier.of("customer", "churn_predictor"));
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-model: Model = catalog.as_model_catalog().get_model(ident=NameIdentifier.of("model_schema", "example_model"))
+model = models.get_model(NameIdentifier.of("customer", "churn_predictor"))
 ```
 
 </TabItem>
@@ -306,979 +92,253 @@ model: Model = catalog.as_model_catalog().get_model(ident=NameIdentifier.of("mod
 
 ### Alter a Model
 
-Modify a model's metadata (e.g. rename, update comment, or modify properties) by 
-sending a `PUT` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/
-{schema_name}/models/{model_name}` endpoint or using the Gravitino Java/Python client. The following is an example of modifying a model:
+| Change             | JSON                                                         | Java                                        |
+|--------------------|--------------------------------------------------------------|---------------------------------------------|
+| Rename             | `{"@type":"rename","newName":"churn_v2"}`                    | `ModelChange.rename("churn_v2")`            |
+| Update the comment | `{"@type":"updateComment","newComment":"new_comment"}`       | `ModelChange.updateComment("new_comment")`  |
+| Set a property     | `{"@type":"setProperty","property":"key1","value":"value1"}` | `ModelChange.setProperty("key1", "value1")` |
+| Remove a property  | `{"@type":"removeProperty","property":"key1"}`               | `ModelChange.removeProperty("key1")`        |
 
-<Tabs groupId="language" queryString>
- <TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
-cat <<EOF >model.json
-{
+curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" -d '{
   "updates": [
-    {
-      "@type": "updateComment",
-      "newComment": "Updated model comment"
-    },
-    {
-      "@type": "rename",
-      "newName": "new_name"
-    },
-    {
-      "@type": "setProperty",
-      "property": "k2",
-      "value": "v2"
-    },
-    {
-      "@type": "removeProperty",
-      "property": "k1"
-    }
+    {"@type": "setProperty", "property": "default-uri-name", "value": "us"}
   ]
-}
-EOF
- 
-curl -X PUT \
-  -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" \
-  -d '@model.json' \
-  http://localhost:8090/api/metalakes/mymetalake/catalogs/mycatalog/schemas/myschema/models/mymodel
- ```
-
-
- </TabItem>
- <TabItem value="java" label="Java">
-
- ```java
- // Load the catalog and model
- GravitinoClient gravitinoClient = GravitinoClient
-     .builder("http://localhost:8090")
-     .withMetalake("example")
-     .build();
-
- Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
- ModelCatalog modelCatalog = catalog.asModelCatalog();
-
- // Define modifications
- ModelChange[] changes = {
-     ModelChange.rename("example_model_renamed"),
-     ModelChange.updatComment("new comment"),
-     ModelChange.setProperty("k2", "v2"),
-     ModelChange.removeProperty("k1")
- };
-
- // Apply changes
- Model updatedModel = modelCatalog.alterModel(
-     NameIdentifier.of("model_schema", "example_model"),
-     changes
- );
- ```
-
- </TabItem>
-<TabItem value="python" label="Python">
-
- ```python
-client = GravitinoClient(uri="http://localhost:8090", 
-                         metalake_name="mymetalake")
-
-catalog = client.load_catalog(name="mycatalog").as_model_catalog()
-
-# Define modifications
-changes = (
-    ModelChange.rename("renamed"),
-    ModelChange.update_comment("new comment"),
-    ModelChange.set_property("k2", "v2"),
-    ModelChange.remove_property("k1"),
-)
-
-# Apply changes
-updated_model = model_catalog.alter_model(
-    ident=NameIdentifier.of("myschema", "mymodel"), *changes
-)
- ```
- </TabItem>
- </Tabs>
-
-#### Supported Modifications
-
-The following operations are supported for altering a model:
-
-
-| Operation           | JSON Example                                               | Java Method                                | Python Method                               |
-|---------------------|------------------------------------------------------------|--------------------------------------------|---------------------------------------------|
-| **Rename model**    | `{"@type":"rename","newName":"new_name"}`                  | `ModelChange.rename("new_name")`           | `ModelChange.rename("new_name")`            |
-| **Update comment**  | `{"@type":"updateComment","newComment":"new comment"}`     | `ModelChange.updateComment("new comment")` | `ModelChange.update_comment("new comment")` |
-| **Set property**    | `{"@type":"setProperty","property":"key","value":"value"}` | `ModelChange.setProperty("key", "value")`  | `ModelChange.set_property("key", "value")`  |
-| **Remove property** | `{"@type":"removeProperty","property":"key"}`              | `ModelChange.removeProperty("key")`        | `ModelChange.remove_property("key")`        |
-
-:::note
-- Multiple modifications can be applied in a single request.
-- If the target model does not exist, a `404 Not Found` error will be returned.
-  :::
-
-### Delete a Model
-
-Delete a model by sending a `DELETE` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}` endpoint or by using the
-Gravitino Java/Python client. The following is an example of deleting a model:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model
+}' http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().deleteModel(NameIdentifier.of("model_schema", "example_model"));
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().delete_model(NameIdentifier.of("model_schema", "example_model"))
+Model model = models.alterModel(
+    NameIdentifier.of("customer", "churn_predictor"),
+    ModelChange.setProperty("default-uri-name", "us"));
 ```
 
 </TabItem>
 </Tabs>
 
-Note that the delete operation will delete all the model versions under this model.
+### List and Delete Models
 
-### List Models
-
-List all the models in a schema by sending a `GET` request to the `/api/metalakes/
-{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/models` endpoint or by using the
-Gravitino Java/Python client. The following is an example of listing all the models in a schema:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models
+  http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models
+
+curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
+  http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-NameIdentifier[] identifiers = catalog.asModelCatalog().listModels(Namespace.of("model_schema"));
-// ...
+NameIdentifier[] identifiers = models.listModels(Namespace.of("customer"));
+boolean deleted = models.deleteModel(NameIdentifier.of("customer", "churn_predictor"));
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-model_list = catalog.as_model_catalog().list_models(namespace=Namespace.of("model_schema")))
+identifiers = models.list_models(Namespace.of("customer"))
+deleted = models.delete_model(NameIdentifier.of("customer", "churn_predictor"))
 ```
 
 </TabItem>
 </Tabs>
 
-## ModelVersion Operations
+Deleting a model deletes all of its versions.
 
-:::tip
- - Users should create a metalake, a catalog, a schema, and a model before link a model version
-   to the model.
-:::
+## Model Version Operations
 
-### Link a ModelVersion
+### Link a Version
 
-Link a ModelVersion by sending a `POST` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/versions` endpoint or by using
-the Gravitino Java/Python client. The following is an example of linking a ModelVersion:
+Linking creates a version of an existing model. The version number is assigned in sequence starting
+at zero.
 
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "uri": "path/to/model",
-  "aliases": ["alias1", "alias2"],
-  "comment": "This is version 0",
-  "properties": {
-    "k1": "v1"
-  }
-}' http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/versions
+  -H "Content-Type: application/json" -d '{
+  "uri": "s3a://models/churn/v0",
+  "aliases": ["production"],
+  "comment": "First release",
+  "properties": {"framework": "xgboost"}
+}' http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor/versions
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().linkModelVersion(
-    NameIdentifier.of("model_schema", "example_model"),
-    "path/to/model",
-    new String[] {"alias1", "alias2"},
-    "This is version 0",
-    ImmutableMap.of("k1", "v1"));
+models.linkModelVersion(
+    NameIdentifier.of("customer", "churn_predictor"),
+    "s3a://models/churn/v0",
+    new String[] {"production"},
+    "First release",
+    ImmutableMap.of("framework", "xgboost"));
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().link_model_version(model_ident=NameIdentifier.of("model_schema", "example_model"),
-                                              uri="path/to/model",
-                                              aliases=["alias1", "alias2"],
-                                              comment="This is version 0",
-                                              properties={"k1": "v1"})
+models.link_model_version(
+    model_ident=NameIdentifier.of("customer", "churn_predictor"),
+    uri="s3a://models/churn/v0",
+    aliases=["production"],
+    comment="First release",
+    properties={"framework": "xgboost"})
 ```
 
 </TabItem>
 </Tabs>
 
-The comment and properties of ModelVersion can be different from the model.
-
-Link a ModelVersion with multiple model URIs. The URIs is a map of URI name to URI. 
-
-If you associate only one URI with a ModelVersion and do not specify a URI name
-(as introduced in the previous paragraph), Gravitino will automatically generate a default URI name "unknown".
-
-The following is an example of linking a ModelVersion with multiple model URIs:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+To give a version several named URIs, send `uris` as a map instead of a single `uri`, and set
+`default-uri-name` to pick the one returned when a caller does not name one. In Java the same
+`linkModelVersion` takes a map; in Python it is `link_model_version_with_multiple_uris`.
 
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
+  -H "Content-Type: application/json" -d '{
   "uris": {
-    "s3": "s3://path/to/model",
-    "hdfs": "hdfs://path/to/model"
+    "us": "s3a://models-us/churn/v0",
+    "eu": "s3a://models-eu/churn/v0"
   },
-  "aliases": ["alias1", "alias2"],
-  "comment": "This is version 0",
-  "properties": {
-    "k1": "v1"
-  }
-}' http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/versions
+  "aliases": ["production"],
+  "properties": {"default-uri-name": "us"}
+}' http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor/versions
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
+### Get a Version
 
-```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().linkModelVersion(
-    NameIdentifier.of("model_schema", "example_model"),
-    ImmutableMap.of("s3", "s3://path/to/model", "hdfs", "hdfs://path/to/model"),
-    new String[] {"alias1", "alias2"},
-    "This is version 0",
-    ImmutableMap.of("k1", "v1"));
-```
+A version is fetched by number or by alias, and its URI can be fetched directly.
 
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().link_model_version_with_multiple_uris(model_ident=NameIdentifier.of("model_schema", "example_model"),
-                                                                 uris={"s3": "s3://path/to/model", "hdfs": "hdfs://path/to/model"},
-                                                                 aliases=["alias1", "alias2"],
-                                                                 comment="This is version 0",
-                                                                 properties={"k1": "v1"})
-```
-
-</TabItem>
-</Tabs>
-
-### Get a ModelVersion
-
-Get a ModelVersion by sending a `GET` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/versions/{version_number}`
-endpoint or by using the Gravitino Java/Python client. The following is an example of getting
-a ModelVersion:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/versions/0
-```
+  http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor/versions/0
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().getModelVersion(NameIdentifier.of("model_schema", "example_model"), 0);
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().get_model_version(model_ident=NameIdentifier.of("model_schema", "example_model"), version=0)
-```
-
-</TabItem>
-</Tabs>
-
-### Get a ModelVersion by Alias
-
-Get a ModelVersion by sending a `GET` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/aliases/{alias}` endpoint or
-by using the Gravitino Java/Python client. The following is an example of getting a ModelVersion
-by alias:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/aliases/alias1
-```
+  http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor/aliases/production
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-ModelVersion modelVersion = catalog.asModelCatalog().getModelVersion(NameIdentifier.of("model_schema", "example_model"), "alias1");
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-model_version: ModelVersion = catalog.as_model_catalog().get_model_version_by_alias(model_ident=NameIdentifier.of("model_schema", "example_model"), alias="alias1")
-```
-
-</TabItem>
-</Tabs>
-
-### Get ModelVersion URI
-
-Get the URI of a ModelVersion by sending a `GET` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/versions/{version_number}/uri?uriName={uriName}`
-endpoint or by using the Gravitino Java/Python client. The following is an example of getting
-the URI of a ModelVersion:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/versions/0/uri?uriName=s3
+  http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor/aliases/production/uri
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().getModelVersionUri(NameIdentifier.of("model_schema", "example_model"), 0, "s3");
-// ...
+ModelVersion byNumber = models.getModelVersion(
+    NameIdentifier.of("customer", "churn_predictor"), 0);
+
+ModelVersion byAlias = models.getModelVersion(
+    NameIdentifier.of("customer", "churn_predictor"), "production");
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
+by_number = models.get_model_version(
+    NameIdentifier.of("customer", "churn_predictor"), 0)
 
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().get_model_version_uri(model_ident=NameIdentifier.of("model_schema", "example_model"), version=0, uri_name="s3")
+by_alias = models.get_model_version_by_alias(
+    NameIdentifier.of("customer", "churn_predictor"), "production")
 ```
 
 </TabItem>
 </Tabs>
 
-The param `uriName` is not required. If it is not specified, Gravitino will obtain 
-the corresponding URI based on the `default-uri-name` property set in the Model or ModelVersion.
-Refer to [Model Properties](./model-catalog.md#model-properties) and
-[ModelVersion properties](./model-catalog.md#modelversion-properties) for more details.
-If the `default-uri-name` property is not set in either the model or the model version, 
-an `IllegalArgumentException` will be thrown.
+### Alter a Version
 
-The following is an example of getting the URI of a ModelVersion without specifying the uriName:
+Aliases move between versions with `updateAliases`, which adds and removes in one call. URIs are
+added, updated, and removed by name.
 
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+| Change             | JSON                                                                        | Java                                                       |
+|--------------------|-----------------------------------------------------------------------------|------------------------------------------------------------|
+| Update the comment | `{"@type":"updateComment","newComment":"new_comment"}`                      | `ModelVersionChange.updateComment("new_comment")`          |
+| Set a property     | `{"@type":"setProperty","property":"key1","value":"value1"}`                | `ModelVersionChange.setProperty("key1", "value1")`         |
+| Remove a property  | `{"@type":"removeProperty","property":"key1"}`                              | `ModelVersionChange.removeProperty("key1")`                |
+| Update the URI     | `{"@type":"updateUri","newUri":"s3a://models/churn/v1"}`                    | `ModelVersionChange.updateUri(...)`                        |
+| Add a named URI    | `{"@type":"addUri","uriName":"eu","uri":"s3a://models-eu/churn/v0"}`        | `ModelVersionChange.addUri("eu", ...)`                     |
+| Remove a named URI | `{"@type":"removeUri","uriName":"eu"}`                                      | `ModelVersionChange.removeUri("eu")`                       |
+| Move aliases       | `{"@type":"updateAliases","aliasesToAdd":["production"],"aliasesToRemove":[]}` | `ModelVersionChange.updateAliases(...)`                  |
 
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/versions/0/uri
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().getModelVersionUri(NameIdentifier.of("model_schema", "example_model"), 0, null);
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().get_model_version_uri(model_ident=NameIdentifier.of("model_schema", "example_model"), version=0)
-```
-
-</TabItem>
-</Tabs>
-
-### Get ModelVersion URI by Alias
-
-Get the URI of a ModelVersion by sending a `GET` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/aliases/{alias}/uri?uriName={uriName}`
-endpoint or by using the Gravitino Java/Python client. The following is an example of getting
-the URI of a ModelVersion:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/aliases/alias1/uri?uriName=s3
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().getModelVersionUri(NameIdentifier.of("model_schema", "example_model"), "alias", "s3");
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().get_model_version_uri_by_alias(model_ident=NameIdentifier.of("model_schema", "example_model"), alias="alias1", uri_name="s3")
-```
-
-</TabItem>
-</Tabs>
-
-Similarly, The param `uriName` is not required.
-The following is an example of getting the URI of a ModelVersion by alias without specifying the uriName:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/aliases/alias1/uri
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().getModelVersionUri(NameIdentifier.of("model_schema", "example_model"), "alias", null);
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().get_model_version_uri_by_alias(model_ident=NameIdentifier.of("model_schema", "example_model"), alias="alias1")
-```
-
-</TabItem>
-</Tabs>
-
-### Alter a ModelVersion
-
-Modify a modelVersion's metadata (e.g. update uri, update comment, or modify properties) 
-by sending a `PUT` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}
-/schemas/{schema_name} /models/{model_name}/versions/{version_number}` endpoint or using the Gravitino 
-Java/Python client. The following is an example of modifying a model version:
-
-<Tabs groupId="language" queryString>
- <TabItem value="shell" label="Shell">
-
-```shell
-cat <<EOF >model.json
-{
+curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" -d '{
   "updates": [
-    {
-      "@type": "updateComment",
-      "newComment": "Updated comment of model version"
-    },
-    {
-      "@type": "updateUri",
-      "uriName": "uri_name",
-      "newUri": "new_uri"
-    },
-    {
-      "@type": "addUri",
-      "uriName": "uri_name",
-      "uri": "uri"
-    },
-    {
-      "@type": "removeUri",
-      "uriName": "uri_name"
-    },
-    {
-      "@type": "setProperty",
-      "property": "key",
-      "value": "value"
-    },
-    {
-      "@type": "removeProperty",
-      "property": "key"
-    },
-    {
-      "@type": "updateAliases",
-      "aliasesToAdd": [
-          "alias1",
-          "alias2"
-      ],
-      "aliasesToRemove": [
-          "alias3"
-      ]
-    }
+    {"@type": "updateAliases", "aliasesToAdd": ["production"], "aliasesToRemove": []}
   ]
-}
-EOF
- 
-curl -X PUT \
-  -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" \
-  -d '@model.json' \
-  http://localhost:8090/api/metalakes/mymetalake/catalogs/mycatalog/schemas/myschema/models/mymodel/versions/0
-```
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// Load the model catalog
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://localhost:8090")
-    .withMetalake("example")
-    .build();
-
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-ModelCatalog modelCatalog = catalog.asModelCatalog();
-
-// Define modifications
-ModelVersionChange[] changes = {
-     ModelVersionChange.updateComment("Updated comment of model version"),
-     ModelVersionChange.updateUri("uri_name", "new_uri"),
-     ModelVersionChange.addUri("uri_name", "new_uri"),
-     ModelVersionChange.removeUri("uri_name"),
-     ModelVersionChange.setProperty("key", "value"),
-     ModelVersionChange.removeProperty("key"),
-     ModelVersionChange.updateAliases(new String[] {"alias1", "alias2"}, new String[] {"alias3"})
- };
-
-// Apply changes
-ModelVersion updatedModelVersion = modelCatalog.alterModelVersion(
-     NameIdentifier.of("model_schema", "example_model"),
-     0,
-     changes
- );
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-client = GravitinoClient(
-    uri="http://localhost:8090", metalake_name="mymetalake"
-)
-
-# Load Model Catalog
-model_catalog = client.load_catalog(name="mycatalog").as_model_catalog()
-
-# Define modifications
-changes = (
-    ModelVersionChange.update_comment("Updated comment of model version"),
-    ModelVersionChange.update_uri("new_uri", "uri_name"),
-    ModelVersionChange.add_uri("uri_name", "uri"),
-    ModelVersionChange.remove_uri("uri_name"),
-    ModelVersionChange.set_property("k2", "v2"),
-    ModelVersionChange.remove_property("k1"),
-    ModelVersionChange.update_aliases(["alias1", "alias2"], ["alias3"])
-)
-
-# Apply changes
-updated_model = model_catalog.alter_model_version(
-    NameIdentifier.of("myschema", "mymodel"), 0, *changes
-)
-```
-
-</TabItem>
-</Tabs>
-
-#### Supported Modifications
-
-| Operation           | JSON Example                                                                                | Java Method                                                                                    | Python Method                                                         |
-|---------------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
-| **Update uri**      | `{"@type":"updateUri","newName":"new_uri","uriName":"uri_name"}`                            | `ModelVersionChange.updateUri("uri_name", "new_uri")`                                          | `ModelVersionChange.update_uri("new_uri", "uri_name")`                |
-| **Update comment**  | `{"@type":"updateComment","newComment":"new_comment"}`                                      | `ModelVersionChange.updateComment("new_comment")`                                              | `ModelVersionChange.update_comment("new_comment")`                    |
-| **Set property**    | `{"@type":"setProperty","property":"key","value":"value"}`                                  | `ModelVersionChange.setProperty("key", "value")`                                               | `ModelVersionChange.set_property("key", "value")`                     |
-| **Remove property** | `{"@type":"removeProperty","property":"key"}`                                               | `ModelVersionChange.removeProperty("key")`                                                     | `ModelVersionChange.remove_property("key")`                           |
-| **Update Aliases**  | `{"@type":"updateAliases","aliasesToAdd":["alias1","alias2"],"aliasesToRemove":["alias3"]}` | `ModelVersionChange.updateAliases(new String[] {"alias1", "alias2"}, new String[] {"alias3"})` | `ModelVersionChange.update_aliases(["alias1", "alias2"], ["alias3"])` |
-| **Add uri**         | `{"@type":"addUri","uriName":"uri_name","uri":"uri"}`                                       | `ModelVersionChange.addUri("uri_name", "new_uri")`                                             | `ModelVersionChange.add_uri("uri_name", "uri")`                       |
-| **Remove uri**      | `{"@type":"removeUri","uriName":"uri_name"}`                                                | `ModelVersionChange.removeUri("uri_name")`                                                     | `ModelVersionChange.remove_uri("uri_name")`                           |
-
-:::note
-- Multiple modifications can be applied in a single request.
-- If the target model does not exist, a `404 Not Found` error will be returned.
-- If the target model version does not exist, a `404 Not Found` error will be returned.
-  :::
-
-### Alter a ModelVersion by Alias
-
-Modify a modelVersion's metadata (e.g. update uri, update comment, or modify 
-properties) by sending a `PUT` request to the `/api/metalakes/{metalake_name}/catalogs/
-{catalog_name}/schemas/{schema_name}/models/{model_name}/aliases/{alias}` endpoint or using the Gravitino
-Java/Python client. The following is an example of modifying a model version:
-
-<Tabs groupId="language" queryString>
- <TabItem value="shell" label="Shell">
-
-```shell
-cat <<EOF >model.json
-{
-  "updates": [
-    {
-      "@type": "updateComment",
-      "newComment": "Updated comment of model version"
-    },
-    {
-      "@type": "updateUri",
-      "uriName": "uri_name",
-      "newUri": "new_uri"
-    },
-    {
-      "@type": "addUri",
-      "uriName": "uri_name",
-      "uri": "uri"
-    },
-    {
-      "@type": "removeUri",
-      "uriName": "uri_name"
-    },
-    {
-      "@type": "setProperty",
-      "property": "key",
-      "value": "value"
-    },
-    {
-      "@type": "removeProperty",
-      "property": "key"
-    },
-    {
-      "@type": "updateAliases",
-      "aliasesToAdd": [
-          "alias1",
-          "alias2"
-      ],
-      "aliasesToRemove": [
-          "alias3"
-      ]
-    }
-  ]
-}
-EOF
- 
-curl -X PUT \
-  -H "Accept: application/vnd.gravitino.v1+json" \
-  -H "Content-Type: application/json" \
-  -d '@model.json' \
-  http://localhost:8090/api/metalakes/mymetalake/catalogs/mycatalog/schemas/myschema/models/mymodel/aliases/myalias
-```
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// Load the model catalog
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://localhost:8090")
-    .withMetalake("example")
-    .build();
-
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-ModelCatalog modelCatalog = catalog.asModelCatalog();
-
-// Define modifications
-ModelVersionChange[] changes = {
-     ModelVersionChange.updateComment("Updated comment of model version"), 
-     ModelVersionChange.updateUri("uri_name", "new_uri"),
-     ModelVersionChange.addUri("uri_name", "new_uri"),
-     ModelVersionChange.removeUri("uri_name"),
-     ModelVersionChange.setProperty("key", "value"),
-     ModelVersionChange.removeProperty("key"),
-     ModelVersionChange.updateAliases(new String[] {"alias1", "alias2"}, new String[] {"alias3"})
- };
-
-// Apply changes
-ModelVersion updatedModelVersion = modelCatalog.alterModelVersion(
-     NameIdentifier.of("model_schema", "example_model"),
-     "myalias",
-     changes
- );
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-client = GravitinoClient(
-    uri="http://localhost:8090", metalake_name="mymetalake"
-)
-
-# Load Model Catalog
-model_catalog = client.load_catalog(name="mycatalog").as_model_catalog()
-
-# Define modifications
-changes = (
-    ModelVersionChange.update_comment("Updated comment of model version"),
-    ModelVersionChange.update_uri("new_uri", "uri_name"),
-    ModelVersionChange.add_uri("uri_name", "uri"),
-    ModelVersionChange.remove_uri("uri_name"),
-    ModelVersionChange.set_property("k2", "v2"),
-    ModelVersionChange.remove_property("k1"),
-    ModelVersionChange.update_aliases(["alias1", "alias2"], ["alias3"])
-)
-
-# Apply changes
-updated_model = model_catalog.alter_model_version_by_alias(
-    NameIdentifier.of("myschema", "myalias", "mymodel"), *changes
-)
-```
-
-</TabItem>
-</Tabs>
-
-#### Supported Modifications
-
-| Operation           | JSON Example                                                                                | Java Method                                                                                    | Python Method                                                         |
-|---------------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
-| **Update uri**      | `{"@type":"updateUri","newName":"new_uri","uriName":"uri_name"}`                            | `ModelVersionChange.updateUri("new_uri")`                                                      | `ModelVersionChange.update_uri("new_uri")`                            |
-| **Update comment**  | `{"@type":"updateComment","newComment":"new_comment"}`                                      | `ModelVersionChange.updateComment("new_comment")`                                              | `ModelVersionChange.update_comment("new_comment")`                    |
-| **Set property**    | `{"@type":"setProperty","property":"key","value":"value"}`                                  | `ModelVersionChange.setProperty("key", "value")`                                               | `ModelVersionChange.set_property("key", "value")`                     |
-| **Remove property** | `{"@type":"removeProperty","property":"key"}`                                               | `ModelVersionChange.removeProperty("key")`                                                     | `ModelVersionChange.remove_property("key")`                           |
-| **Update Aliases**  | `{"@type":"updateAliases","aliasesToAdd":["alias1","alias2"],"aliasesToRemove":["alias3"]}` | `ModelVersionChange.updateAliases(new String[] {"alias1", "alias2"}, new String[] {"alias3"})` | `ModelVersionChange.update_aliases(["alias1", "alias2"], ["alias3"])` |
-| **Add uri**         | `{"@type":"addUri","uriName":"uri_name","uri":"uri"}`                                       | `ModelVersionChange.addUri("uri_name", "new_uri")`                                             | `ModelVersionChange.add_uri("uri_name", "uri")`                       |
-| **Remove uri**      | `{"@type":"removeUri","uriName":"uri_name"}`                                                | `ModelVersionChange.removeUri("uri_name")`                                                     | `ModelVersionChange.remove_uri("uri_name")`                           |
-
-
-:::note
-- Multiple modifications can be applied in a single request.
-- If the target model does not exist, a `404 Not Found` error will be returned.
-- If the target model version does not exist, a `404 Not Found` error will be returned.
-  :::
-
-### Delete a ModelVersion
-
-Delete a ModelVersion by sending a `DELETE` request to the `/api/metalakes/{metalake_name}
-/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/versions/{version_number}`
-endpoint or by using the Gravitino Java/Python client. The following is an example of deleting
-a ModelVersion:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/versions/0
+}' http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor/versions/1
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().deleteModelVersion(NameIdentifier.of("model_schema", "example_model"), 0);
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().delete_model_version(model_ident=NameIdentifier.of("model_schema", "example_model"), version=0)
+models.alterModelVersion(
+    NameIdentifier.of("customer", "churn_predictor"),
+    1,
+    ModelVersionChange.updateAliases(new String[] {"production"}, new String[] {}));
 ```
 
 </TabItem>
 </Tabs>
 
-### Delete a ModelVersion by Alias
+Moving an alias onto a new version removes it from the version that held it, since an alias belongs
+to one version at a time.
 
-Delete a ModelVersion by sending a `DELETE` request to the `/api/metalakes/
-{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/aliases/{alias}` endpoint or
-by using the Gravitino Java/Python client. The following is an example of deleting a ModelVersion
-by alias:
+### List and Delete Versions
 
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/aliases/alias1
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-catalog.asModelCatalog().deleteModelVersion(NameIdentifier.of("model_schema", "example_model"), "alias1");
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-catalog.as_model_catalog().delete_model_version_by_alias(model_ident=NameIdentifier.of("model_schema", "example_model"), alias="alias1")
-```
-
-</TabItem>
-</Tabs>
-
-### List ModelVersions
-
-List all the ModelVersions in a model by sending a `GET` request to the `/api/metalakes/
-{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/versions` endpoint
-or by using the Gravitino Java/Python client. The following is an example of listing all the 
-ModelVersions in a model:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/versions
+  http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor/versions
+
+curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
+  http://localhost:8090/api/metalakes/example/catalogs/models/schemas/customer/models/churn_predictor/versions/0
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-int[] modelVersions = catalog.asModelCatalog().listModelVersions(NameIdentifier.of("model_schema", "example_model"));
-// ...
+int[] versions = models.listModelVersions(
+    NameIdentifier.of("customer", "churn_predictor"));
+
+boolean deleted = models.deleteModelVersion(
+    NameIdentifier.of("customer", "churn_predictor"), 0);
 ```
 
 </TabItem>
 <TabItem value="python" label="Python">
 
 ```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
+versions = models.list_model_versions(
+    NameIdentifier.of("customer", "churn_predictor"))
 
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-model_versions: List[int] = catalog.as_model_catalog().list_model_versions(model_ident=NameIdentifier.of("model_schema", "example_model"))
-```
-
-</TabItem>
-</Tabs>
-
-### List All Version Information in a Model
-
-List all versions' information in a model by sending a `GET` request to the `/api/metalakes/
-{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}/versions?detail=true` endpoint
-or by using the Gravitino Java/Python client. The following is an example of listing all the
-versions' information in a model:
-
-<Tabs groupId="language" queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model/versions?detail=true
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
-ModelVersion[] versions = catalog.asModelCatalog().listModelVersionInfos(NameIdentifier.of("model_schema", "example_model"));
-// ...
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
-
-```python
-gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
-
-catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
-model_versions: List[ModelVersion] = catalog.as_model_catalog().list_model_version_infos(model_ident=NameIdentifier.of("model_schema", "example_model"))
+deleted = models.delete_model_version(
+    NameIdentifier.of("customer", "churn_predictor"), 0)
 ```
 
 </TabItem>

--- a/docs/manage-statistics-in-gravitino.md
+++ b/docs/manage-statistics-in-gravitino.md
@@ -1,8 +1,7 @@
 ---
 title: "Manage Statistics"
 slug: "/manage-statistics-in-gravitino"
-date: 2025-08-21
-keyword: "statistics management, statistics, statistic, Gravitino"
+keyword: "statistics management, statistics, partition statistics, Gravitino"
 license: "This software is licensed under the Apache License version 2."
 ---
 
@@ -11,226 +10,187 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-Gravitino provides statistics of tables and partitions.
+This page covers the Gravitino API for statistics. For what a statistic is, the difference between
+reserved and custom, and how partition statistics relate to partitions, see
+[Statistics](./statistics.md).
 
-This document provides a brief introduction using both Gravitino Java client and
-REST APIs. If you want to know more about the statistics system in Gravitino, refer to the
-Javadoc and REST API documentation.
+Statistics attach to tables. Custom names must begin with `custom.` to stay clear of names Gravitino
+may reserve later.
 
-Statistics only support the custom statistics, which names must start with `custom-`.
-Gravitino will support built-in statistics in the future.
+## Table Statistics
 
-The query engine uses statistics for cost-based optimization (CBO). Meanwhile, statistics can also
-be used for metadata action systems to trigger some jobs, such as compaction, data archiving, etc.
+### Update Statistics
 
-Create statistics. And then you can create policies based on statistics. Users can analyze the statistics
-and policies to decide the next action. For example,
-you can create a statistic named `custom-tableLastModifiedTime` to record the last modified time of a table.
-Then you can create a policy to check if the table hasn't been modified for a long time, and archive the table data to
-cold storage.
-
-Gravitino doesn't handle the computation of the statistics, you need to compute the statistics
-and update them to Gravitino. Gravitino can't judge the expiration of the statistics, 
-Ensure the statistics are up-to-date.
-
-
-## Metadata Object Statistic Operations
-
-### Update Statistics of Metadata Objects
-
-Update the statistics of a metadata object by providing the statistics key and value.
-Now only table statistics can be updated.
-
-The request path for REST API is `/api/metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectName}/statistics`.
+Updating creates a statistic that does not exist and overwrites one that does. Reserved statistics
+maintained by the system are not modifiable and the request is rejected.
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "updates" : {
-      "custom-tableLastModifiedTime": "20250128",
+  -H "Content-Type: application/json" -d '{
+  "updates": {
+    "custom.last_reviewed": "2026-08-02",
+    "custom.owner_team": "risk"
   }
-}' http://localhost:8090/api/metalakes/metalake/objects/table/catalog.schema.table/statistics
+}' http://localhost:8090/api/metalakes/example/objects/table/sales.public.orders/statistics
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-Table table = ...
-Map<String, StatisticValue<?>> updateStatistics = Maps.newHashMap();
-updateStatistics.put("custom-k1", StatisticValues.stringValue("v1"));
-updateStatistics.put("custom-k2", StatisticValues.stringValue("v2"));
-table.updateStatistics(updateStatistics);
+Table orders = ...
+Map<String, StatisticValue<?>> updates = Maps.newHashMap();
+updates.put("custom.last_reviewed", StatisticValues.stringValue("2026-08-02"));
+updates.put("custom.owner_team", StatisticValues.stringValue("risk"));
+
+orders.supportsStatistics().updateStatistics(updates);
 ```
 
 </TabItem>
 </Tabs>
 
-### List Statistics of Metadata Objects
-
-List all the statistics of a metadata object.
-Now only table statistics can be listed.
-
-The request path for REST API is `/api/metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectName}/statistics`.
+### List Statistics
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
- -H "Content-Type: application/json" \
- http://localhost:8090/api/metalakes/metalake/objects/table/catalog.schema.table/statistics
+  http://localhost:8090/api/metalakes/example/objects/table/sales.public.orders/statistics
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-Table table = ...
-table.listStatistics();
+List<Statistic> statistics = orders.supportsStatistics().listStatistics();
 ```
 
 </TabItem>
 </Tabs>
 
-### Drop Statistics of Metadata Objects
-
-Drop the statistics of a metadata object by providing the statistics keys.
-Now only table statistics can be dropped.
-
-The request path for REST API is `/api/metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectName}/statistics`.
+### Drop Statistics
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
- -H "Content-Type: application/json" -d '{
- "names":["custom-k1"]
-}' http://localhost:8090/api/metalakes/metalake/objects/table/catalog.schema.table/statistics
+  -H "Content-Type: application/json" -d '{
+  "names": ["custom.owner_team"]
+}' http://localhost:8090/api/metalakes/example/objects/table/sales.public.orders/statistics
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-Table table = ...
-List<String> statisticsToDrop = Lists.newArrayList("custom-k1");
-table.dropStatistics(statisticsToDrop);
+orders.supportsStatistics().dropStatistics(ImmutableList.of("custom.owner_team"));
 ```
 
 </TabItem>
 </Tabs>
 
-### Partition Statistics Operations
+## Partition Statistics
 
-### Update Statistics of Partitions
+Partition statistics are held by Gravitino rather than by the catalog, so they work on any table
+including catalogs that expose no partition objects. Partition names are supplied by the caller, and
+several partitions are read or written in one request.
 
-Update the statistics of a partition by providing the statistics key and value. If the statistics
-already exist, it will be updated; otherwise, a new statistic will be created.
-
-The request path for REST API is `/api/metalakes/{metalake}/objects/table/{metadataObjectName}/statistics/partitions`.
+### Update Partition Statistics
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "updates":[{
-  "partitionName" : "p0" ,
-  "statistics" : {
-    "custom-k1" : "v1"
-  }
-  }]
-}' http://localhost:8090/api/metalakes/metalake/objects/table/catalog.schema.table/statistics/partitions
+  -H "Content-Type: application/json" -d '{
+  "updates": [
+    {
+      "partitionName": "dt=2026-08-02",
+      "statistics": {"custom.row_estimate": "18000"}
+    }
+  ]
+}' http://localhost:8090/api/metalakes/example/objects/table/sales.public.orders/statistics/partitions
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-Table table = ...
-List<PartitionStatisticsUpdate> statisticsToUpdate = Lists.newArrayList();
 Map<String, StatisticValue<?>> stats = Maps.newHashMap();
-stats.put("custom-k1", StatisticValues.stringValue("v1"));
-stats.put("custom-k2", StatisticValues.stringValue("v2"));
-statisticsToUpdate.add(PartitionStatisticsModification.update("p1", stats));
-table.updatePartitionStatistics(statisticsToUpdate);
+stats.put("custom.row_estimate", StatisticValues.longValue(18000L));
+
+orders.supportsPartitionStatistics().updatePartitionStatistics(
+    ImmutableList.of(PartitionStatisticsModification.update("dt=2026-08-02", stats)));
 ```
 
 </TabItem>
 </Tabs>
 
+### List Partition Statistics
 
-### List Statistics of Partitions
-
-List the statistics of specified partitions.
-Specify a range of partitions by providing the `from` and `to` parameters,
-and whether the range is inclusive using `fromInclusive` and `toInclusive` parameters.
-
-The request path for REST API is `/api/metalakes/{metalake}/objects/table/{metadataObjectName}/statistics/partitions`.
+Listing takes a partition range rather than a single name.
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
- -H "Content-Type: application/json" \
- 'http://localhost:8090/api/metalakes/metalake/objects/table/catalog.schema.table/statistics/partitions?from=p0&to=p1&fromInclusive=true&toInclusive=false'
+  "http://localhost:8090/api/metalakes/example/objects/table/sales.public.orders/statistics/partitions?from=dt=2026-08-01&to=dt=2026-08-31"
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-Table table = ...
-PartitionRange range = PartitionRange.downTo("p0", PartitionRange.BoundType.CLOSED);
-table.listPartitionStatistics(range);
+List<PartitionStatistics> statistics = orders.supportsPartitionStatistics().listPartitionStatistics(
+    PartitionRange.between(
+        "dt=2026-08-01", PartitionRange.BoundType.CLOSED,
+        "dt=2026-08-31", PartitionRange.BoundType.CLOSED));
 ```
 
 </TabItem>
 </Tabs>
 
-
-### Drop Statistics of Partitions
-
-Drop the statistics of specified partitions by providing the statistics keys.
-
-The request path for REST API is `/api/metalakes/{metalake}/objects/table/{metadataObjectName}/statistics/partitions`.
+### Drop Partition Statistics
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "drops" : [{
-  "partitionName" : "p0",
-  "statisticNames": ["custom-k1"]
-  }]
-}' http://localhost:8090/api/metalakes/metalake/objects/table/catalog.schema.table/statistics/partitions 
+  -H "Content-Type: application/json" -d '{
+  "drops": [
+    {
+      "partitionName": "dt=2026-08-02",
+      "statisticNames": ["custom.row_estimate"]
+    }
+  ]
+}' http://localhost:8090/api/metalakes/example/objects/table/sales.public.orders/statistics/partitions
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-
-List<PartitionStatisticsDrop> statisticsToDrop = Lists.newArrayList();
-statisticsToDrop.add(
-    PartitionStatisticsModification.drop("p0", Lists.newArrayList("custom-k1")));
-
-table.dropPartitionStatistics(statisticsToDrop);
-
+orders.supportsPartitionStatistics().dropPartitionStatistics(
+    ImmutableList.of(
+        PartitionStatisticsModification.drop(
+            "dt=2026-08-02", ImmutableList.of("custom.row_estimate"))));
 ```
 
 </TabItem>
 </Tabs>
 
+## Storage Configuration
+
+Partition statistics use a pluggable storage backend, configured on the server. See
+[Server Configuration](#server-configuration) below. Writing a custom backend is covered in
+[Custom partition storage](./development/custom-partition-storage.md).
 
 ### Server Configuration
 
@@ -326,49 +286,4 @@ If you have many tables with a small number of partitions, you should set a smal
 ```properties
 gravitino.stats.partition.storageFactoryClass = org.apache.gravitino.stats.storage.LancePartitionStatisticStorageFactory
 gravitino.stats.partition.storageOption.location = /data/lance
-```
-
-### Implement a Custom Partition Storage
-
-Implement a custom partition storage by implementing the interface `org.apache.gravitino.stats.storage.PartitionStatisticStorageFactory` and
-setting the configuration item `gravitino.stats.partition.storageFactoryClass` to your class name.
-
-For example:
-
-```java
-public class MyPartitionStatsStorageFactory implements PartitionStatisticStorageFactory {
-    @Override
-    public PartitionStatisticStorage create(Map<String, String> options) {
-        // Create your custom PartitionStatsStorage here
-        return new MyPartitionStatsStorage(...);
-    }
-}
-```
-
-```java
-public class MyPartitionStatsStorage implements PartitionStatisticStorage {
-
-
-    @Override
-    public void close() {
-        // Close your storage here
-    }
-
-    @Override
-    public void updateStatistics(String metalake, List<MetadataObjectStatisticsUpdate> updates) {
-        // Update partition statistics in your storage here
-    }
-
-    @Override
-    public List<PersistedPartitionStatistics> listStatistics(
-            String metalake, MetadataObject metadataObject, PartitionRange range) {
-        // List partition statistics from your storage here
-        return Maps.newHashMap();
-    }
-
-    @Override
-    public int dropStatistics(String metalake, List<MetadataObjectStatisticsDrop> drops) {    
-        // Drop partition statistics from your storage here
-    }
-}
 ```

--- a/docs/manage-table-partition-using-gravitino.md
+++ b/docs/manage-table-partition-using-gravitino.md
@@ -1,8 +1,7 @@
 ---
 title: "Manage Table Partitions"
 slug: "/manage-table-partition-using-gravitino"
-date: 2024-02-03
-keyword: "table partition management"
+keyword: "partition management, partition, Gravitino"
 license: "This software is licensed under the Apache License version 2."
 ---
 
@@ -11,408 +10,175 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-Although many catalogs inherently manage partitions automatically, there are scenarios where manual partition management is necessary. Usage scenarios like managing the TTL (Time-To-Live) of partition data, gathering statistics on partition metadata, and optimizing queries through partition pruning. For these reasons, Apache Gravitino provides capabilities of partition management.
+This page covers the Gravitino API for partitions. For what a partition is, the partition types, and
+which catalogs support managing them, see [Partitions](./partitions.md).
 
-### Requirements and Limitations
-
-- Partition management is based on the partitioned table, so ensure you are operating on a partitioned table.
-
-The following table shows the partition operations supported across various catalogs in Gravitino:
-
-| Operation             | Hive catalog | Iceberg catalog | Jdbc-MySQL catalog | Jdbc-PostgreSQL catalog | Jdbc-Doris catalog |
-|-----------------------|--------------|-----------------|--------------------|-------------------------|--------------------|
-| Add Partition         | &#10004;     | &#10008;        | &#10008;           | &#10008;                | &#10004;           |
-| Get Partition by Name | &#10004;     | &#10008;        | &#10008;           | &#10008;                | &#10004;           |
-| List Partition Names  | &#10004;     | &#10008;        | &#10008;           | &#10008;                | &#10004;           |
-| List Partitions       | &#10004;     | &#10008;        | &#10008;           | &#10008;                | &#10004;           |
-| Drop Partition        | &#10004;     | &#10008;        | &#10008;           | &#10008;                | &#10004;           | 
-
-:::tip[WELCOME FEEDBACK]
-If you need additional partition management support for a specific catalog, [create an issue](https://github.com/apache/gravitino/issues/new/choose) on the [Gravitino repository](https://github.com/apache/gravitino).
-:::
+Partition management works on Hive and Doris catalogs. Iceberg, MySQL, and PostgreSQL catalogs
+manage partitions themselves and do not expose them here.
 
 ## Partition Operations
 
-### Add Partition
+### Add a Partition
 
-Match the partition types you want to add with the table's [partitioning](./table-partitioning-distribution-sort-order-indexes.md#table-partitioning) types; Gravitino supports adding the following partition types:
-
-| Partition Type | Description                                                                                                                                       |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| identity       | An identity partition represents a result of identity [partitioning](./table-partitioning-distribution-sort-order-indexes.md#table-partitioning). |
-| range          | A range partition represents a result of range [partitioning](./table-partitioning-distribution-sort-order-indexes.md#table-partitioning).        |
-| list           | A list partition represents a result of list [partitioning](./table-partitioning-distribution-sort-order-indexes.md#table-partitioning).          |
-
-For JSON examples:
-
-<Tabs groupId="partitions">
-<TabItem value="identity" label="identity">
-
-```json
-{
-  "type": "identity",
-  "name": "dt=2008-08-08/country=us",
-  "fieldNames": [
-    [
-      "dt"
-    ],
-    [
-      "country"
-    ]
-  ],
-  "values": [
-    {
-      "type": "literal",
-      "dataType": "date",
-      "value": "2008-08-08"
-    },
-    {
-      "type": "literal",
-      "dataType": "string",
-      "value": "us"
-    }
-  ]
-}
-```
-
-:::note
-The values of the field `values` must be the same ordering as the values of `fieldNames`.
-
-When adding an identity partition to a partitioned Hive table, the specified partition name is ignored. This is because Hive generates the partition name based on field names and values.
-:::
-
-</TabItem>
-<TabItem value="range" label="range">
-
-```json
-{
-  "type": "range",
-  "name": "p20200321",
-  "upper": {
-    "type": "literal",
-    "dataType": "date",
-    "value": "2020-03-21"
-  },
-  "lower": {
-    "type": "literal",
-    "dataType": "null",
-    "value": "null"
-  }
-}
-```
-
-</TabItem>
-<TabItem value="list" label="list">
-
-```json
-{
-  "type": "list",
-  "name": "p202204_California",
-  "lists": [
-    [
-      {
-        "type": "literal",
-        "dataType": "date",
-        "value": "2022-04-01"
-      },
-      {
-        "type": "literal",
-        "dataType": "string",
-        "value": "Los Angeles"
-      }
-    ],
-    [
-      {
-        "type": "literal",
-        "dataType": "date",
-        "value": "2022-04-01"
-      },
-      {
-        "type": "literal",
-        "dataType": "string",
-        "value": "San Francisco"
-      }
-    ]
-  ]
-}
-```
-
-:::note
-Each list in the lists must have the same length. The values in each list must correspond to the field definitions in the list [partitioning](./table-partitioning-distribution-sort-order-indexes.md#table-partitioning).
-:::
-
-</TabItem>
-</Tabs>
-
-For Java examples:
+The partition type must match the table's partitioning strategy. The three shapes are below.
 
 <Tabs groupId="partitions">
 <TabItem value="identity" label="Identity">
 
-```java
-Partition partition =
-        Partitions.identity(
-            "dt=2008-08-08/country=us",
-            new String[][] {{"dt"}, {"country"}},
-            new Literal[] {
-              Literals.dateLiteral(LocalDate.parse("2008-08-08")), Literals.stringLiteral("us")
-            },
-            Maps.newHashMap());
+```json
+{
+  "type": "identity",
+  "name": "dt=2026-08-02/country=us",
+  "fieldNames": [["dt"], ["country"]],
+  "values": [
+    {"type": "literal", "dataType": "date", "value": "2026-08-02"},
+    {"type": "literal", "dataType": "string", "value": "us"}
+  ]
+}
 ```
 
-:::note
-The values are in the same order as the field names.
-
-When adding an identity partition to a partitioned Hive table, the specified partition name is ignored. This is because Hive generates the partition name based on field names and values.
-:::
+`values` must be in the same order as `fieldNames`. On a Hive table the partition name is ignored,
+since Hive derives it from the field names and values.
 
 </TabItem>
 <TabItem value="range" label="Range">
 
-```java
-Partition partition =
-        Partitions.range(
-            "p20200321",
-            Literals.dateLiteral(LocalDate.parse("2020-03-21")),
-            Literals.NULL,
-            Maps.newHashMap());
+```json
+{
+  "type": "range",
+  "name": "p20260802",
+  "upper": {"type": "literal", "dataType": "date", "value": "2026-08-02"},
+  "lower": {"type": "literal", "dataType": "date", "value": "2026-08-01"}
+}
 ```
 
 </TabItem>
-
 <TabItem value="list" label="List">
 
-```java
-Partition partition =
-        Partitions.list(
-            "p202204_California",
-            new Literal[][] {
-              {
-                Literals.dateLiteral(LocalDate.parse("2022-04-01")),
-                Literals.stringLiteral("Los Angeles")
-              },
-              {
-                Literals.dateLiteral(LocalDate.parse("2022-04-01")),
-                Literals.stringLiteral("San Francisco")
-              }
-            },
-            Maps.newHashMap());
+```json
+{
+  "type": "list",
+  "name": "p_north_america",
+  "lists": [
+    [{"type": "literal", "dataType": "string", "value": "us"}],
+    [{"type": "literal", "dataType": "string", "value": "ca"}]
+  ]
+}
 ```
-
-:::note
-Each list in the lists must have the same length. The values in each list must correspond to the field definitions in the list [partitioning](./table-partitioning-distribution-sort-order-indexes.md#table-partitioning).
-:::
 
 </TabItem>
 </Tabs>
 
-Add a partition to a partitioned table by sending a `POST` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions` endpoint or by using the Gravitino Java client.
-The following is an example of adding an identity partition to a Hive partitioned table:
-
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
+  -H "Content-Type: application/json" -d '{
   "partitions": [
     {
       "type": "identity",
-      "fieldNames": [
-        [
-          "dt"
-        ],
-        [
-          "country"
-        ]
-      ],
+      "name": "dt=2026-08-02/country=us",
+      "fieldNames": [["dt"], ["country"]],
       "values": [
-        {
-          "type": "literal",
-          "dataType": "date",
-          "value": "2008-08-08"
-        },
-        {
-          "type": "literal",
-          "dataType": "string",
-          "value": "us"
-        }
+        {"type": "literal", "dataType": "date", "value": "2026-08-02"},
+        {"type": "literal", "dataType": "string", "value": "us"}
       ]
     }
   ]
-}' http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tables/table/partitions
+}' http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/tables/orders/partitions
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .withMetalake("metalake")
-    .build();
+Table orders = catalog.asTableCatalog().loadTable(
+    NameIdentifier.of("public", "orders"));
 
-// Assume that you have a partitioned table named "metalake.catalog.schema.table".
-Partition addedPartition = 
-    gravitinoClient
-        .loadCatalog("catalog")
-        .asTableCatalog()
-        .loadTable(NameIdentifier.of("schema", "table"))
-        .supportPartitions()
-        .addPartition(
-            Partitions.identity(
-              new String[][] {{"dt"}, {"country"}},
-              new Literal[] {
-              Literals.dateLiteral(LocalDate.parse("2008-08-08")), Literals.stringLiteral("us")},
-              Maps.newHashMap()));
+Partition partition = Partitions.identity(
+    new String[][] {{"dt"}, {"country"}},
+    new Literal[] {
+        Literals.dateLiteral(LocalDate.of(2026, 8, 2)),
+        Literals.stringLiteral("us")
+    });
+
+orders.supportPartitions().addPartition(partition);
 ```
 
 </TabItem>
 </Tabs>
 
-### Get a Partition by Name
-
-Get a partition by its name via sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions/{partition_name}` endpoint or by using the Gravitino Java client.
-The following is an example of getting a partition by its name:
+### Get a Partition
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tables/table/partitions/p20200321
+  "http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/tables/orders/partitions/dt=2026-08-02%2Fcountry=us"
 ```
-
-:::tip
-If the partition name contains special characters, you should use [URL encoding](https://en.wikipedia.org/wiki/Percent-encoding#Reserved_characters). For example, if the partition name is `dt=2008-08-08/country=us` you should use `dt%3D2008-08-08%2Fcountry%3Dus` in the URL.
-:::
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .withMetalake("metalake")
-    .build();
-
-// Assume that you have a partitioned table named "metalake.catalog.schema.table".
-Partition Partition = 
-    gravitinoClient
-        .loadCatalog("catalog")
-        .asTableCatalog()
-        .loadTable(NameIdentifier.of("schema", "table"))
-        .supportPartitions()
-        .getPartition("partition_name");
+Partition partition = orders.supportPartitions().getPartition(
+    "dt=2026-08-02/country=us");
 ```
 
 </TabItem>
 </Tabs>
 
-### List Partition Names Under a Partitioned Table
+### List Partitions
 
-List all partition names under a partitioned table by sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions` endpoint or by using the Gravitino Java client.
-The following is an example of listing all the partition names under a partitioned table:
+Listing returns names, or full partition objects when `details=true` is set.
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tables/table/partitions
-```
+  http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/tables/orders/partitions
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .withMetalake("metalake")
-    .build();
-
-// Assume that you have a partitioned table named "metalake.catalog.schema.table".
-String[] partitionNames = 
-    gravitinoClient
-        .loadCatalog("catalog")
-        .asTableCatalog()
-        .loadTable(NameIdentifier.of("schema", "table"))
-        .supportPartitions()
-        .listPartitionNames();
-```
-
-</TabItem>
-</Tabs>
-
-### List Partitions Under a Partitioned Table
-
-If you want to get more detailed information about the partitions under a partitioned table, you can list all partitions under a partitioned table by sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions` endpoint or by using the Gravitino Java client.
-The following is an example of listing all the partitions under a partitioned table:
-
-<Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
-
-```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tables/table/partitions?details=true
+  "http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/tables/orders/partitions?details=true"
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// Assume that you have a partitioned table named "metalake.catalog.schema.table".
-Partition[] partitions =
-        gravitinoClient
-            .loadCatalog("catalog")
-            .asTableCatalog()
-            .loadTable(NameIdentifier.of("schema", "table"))
-            .supportPartitions()
-            .listPartitions();
+String[] names = orders.supportPartitions().listPartitionNames();
+Partition[] partitions = orders.supportPartitions().listPartitions();
 ```
 
 </TabItem>
 </Tabs>
 
-### Drop a Partition by Name
-
-Drop a partition by its name via sending a `DELETE` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions/{partition_name}` endpoint or by using the Gravitino Java client.
-The following is an example of dropping a partition by its name:
+### Drop a Partition
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tables/table/partitions/p20200321
+  "http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/tables/orders/partitions/dt=2026-08-02%2Fcountry=us"
 ```
-
-:::tip
-If the partition name contains special characters, you should use [URL encoding](https://en.wikipedia.org/wiki/Percent-encoding#Reserved_characters). For example, if the partition name is `dt=2008-08-08/country=us` you should use `dt%3D2008-08-08%2Fcountry%3Dus` in the URL.
-:::
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .withMetalake("metalake")
-    .build();
+boolean dropped = orders.supportPartitions().dropPartition(
+    "dt=2026-08-02/country=us");
 
-// Assume that you have a partitioned table named "metalake.catalog.schema.table".
-Partition Partition = 
-    gravitinoClient
-        .loadCatalog("catalog")
-        .asTableCatalog()
-        .loadTable(NameIdentifier.of("schema", "table"))
-        .supportPartitions()
-        .dropPartition("partition_name");
+boolean purged = orders.supportPartitions().purgePartition(
+    "dt=2026-08-02/country=us");
 ```
 
 </TabItem>
 </Tabs>
+
+Dropping removes the partition metadata. Purging removes its data as well, and is not supported by
+every catalog.

--- a/docs/manage-view-metadata-using-gravitino.md
+++ b/docs/manage-view-metadata-using-gravitino.md
@@ -1,8 +1,7 @@
 ---
 title: "Manage View Metadata"
 slug: "/manage-view-metadata-using-gravitino"
-date: 2026-5-17
-keyword: "Gravitino view metadata manage"
+keyword: "view management, view, SQL view, Gravitino"
 license: "This software is licensed under the Apache License version 2."
 ---
 
@@ -11,279 +10,164 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-This page introduces how to manage view metadata by Apache Gravitino. A view stores a logical
-query definition rather than physical data. Through Gravitino, you can create, load, alter,
-drop, and list views in supported catalogs via unified REST APIs or the Java client.
+This page covers the Gravitino API for views. For what a view is, which catalogs support them, and
+how they relate to tables, see [Tables and Views](./tables-and-views.md). For creating the catalog
+and schema a view lives in, see [Manage Catalogs and Schemas](./manage-catalogs-and-schemas.md).
 
-When a catalog implements view management, Gravitino operates on the provider's native view
-metadata rather than a separate Gravitino-only view type. View capabilities are implemented by
-each catalog provider and may differ in operation coverage and SQL dialect behavior. For detailed
-support, see:
-
-- [Hive view capabilities](./apache-hive-catalog.md#view-capabilities)
-- [Iceberg view capabilities](./lakehouse-iceberg-catalog.md#view-capabilities)
-- [Paimon view capabilities](./lakehouse-paimon-catalog.md#view-capabilities)
-
-Unlike tables, views define query output and one or more representations, but do not manage
-partitions, sort orders, indexes, or physical storage locations. The representation model is
-extensible, but only SQL representations are supported.
-
-To use view management, make sure that:
-
- - Gravitino server has started, and the host and port are [http://localhost:8090](http://localhost:8090).
- - A metalake has been created and [enabled](./manage-metalake-using-gravitino.md#enable-a-metalake).
- - A relational catalog has been created within the metalake.
- - A schema has been created within the catalog.
+Views are supported by the Hive, Iceberg, and Paimon catalogs.
 
 ## View Operations
 
-:::tip
-Users should create a metalake, a catalog, and a schema, and ensure that the metalake and
-catalog are enabled before operating views.
-:::
-
 ### Create a View
 
-Create a view by sending a `POST` request to the
-`/api/metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/views` endpoint or just use the
-Gravitino Java client. The following is an example of creating a view:
+A view carries its columns and one or more representations, each holding a query and the dialect it
+is written in. SQL is the only representation type today. A default catalog and schema can be set so
+unqualified names in the query resolve.
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "name": "example_view",
-  "comment": "This is an example view",
+  -H "Content-Type: application/json" -d '{
+  "name": "active_customers",
+  "comment": "Customers with orders in the last year",
+  "query": "SELECT * FROM customers WHERE last_order_at > current_date - interval 365 day",
+  "dialect": "spark",
   "columns": [
-    {
-      "name": "id",
-      "type": "long",
-      "comment": "id column",
-      "nullable": true
-    }
+    {"name": "id", "type": "integer", "nullable": false},
+    {"name": "name", "type": "varchar(500)", "nullable": true}
   ],
-  "representations": [
-    {
-      "type": "sql",
-      "dialect": "trino",
-      "sql": "SELECT id FROM example_table"
-    },
-    {
-      "type": "sql",
-      "dialect": "spark",
-      "sql": "SELECT id FROM example_table"
-    }
-  ],
-  "defaultCatalog": "iceberg_catalog",
-  "defaultSchema": "schema",
-  "properties": {
-    "key": "value"
-  }
-}' http://localhost:8090/api/metalakes/metalake/catalogs/iceberg_catalog/schemas/schema/views
+  "properties": {}
+}' http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/views
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// Assuming you have just created an Iceberg catalog named `iceberg_catalog`
-Catalog catalog = gravitinoClient.loadCatalog("iceberg_catalog");
-ViewCatalog viewCatalog = catalog.asViewCatalog();
+Catalog catalog = client.loadCatalog("sales");
+ViewCatalog views = catalog.asViewCatalog();
 
-View view = viewCatalog.createView(
-    NameIdentifier.of("schema", "example_view"),
-    "This is an example view",
-    new Column[] {
-        Column.of("id", Types.LongType.get(), "id column")
-    },
-    new Representation[] {
-        SQLRepresentation.builder()
-            .withSql("SELECT id FROM example_table")
-            .withDialect("trino")
-            .build(),
-        SQLRepresentation.builder()
-            .withSql("SELECT id FROM example_table")
-            .withDialect("spark")
-            .build()
-    },
-    "iceberg_catalog",
-    "schema",
-    ImmutableMap.of("key", "value")
-);
-// ...
+Column[] columns = new Column[] {
+    Column.of("id", Types.IntegerType.get(), null, false, false, null),
+    Column.of("name", Types.VarCharType.of(500))
+};
+
+Representation[] representations = new Representation[] {
+    SQLRepresentation.builder()
+        .withDialect("spark")
+        .withSql("SELECT * FROM customers "
+            + "WHERE last_order_at > current_date - interval 365 day")
+        .build()
+};
+
+View view = views.createView(
+    NameIdentifier.of("public", "active_customers"),
+    "Customers with orders in the last year",
+    columns,
+    representations,
+    "sales",
+    "public",
+    ImmutableMap.of());
 ```
 
 </TabItem>
 </Tabs>
 
-:::caution
-The provided example uses an Iceberg catalog and includes `trino` and `spark` SQL
-representations for the same logical view. Supported dialects, representation counts, and
-default-resolution fields depend on the catalog provider.
-:::
-
-#### Create Request Fields
-
-Use the following fields when creating a view:
-
-- `columns`: Defines the output schema of the view.
-- `representations`: Provides one or more SQL definitions. The API uses the extensible
-  `Representation` model, but only the `sql` type is supported, which maps to
-  `SQLRepresentation` in Java.
-- `defaultCatalog` and `defaultSchema`: Optionally define how unqualified identifiers in the SQL
-  text are resolved for dialects that use them. For the `hive` and `flink` dialects in Hive
-  catalogs, both fields must be `null`.
-- `properties`: Carries provider-specific metadata.
-
-Column types use the same Gravitino type system as table columns. For the full type list and the
-behavior of special types such as external and unparsed types, refer to [Apache Gravitino table column type](./manage-relational-metadata-using-gravitino.md#table-column-type).
+Gravitino stores the definition and does not execute it, so whether the query resolves is a question
+for the engine reading the view.
 
 ### Load a View
 
-Load a view by sending a `GET` request to the
-`/api/metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/views/{view}` endpoint or just use
-the Gravitino Java client. The following is an example of loading a view:
-
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/metalake/catalogs/iceberg_catalog/schemas/schema/views/example_view
+  http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/views/active_customers
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// Assuming you have just created an Iceberg catalog named `iceberg_catalog`
-Catalog catalog = gravitinoClient.loadCatalog("iceberg_catalog");
-ViewCatalog viewCatalog = catalog.asViewCatalog();
-View view = viewCatalog.loadView(NameIdentifier.of("schema", "example_view"));
-// ...
+View view = views.loadView(NameIdentifier.of("public", "active_customers"));
 ```
 
 </TabItem>
 </Tabs>
-
-:::note
-- Loading a view returns the metadata exposed by the underlying catalog, including output columns,
-stored representations, default catalog, default schema, comment, and properties.
-- If the provider already exposes a native view through its metadata API, Gravitino can load it
-directly without a separate import step.
-:::
 
 ### Alter a View
 
-Modify a view by sending a `PUT` request to the
-`/api/metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/views/{view}` endpoint or just use
-the Gravitino Java client. The following is an example of modifying a view:
+| Change             | JSON                                                         | Java                                       |
+|--------------------|--------------------------------------------------------------|--------------------------------------------|
+| Rename             | `{"@type":"rename","newName":"view_renamed"}`                | `ViewChange.rename("view_renamed")`        |
+| Update the comment | `{"@type":"updateComment","newComment":"new_comment"}`       | `ViewChange.updateComment("new_comment")`  |
+| Set a property     | `{"@type":"setProperty","property":"key1","value":"value1"}` | `ViewChange.setProperty("key1", "value1")` |
+| Remove a property  | `{"@type":"removeProperty","property":"key1"}`               | `ViewChange.removeProperty("key1")`        |
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
+  -H "Content-Type: application/json" -d '{
   "updates": [
-    {
-      "@type": "rename",
-      "newName": "new_view_name"
-    }
+    {"@type": "updateComment", "newComment": "Customers active in the last year"}
   ]
-}' http://localhost:8090/api/metalakes/metalake/catalogs/iceberg_catalog/schemas/schema/views/example_view
+}' http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/views/active_customers
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// Assuming you have just created an Iceberg catalog named `iceberg_catalog`
-Catalog catalog = gravitinoClient.loadCatalog("iceberg_catalog");
-ViewCatalog viewCatalog = catalog.asViewCatalog();
-View view = viewCatalog.alterView(
-    NameIdentifier.of("schema", "example_view"),
-    ViewChange.rename("new_view_name"),
-    ViewChange.setProperty("key", "value")
-);
-// ...
+View view = views.alterView(
+    NameIdentifier.of("public", "active_customers"),
+    ViewChange.updateComment("Customers active in the last year"));
 ```
 
 </TabItem>
 </Tabs>
-
-Gravitino supports the following changes to a view:
-
-| Supported modification                                 | REST / JSON                                                                                                    | Java                                                                                                  |
-|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
-| Rename view                                            | `{"@type":"rename","newName":"new_view_name"}`                                                          | `ViewChange.rename("new_view_name")`                                                                 |
-| Set a view property                                    | `{"@type":"setProperty","property":"key","value":"value"}`                                           | `ViewChange.setProperty("key", "value")`                                                           |
-| Remove a view property                                 | `{"@type":"removeProperty","property":"key"}`                                                            | `ViewChange.removeProperty("key")`                                                                   |
-| Replace view definition (columns/representations/etc.) | Replace columns, representations, default catalog, default schema, and comment in one update request.         | `ViewChange.replaceView(columns, representations, defaultCatalog, defaultSchema, comment)`            |
-
-`ViewChange.replaceView(...)` performs a full replacement of the view body. If you only want to
-change one part of the body, load the current view first and pass the unchanged fields back in the
-replacement request.
 
 ### Drop a View
 
-Remove a view by sending a `DELETE` request to the
-`/api/metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/views/{view}` endpoint or just use
-the Gravitino Java client. The following is an example of dropping a view:
+Dropping a view removes the definition. The tables it reads are untouched.
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/metalake/catalogs/iceberg_catalog/schemas/schema/views/example_view
+  http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/views/active_customers
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// Assuming you have just created an Iceberg catalog named `iceberg_catalog`
-Catalog catalog = gravitinoClient.loadCatalog("iceberg_catalog");
-ViewCatalog viewCatalog = catalog.asViewCatalog();
-viewCatalog.dropView(NameIdentifier.of("schema", "example_view"));
-// ...
+boolean dropped = views.dropView(NameIdentifier.of("public", "active_customers"));
 ```
 
 </TabItem>
 </Tabs>
 
-Dropping a view removes the view metadata definition only. It does not remove underlying table
-data because a view does not own storage.
-
-### List All Views Under a Schema
-
-List all views in a schema by sending a `GET` request to the
-`/api/metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/views` endpoint or just use the
-Gravitino Java client. The following is an example of listing all the views in a schema:
+### List Views
 
 <Tabs groupId='language' queryString>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label="REST">
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" \
-http://localhost:8090/api/metalakes/metalake/catalogs/iceberg_catalog/schemas/schema/views
+  http://localhost:8090/api/metalakes/example/catalogs/sales/schemas/public/views
 ```
 
 </TabItem>
 <TabItem value="java" label="Java">
 
 ```java
-// Assuming you have just created an Iceberg catalog named `iceberg_catalog`
-Catalog catalog = gravitinoClient.loadCatalog("iceberg_catalog");
-ViewCatalog viewCatalog = catalog.asViewCatalog();
-NameIdentifier[] identifiers = viewCatalog.listViews(Namespace.of("schema"));
-// ...
+NameIdentifier[] identifiers = views.listViews(Namespace.of("public"));
 ```
 
 </TabItem>

--- a/docs/metalakes.md
+++ b/docs/metalakes.md
@@ -1,0 +1,97 @@
+---
+title: "Metalakes"
+slug: "/metalakes"
+keyword: "metalake, tenant, namespace, Gravitino"
+license: "This software is licensed under the Apache License version 2."
+---
+
+## Introduction
+
+A metalake is the top of the Gravitino hierarchy and the boundary everything else lives inside.
+Catalogs, schemas, tables, filesets, topics, models, and functions all sit beneath one, and so do the
+users, groups, roles, tags, policies, and jobs that apply to them.
+
+Nothing crosses that boundary:
+
+- Users and groups are records in one metalake. The same person working in two metalakes needs a
+  user in each, and provisioning them is done per metalake
+- Roles are defined and granted within one metalake, so a role held in one carries no privilege in
+  another
+- A tag or policy created in one metalake cannot be attached to an object in another
+- Names only have to be unique within one metalake
+
+That makes a metalake the unit to reach for when separating environments, business units, or tenants
+that should not see each other's metadata.
+
+Most installations need very few. A metalake per production estate, and perhaps one for development,
+is a common shape. Every client connects to a single metalake and works inside it, so adding more
+means people have to know which one they are in.
+
+## Quick Start
+
+**1. Create the metalake.** Metalakes are created from the metalake list in the UI, or with the
+admin client. A metalake needs a name, and can carry a comment and properties. Only service admins
+can create one.
+
+**2. Connect a catalog.** A new metalake is empty. See
+[Catalogs and Schemas](./catalogs-and-schemas.md).
+
+**3. Point clients at it.** Clients name the metalake when they connect, so everything they do
+afterward happens inside it.
+
+## The Metalake Model
+
+### Names and Properties
+
+A metalake name is unique across the server and is what every client names when it connects, so
+renaming one changes what every stored connection has to ask for.
+
+Properties are free-form key and value pairs, with one reserved key. `in-use` records whether the
+metalake is available, defaults to `true`, and is set through the enable and disable operations
+rather than by writing the property directly.
+
+A metalake cannot carry a tag or a policy, so there is no way to classify or govern everything at
+once from the top. The widest attachment point is a catalog.
+
+### In Use and Not In Use
+
+A metalake that is not in use can only be listed, loaded, enabled, or dropped. Every other operation
+on it or on anything inside it fails, which makes disabling a way to take an estate out of service
+without deleting anything.
+
+Enabling a metalake that is already in use does nothing, and the same is true of disabling one that
+is already out of use.
+
+## Working With Metalakes in the UI
+
+The metalake list holds every metalake on the server. A metalake can be created, edited, enabled or
+disabled, and deleted from there.
+
+Selecting a metalake is what scopes the rest of the UI. Every other screen, including the catalogs,
+compliance, and dashboard views, describes the metalake currently selected.
+
+## Deleting a Metalake
+
+A metalake is deleted with or without force, and the difference matters.
+
+Without force, the metalake must be empty of catalogs and must not be in use. Either condition fails
+the request rather than removing anything.
+
+With force, Gravitino deletes the metalake and everything registered under it, including catalogs,
+schemas, tags, and policies, whether or not the metalake is in use. External systems are left alone,
+so a Hive table or an S3 bucket that was registered rather than created by Gravitino survives.
+Managed objects, such as a managed fileset, are removed with their data.
+
+## Permissions
+
+Creating a metalake is reserved for service admins, configured with
+`gravitino.authorization.serviceAdmins` in the server configuration. Nobody else can create one, no
+matter what privileges they hold.
+
+Altering, enabling, disabling, and dropping a metalake are reserved for its owner.
+
+## Using the API
+
+Metalakes can be created, listed, altered, enabled, disabled, and dropped over REST and through the
+Java and Python admin clients. Endpoints, payload shapes, and worked examples are in
+[Manage Metalakes](./manage-metalake-using-gravitino.md).

--- a/docs/model-catalog.md
+++ b/docs/model-catalog.md
@@ -1,91 +1,88 @@
 ---
 title: "Model Catalog"
 slug: "/model-catalog"
-date: 2024-12-26
-keyword: "model catalog"
+keyword: "model catalog, ML model, model version, model registry, Gravitino"
 license: "This software is licensed under the Apache License version 2."
 ---
 
 ## Introduction
 
-A Model catalog is a metadata catalog that provides the unified interface to manage the metadata of
-machine learning models in a centralized way. It follows the typical Gravitino 3-level namespace
-(catalog, schema, and model) to manage the ML models metadata. In addition, it supports
-managing the versions for each model.
+A model catalog is a registry for machine learning models. It follows the same three-level namespace
+as every other catalog, catalog then schema then model, and adds a fourth level beneath each model
+for its versions.
 
-The advantages of using model catalog are:
+What it stores is the mapping from a name to a location. Instead of jobs and notebooks carrying a
+path to a model file, they resolve a model by name and get the version they asked for. The model
+files themselves stay wherever they live.
 
-* Centralized management of ML models with user defined namespaces. Users can better discover
-  and govern the models from semantic level, rather than managing the model files directly.
-* Version management for each model. Users can easily track the model versions and manage the
-  model lifecycle.
+That indirection is what makes the rest possible. Models sit in the same hierarchy as the tables
+they were trained on, carry tags and policies like anything else, and are governed by the same roles
+and privileges.
 
-The key concept of model management is to manage the path (URI) of the model. Instead of
-managing the model storage path physically and separately, model metadata defines the mapping
-relation between the model name and the storage path. In the meantime, with the support of
-extensible properties of model metadata, users can define the model metadata with more detailed information
-rather than just the storage path.
+Gravitino manages this catalog itself rather than federating an external registry, so a model
+catalog takes no provider.
 
-* **Model**: A model is a metadata object defined in the model catalog, to manage a ML model. Each
-  model can have many **Model Versions**, and each version can have its own properties. Models
-  can be retrieved by the name.
-* **ModelVersion**: The model version is a metadata defined in the model catalog, to manage each
-  version of the ML model. Each version has a unique version number, and can have its own
-  properties and storage path. ModelVersion can be retrieved by the model name and version
-  number. Also, each version can have a list of aliases, which can also be used to retrieve.
+## Quick Start
 
-## Catalog
+**1. Create a model catalog and schema.** See
+[Catalogs and Schemas](./catalogs-and-schemas.md). A model catalog takes no provider and has no
+required properties.
 
-### Catalog Properties
+**2. Register a model.** Registering creates the model as a named object with no versions yet.
 
-A Model catalog doesn't have specific properties. It uses the [common catalog properties](./gravitino-server-config.md#catalog-properties-configuration).
+**3. Link a version.** A version carries the URI where the model lives, plus any aliases you want to
+resolve it by.
 
-### Catalog Operations
+## The Model Registry
 
-Refer to [Catalog operations](./manage-model-metadata-using-gravitino.md#catalog-operations) for more details.
+### Models and Versions
 
-## Schema
+A model is a named object in a schema, and holds no location of its own.
 
-### Schema Capabilities
+A model version is one release of that model. It carries the URI where the files live, an optional
+comment, its own properties, and a version number assigned in sequence starting at zero. A new
+release is a new version rather than an edit of an existing one.
 
-Schema is the second level of the model catalog namespace, the model catalog supports creating, updating, deleting, and listing schemas.
+### Aliases
 
-### Schema Properties
+A version can carry aliases, and an alias resolves to a version the same way its number does. That
+is how a moving pointer such as `production` or `champion` is expressed: link a new version, move
+the alias, and everything resolving by that alias picks up the new release without any code
+changing.
 
-Schema in the model catalog doesn't have predefined properties. Users can define the properties for each schema.
+An alias belongs to one version at a time within a model.
 
-### Schema Operations
+### Several URIs on One Version
 
-Refer to [Schema operation](./manage-model-metadata-using-gravitino.md#schema-operations) for more details.
+A version can carry more than one URI, each with a name, held as a map rather than a single value.
+That is how the same release is described in more than one place, such as a copy per region or per
+storage system.
 
-## Model
+`default-uri-name` picks which one is returned when a caller does not name one, and can be set on
+the version or on the model as a default for all of its versions. A URI supplied without a name is
+recorded as `unknown`.
 
-### Model Capabilities
+### Properties
 
-The Model catalog supports registering, listing and deleting models and model versions.
+Neither the catalog nor its schemas have predefined properties beyond the
+[common catalog properties](./gravitino-server-config.md#catalog-properties-configuration). Models
+and versions carry free-form properties of their own, with `default-uri-name` reserved.
 
-### Model Properties
+## Working With Models in the UI
 
-| Property name      | Description                                         | Default value | Required | Immutable |
-|--------------------|-----------------------------------------------------|---------------|----------|-----------|
-| `default-uri-name` | The default URI name for the versions of the model. | (none)        | No       | No        |
+Opening a model catalog lists its schemas and the models inside them. A model shows its versions,
+their URIs, and their aliases, and versions can be linked from there.
 
-### Model Operations
+Models display the tags they carry, including inherited ones, but cannot be tagged from the UI
+today. Attaching a tag to a model goes through the API.
 
-Refer to [Model operation](./manage-model-metadata-using-gravitino.md#model-operations) for more details.
+## Permissions
 
-## ModelVersion
+Models follow the privileges of the catalog and schema that hold them. See
+[Catalogs and Schemas](./catalogs-and-schemas.md).
 
-### ModelVersion Capabilities
+## Using the API
 
-The Model catalog supports linking, listing and deleting model versions.
-
-### ModelVersion Properties
-
-| Property name      | Description                                                                                                          | Default value | Required | Immutable |
-|--------------------|----------------------------------------------------------------------------------------------------------------------|---------------|----------|-----------|
-| `default-uri-name` | The default URI name for the model version. If set, it will override the `default-uri-name` property at model level. | (none)        | No       | No        |
-
-### ModelVersion Operations
-
-Refer to [ModelVersion operation](./manage-model-metadata-using-gravitino.md#modelversion-operations) for more details.
+Models and versions can be registered, linked, listed, altered, and dropped over REST and through
+the Java and Python clients. Endpoints, payload shapes, and worked examples are in
+[Manage Model Metadata](./manage-model-metadata-using-gravitino.md).

--- a/docs/partitions.md
+++ b/docs/partitions.md
@@ -1,0 +1,119 @@
+---
+title: "Partitions"
+slug: "/partitions"
+keyword: "partition, partition management, partition pruning, Gravitino"
+license: "This software is licensed under the Apache License version 2."
+---
+
+## Introduction
+
+A partition is a named slice of a table's data, and in Gravitino it is a metadata object you can
+list, inspect, add, and remove.
+
+Most of the time partitions look after themselves. A catalog creates them as data arrives and an
+engine prunes them at query time without anyone asking. Managing them by hand matters in a few
+specific cases: expiring data by partition rather than by row, recording statistics per partition so
+a planner can prune on them, and adding a partition ahead of the data that will fill it.
+
+Partitions belong to partitioned tables. A table becomes partitioned when it is created with a
+partitioning strategy, which is a separate thing from the partitions themselves. See
+[Table partitioning, distribution, sort order, and indexes](./table-partitioning-distribution-sort-order-indexes.md).
+
+## Quick Start
+
+**1. Start with a partitioned table.** A table with no partitioning strategy has no partitions to
+manage. See [Tables and Views](./tables-and-views.md).
+
+**2. Pick the path your catalog uses.** On Hive, Glue, and Doris, partitions are objects you manage
+through the Gravitino API. On Iceberg, partitioning is changed through an Iceberg-compatible engine
+pointed at the Iceberg REST catalog service, which listens on port 9001 by default.
+
+**3. List, add, or drop.** Either path goes through an API. The UI shows a table's partitioning but
+does not list, add, or drop individual partitions.
+
+## The Partition Model
+
+### Partition Types
+
+| Type       | Describes                                                        |
+|------------|------------------------------------------------------------------|
+| `IDENTITY` | One value per partitioning column, such as `dt=2026-08-02`       |
+| `RANGE`    | An upper and lower bound, such as a date range                   |
+| `LIST`     | An explicit set of value combinations                            |
+
+The type follows from how the table was partitioned rather than being chosen per partition.
+
+### Where Partition Management Works
+
+Partition management through the Gravitino API works on Hive, Glue, and Doris catalogs. Every
+operation below is available on those three and on no others.
+
+Iceberg, Paimon, and Hudi manage partitions themselves, and the JDBC catalogs other than Doris have
+no partition operations, so a call against one of them fails rather than returning an empty list.
+Nothing is missing from Gravitino for those catalogs, and the sections below say what to do instead.
+
+### Iceberg Tables
+
+Iceberg partitions differently, and the difference is deliberate rather than a gap.
+
+An Iceberg table declares a partition spec, a set of transforms over its columns such as
+`day(event_time)` or `bucket(16, customer_id)`. Partitions are then derived from the data as it
+arrives, which Iceberg calls hidden partitioning. There is no partition object to add, get, or drop,
+which is why Iceberg is not in the list above.
+
+Gravitino sets the spec when it creates the table. Identity, bucket, truncate, year, month, day, and
+hour transforms all convert to an Iceberg spec, with bucket limited to one field. List and range
+partitioning have no Iceberg equivalent and are rejected.
+
+After creation, partitioning is changed through the engine rather than through the Gravitino API.
+Point Spark, Trino, or another Iceberg client at the Iceberg REST catalog service, which listens on
+port 9001 by default, and use the engine's own syntax:
+
+```sql
+ALTER TABLE sales.public.orders ADD PARTITION FIELD day(event_time);
+ALTER TABLE sales.public.orders DROP PARTITION FIELD country;
+```
+
+The Iceberg REST catalog service handles the resulting `AddPartitionSpec` and
+`SetDefaultPartitionSpec` updates, so partition evolution behaves exactly as it does against any
+Iceberg catalog. Existing data is not rewritten, and the new spec applies to what is written
+afterward.
+
+See [Iceberg REST catalog service](./iceberg-rest-service.md).
+
+### Partitions and Statistics
+
+Statistics attach to partitions as well as to whole tables, which is what makes per-partition
+measurements available to a planner. See [Statistics](./statistics.md).
+
+## Working With Partitions in the UI
+
+A table page shows the table's partitioning strategy, the transforms it was created with, and a
+count of how many partition fields it has. A table partitioned by `dt` and `country` shows two.
+Individual partitions are not listed, and adding or dropping one goes through the API.
+
+The display comes from the table itself, so it works for every relational catalog including Iceberg.
+An Iceberg table partitioned by `day(event_time)` shows that transform like any other table, because
+the partition spec is read back and presented in the same form. A count of zero means the table
+declares no partitioning rather than that partitions could not be read.
+
+## Permissions
+
+Partitions follow the table they belong to. Listing them requires the privilege to read the table,
+and adding or dropping requires the privilege to modify it. See
+[Tables and Views](./tables-and-views.md).
+
+## Using the API
+
+On Hive, Glue, and Doris, partitions are listed, added, inspected, and dropped over REST and through
+the Java and Python clients. Endpoints, payload shapes, and worked examples are in
+[Manage Table Partitions](./manage-table-partition-using-gravitino.md).
+
+On Iceberg, partitioning is changed through an Iceberg-compatible engine pointed at the
+[Iceberg REST catalog service](./iceberg-rest-service.md) rather than through these endpoints.
+
+Partition statistics are a separate path and work on any table, including Iceberg. They are held by
+Gravitino rather than by the catalog, so a partition can carry statistics even where the catalog
+exposes no partition objects to list. Partition names are supplied by the caller rather than
+discovered, and statistics are read and written over a range rather than one at a time. See
+[Statistics](./statistics.md) and [Manage Statistics](./manage-statistics-in-gravitino.md).


### PR DESCRIPTION
**Cherry-pick Information:**
- Original commit: 33808f64d791db8463ff249f33507499c8d53170
- Target branch: `branch-1.3`
- Status: ✅ Clean cherry-pick (no conflicts)

**Notes for reviewers:**

Several of the pages this commit touches link to concept pages added by #12327
(`jobs.md`, `statistics.md`, `tables-and-views.md`, `catalogs-and-schemas.md`,
`manage-catalogs-and-schemas.md`). Those are backported by #12373, which is open
and mergeable but not yet merged into `branch-1.3`. Please merge #12373 before
this one, or `branch-1.3` will briefly have dangling links until it lands — the
original PR carried the same ordering note for `main`.