### PR TITLE
[#12382] feat(lance): Support AddColumn via Gravitino API

### DIFF
--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -26,11 +26,14 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -244,7 +247,7 @@ public class LanceTableOperations extends ManagedTableOperations {
   @Override
   public Table alterTable(NameIdentifier ident, TableChange... changes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
-
+    List<Field> fieldsToAdd = prepareFieldsToAdd(changes);
     // Hydrate an empty stored schema before changing the dataset. Otherwise this method can write
     // the latest lance.version while leaving columns empty, making that incomplete metadata look
     // like a zero-column schema already confirmed at the same version.
@@ -254,19 +257,28 @@ public class LanceTableOperations extends ManagedTableOperations {
             || (loadedTable.columns().length == 0
                 && StringUtils.isBlank(
                     loadedTable.properties().get(LanceConstants.LANCE_TABLE_VERSION)));
-    if (unhydratedSchema) {
+    // AddColumn can initialize an empty declared dataset. Other alterations require an existing
+    // schema because they operate on columns or indexes that must already be present.
+    if (fieldsToAdd.isEmpty() && unhydratedSchema) {
       throw new IllegalStateException(
           "Cannot alter Lance table "
               + ident
               + " because its dataset schema is not initialized or could not be loaded");
     }
-    long version = handleLanceTableChange(loadedTable, changes);
+    validateFieldsToAdd(loadedTable, fieldsToAdd);
+    long version = handleLanceTableChange(loadedTable, changes, fieldsToAdd);
+
     // After making changes to the Lance dataset, we need to update the table metadata in
     // Gravitino. If there's any failure during this process, the code will throw an exception
     // and the update won't be applied in Gravitino.
-    TableChange[] metadataChanges = Arrays.copyOf(changes, changes.length + 1);
+    int internalChangeCount = fieldsToAdd.isEmpty() ? 1 : 2;
+    TableChange[] metadataChanges = Arrays.copyOf(changes, changes.length + internalChangeCount);
     metadataChanges[changes.length] =
         TableChange.setProperty(LanceConstants.LANCE_TABLE_VERSION, String.valueOf(version));
+    if (!fieldsToAdd.isEmpty()) {
+      metadataChanges[changes.length + 1] =
+          TableChange.removeProperty(LanceConstants.LANCE_TABLE_DECLARED);
+    }
     return super.alterTable(ident, metadataChanges);
   }
 
@@ -769,10 +781,24 @@ public class LanceTableOperations extends ManagedTableOperations {
    * @return the new version id of the Lance dataset after applying the changes
    */
   long handleLanceTableChange(Table table, TableChange[] changes) {
+    List<Field> fieldsToAdd = prepareFieldsToAdd(changes);
+    validateFieldsToAdd(table, fieldsToAdd);
+    return handleLanceTableChange(table, changes, fieldsToAdd);
+  }
+
+  private long handleLanceTableChange(Table table, TableChange[] changes, List<Field> fieldsToAdd) {
     String location = table.properties().get(Table.PROPERTY_LOCATION);
     Map<String, String> storageOptions =
         LancePropertiesUtils.resolveLanceStorageOptions(catalogProperties, table.properties());
     try (Dataset dataset = openDataset(location, storageOptions)) {
+      if (!fieldsToAdd.isEmpty()) {
+        // Adding all fields in one call creates one Lance schema version and backfills existing
+        // rows with null for the new nullable columns.
+        dataset.addColumns(fieldsToAdd);
+        dataset.checkoutLatest();
+        return dataset.getVersion().getId();
+      }
+
       for (TableChange change : changes) {
         if (change instanceof TableChange.DeleteColumn deleteColumn) {
           dataset.dropColumns(List.of(String.join(".", deleteColumn.fieldName())));
@@ -796,7 +822,7 @@ public class LanceTableOperations extends ManagedTableOperations {
                   .build();
           dataset.alterColumns(List.of(lanceColumnAlter));
         } else {
-          // Currently, only column drop/rename and index addition are supported.
+          // Currently, only column add/drop/rename and index addition are supported.
           // TODO: Support change column type once we have a clear knowledge about the means of
           // castTo in Lance.
           throw new UnsupportedOperationException(
@@ -824,6 +850,78 @@ public class LanceTableOperations extends ManagedTableOperations {
         .uri(location)
         .readOptions(new ReadOptions.Builder().setStorageOptions(storageOptions).build())
         .build();
+  }
+
+  private List<Field> prepareFieldsToAdd(TableChange[] changes) {
+    Preconditions.checkArgument(changes != null && changes.length > 0, "Changes cannot be empty");
+
+    int addColumnCount = 0;
+    for (TableChange change : changes) {
+      Preconditions.checkArgument(change != null, "Table change cannot be null");
+      if (change instanceof TableChange.AddColumn) {
+        addColumnCount++;
+      } else if (!(change instanceof TableChange.DeleteColumn)
+          && !(change instanceof TableChange.AddIndex)
+          && !(change instanceof TableChange.RenameColumn)) {
+        throw new UnsupportedOperationException(
+            "Unsupported changes to lance table: " + change.getClass().getSimpleName());
+      }
+    }
+
+    if (addColumnCount == 0) {
+      return List.of();
+    }
+
+    Preconditions.checkArgument(
+        addColumnCount == changes.length,
+        "Lance AddColumn cannot be combined with other table changes");
+
+    Set<String> columnNames = new HashSet<>();
+    List<Field> fieldsToAdd = new ArrayList<>(changes.length);
+    for (TableChange change : changes) {
+      TableChange.AddColumn addColumn = (TableChange.AddColumn) change;
+      Preconditions.checkArgument(
+          addColumn.fieldName().length == 1,
+          "Lance only supports adding top-level columns: %s",
+          String.join(".", addColumn.fieldName()));
+      String columnName = addColumn.fieldName()[0];
+      Preconditions.checkArgument(
+          addColumn.isNullable(),
+          "Lance only supports adding nullable columns because existing rows are backfilled "
+              + "with null: %s",
+          columnName);
+      Preconditions.checkArgument(
+          TableChange.ColumnPosition.defaultPos().equals(addColumn.getPosition()),
+          "Lance only supports appending new columns: %s",
+          columnName);
+      Preconditions.checkArgument(
+          !addColumn.isAutoIncrement(),
+          "Lance does not support adding auto-increment columns: %s",
+          columnName);
+      Preconditions.checkArgument(
+          addColumn.getDefaultValue() == null
+              || addColumn.getDefaultValue().equals(DEFAULT_VALUE_NOT_SET),
+          "Lance does not support default values when adding columns: %s",
+          columnName);
+      Preconditions.checkArgument(
+          columnNames.add(columnName), "Column %s already exists", columnName);
+      fieldsToAdd.add(
+          LanceDataTypeConverter.CONVERTER.toArrowField(columnName, addColumn.getDataType(), true));
+    }
+    return fieldsToAdd;
+  }
+
+  private void validateFieldsToAdd(Table table, List<Field> fieldsToAdd) {
+    if (fieldsToAdd.isEmpty()) {
+      return;
+    }
+
+    Set<String> columnNames =
+        new HashSet<>(Arrays.stream(table.columns()).map(Column::name).toList());
+    for (Field field : fieldsToAdd) {
+      Preconditions.checkArgument(
+          columnNames.add(field.getName()), "Column %s already exists", field.getName());
+    }
   }
 
   private IndexParams getIndexParamsByIndexType(IndexType indexType) {

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
@@ -271,13 +272,14 @@ public class LanceTableOperations extends ManagedTableOperations {
     // After making changes to the Lance dataset, we need to update the table metadata in
     // Gravitino. If there's any failure during this process, the code will throw an exception
     // and the update won't be applied in Gravitino.
-    int internalChangeCount = fieldsToAdd.isEmpty() ? 1 : 2;
-    TableChange[] metadataChanges = Arrays.copyOf(changes, changes.length + internalChangeCount);
-    metadataChanges[changes.length] =
-        TableChange.setProperty(LanceConstants.LANCE_TABLE_VERSION, String.valueOf(version));
+    TableChange[] metadataChanges =
+        ArrayUtils.add(
+            changes,
+            TableChange.setProperty(LanceConstants.LANCE_TABLE_VERSION, String.valueOf(version)));
     if (!fieldsToAdd.isEmpty()) {
-      metadataChanges[changes.length + 1] =
-          TableChange.removeProperty(LanceConstants.LANCE_TABLE_DECLARED);
+      metadataChanges =
+          ArrayUtils.add(
+              metadataChanges, TableChange.removeProperty(LanceConstants.LANCE_TABLE_DECLARED));
     }
     return super.alterTable(ident, metadataChanges);
   }
@@ -856,58 +858,53 @@ public class LanceTableOperations extends ManagedTableOperations {
     Preconditions.checkArgument(changes != null && changes.length > 0, "Changes cannot be empty");
 
     int addColumnCount = 0;
+    Set<String> columnNames = new HashSet<>();
+    List<Field> fieldsToAdd = new ArrayList<>(changes.length);
     for (TableChange change : changes) {
       Preconditions.checkArgument(change != null, "Table change cannot be null");
-      if (change instanceof TableChange.AddColumn) {
+      if (change instanceof TableChange.AddColumn addColumn) {
         addColumnCount++;
-      } else if (!(change instanceof TableChange.DeleteColumn)
-          && !(change instanceof TableChange.AddIndex)
-          && !(change instanceof TableChange.RenameColumn)) {
+
+        Preconditions.checkArgument(
+            addColumn.fieldName().length == 1,
+            "Lance only supports adding top-level columns: %s",
+            String.join(".", addColumn.fieldName()));
+        String columnName = addColumn.fieldName()[0];
+        Preconditions.checkArgument(
+            addColumn.isNullable(),
+            "Lance only supports adding nullable columns because existing rows are backfilled "
+                + "with null: %s",
+            columnName);
+        Preconditions.checkArgument(
+            TableChange.ColumnPosition.defaultPos().equals(addColumn.getPosition()),
+            "Lance only supports appending new columns: %s",
+            columnName);
+        Preconditions.checkArgument(
+            !addColumn.isAutoIncrement(),
+            "Lance does not support adding auto-increment columns: %s",
+            columnName);
+        Preconditions.checkArgument(
+            addColumn.getDefaultValue() == null
+                || addColumn.getDefaultValue().equals(DEFAULT_VALUE_NOT_SET),
+            "Lance does not support default values when adding columns: %s",
+            columnName);
+        Preconditions.checkArgument(
+            columnNames.add(columnName), "Column %s already exists", columnName);
+        fieldsToAdd.add(
+            LanceDataTypeConverter.CONVERTER.toArrowField(
+                columnName, addColumn.getDataType(), true));
+      } else if (change instanceof TableChange.DeleteColumn
+          || change instanceof TableChange.AddIndex
+          || change instanceof TableChange.RenameColumn) {
+        // Handled by the existing Lance alter-table flow.
+      } else {
         throw new UnsupportedOperationException(
             "Unsupported changes to lance table: " + change.getClass().getSimpleName());
       }
     }
-
-    if (addColumnCount == 0) {
-      return List.of();
-    }
-
     Preconditions.checkArgument(
-        addColumnCount == changes.length,
+        addColumnCount == 0 || addColumnCount == changes.length,
         "Lance AddColumn cannot be combined with other table changes");
-
-    Set<String> columnNames = new HashSet<>();
-    List<Field> fieldsToAdd = new ArrayList<>(changes.length);
-    for (TableChange change : changes) {
-      TableChange.AddColumn addColumn = (TableChange.AddColumn) change;
-      Preconditions.checkArgument(
-          addColumn.fieldName().length == 1,
-          "Lance only supports adding top-level columns: %s",
-          String.join(".", addColumn.fieldName()));
-      String columnName = addColumn.fieldName()[0];
-      Preconditions.checkArgument(
-          addColumn.isNullable(),
-          "Lance only supports adding nullable columns because existing rows are backfilled "
-              + "with null: %s",
-          columnName);
-      Preconditions.checkArgument(
-          TableChange.ColumnPosition.defaultPos().equals(addColumn.getPosition()),
-          "Lance only supports appending new columns: %s",
-          columnName);
-      Preconditions.checkArgument(
-          !addColumn.isAutoIncrement(),
-          "Lance does not support adding auto-increment columns: %s",
-          columnName);
-      Preconditions.checkArgument(
-          addColumn.getDefaultValue() == null
-              || addColumn.getDefaultValue().equals(DEFAULT_VALUE_NOT_SET),
-          "Lance does not support default values when adding columns: %s",
-          columnName);
-      Preconditions.checkArgument(
-          columnNames.add(columnName), "Column %s already exists", columnName);
-      fieldsToAdd.add(
-          LanceDataTypeConverter.CONVERTER.toArrowField(columnName, addColumn.getDataType(), true));
-    }
     return fieldsToAdd;
   }
 

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -688,6 +688,78 @@ public class TestLanceTableOperations {
   }
 
   @Test
+  public void testVersionCheckRecoversAfterAddColumnMetadataUpdateFailure() throws Exception {
+    lanceTableOps.setCatalogProperties(Map.of(LANCE_SCHEMA_REFRESH_MODE, "version-check"));
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("add-column-metadata-failure").toString();
+    AtomicReference<TableEntity> storedTable =
+        new AtomicReference<>(
+            tableEntity(
+                ident,
+                List.of(
+                    ColumnEntity.builder()
+                        .withId(10L)
+                        .withName("id")
+                        .withDataType(Types.IntegerType.get())
+                        .withPosition(0)
+                        .withNullable(true)
+                        .withAuditInfo(AuditInfo.EMPTY)
+                        .build()),
+                Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "8")));
+    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
+        .thenAnswer(invocation -> storedTable.get());
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenThrow(new IOException("metadata unavailable"))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              TableEntity updated = updater.apply(storedTable.get());
+              storedTable.set(updated);
+              return updated;
+            });
+    when(idGenerator.nextId()).thenReturn(11L, 12L);
+
+    Dataset versionCheckDataset = mock(Dataset.class);
+    when(versionCheckDataset.version()).thenReturn(8L);
+    Dataset addDataset = successfulAddDataset(9L);
+    Dataset recoveryDataset = mock(Dataset.class);
+    when(recoveryDataset.version()).thenReturn(9L);
+    when(recoveryDataset.getSchema())
+        .thenReturn(
+            new Schema(
+                List.of(
+                    Field.nullable("id", new ArrowType.Int(32, true)),
+                    Field.nullable("added", new ArrowType.Utf8()))));
+    Mockito.doReturn(versionCheckDataset, addDataset, recoveryDataset)
+        .when(lanceTableOps)
+        .openDataset(location, Map.of());
+
+    RuntimeException failure =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () ->
+                PrincipalUtils.doAs(
+                    new UserPrincipal("tester"),
+                    () ->
+                        lanceTableOps.alterTable(
+                            ident,
+                            TableChange.addColumn(
+                                new String[] {"added"}, Types.StringType.get()))));
+
+    Assertions.assertTrue(failure.getMessage().contains("Failed to alter table"));
+    Assertions.assertEquals(List.of("id"), columnNames(storedTable.get()));
+    verify(addDataset).addColumns(List.of(Field.nullable("added", new ArrowType.Utf8())));
+
+    Table recoveredTable =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+
+    Assertions.assertEquals(List.of("id", "added"), columnNames(recoveredTable));
+    Assertions.assertEquals("9", recoveredTable.properties().get(LANCE_TABLE_VERSION));
+    Assertions.assertEquals(List.of("id", "added"), columnNames(storedTable.get()));
+  }
+
+  @Test
   public void testDirectAddColumnHydratesDeclaredSchema() throws Exception {
     assertDirectAddColumnHydratesEmptyStoredSchema(true);
   }
@@ -790,6 +862,33 @@ public class TestLanceTableOperations {
                 new TableChange[] {
                   TableChange.addColumn(new String[] {"added"}, Types.StringType.get()),
                   TableChange.renameColumn(new String[] {"id"}, "renamed")
+                }));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            lanceTableOps.handleLanceTableChange(
+                table,
+                new TableChange[] {
+                  TableChange.addColumn(new String[] {"added"}, Types.StringType.get()),
+                  TableChange.deleteColumn(new String[] {"id"}, false)
+                }));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            lanceTableOps.handleLanceTableChange(
+                table,
+                new TableChange[] {
+                  TableChange.deleteColumn(new String[] {"id"}, false),
+                  TableChange.addColumn(new String[] {"added"}, Types.StringType.get())
+                }));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            lanceTableOps.handleLanceTableChange(
+                table,
+                new TableChange[] {
+                  TableChange.addColumn(new String[] {"added"}, Types.StringType.get()),
+                  TableChange.addIndex(Index.IndexType.SCALAR, "idx_id", new String[][] {{"id"}})
                 }));
     Assertions.assertThrows(
         IllegalArgumentException.class,
@@ -1314,21 +1413,6 @@ public class TestLanceTableOperations {
     Assertions.assertEquals(List.of("id", "name", "age"), columnNames(storedTable.get()));
     verify(schemaHydrationDataset).getSchema();
     verify(addDataset).addColumns(List.of(Field.nullable("age", new ArrowType.Int(64, true))));
-  }
-
-  private void stubMutableTable(NameIdentifier ident, AtomicReference<TableEntity> storedTable)
-      throws IOException {
-    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
-        .thenAnswer(invocation -> storedTable.get());
-    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
-              TableEntity updated = updater.apply(storedTable.get());
-              storedTable.set(updated);
-              return updated;
-            });
   }
 
   private static List<String> columnNames(Table table) {

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -56,6 +57,7 @@ import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
 import org.apache.gravitino.rel.TableChange;
+import org.apache.gravitino.rel.expressions.literals.Literals;
 import org.apache.gravitino.rel.expressions.sorts.SortOrder;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
@@ -635,6 +637,168 @@ public class TestLanceTableOperations {
   }
 
   @Test
+  public void testAlterTableAddsNullableColumnsInSingleLanceCommit() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("add-column").toString();
+    AtomicReference<TableEntity> storedTable =
+        new AtomicReference<>(
+            tableEntity(
+                ident,
+                List.of(
+                    ColumnEntity.builder()
+                        .withId(10L)
+                        .withName("event_time")
+                        .withDataType(Types.TimestampType.withTimeZone(3))
+                        .withPosition(0)
+                        .withNullable(true)
+                        .withAuditInfo(AuditInfo.EMPTY)
+                        .build()),
+                Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "8")));
+    stubMutableTable(ident, storedTable);
+    when(idGenerator.nextId()).thenReturn(11L, 12L);
+
+    Dataset dataset = mock(Dataset.class);
+    Version version = mock(Version.class);
+    when(dataset.getVersion()).thenReturn(version);
+    when(version.getId()).thenReturn(9L);
+    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
+
+    Table alteredTable =
+        PrincipalUtils.doAs(
+            new UserPrincipal("tester"),
+            () ->
+                lanceTableOps.alterTable(
+                    ident,
+                    TableChange.addColumn(
+                        new String[] {"name"}, Types.StringType.get(), "name comment"),
+                    TableChange.addColumn(
+                        new String[] {"active"}, Types.BooleanType.get(), "active comment")));
+
+    verify(dataset)
+        .addColumns(
+            List.of(
+                Field.nullable("name", new ArrowType.Utf8()),
+                Field.nullable("active", new ArrowType.Bool())));
+    verify(dataset).checkoutLatest();
+    verify(dataset, never()).getSchema();
+    Assertions.assertEquals(List.of("event_time", "name", "active"), columnNames(alteredTable));
+    Assertions.assertEquals("name comment", alteredTable.columns()[1].comment());
+    Assertions.assertEquals("active comment", alteredTable.columns()[2].comment());
+    Assertions.assertEquals("9", alteredTable.properties().get(LANCE_TABLE_VERSION));
+  }
+
+  @Test
+  public void testDirectAddColumnHydratesDeclaredSchema() throws Exception {
+    assertDirectAddColumnHydratesEmptyStoredSchema(true);
+  }
+
+  @Test
+  public void testDirectAddColumnHydratesNonDeclaredEmptySchema() throws Exception {
+    assertDirectAddColumnHydratesEmptyStoredSchema(false);
+  }
+
+  @Test
+  public void testAddColumnClearsDeclaredMarkerForInitiallyEmptyDataset() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("declared-zero-column-add").toString();
+    AtomicReference<TableEntity> storedTable =
+        new AtomicReference<>(
+            tableEntity(
+                ident,
+                List.of(),
+                Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_DECLARED, "true")));
+    stubMutableTable(ident, storedTable);
+    when(idGenerator.nextId()).thenReturn(10L);
+
+    Dataset schemaHydrationDataset = mock(Dataset.class);
+    when(schemaHydrationDataset.version()).thenReturn(3L);
+    when(schemaHydrationDataset.getSchema()).thenReturn(new Schema(List.of()));
+    Dataset addDataset = successfulAddDataset(4L);
+    Mockito.doReturn(schemaHydrationDataset, addDataset)
+        .when(lanceTableOps)
+        .openDataset(location, Map.of());
+
+    Table alteredTable =
+        PrincipalUtils.doAs(
+            new UserPrincipal("tester"),
+            () ->
+                lanceTableOps.alterTable(
+                    ident, TableChange.addColumn(new String[] {"added"}, Types.StringType.get())));
+
+    Assertions.assertEquals(List.of("added"), columnNames(alteredTable));
+    Assertions.assertEquals("4", alteredTable.properties().get(LANCE_TABLE_VERSION));
+    Assertions.assertFalse(alteredTable.properties().containsKey(LANCE_TABLE_DECLARED));
+    Assertions.assertFalse(storedTable.get().properties().containsKey(LANCE_TABLE_DECLARED));
+    verify(addDataset).addColumns(List.of(Field.nullable("added", new ArrowType.Utf8())));
+  }
+
+  @Test
+  public void testAddColumnRejectsUnsupportedOptionsBeforeOpeningDataset() {
+    Table table = mock(Table.class);
+    when(table.properties()).thenReturn(Map.of(Table.PROPERTY_LOCATION, "location"));
+    when(table.columns()).thenReturn(new Column[0]);
+
+    List<TableChange> unsupportedChanges =
+        List.of(
+            TableChange.addColumn(new String[] {"parent", "nested"}, Types.StringType.get()),
+            TableChange.addColumn(new String[] {"required"}, Types.StringType.get(), false),
+            TableChange.addColumn(
+                new String[] {"first"}, Types.StringType.get(), TableChange.ColumnPosition.first()),
+            TableChange.addColumn(
+                new String[] {"sequence"}, Types.LongType.get(), null, null, true, true),
+            TableChange.addColumn(
+                new String[] {"with_default"},
+                Types.IntegerType.get(),
+                Literals.integerLiteral(1)));
+
+    for (TableChange change : unsupportedChanges) {
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> lanceTableOps.handleLanceTableChange(table, new TableChange[] {change}));
+    }
+    verify(lanceTableOps, never()).openDataset("location", Map.of());
+  }
+
+  @Test
+  public void testAddColumnRejectsNameConflictsAndMixedChangesBeforeOpeningDataset() {
+    Table table = mock(Table.class);
+    when(table.properties()).thenReturn(Map.of(Table.PROPERTY_LOCATION, "location"));
+    when(table.columns()).thenReturn(new Column[] {Column.of("id", Types.IntegerType.get(), "id")});
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            lanceTableOps.handleLanceTableChange(
+                table,
+                new TableChange[] {
+                  TableChange.addColumn(new String[] {"id"}, Types.StringType.get())
+                }));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            lanceTableOps.handleLanceTableChange(
+                table,
+                new TableChange[] {
+                  TableChange.addColumn(new String[] {"new_col"}, Types.StringType.get()),
+                  TableChange.addColumn(new String[] {"new_col"}, Types.LongType.get())
+                }));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            lanceTableOps.handleLanceTableChange(
+                table,
+                new TableChange[] {
+                  TableChange.addColumn(new String[] {"added"}, Types.StringType.get()),
+                  TableChange.renameColumn(new String[] {"id"}, "renamed")
+                }));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> lanceTableOps.handleLanceTableChange(table, new TableChange[0]));
+
+    verify(lanceTableOps, never()).openDataset("location", Map.of());
+  }
+
+  @Test
   public void testHandleLanceTableChangeRespectsOrder() {
     Table table = mock(Table.class);
     when(table.properties()).thenReturn(Map.of(Table.PROPERTY_LOCATION, "location"));
@@ -1100,6 +1264,79 @@ public class TestLanceTableOperations {
         loaded.properties().containsKey(LANCE_TABLE_DECLARED),
         "lance.declared must be removed after schema is written");
     verify(dataset).getSchema();
+  }
+
+  private static Dataset successfulAddDataset(long versionId) {
+    Dataset dataset = mock(Dataset.class);
+    Version version = mock(Version.class);
+    when(dataset.getVersion()).thenReturn(version);
+    when(version.getId()).thenReturn(versionId);
+    return dataset;
+  }
+
+  private void assertDirectAddColumnHydratesEmptyStoredSchema(boolean declared) throws Exception {
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location =
+        tempDir.resolve(declared ? "declared-direct-add" : "empty-schema-direct-add").toString();
+    Map<String, String> properties =
+        declared
+            ? Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_DECLARED, "true")
+            : Map.of(Table.PROPERTY_LOCATION, location);
+    AtomicReference<TableEntity> storedTable =
+        new AtomicReference<>(tableEntity(ident, List.of(), properties));
+    stubMutableTable(ident, storedTable);
+    when(idGenerator.nextId()).thenReturn(10L, 11L, 12L);
+
+    Dataset schemaHydrationDataset = mock(Dataset.class);
+    when(schemaHydrationDataset.version()).thenReturn(8L);
+    when(schemaHydrationDataset.getSchema())
+        .thenReturn(
+            new Schema(
+                List.of(
+                    Field.nullable("id", new ArrowType.Int(32, true)),
+                    Field.nullable("name", new ArrowType.Utf8()))));
+    Dataset addDataset = successfulAddDataset(9L);
+    Mockito.doReturn(schemaHydrationDataset, addDataset)
+        .when(lanceTableOps)
+        .openDataset(location, Map.of());
+
+    Table alteredTable =
+        PrincipalUtils.doAs(
+            new UserPrincipal("tester"),
+            () ->
+                lanceTableOps.alterTable(
+                    ident,
+                    TableChange.addColumn(new String[] {"age"}, Types.LongType.get(), "age")));
+
+    Assertions.assertEquals(List.of("id", "name", "age"), columnNames(alteredTable));
+    Assertions.assertEquals("9", alteredTable.properties().get(LANCE_TABLE_VERSION));
+    Assertions.assertFalse(alteredTable.properties().containsKey(LANCE_TABLE_DECLARED));
+    Assertions.assertEquals(List.of("id", "name", "age"), columnNames(storedTable.get()));
+    verify(schemaHydrationDataset).getSchema();
+    verify(addDataset).addColumns(List.of(Field.nullable("age", new ArrowType.Int(64, true))));
+  }
+
+  private void stubMutableTable(NameIdentifier ident, AtomicReference<TableEntity> storedTable)
+      throws IOException {
+    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
+        .thenAnswer(invocation -> storedTable.get());
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              TableEntity updated = updater.apply(storedTable.get());
+              storedTable.set(updated);
+              return updated;
+            });
+  }
+
+  private static List<String> columnNames(Table table) {
+    return Arrays.stream(table.columns()).map(Column::name).toList();
+  }
+
+  private static List<String> columnNames(TableEntity tableEntity) {
+    return tableEntity.columns().stream().map(ColumnEntity::name).toList();
   }
 
   private static TableEntity tableEntity(

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_CREAT
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_DECLARED;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_FORMAT;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_REGISTER;
+import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_VERSION;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
@@ -417,6 +418,162 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
 
     Assertions.assertThrows(
         RuntimeException.class, () -> catalog.asTableCatalog().loadTable(newNameIdentifier));
+  }
+
+  @Test
+  public void testAddNullableColumnsBackfillNullInSingleLanceVersion() throws Exception {
+    String addColumnTableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
+    NameIdentifier tableIdentifier = NameIdentifier.of(schemaName, addColumnTableName);
+    String tableLocation = String.format("%s/%s/%s", tempDirectory, schemaName, addColumnTableName);
+    Map<String, String> properties = createProperties();
+    properties.put(Table.PROPERTY_TABLE_FORMAT, LANCE_TABLE_FORMAT);
+    properties.put(Table.PROPERTY_LOCATION, tableLocation);
+
+    catalog
+        .asTableCatalog()
+        .createTable(
+            tableIdentifier,
+            createColumns(),
+            TABLE_COMMENT,
+            properties,
+            Transforms.EMPTY_TRANSFORM,
+            Distributions.NONE,
+            new SortOrder[0]);
+
+    try (Dataset dataset = Dataset.open().uri(tableLocation).build()) {
+      SourcedTransaction transaction =
+          dataset
+              .newTransactionBuilder()
+              .operation(
+                  Append.builder()
+                      .fragments(
+                          createFragmentMetadata(
+                              tableLocation,
+                              List.of(
+                                  new LanceDataValue(1, 100L, "first"),
+                                  new LanceDataValue(2, 200L, "second")),
+                              dataset.getSchema()))
+                      .build())
+              .transactionProperties(Map.of())
+              .build();
+      try (Dataset ignored = transaction.commit()) {
+        // The committed dataset is closed after the historical rows have been written.
+      }
+    }
+
+    long versionBeforeAlter;
+    try (Dataset dataset = Dataset.open().uri(tableLocation).build()) {
+      versionBeforeAlter = dataset.version();
+    }
+
+    Table alteredTable =
+        catalog
+            .asTableCatalog()
+            .alterTable(
+                tableIdentifier,
+                TableChange.addColumn(
+                    new String[] {"new_nullable_col"}, Types.StringType.get(), "nullable column"),
+                TableChange.addColumn(
+                    new String[] {"new_nullable_long"}, Types.LongType.get(), "nullable long"));
+
+    Assertions.assertEquals(5, alteredTable.columns().length);
+    Assertions.assertEquals("new_nullable_col", alteredTable.columns()[3].name());
+    Assertions.assertEquals("nullable column", alteredTable.columns()[3].comment());
+    Assertions.assertEquals("new_nullable_long", alteredTable.columns()[4].name());
+    Assertions.assertEquals("nullable long", alteredTable.columns()[4].comment());
+
+    int rowCount = 0;
+    try (Dataset dataset = Dataset.open().uri(tableLocation).build();
+        LanceScanner scanner =
+            dataset.newScan(
+                new ScanOptions.Builder()
+                    .columns(List.of("new_nullable_col", "new_nullable_long"))
+                    .build());
+        ArrowReader reader = scanner.scanBatches()) {
+      Assertions.assertEquals(versionBeforeAlter + 1, dataset.version());
+      Assertions.assertEquals(
+          String.valueOf(dataset.version()), alteredTable.properties().get(LANCE_TABLE_VERSION));
+      Field addedStringField = dataset.getSchema().findField("new_nullable_col");
+      Assertions.assertNotNull(addedStringField);
+      Assertions.assertTrue(addedStringField.isNullable());
+      Assertions.assertEquals(new ArrowType.Utf8(), addedStringField.getType());
+      Field addedLongField = dataset.getSchema().findField("new_nullable_long");
+      Assertions.assertNotNull(addedLongField);
+      Assertions.assertTrue(addedLongField.isNullable());
+      Assertions.assertEquals(new ArrowType.Int(64, true), addedLongField.getType());
+
+      while (reader.loadNextBatch()) {
+        VectorSchemaRoot root = reader.getVectorSchemaRoot();
+        VarCharVector stringVector = (VarCharVector) root.getVector("new_nullable_col");
+        BigIntVector longVector = (BigIntVector) root.getVector("new_nullable_long");
+        for (int i = 0; i < root.getRowCount(); i++) {
+          Assertions.assertTrue(stringVector.isNull(i));
+          Assertions.assertTrue(longVector.isNull(i));
+          rowCount++;
+        }
+      }
+    }
+    Assertions.assertEquals(2, rowCount);
+  }
+
+  @Test
+  public void testAddColumnHydratesDeclaredTableWithoutPriorLoad() throws Exception {
+    String declaredTableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
+    NameIdentifier tableIdentifier = NameIdentifier.of(schemaName, declaredTableName);
+    String tableLocation = String.format("%s/%s/%s", tempDirectory, schemaName, declaredTableName);
+    org.apache.arrow.vector.types.pojo.Schema physicalSchema =
+        new org.apache.arrow.vector.types.pojo.Schema(
+            List.of(
+                Field.nullable("id", new ArrowType.Int(32, true)),
+                Field.nullable("name", new ArrowType.Utf8())));
+
+    try (RootAllocator allocator = new RootAllocator();
+        Dataset ignored =
+            Dataset.write()
+                .allocator(allocator)
+                .schema(physicalSchema)
+                .uri(tableLocation)
+                .mode(WriteParams.WriteMode.CREATE)
+                .execute()) {
+      // The physical dataset exists before its declared-only Gravitino metadata is created.
+    }
+
+    Map<String, String> properties = createProperties();
+    properties.put(Table.PROPERTY_TABLE_FORMAT, LANCE_TABLE_FORMAT);
+    properties.put(Table.PROPERTY_LOCATION, tableLocation);
+    properties.put(Table.PROPERTY_EXTERNAL, "true");
+    properties.put(LANCE_TABLE_DECLARED, "true");
+    Table declaredTable =
+        catalog
+            .asTableCatalog()
+            .createTable(
+                tableIdentifier,
+                new Column[0],
+                TABLE_COMMENT,
+                properties,
+                Transforms.EMPTY_TRANSFORM,
+                Distributions.NONE,
+                new SortOrder[0]);
+    Assertions.assertEquals(0, declaredTable.columns().length);
+
+    Table alteredTable =
+        catalog
+            .asTableCatalog()
+            .alterTable(
+                tableIdentifier,
+                TableChange.addColumn(new String[] {"age"}, Types.LongType.get(), "age"));
+
+    Assertions.assertEquals(
+        List.of("id", "name", "age"),
+        Arrays.stream(alteredTable.columns()).map(Column::name).toList());
+    Assertions.assertFalse(alteredTable.properties().containsKey(LANCE_TABLE_DECLARED));
+    try (Dataset dataset = Dataset.open().uri(tableLocation).build()) {
+      Assertions.assertEquals(
+          List.of("id", "name", "age"),
+          dataset.getSchema().getFields().stream().map(Field::getName).toList());
+      Assertions.assertEquals(
+          String.valueOf(dataset.version()), alteredTable.properties().get(LANCE_TABLE_VERSION));
+    }
   }
 
   @Test

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -28,7 +28,7 @@ For Lance tables in a Generic Lakehouse Catalog, the following table summarizes 
 |-----------|-----------------|
 | List      | ✅ Full          |
 | Load      | ✅ Full          |
-| Alter     | Not support now |
+| Alter     | ✅ Partial       |
 | Create    | ✅ Full          |
 | Register  | ✅ Full          |
 | Drop      | ✅ Full          |
@@ -145,6 +145,43 @@ metadata is not associated with the latest dataset version.
 Table operations follow standard relational catalog patterns. See [Table Operations](./manage-relational-metadata-using-gravitino.md#table-operations) for comprehensive documentation.
 
 The following sections provide examples and important details for working with Lance tables. 
+
+#### Add a Column
+
+Lance tables support adding nullable, top-level columns through the Gravitino table API. New
+columns are appended to the schema, and Lance backfills existing rows with `NULL`. Multiple
+`AddColumn` changes in one request are committed as a single Lance schema change.
+
+```shell
+curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" -d '{
+  "updates": [
+    {
+      "@type": "addColumn",
+      "fieldName": ["new_column"],
+      "type": "string",
+      "comment": "New nullable column",
+      "position": "default",
+      "nullable": true,
+      "autoIncrement": false
+    }
+  ]
+}' http://localhost:8090/api/metalakes/test/catalogs/generic_lakehouse_lance_catalog/schemas/schema/tables/lance_table
+```
+
+The following add-column options are not supported:
+
+- Nested columns
+- Non-nullable columns
+- `FIRST` or `AFTER` column positions
+- Default values
+- Auto-increment columns
+- Combining `AddColumn` with another table-change type in the same request
+
+:::note
+This operation is available through the Gravitino table API and Java client. The Lance REST
+`/add_columns` endpoint is not supported yet.
+:::
 
 #### Create a Lance Table
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds first-phase `AddColumn` support for Lance tables through the Gravitino table API.

The implementation:

- Supports nullable, top-level, append-only columns without default values or auto-increment.
- Batches multiple `AddColumn` changes into one `Dataset.addColumns` call.
- Uses Lance's native `NULL` backfill for existing rows.
- Hydrates declared or empty stored metadata before applying the incremental column changes.
- Reuses `super.alterTable` to persist the requested columns, `lance.version`, and remove `lance.declared`.

The implementation follows the existing Lance alter-table consistency model. It does not introduce custom metadata CAS, physical rollback, or strict schema reconstruction.

### Why are the changes needed?

Lance tables currently cannot add columns through the Gravitino table API.

This change provides initial AddColumn support while keeping Lance as the source of truth and keeping broader Lance-to-Gravitino schema reconciliation outside the scope of this PR.

Fix: #12382

### Does this PR introduce _any_ user-facing change?

Yes.

Users can add nullable, top-level columns to Lance tables through the Gravitino table API. Existing rows are backfilled with `NULL`.

The Lance REST `/add_columns` endpoint is not included in this change.

### How was this patch tested?

- Added unit tests for batched AddColumn, validation, declared/empty metadata hydration, and zero-column declared tables.
- Added integration coverage verifying that historical rows are backfilled with `NULL` and multiple columns produce one Lance version.
- Added integration coverage for direct AddColumn on a declared table without a preceding `loadTable`.

Commands:

- `./gradlew spotlessApply`
- `./gradlew :catalogs:catalog-lakehouse-generic:test --tests org.apache.gravitino.catalog.lakehouse.lance.TestLanceTableOperations -PskipITs`
- `./gradlew :catalogs:catalog-lakehouse-generic:check -PskipITs`