### PR TITLE
[#12385] feat(api): Add structured Metric View Java API

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/MetricRepresentation.java
+++ b/api/src/main/java/org/apache/gravitino/rel/MetricRepresentation.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import org.apache.gravitino.annotation.Unstable;
+import org.apache.gravitino.rel.metric.SemanticModel;
+
+/** A structured OSI-compatible {@link Representation} of a Metric View. */
+@Unstable
+public final class MetricRepresentation implements Representation {
+
+  private final SemanticModel semanticModel;
+
+  private MetricRepresentation(SemanticModel semanticModel) {
+    this.semanticModel = semanticModel;
+  }
+
+  /**
+   * Creates a builder for a metric representation.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public String type() {
+    return Representation.TYPE_METRIC;
+  }
+
+  /**
+   * Returns the structured semantic model.
+   *
+   * @return The semantic model.
+   */
+  public SemanticModel semanticModel() {
+    return semanticModel;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof MetricRepresentation)) {
+      return false;
+    }
+    MetricRepresentation that = (MetricRepresentation) other;
+    return Objects.equals(semanticModel, that.semanticModel);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(semanticModel);
+  }
+
+  @Override
+  public String toString() {
+    return "MetricRepresentation{" + "semanticModel=" + semanticModel + '}';
+  }
+
+  /** Builder for {@link MetricRepresentation}. */
+  public static final class Builder {
+    private SemanticModel semanticModel;
+
+    private Builder() {}
+
+    /**
+     * Sets the structured semantic model.
+     *
+     * @param semanticModel The semantic model.
+     * @return This builder.
+     */
+    public Builder withSemanticModel(SemanticModel semanticModel) {
+      this.semanticModel = semanticModel;
+      return this;
+    }
+
+    /**
+     * Builds the metric representation.
+     *
+     * @return The metric representation.
+     */
+    public MetricRepresentation build() {
+      Preconditions.checkArgument(semanticModel != null, "semanticModel must not be null");
+      return new MetricRepresentation(semanticModel);
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/Representation.java
+++ b/api/src/main/java/org/apache/gravitino/rel/Representation.java
@@ -22,8 +22,7 @@ import org.apache.gravitino.annotation.Unstable;
 
 /**
  * A representation of a view's underlying definition. A view can carry multiple representations
- * targeting different engines or dialects. Currently only the {@link #TYPE_SQL SQL} representation
- * type is supported.
+ * targeting different engines or semantic models.
  */
 @Unstable
 public interface Representation {
@@ -31,8 +30,11 @@ public interface Representation {
   /** The representation type for SQL-based view definitions. */
   String TYPE_SQL = "sql";
 
+  /** The representation type for structured metric view definitions. */
+  String TYPE_METRIC = "metric";
+
   /**
-   * Returns the representation type. The only supported value today is {@link #TYPE_SQL}.
+   * Returns the representation type.
    *
    * @return The representation type identifier.
    */

--- a/api/src/main/java/org/apache/gravitino/rel/View.java
+++ b/api/src/main/java/org/apache/gravitino/rel/View.java
@@ -28,9 +28,10 @@ import org.apache.gravitino.annotation.Unstable;
 import org.apache.gravitino.tag.SupportsTags;
 
 /**
- * An interface representing a logical view in a {@link Namespace}. A view is a named query whose
- * definition may be expressed in one or more SQL dialects. A catalog implementation with {@link
- * ViewCatalog} should implement this interface.
+ * An interface representing a view in a {@link Namespace}. A logical view is a named query whose
+ * definition may be expressed in one or more SQL dialects. A Metric View carries a structured
+ * {@link MetricRepresentation}. A catalog implementation with {@link ViewCatalog} should implement
+ * this interface.
  */
 @Unstable
 public interface View extends Auditable {
@@ -111,6 +112,21 @@ public interface View extends Auditable {
         if (dialect.equalsIgnoreCase(sqlRep.dialect())) {
           return Optional.of(sqlRep);
         }
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the structured metric representation when this is a Metric View.
+   *
+   * @return The metric representation, or {@link Optional#empty()} for a logical View.
+   */
+  default Optional<MetricRepresentation> metricRepresentation() {
+    Representation[] reps = representations();
+    for (Representation rep : reps) {
+      if (rep instanceof MetricRepresentation) {
+        return Optional.of((MetricRepresentation) rep);
       }
     }
     return Optional.empty();

--- a/api/src/main/java/org/apache/gravitino/rel/ViewCatalog.java
+++ b/api/src/main/java/org/apache/gravitino/rel/ViewCatalog.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.rel;
 
+import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.gravitino.NameIdentifier;
@@ -101,6 +102,40 @@ public interface ViewCatalog {
       Map<String, String> properties)
       throws NoSuchSchemaException, ViewAlreadyExistsException {
     throw new UnsupportedOperationException("createView is not supported");
+  }
+
+  /**
+   * Creates a Metric View through the existing View lifecycle.
+   *
+   * <p>A Metric View has no fixed output columns and contains exactly one {@link
+   * MetricRepresentation}. It does not use a default catalog or schema because each dataset source
+   * is catalog and schema qualified.
+   *
+   * @param ident A view identifier.
+   * @param comment The view comment, or {@code null}.
+   * @param representation The Metric View representation.
+   * @param properties The view properties.
+   * @return The created Metric View.
+   * @throws NoSuchSchemaException If the schema does not exist.
+   * @throws ViewAlreadyExistsException If the view already exists.
+   * @throws IllegalArgumentException If the Metric View constraints are violated.
+   */
+  default View createMetricView(
+      NameIdentifier ident,
+      @Nullable String comment,
+      MetricRepresentation representation,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, ViewAlreadyExistsException {
+    Preconditions.checkArgument(
+        representation != null, "A Metric View must contain one MetricRepresentation");
+    return createView(
+        ident,
+        comment,
+        new Column[0],
+        new Representation[] {representation},
+        null,
+        null,
+        properties);
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/rel/metric/AIContext.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/AIContext.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.annotation.Unstable;
+
+/** AI-oriented context represented either as text or as a structured object. */
+@Unstable
+public final class AIContext {
+
+  private static final List<String> RESERVED_PROPERTIES =
+      java.util.Arrays.asList("instructions", "synonyms", "examples");
+
+  @Nullable private final String text;
+  @Nullable private final String instructions;
+  private final List<String> synonyms;
+  private final List<String> examples;
+  private final Map<String, Object> additionalProperties;
+
+  private AIContext(
+      @Nullable String text,
+      @Nullable String instructions,
+      List<String> synonyms,
+      List<String> examples,
+      Map<String, Object> additionalProperties) {
+    this.text = text;
+    this.instructions = instructions;
+    this.synonyms = synonyms;
+    this.examples = examples;
+    this.additionalProperties = additionalProperties;
+  }
+
+  /**
+   * Creates text-form AI context.
+   *
+   * @param text The context text.
+   * @return Text-form AI context.
+   */
+  public static AIContext of(String text) {
+    return new AIContext(
+        SemanticModelUtils.requireNonBlank(text, "text"),
+        null,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyMap());
+  }
+
+  /**
+   * Creates a builder for structured AI context.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns whether this context uses the text form.
+   *
+   * @return {@code true} for text-form context.
+   */
+  public boolean isText() {
+    return text != null;
+  }
+
+  /**
+   * Returns the text-form value.
+   *
+   * @return The text, or {@code null} for structured context.
+   */
+  @Nullable
+  public String text() {
+    return text;
+  }
+
+  /**
+   * Returns structured instructions.
+   *
+   * @return The instructions, or {@code null} when absent or when this is text-form context.
+   */
+  @Nullable
+  public String instructions() {
+    return instructions;
+  }
+
+  /**
+   * Returns structured synonyms.
+   *
+   * @return An immutable list of synonyms.
+   */
+  public List<String> synonyms() {
+    return synonyms;
+  }
+
+  /**
+   * Returns structured examples.
+   *
+   * @return An immutable list of examples.
+   */
+  public List<String> examples() {
+    return examples;
+  }
+
+  /**
+   * Returns additional structured properties retained from the OSI model.
+   *
+   * @return An immutable map of additional properties.
+   */
+  public Map<String, Object> additionalProperties() {
+    return additionalProperties;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof AIContext)) {
+      return false;
+    }
+    AIContext that = (AIContext) other;
+    return Objects.equals(text, that.text)
+        && Objects.equals(instructions, that.instructions)
+        && Objects.equals(synonyms, that.synonyms)
+        && Objects.equals(examples, that.examples)
+        && Objects.equals(additionalProperties, that.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(text, instructions, synonyms, examples, additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return "AIContext{"
+        + "text='"
+        + text
+        + '\''
+        + ", instructions='"
+        + instructions
+        + '\''
+        + ", synonyms="
+        + synonyms
+        + ", examples="
+        + examples
+        + ", additionalProperties="
+        + additionalProperties
+        + '}';
+  }
+
+  /** Builder for structured {@link AIContext}. */
+  public static final class Builder {
+    @Nullable private String instructions;
+    private List<String> synonyms;
+    private List<String> examples;
+    private Map<String, Object> additionalProperties;
+
+    private Builder() {}
+
+    /**
+     * Sets instructions for consumers of the semantic definition.
+     *
+     * @param instructions The instructions.
+     * @return This builder.
+     */
+    public Builder withInstructions(@Nullable String instructions) {
+      this.instructions = instructions;
+      return this;
+    }
+
+    /**
+     * Sets synonyms for the semantic definition.
+     *
+     * @param synonyms The synonyms.
+     * @return This builder.
+     */
+    public Builder withSynonyms(List<String> synonyms) {
+      this.synonyms = synonyms;
+      return this;
+    }
+
+    /**
+     * Sets examples for the semantic definition.
+     *
+     * @param examples The examples.
+     * @return This builder.
+     */
+    public Builder withExamples(List<String> examples) {
+      this.examples = examples;
+      return this;
+    }
+
+    /**
+     * Sets additional structured properties.
+     *
+     * @param additionalProperties Additional OSI properties.
+     * @return This builder.
+     */
+    public Builder withAdditionalProperties(Map<String, Object> additionalProperties) {
+      this.additionalProperties = additionalProperties;
+      return this;
+    }
+
+    /**
+     * Builds structured AI context.
+     *
+     * @return The structured AI context.
+     */
+    public AIContext build() {
+      Map<String, Object> copiedProperties = SemanticModelUtils.immutableMap(additionalProperties);
+      Preconditions.checkArgument(
+          copiedProperties.keySet().stream().noneMatch(RESERVED_PROPERTIES::contains),
+          "additionalProperties must not redefine instructions, synonyms, or examples");
+      return new AIContext(
+          null,
+          instructions,
+          SemanticModelUtils.immutableList(synonyms, "synonyms"),
+          SemanticModelUtils.immutableList(examples, "examples"),
+          copiedProperties);
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/CustomExtension.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/CustomExtension.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import java.util.Objects;
+import org.apache.gravitino.annotation.Unstable;
+
+/** Vendor-specific extension data carried by an OSI-compatible semantic model. */
+@Unstable
+public final class CustomExtension {
+
+  private final String vendorName;
+  private final String data;
+
+  private CustomExtension(String vendorName, String data) {
+    this.vendorName = vendorName;
+    this.data = data;
+  }
+
+  /**
+   * Creates a builder for a custom extension.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns the extension vendor name.
+   *
+   * @return The vendor name.
+   */
+  public String vendorName() {
+    return vendorName;
+  }
+
+  /**
+   * Returns the opaque extension data.
+   *
+   * @return The extension data.
+   */
+  public String data() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof CustomExtension)) {
+      return false;
+    }
+    CustomExtension that = (CustomExtension) other;
+    return Objects.equals(vendorName, that.vendorName) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(vendorName, data);
+  }
+
+  @Override
+  public String toString() {
+    return "CustomExtension{" + "vendorName='" + vendorName + '\'' + ", data='" + data + '\'' + '}';
+  }
+
+  /** Builder for {@link CustomExtension}. */
+  public static final class Builder {
+    private String vendorName;
+    private String data;
+
+    private Builder() {}
+
+    /**
+     * Sets the extension vendor name.
+     *
+     * @param vendorName The vendor name.
+     * @return This builder.
+     */
+    public Builder withVendorName(String vendorName) {
+      this.vendorName = vendorName;
+      return this;
+    }
+
+    /**
+     * Sets the opaque extension data.
+     *
+     * @param data The extension data.
+     * @return This builder.
+     */
+    public Builder withData(String data) {
+      this.data = data;
+      return this;
+    }
+
+    /**
+     * Builds the custom extension.
+     *
+     * @return The custom extension.
+     */
+    public CustomExtension build() {
+      return new CustomExtension(
+          SemanticModelUtils.requireNonBlank(vendorName, "vendorName"),
+          SemanticModelUtils.requireNonBlank(data, "data"));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/Dataset.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/Dataset.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.Unstable;
+
+/** A dataset participating in an OSI-compatible semantic model. */
+@Unstable
+public final class Dataset {
+
+  private final String name;
+  private final NameIdentifier source;
+  private final List<String> primaryKey;
+  private final List<List<String>> uniqueKeys;
+  @Nullable private final String description;
+  @Nullable private final AIContext aiContext;
+  private final List<Field> fields;
+  private final List<CustomExtension> customExtensions;
+
+  private Dataset(
+      String name,
+      NameIdentifier source,
+      List<String> primaryKey,
+      List<List<String>> uniqueKeys,
+      @Nullable String description,
+      @Nullable AIContext aiContext,
+      List<Field> fields,
+      List<CustomExtension> customExtensions) {
+    this.name = name;
+    this.source = source;
+    this.primaryKey = primaryKey;
+    this.uniqueKeys = uniqueKeys;
+    this.description = description;
+    this.aiContext = aiContext;
+    this.fields = fields;
+    this.customExtensions = customExtensions;
+  }
+
+  /**
+   * @return A new dataset builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * @return The dataset name.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * @return The catalog and schema-qualified source identifier.
+   */
+  public NameIdentifier source() {
+    return source;
+  }
+
+  /**
+   * @return An immutable primary-key column list.
+   */
+  public List<String> primaryKey() {
+    return primaryKey;
+  }
+
+  /**
+   * @return An immutable list of unique-key column lists.
+   */
+  public List<List<String>> uniqueKeys() {
+    return uniqueKeys;
+  }
+
+  /**
+   * @return The dataset description, or {@code null}.
+   */
+  @Nullable
+  public String description() {
+    return description;
+  }
+
+  /**
+   * @return The AI context, or {@code null}.
+   */
+  @Nullable
+  public AIContext aiContext() {
+    return aiContext;
+  }
+
+  /**
+   * @return An immutable list of fields.
+   */
+  public List<Field> fields() {
+    return fields;
+  }
+
+  /**
+   * @return An immutable list of custom extensions.
+   */
+  public List<CustomExtension> customExtensions() {
+    return customExtensions;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Dataset)) {
+      return false;
+    }
+    Dataset that = (Dataset) other;
+    return Objects.equals(name, that.name)
+        && Objects.equals(source, that.source)
+        && Objects.equals(primaryKey, that.primaryKey)
+        && Objects.equals(uniqueKeys, that.uniqueKeys)
+        && Objects.equals(description, that.description)
+        && Objects.equals(aiContext, that.aiContext)
+        && Objects.equals(fields, that.fields)
+        && Objects.equals(customExtensions, that.customExtensions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        name, source, primaryKey, uniqueKeys, description, aiContext, fields, customExtensions);
+  }
+
+  @Override
+  public String toString() {
+    return "Dataset{"
+        + "name='"
+        + name
+        + '\''
+        + ", source="
+        + source
+        + ", primaryKey="
+        + primaryKey
+        + ", uniqueKeys="
+        + uniqueKeys
+        + ", description='"
+        + description
+        + '\''
+        + ", aiContext="
+        + aiContext
+        + ", fields="
+        + fields
+        + ", customExtensions="
+        + customExtensions
+        + '}';
+  }
+
+  /** Builder for {@link Dataset}. */
+  public static final class Builder {
+    private String name;
+    private NameIdentifier source;
+    private List<String> primaryKey;
+    private List<List<String>> uniqueKeys;
+    @Nullable private String description;
+    @Nullable private AIContext aiContext;
+    private List<Field> fields;
+    private List<CustomExtension> customExtensions;
+
+    private Builder() {}
+
+    /**
+     * Sets the dataset name.
+     *
+     * @param name The dataset name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the catalog and schema-qualified source.
+     *
+     * @param source The source identifier.
+     * @return This builder.
+     */
+    public Builder withSource(NameIdentifier source) {
+      this.source = source;
+      return this;
+    }
+
+    /**
+     * Sets the primary-key columns.
+     *
+     * @param primaryKey The primary-key columns.
+     * @return This builder.
+     */
+    public Builder withPrimaryKey(List<String> primaryKey) {
+      this.primaryKey = primaryKey;
+      return this;
+    }
+
+    /**
+     * Sets the unique-key column lists.
+     *
+     * @param uniqueKeys The unique-key column lists.
+     * @return This builder.
+     */
+    public Builder withUniqueKeys(List<List<String>> uniqueKeys) {
+      this.uniqueKeys = uniqueKeys;
+      return this;
+    }
+
+    /**
+     * Sets the dataset description.
+     *
+     * @param description The dataset description.
+     * @return This builder.
+     */
+    public Builder withDescription(@Nullable String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Sets the AI context.
+     *
+     * @param aiContext The AI context.
+     * @return This builder.
+     */
+    public Builder withAIContext(@Nullable AIContext aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+
+    /**
+     * Sets the dataset fields.
+     *
+     * @param fields The dataset fields.
+     * @return This builder.
+     */
+    public Builder withFields(List<Field> fields) {
+      this.fields = fields;
+      return this;
+    }
+
+    /**
+     * Sets the custom extensions.
+     *
+     * @param customExtensions The custom extensions.
+     * @return This builder.
+     */
+    public Builder withCustomExtensions(List<CustomExtension> customExtensions) {
+      this.customExtensions = customExtensions;
+      return this;
+    }
+
+    /**
+     * @return The dataset.
+     */
+    public Dataset build() {
+      Preconditions.checkArgument(source != null, "source must not be null");
+      Preconditions.checkArgument(
+          source.namespace().length() == 2,
+          "source namespace must contain catalog and schema: %s",
+          source);
+      return new Dataset(
+          SemanticModelUtils.requireNonBlank(name, "name"),
+          source,
+          SemanticModelUtils.immutableList(primaryKey, "primaryKey"),
+          SemanticModelUtils.immutableNestedStringList(uniqueKeys, "uniqueKeys"),
+          description,
+          aiContext,
+          SemanticModelUtils.immutableList(fields, "fields"),
+          SemanticModelUtils.immutableList(customExtensions, "customExtensions"));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/DialectExpression.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/DialectExpression.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import java.util.Objects;
+import org.apache.gravitino.annotation.Unstable;
+
+/** An expression written in a particular dialect. */
+@Unstable
+public final class DialectExpression {
+
+  private final String dialect;
+  private final String expression;
+
+  private DialectExpression(String dialect, String expression) {
+    this.dialect = dialect;
+    this.expression = expression;
+  }
+
+  /**
+   * Creates a builder for a dialect expression.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns the expression dialect.
+   *
+   * @return The dialect.
+   */
+  public String dialect() {
+    return dialect;
+  }
+
+  /**
+   * Returns the expression text.
+   *
+   * @return The expression text.
+   */
+  public String expression() {
+    return expression;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof DialectExpression)) {
+      return false;
+    }
+    DialectExpression that = (DialectExpression) other;
+    return Objects.equals(dialect, that.dialect) && Objects.equals(expression, that.expression);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dialect, expression);
+  }
+
+  @Override
+  public String toString() {
+    return "DialectExpression{" + "dialect=" + dialect + ", expression='" + expression + '\'' + '}';
+  }
+
+  /** Builder for {@link DialectExpression}. */
+  public static final class Builder {
+    private String dialect;
+    private String expression;
+
+    private Builder() {}
+
+    /**
+     * Sets the expression dialect.
+     *
+     * @param dialect The dialect.
+     * @return This builder.
+     */
+    public Builder withDialect(String dialect) {
+      this.dialect = dialect;
+      return this;
+    }
+
+    /**
+     * Sets the expression text.
+     *
+     * @param expression The expression text.
+     * @return This builder.
+     */
+    public Builder withExpression(String expression) {
+      this.expression = expression;
+      return this;
+    }
+
+    /**
+     * Builds the dialect expression.
+     *
+     * @return The dialect expression.
+     */
+    public DialectExpression build() {
+      return new DialectExpression(
+          SemanticModelUtils.requireNonBlank(dialect, "dialect"),
+          SemanticModelUtils.requireNonBlank(expression, "expression"));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/Dimension.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/Dimension.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.annotation.Unstable;
+
+/** Optional dimensional metadata for a metric field. */
+@Unstable
+public final class Dimension {
+
+  @Nullable private final Boolean time;
+
+  private Dimension(@Nullable Boolean time) {
+    this.time = time;
+  }
+
+  /**
+   * Creates a builder for dimensional metadata.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns whether this is a time dimension.
+   *
+   * @return The time flag, or {@code null} when unspecified.
+   */
+  @Nullable
+  public Boolean isTime() {
+    return time;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Dimension)) {
+      return false;
+    }
+    Dimension that = (Dimension) other;
+    return Objects.equals(time, that.time);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(time);
+  }
+
+  @Override
+  public String toString() {
+    return "Dimension{" + "time=" + time + '}';
+  }
+
+  /** Builder for {@link Dimension}. */
+  public static final class Builder {
+    @Nullable private Boolean time;
+
+    private Builder() {}
+
+    /**
+     * Sets whether this is a time dimension.
+     *
+     * @param time The time flag.
+     * @return This builder.
+     */
+    public Builder withTime(@Nullable Boolean time) {
+      this.time = time;
+      return this;
+    }
+
+    /**
+     * Builds the dimensional metadata.
+     *
+     * @return The dimensional metadata.
+     */
+    public Dimension build() {
+      return new Dimension(time);
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/Expression.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/Expression.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.gravitino.annotation.Unstable;
+
+/** A semantic-model expression with one or more dialect-specific forms. */
+@Unstable
+public final class Expression {
+
+  private final List<DialectExpression> dialects;
+
+  private Expression(List<DialectExpression> dialects) {
+    this.dialects = dialects;
+  }
+
+  /**
+   * Creates a builder for an expression.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns the dialect-specific expressions.
+   *
+   * @return An immutable, non-empty list of expressions.
+   */
+  public List<DialectExpression> dialects() {
+    return dialects;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Expression)) {
+      return false;
+    }
+    Expression that = (Expression) other;
+    return Objects.equals(dialects, that.dialects);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dialects);
+  }
+
+  @Override
+  public String toString() {
+    return "Expression{" + "dialects=" + dialects + '}';
+  }
+
+  /** Builder for {@link Expression}. */
+  public static final class Builder {
+    private List<DialectExpression> dialects;
+
+    private Builder() {}
+
+    /**
+     * Sets the dialect-specific expressions.
+     *
+     * @param dialects The expressions.
+     * @return This builder.
+     */
+    public Builder withDialects(List<DialectExpression> dialects) {
+      this.dialects = dialects;
+      return this;
+    }
+
+    /**
+     * Builds the expression.
+     *
+     * @return The expression.
+     */
+    public Expression build() {
+      return new Expression(SemanticModelUtils.requireNonEmptyList(dialects, "dialects"));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/Field.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/Field.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.annotation.Unstable;
+
+/** A named field in a semantic-model dataset. */
+@Unstable
+public final class Field {
+
+  private final String name;
+  private final Expression expression;
+  @Nullable private final Dimension dimension;
+  @Nullable private final String label;
+  @Nullable private final String description;
+  @Nullable private final AIContext aiContext;
+  private final List<CustomExtension> customExtensions;
+
+  private Field(
+      String name,
+      Expression expression,
+      @Nullable Dimension dimension,
+      @Nullable String label,
+      @Nullable String description,
+      @Nullable AIContext aiContext,
+      List<CustomExtension> customExtensions) {
+    this.name = name;
+    this.expression = expression;
+    this.dimension = dimension;
+    this.label = label;
+    this.description = description;
+    this.aiContext = aiContext;
+    this.customExtensions = customExtensions;
+  }
+
+  /**
+   * Creates a builder for a field.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * @return The field name.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * @return The field expression.
+   */
+  public Expression expression() {
+    return expression;
+  }
+
+  /**
+   * @return The dimension metadata, or {@code null}.
+   */
+  @Nullable
+  public Dimension dimension() {
+    return dimension;
+  }
+
+  /**
+   * @return The display label, or {@code null}.
+   */
+  @Nullable
+  public String label() {
+    return label;
+  }
+
+  /**
+   * @return The field description, or {@code null}.
+   */
+  @Nullable
+  public String description() {
+    return description;
+  }
+
+  /**
+   * @return The AI context, or {@code null}.
+   */
+  @Nullable
+  public AIContext aiContext() {
+    return aiContext;
+  }
+
+  /**
+   * @return An immutable list of custom extensions.
+   */
+  public List<CustomExtension> customExtensions() {
+    return customExtensions;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Field)) {
+      return false;
+    }
+    Field that = (Field) other;
+    return Objects.equals(name, that.name)
+        && Objects.equals(expression, that.expression)
+        && Objects.equals(dimension, that.dimension)
+        && Objects.equals(label, that.label)
+        && Objects.equals(description, that.description)
+        && Objects.equals(aiContext, that.aiContext)
+        && Objects.equals(customExtensions, that.customExtensions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        name, expression, dimension, label, description, aiContext, customExtensions);
+  }
+
+  @Override
+  public String toString() {
+    return "Field{"
+        + "name='"
+        + name
+        + '\''
+        + ", expression="
+        + expression
+        + ", dimension="
+        + dimension
+        + ", label='"
+        + label
+        + '\''
+        + ", description='"
+        + description
+        + '\''
+        + ", aiContext="
+        + aiContext
+        + ", customExtensions="
+        + customExtensions
+        + '}';
+  }
+
+  /** Builder for {@link Field}. */
+  public static final class Builder {
+    private String name;
+    private Expression expression;
+    @Nullable private Dimension dimension;
+    @Nullable private String label;
+    @Nullable private String description;
+    @Nullable private AIContext aiContext;
+    private List<CustomExtension> customExtensions;
+
+    private Builder() {}
+
+    /**
+     * Sets the field name.
+     *
+     * @param name The field name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the field expression.
+     *
+     * @param expression The field expression.
+     * @return This builder.
+     */
+    public Builder withExpression(Expression expression) {
+      this.expression = expression;
+      return this;
+    }
+
+    /**
+     * Sets the dimension metadata.
+     *
+     * @param dimension The dimension metadata.
+     * @return This builder.
+     */
+    public Builder withDimension(@Nullable Dimension dimension) {
+      this.dimension = dimension;
+      return this;
+    }
+
+    /**
+     * Sets the display label.
+     *
+     * @param label The display label.
+     * @return This builder.
+     */
+    public Builder withLabel(@Nullable String label) {
+      this.label = label;
+      return this;
+    }
+
+    /**
+     * Sets the field description.
+     *
+     * @param description The field description.
+     * @return This builder.
+     */
+    public Builder withDescription(@Nullable String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Sets the AI context.
+     *
+     * @param aiContext The AI context.
+     * @return This builder.
+     */
+    public Builder withAIContext(@Nullable AIContext aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+
+    /**
+     * Sets the custom extensions.
+     *
+     * @param customExtensions The custom extensions.
+     * @return This builder.
+     */
+    public Builder withCustomExtensions(List<CustomExtension> customExtensions) {
+      this.customExtensions = customExtensions;
+      return this;
+    }
+
+    /**
+     * @return The field.
+     */
+    public Field build() {
+      Preconditions.checkArgument(expression != null, "expression must not be null");
+      return new Field(
+          SemanticModelUtils.requireNonBlank(name, "name"),
+          expression,
+          dimension,
+          label,
+          description,
+          aiContext,
+          SemanticModelUtils.immutableList(customExtensions, "customExtensions"));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/Metric.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/Metric.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.annotation.Unstable;
+
+/** A named metric in a semantic model. */
+@Unstable
+public final class Metric {
+
+  private final String name;
+  private final Expression expression;
+  @Nullable private final String description;
+  @Nullable private final AIContext aiContext;
+  private final List<CustomExtension> customExtensions;
+
+  private Metric(
+      String name,
+      Expression expression,
+      @Nullable String description,
+      @Nullable AIContext aiContext,
+      List<CustomExtension> customExtensions) {
+    this.name = name;
+    this.expression = expression;
+    this.description = description;
+    this.aiContext = aiContext;
+    this.customExtensions = customExtensions;
+  }
+
+  /**
+   * @return A new metric builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * @return The metric name.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * @return The metric expression.
+   */
+  public Expression expression() {
+    return expression;
+  }
+
+  /**
+   * @return The metric description, or {@code null}.
+   */
+  @Nullable
+  public String description() {
+    return description;
+  }
+
+  /**
+   * @return The AI context, or {@code null}.
+   */
+  @Nullable
+  public AIContext aiContext() {
+    return aiContext;
+  }
+
+  /**
+   * @return An immutable list of custom extensions.
+   */
+  public List<CustomExtension> customExtensions() {
+    return customExtensions;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Metric)) {
+      return false;
+    }
+    Metric that = (Metric) other;
+    return Objects.equals(name, that.name)
+        && Objects.equals(expression, that.expression)
+        && Objects.equals(description, that.description)
+        && Objects.equals(aiContext, that.aiContext)
+        && Objects.equals(customExtensions, that.customExtensions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, expression, description, aiContext, customExtensions);
+  }
+
+  @Override
+  public String toString() {
+    return "Metric{"
+        + "name='"
+        + name
+        + '\''
+        + ", expression="
+        + expression
+        + ", description='"
+        + description
+        + '\''
+        + ", aiContext="
+        + aiContext
+        + ", customExtensions="
+        + customExtensions
+        + '}';
+  }
+
+  /** Builder for {@link Metric}. */
+  public static final class Builder {
+    private String name;
+    private Expression expression;
+    @Nullable private String description;
+    @Nullable private AIContext aiContext;
+    private List<CustomExtension> customExtensions;
+
+    private Builder() {}
+
+    /**
+     * Sets the metric name.
+     *
+     * @param name The metric name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the metric expression.
+     *
+     * @param expression The metric expression.
+     * @return This builder.
+     */
+    public Builder withExpression(Expression expression) {
+      this.expression = expression;
+      return this;
+    }
+
+    /**
+     * Sets the metric description.
+     *
+     * @param description The metric description.
+     * @return This builder.
+     */
+    public Builder withDescription(@Nullable String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Sets the AI context.
+     *
+     * @param aiContext The AI context.
+     * @return This builder.
+     */
+    public Builder withAIContext(@Nullable AIContext aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+
+    /**
+     * Sets the custom extensions.
+     *
+     * @param customExtensions The custom extensions.
+     * @return This builder.
+     */
+    public Builder withCustomExtensions(List<CustomExtension> customExtensions) {
+      this.customExtensions = customExtensions;
+      return this;
+    }
+
+    /**
+     * @return The metric.
+     */
+    public Metric build() {
+      Preconditions.checkArgument(expression != null, "expression must not be null");
+      return new Metric(
+          SemanticModelUtils.requireNonBlank(name, "name"),
+          expression,
+          description,
+          aiContext,
+          SemanticModelUtils.immutableList(customExtensions, "customExtensions"));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/MetricDialects.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/MetricDialects.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import org.apache.gravitino.annotation.Unstable;
+
+/**
+ * Predefined expression dialect identifiers used by {@link DialectExpression#dialect()}.
+ *
+ * <p>These constants match the dialects defined by the pinned Apache Ossie schema. The API uses
+ * strings so dialect identifiers remain extensible; the active Metric View profile determines which
+ * values it supports.
+ */
+@Unstable
+public final class MetricDialects {
+
+  /** ANSI SQL. */
+  public static final String ANSI_SQL = "ANSI_SQL";
+
+  /** Snowflake SQL. */
+  public static final String SNOWFLAKE = "SNOWFLAKE";
+
+  /** Multidimensional Expressions. */
+  public static final String MDX = "MDX";
+
+  /** Tableau expression language. */
+  public static final String TABLEAU = "TABLEAU";
+
+  /** Databricks SQL. */
+  public static final String DATABRICKS = "DATABRICKS";
+
+  /** MicroStrategy Analytical Engine language. */
+  public static final String MAQL = "MAQL";
+
+  /** GoogleSQL for BigQuery. */
+  public static final String BIGQUERY = "BIGQUERY";
+
+  private MetricDialects() {}
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/Relationship.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/Relationship.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.annotation.Unstable;
+
+/** A named relationship between two datasets in a semantic model. */
+@Unstable
+public final class Relationship {
+
+  private final String name;
+  private final String from;
+  private final String to;
+  private final List<String> fromColumns;
+  private final List<String> toColumns;
+  @Nullable private final AIContext aiContext;
+  private final List<CustomExtension> customExtensions;
+
+  private Relationship(
+      String name,
+      String from,
+      String to,
+      List<String> fromColumns,
+      List<String> toColumns,
+      @Nullable AIContext aiContext,
+      List<CustomExtension> customExtensions) {
+    this.name = name;
+    this.from = from;
+    this.to = to;
+    this.fromColumns = fromColumns;
+    this.toColumns = toColumns;
+    this.aiContext = aiContext;
+    this.customExtensions = customExtensions;
+  }
+
+  /**
+   * Creates a relationship builder.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * @return The relationship name.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * @return The source dataset name.
+   */
+  public String from() {
+    return from;
+  }
+
+  /**
+   * @return The target dataset name.
+   */
+  public String to() {
+    return to;
+  }
+
+  /**
+   * @return An immutable list of source columns.
+   */
+  public List<String> fromColumns() {
+    return fromColumns;
+  }
+
+  /**
+   * @return An immutable list of target columns.
+   */
+  public List<String> toColumns() {
+    return toColumns;
+  }
+
+  /**
+   * @return The AI context, or {@code null}.
+   */
+  @Nullable
+  public AIContext aiContext() {
+    return aiContext;
+  }
+
+  /**
+   * @return An immutable list of custom extensions.
+   */
+  public List<CustomExtension> customExtensions() {
+    return customExtensions;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Relationship)) {
+      return false;
+    }
+    Relationship that = (Relationship) other;
+    return Objects.equals(name, that.name)
+        && Objects.equals(from, that.from)
+        && Objects.equals(to, that.to)
+        && Objects.equals(fromColumns, that.fromColumns)
+        && Objects.equals(toColumns, that.toColumns)
+        && Objects.equals(aiContext, that.aiContext)
+        && Objects.equals(customExtensions, that.customExtensions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, from, to, fromColumns, toColumns, aiContext, customExtensions);
+  }
+
+  @Override
+  public String toString() {
+    return "Relationship{"
+        + "name='"
+        + name
+        + '\''
+        + ", from='"
+        + from
+        + '\''
+        + ", to='"
+        + to
+        + '\''
+        + ", fromColumns="
+        + fromColumns
+        + ", toColumns="
+        + toColumns
+        + ", aiContext="
+        + aiContext
+        + ", customExtensions="
+        + customExtensions
+        + '}';
+  }
+
+  /** Builder for {@link Relationship}. */
+  public static final class Builder {
+    private String name;
+    private String from;
+    private String to;
+    private List<String> fromColumns;
+    private List<String> toColumns;
+    @Nullable private AIContext aiContext;
+    private List<CustomExtension> customExtensions;
+
+    private Builder() {}
+
+    /**
+     * Sets the relationship name.
+     *
+     * @param name The relationship name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the source dataset name.
+     *
+     * @param from The source dataset name.
+     * @return This builder.
+     */
+    public Builder withFrom(String from) {
+      this.from = from;
+      return this;
+    }
+
+    /**
+     * Sets the target dataset name.
+     *
+     * @param to The target dataset name.
+     * @return This builder.
+     */
+    public Builder withTo(String to) {
+      this.to = to;
+      return this;
+    }
+
+    /**
+     * Sets the source columns.
+     *
+     * @param fromColumns The source columns.
+     * @return This builder.
+     */
+    public Builder withFromColumns(List<String> fromColumns) {
+      this.fromColumns = fromColumns;
+      return this;
+    }
+
+    /**
+     * Sets the target columns.
+     *
+     * @param toColumns The target columns.
+     * @return This builder.
+     */
+    public Builder withToColumns(List<String> toColumns) {
+      this.toColumns = toColumns;
+      return this;
+    }
+
+    /**
+     * Sets the AI context.
+     *
+     * @param aiContext The AI context.
+     * @return This builder.
+     */
+    public Builder withAIContext(@Nullable AIContext aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+
+    /**
+     * Sets the custom extensions.
+     *
+     * @param customExtensions The custom extensions.
+     * @return This builder.
+     */
+    public Builder withCustomExtensions(List<CustomExtension> customExtensions) {
+      this.customExtensions = customExtensions;
+      return this;
+    }
+
+    /**
+     * Builds the relationship.
+     *
+     * @return The relationship.
+     */
+    public Relationship build() {
+      List<String> copiedFromColumns =
+          SemanticModelUtils.requireNonEmptyList(fromColumns, "fromColumns");
+      List<String> copiedToColumns = SemanticModelUtils.requireNonEmptyList(toColumns, "toColumns");
+      Preconditions.checkArgument(
+          copiedFromColumns.size() == copiedToColumns.size(),
+          "fromColumns and toColumns must have the same size");
+      return new Relationship(
+          SemanticModelUtils.requireNonBlank(name, "name"),
+          SemanticModelUtils.requireNonBlank(from, "from"),
+          SemanticModelUtils.requireNonBlank(to, "to"),
+          copiedFromColumns,
+          copiedToColumns,
+          aiContext,
+          SemanticModelUtils.immutableList(customExtensions, "customExtensions"));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/SemanticModel.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/SemanticModel.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.annotation.Unstable;
+
+/** A structured, OSI-compatible semantic model carried by a Metric View. */
+@Unstable
+public final class SemanticModel {
+
+  private final String name;
+  @Nullable private final String description;
+  @Nullable private final AIContext aiContext;
+  private final List<Dataset> datasets;
+  private final List<Relationship> relationships;
+  private final List<Metric> metrics;
+  private final List<CustomExtension> customExtensions;
+
+  private SemanticModel(
+      String name,
+      @Nullable String description,
+      @Nullable AIContext aiContext,
+      List<Dataset> datasets,
+      List<Relationship> relationships,
+      List<Metric> metrics,
+      List<CustomExtension> customExtensions) {
+    this.name = name;
+    this.description = description;
+    this.aiContext = aiContext;
+    this.datasets = datasets;
+    this.relationships = relationships;
+    this.metrics = metrics;
+    this.customExtensions = customExtensions;
+  }
+
+  /**
+   * @return A new semantic-model builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * @return The semantic-model name.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * @return The semantic-model description, or {@code null}.
+   */
+  @Nullable
+  public String description() {
+    return description;
+  }
+
+  /**
+   * @return The AI context, or {@code null}.
+   */
+  @Nullable
+  public AIContext aiContext() {
+    return aiContext;
+  }
+
+  /**
+   * @return An immutable, non-empty list of datasets.
+   */
+  public List<Dataset> datasets() {
+    return datasets;
+  }
+
+  /**
+   * @return An immutable list of relationships.
+   */
+  public List<Relationship> relationships() {
+    return relationships;
+  }
+
+  /**
+   * @return An immutable list of metrics.
+   */
+  public List<Metric> metrics() {
+    return metrics;
+  }
+
+  /**
+   * @return An immutable list of custom extensions.
+   */
+  public List<CustomExtension> customExtensions() {
+    return customExtensions;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof SemanticModel)) {
+      return false;
+    }
+    SemanticModel that = (SemanticModel) other;
+    return Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(aiContext, that.aiContext)
+        && Objects.equals(datasets, that.datasets)
+        && Objects.equals(relationships, that.relationships)
+        && Objects.equals(metrics, that.metrics)
+        && Objects.equals(customExtensions, that.customExtensions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        name, description, aiContext, datasets, relationships, metrics, customExtensions);
+  }
+
+  @Override
+  public String toString() {
+    return "SemanticModel{"
+        + "name='"
+        + name
+        + '\''
+        + ", description='"
+        + description
+        + '\''
+        + ", aiContext="
+        + aiContext
+        + ", datasets="
+        + datasets
+        + ", relationships="
+        + relationships
+        + ", metrics="
+        + metrics
+        + ", customExtensions="
+        + customExtensions
+        + '}';
+  }
+
+  /** Builder for {@link SemanticModel}. */
+  public static final class Builder {
+    private String name;
+    @Nullable private String description;
+    @Nullable private AIContext aiContext;
+    private List<Dataset> datasets;
+    private List<Relationship> relationships;
+    private List<Metric> metrics;
+    private List<CustomExtension> customExtensions;
+
+    private Builder() {}
+
+    /**
+     * Sets the semantic-model name.
+     *
+     * @param name The semantic-model name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the semantic-model description.
+     *
+     * @param description The semantic-model description.
+     * @return This builder.
+     */
+    public Builder withDescription(@Nullable String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Sets the AI context.
+     *
+     * @param aiContext The AI context.
+     * @return This builder.
+     */
+    public Builder withAIContext(@Nullable AIContext aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+
+    /**
+     * Sets the datasets.
+     *
+     * @param datasets The datasets.
+     * @return This builder.
+     */
+    public Builder withDatasets(List<Dataset> datasets) {
+      this.datasets = datasets;
+      return this;
+    }
+
+    /**
+     * Sets the relationships.
+     *
+     * @param relationships The relationships.
+     * @return This builder.
+     */
+    public Builder withRelationships(List<Relationship> relationships) {
+      this.relationships = relationships;
+      return this;
+    }
+
+    /**
+     * Sets the metrics.
+     *
+     * @param metrics The metrics.
+     * @return This builder.
+     */
+    public Builder withMetrics(List<Metric> metrics) {
+      this.metrics = metrics;
+      return this;
+    }
+
+    /**
+     * Sets the custom extensions.
+     *
+     * @param customExtensions The custom extensions.
+     * @return This builder.
+     */
+    public Builder withCustomExtensions(List<CustomExtension> customExtensions) {
+      this.customExtensions = customExtensions;
+      return this;
+    }
+
+    /**
+     * @return The semantic model.
+     */
+    public SemanticModel build() {
+      return new SemanticModel(
+          SemanticModelUtils.requireNonBlank(name, "name"),
+          description,
+          aiContext,
+          SemanticModelUtils.requireNonEmptyList(datasets, "datasets"),
+          SemanticModelUtils.immutableList(relationships, "relationships"),
+          SemanticModelUtils.immutableList(metrics, "metrics"),
+          SemanticModelUtils.immutableList(customExtensions, "customExtensions"));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/rel/metric/SemanticModelUtils.java
+++ b/api/src/main/java/org/apache/gravitino/rel/metric/SemanticModelUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+
+final class SemanticModelUtils {
+
+  private SemanticModelUtils() {}
+
+  static String requireNonBlank(String value, String fieldName) {
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(value), "%s must not be null or blank", fieldName);
+    return value;
+  }
+
+  static <T> List<T> immutableList(List<T> values, String fieldName) {
+    if (values == null) {
+      return Collections.emptyList();
+    }
+    Preconditions.checkArgument(
+        values.stream().noneMatch(value -> value == null), "%s must not contain null", fieldName);
+    return Collections.unmodifiableList(new ArrayList<>(values));
+  }
+
+  static <T> List<T> requireNonEmptyList(List<T> values, String fieldName) {
+    Preconditions.checkArgument(
+        values != null && !values.isEmpty(), "%s must not be null or empty", fieldName);
+    return immutableList(values, fieldName);
+  }
+
+  static List<List<String>> immutableNestedStringList(List<List<String>> values, String fieldName) {
+    if (values == null) {
+      return Collections.emptyList();
+    }
+    List<List<String>> copied = new ArrayList<>(values.size());
+    for (List<String> value : values) {
+      copied.add(requireNonEmptyList(value, fieldName + " entry"));
+    }
+    return Collections.unmodifiableList(copied);
+  }
+
+  static <K, V> Map<K, V> immutableMap(Map<K, V> values) {
+    if (values == null) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(new java.util.LinkedHashMap<>(values));
+  }
+}

--- a/api/src/test/java/org/apache/gravitino/rel/TestMetricRepresentation.java
+++ b/api/src/test/java/org/apache/gravitino/rel/TestMetricRepresentation.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.rel.metric.Dataset;
+import org.apache.gravitino.rel.metric.SemanticModel;
+import org.junit.jupiter.api.Test;
+
+public class TestMetricRepresentation {
+
+  @Test
+  public void testBuildMetricRepresentation() {
+    SemanticModel model = testModel("sales_semantic_model");
+    MetricRepresentation representation =
+        MetricRepresentation.builder().withSemanticModel(model).build();
+
+    assertEquals(Representation.TYPE_METRIC, representation.type());
+    assertEquals(model, representation.semanticModel());
+  }
+
+  @Test
+  public void testMetricRepresentationEquality() {
+    MetricRepresentation first =
+        MetricRepresentation.builder().withSemanticModel(testModel("sales")).build();
+    MetricRepresentation second =
+        MetricRepresentation.builder().withSemanticModel(testModel("sales")).build();
+    MetricRepresentation different =
+        MetricRepresentation.builder().withSemanticModel(testModel("inventory")).build();
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+    assertNotEquals(first, different);
+  }
+
+  @Test
+  public void testRejectMissingMetricRepresentationFields() {
+    assertThrows(IllegalArgumentException.class, () -> MetricRepresentation.builder().build());
+  }
+
+  private static SemanticModel testModel(String name) {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .build();
+    return SemanticModel.builder()
+        .withName(name)
+        .withDatasets(Collections.singletonList(dataset))
+        .build();
+  }
+}

--- a/api/src/test/java/org/apache/gravitino/rel/TestView.java
+++ b/api/src/test/java/org/apache/gravitino/rel/TestView.java
@@ -24,8 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Optional;
 import org.apache.gravitino.Audit;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.rel.metric.Dataset;
+import org.apache.gravitino.rel.metric.SemanticModel;
 import org.junit.jupiter.api.Test;
 
 public class TestView {
@@ -105,6 +109,22 @@ public class TestView {
     assertNull(view.defaultSchema());
   }
 
+  @Test
+  public void testMetricRepresentationReturnsStructuredRepresentation() {
+    MetricRepresentation representation = testMetricRepresentation();
+    View view = testView(representation);
+
+    assertEquals(representation, view.metricRepresentation().orElseThrow(AssertionError::new));
+  }
+
+  @Test
+  public void testMetricRepresentationReturnsEmptyForLogicalView() {
+    View view =
+        testView(SQLRepresentation.builder().withDialect("trino").withSql("select 1").build());
+
+    assertFalse(view.metricRepresentation().isPresent());
+  }
+
   private static View testView(Representation... representations) {
     return new View() {
       @Override
@@ -151,5 +171,19 @@ public class TestView {
         return Instant.EPOCH;
       }
     };
+  }
+
+  private static MetricRepresentation testMetricRepresentation() {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .build();
+    SemanticModel model =
+        SemanticModel.builder()
+            .withName("sales")
+            .withDatasets(Collections.singletonList(dataset))
+            .build();
+    return MetricRepresentation.builder().withSemanticModel(model).build();
   }
 }

--- a/api/src/test/java/org/apache/gravitino/rel/TestViewCatalog.java
+++ b/api/src/test/java/org/apache/gravitino/rel/TestViewCatalog.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.rel.metric.Dataset;
+import org.apache.gravitino.rel.metric.SemanticModel;
+import org.junit.jupiter.api.Test;
+
+public class TestViewCatalog {
+
+  @Test
+  public void testCreateMetricViewDelegatesToCreateView() {
+    CapturingViewCatalog catalog = new CapturingViewCatalog();
+    MetricRepresentation representation = testMetricRepresentation();
+    NameIdentifier ident = NameIdentifier.of("mart", "sales_metrics");
+
+    catalog.createMetricView(
+        ident, "Sales metrics", representation, Collections.singletonMap("owner", "finance"));
+
+    assertEquals(ident, catalog.ident);
+    assertEquals(0, catalog.columns.length);
+    assertEquals(representation, catalog.representations[0]);
+    assertNull(catalog.defaultCatalog);
+    assertNull(catalog.defaultSchema);
+  }
+
+  @Test
+  public void testCreateMetricViewRejectsNullRepresentation() {
+    CapturingViewCatalog catalog = new CapturingViewCatalog();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            catalog.createMetricView(
+                NameIdentifier.of("mart", "sales_metrics"), null, null, Collections.emptyMap()));
+  }
+
+  private static MetricRepresentation testMetricRepresentation() {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .build();
+    SemanticModel model =
+        SemanticModel.builder()
+            .withName("sales")
+            .withDatasets(Collections.singletonList(dataset))
+            .build();
+    return MetricRepresentation.builder().withSemanticModel(model).build();
+  }
+
+  private static final class CapturingViewCatalog implements ViewCatalog {
+    private NameIdentifier ident;
+    private Column[] columns;
+    private Representation[] representations;
+    private String defaultCatalog;
+    private String defaultSchema;
+
+    @Override
+    public View loadView(NameIdentifier ident) {
+      return null;
+    }
+
+    @Override
+    public View createView(
+        NameIdentifier ident,
+        String comment,
+        Column[] columns,
+        Representation[] representations,
+        String defaultCatalog,
+        String defaultSchema,
+        Map<String, String> properties) {
+      this.ident = ident;
+      this.columns = columns;
+      this.representations = representations;
+      this.defaultCatalog = defaultCatalog;
+      this.defaultSchema = defaultSchema;
+      return null;
+    }
+  }
+}

--- a/api/src/test/java/org/apache/gravitino/rel/metric/TestMetricSupportingTypes.java
+++ b/api/src/test/java/org/apache/gravitino/rel/metric/TestMetricSupportingTypes.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class TestMetricSupportingTypes {
+
+  @Test
+  public void testDialectsMatchPinnedOssieSchema() {
+    assertEquals("ANSI_SQL", MetricDialects.ANSI_SQL);
+    assertEquals("SNOWFLAKE", MetricDialects.SNOWFLAKE);
+    assertEquals("MDX", MetricDialects.MDX);
+    assertEquals("TABLEAU", MetricDialects.TABLEAU);
+    assertEquals("DATABRICKS", MetricDialects.DATABRICKS);
+    assertEquals("MAQL", MetricDialects.MAQL);
+    assertEquals("BIGQUERY", MetricDialects.BIGQUERY);
+  }
+
+  @Test
+  public void testDialectIsExtensibleString() {
+    DialectExpression expression =
+        DialectExpression.builder()
+            .withDialect("CUSTOM_DIALECT")
+            .withExpression("orders.amount")
+            .build();
+
+    assertEquals("CUSTOM_DIALECT", expression.dialect());
+  }
+
+  @Test
+  public void testBuildFieldAndExpression() {
+    List<DialectExpression> dialects = new ArrayList<>();
+    dialects.add(
+        DialectExpression.builder()
+            .withDialect(MetricDialects.ANSI_SQL)
+            .withExpression("orders.amount")
+            .build());
+    Expression expression = Expression.builder().withDialects(dialects).build();
+    Dimension dimension = Dimension.builder().withTime(false).build();
+    CustomExtension extension =
+        CustomExtension.builder().withVendorName("example").withData("{\"key\":1}").build();
+    Field field =
+        Field.builder()
+            .withName("amount")
+            .withExpression(expression)
+            .withDimension(dimension)
+            .withLabel("Amount")
+            .withDescription("Order amount")
+            .withCustomExtensions(Collections.singletonList(extension))
+            .build();
+
+    dialects.clear();
+
+    assertEquals("amount", field.name());
+    assertEquals("orders.amount", field.expression().dialects().get(0).expression());
+    assertEquals(Boolean.FALSE, field.dimension().isTime());
+    assertEquals("Amount", field.label());
+    assertEquals(Collections.singletonList(extension), field.customExtensions());
+    assertThrows(UnsupportedOperationException.class, () -> expression.dialects().clear());
+  }
+
+  @Test
+  public void testAIContextForms() {
+    AIContext textContext = AIContext.of("Use fiscal calendar");
+    AIContext objectContext =
+        AIContext.builder()
+            .withInstructions("Use certified fields")
+            .withSynonyms(Collections.singletonList("sales"))
+            .withExamples(Collections.singletonList("Revenue by month"))
+            .withAdditionalProperties(Collections.singletonMap("audience", "finance"))
+            .build();
+
+    assertTrue(textContext.isText());
+    assertEquals("Use fiscal calendar", textContext.text());
+    assertFalse(objectContext.isText());
+    assertNull(objectContext.text());
+    assertEquals("Use certified fields", objectContext.instructions());
+    assertEquals("finance", objectContext.additionalProperties().get("audience"));
+  }
+
+  @Test
+  public void testRejectInvalidSupportingTypes() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Expression.builder().withDialects(Collections.emptyList()).build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            DialectExpression.builder()
+                .withDialect(MetricDialects.ANSI_SQL)
+                .withExpression(" ")
+                .build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DialectExpression.builder().withDialect(" ").withExpression("amount").build());
+    assertThrows(IllegalArgumentException.class, () -> Field.builder().withName("amount").build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CustomExtension.builder().withVendorName("example").withData(" ").build());
+  }
+
+  @Test
+  public void testRejectReservedAIContextAdditionalProperty() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("instructions", "duplicate");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AIContext.builder().withAdditionalProperties(properties).build());
+  }
+}

--- a/api/src/test/java/org/apache/gravitino/rel/metric/TestSemanticModel.java
+++ b/api/src/test/java/org/apache/gravitino/rel/metric/TestSemanticModel.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.rel.metric;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.gravitino.NameIdentifier;
+import org.junit.jupiter.api.Test;
+
+public class TestSemanticModel {
+
+  @Test
+  public void testBuildCompleteSemanticModel() {
+    DialectExpression dialectExpression =
+        DialectExpression.builder()
+            .withDialect(MetricDialects.ANSI_SQL)
+            .withExpression("orders.amount")
+            .build();
+    Expression expression =
+        Expression.builder().withDialects(Collections.singletonList(dialectExpression)).build();
+    AIContext aiContext =
+        AIContext.builder()
+            .withInstructions("Use certified fields")
+            .withSynonyms(Collections.singletonList("sales"))
+            .withExamples(Collections.singletonList("Revenue by month"))
+            .withAdditionalProperties(Collections.singletonMap("audience", "finance"))
+            .build();
+    CustomExtension extension =
+        CustomExtension.builder().withVendorName("example").withData("{\"key\":1}").build();
+    Field field =
+        Field.builder()
+            .withName("amount")
+            .withExpression(expression)
+            .withDimension(Dimension.builder().withTime(false).build())
+            .withLabel("Amount")
+            .withAIContext(aiContext)
+            .withCustomExtensions(Collections.singletonList(extension))
+            .build();
+    Dataset orders =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withPrimaryKey(Collections.singletonList("order_id"))
+            .withUniqueKeys(
+                Collections.singletonList(Collections.singletonList("external_order_id")))
+            .withFields(Collections.singletonList(field))
+            .build();
+    Dataset customers =
+        Dataset.builder()
+            .withName("customers")
+            .withSource(NameIdentifier.of("sales", "mart", "customers"))
+            .build();
+    Relationship relationship =
+        Relationship.builder()
+            .withName("orders_to_customers")
+            .withFrom("orders")
+            .withTo("customers")
+            .withFromColumns(Collections.singletonList("customer_id"))
+            .withToColumns(Collections.singletonList("customer_id"))
+            .build();
+    Metric metric =
+        Metric.builder()
+            .withName("revenue")
+            .withExpression(expression)
+            .withDescription("Gross revenue")
+            .build();
+
+    SemanticModel model =
+        SemanticModel.builder()
+            .withName("sales_semantic_model")
+            .withDescription("Sales semantics")
+            .withAIContext(aiContext)
+            .withDatasets(java.util.Arrays.asList(orders, customers))
+            .withRelationships(Collections.singletonList(relationship))
+            .withMetrics(Collections.singletonList(metric))
+            .withCustomExtensions(Collections.singletonList(extension))
+            .build();
+
+    assertEquals("sales_semantic_model", model.name());
+    assertEquals("Sales semantics", model.description());
+    assertEquals(aiContext, model.aiContext());
+    assertEquals(java.util.Arrays.asList(orders, customers), model.datasets());
+    assertEquals(Collections.singletonList(relationship), model.relationships());
+    assertEquals(Collections.singletonList(metric), model.metrics());
+    assertEquals(Collections.singletonList(extension), model.customExtensions());
+    assertEquals(NameIdentifier.of("sales", "mart", "orders"), orders.source());
+    assertEquals(Collections.singletonList("order_id"), orders.primaryKey());
+    assertEquals(Collections.singletonList(field), orders.fields());
+    assertEquals(MetricDialects.ANSI_SQL, dialectExpression.dialect());
+    assertEquals("orders.amount", dialectExpression.expression());
+  }
+
+  @Test
+  public void testCollectionsAreImmutableCopies() {
+    List<Dataset> datasets = new ArrayList<>();
+    datasets.add(testDataset("orders"));
+    SemanticModel model = SemanticModel.builder().withName("sales").withDatasets(datasets).build();
+
+    datasets.add(testDataset("customers"));
+
+    assertEquals(1, model.datasets().size());
+    assertThrows(UnsupportedOperationException.class, () -> model.datasets().clear());
+  }
+
+  @Test
+  public void testRejectInvalidRequiredFields() {
+    assertThrows(IllegalArgumentException.class, () -> SemanticModel.builder().build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            SemanticModel.builder()
+                .withName("sales")
+                .withDatasets(Collections.emptyList())
+                .build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Dataset.builder().withName("orders").withSource(NameIdentifier.of("orders")).build());
+  }
+
+  @Test
+  public void testRejectMismatchedRelationshipColumns() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            Relationship.builder()
+                .withName("orders_to_customers")
+                .withFrom("orders")
+                .withTo("customers")
+                .withFromColumns(Collections.singletonList("customer_id"))
+                .withToColumns(java.util.Arrays.asList("customer_id", "tenant_id"))
+                .build());
+  }
+
+  private static Dataset testDataset(String name) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .build();
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the public Java API for structured Metric Views described in #12360:

- Introduce `MetricRepresentation` and OSI-compatible semantic model types.
- Add string-based `MetricDialects` constants and immutable builders.
- Add `View#metricRepresentation()` and `ViewCatalog#createMetricView()`.
- Add API unit tests for the new types and helpers.

### Why are the changes needed?

Gravitino needs a typed public contract for representing Metric Views through the existing View lifecycle. This PR establishes the Java API layer; REST, persistence, clients, server-side validation, and query execution are outside its scope.

Fix: #12385

### Does this PR introduce _any_ user-facing change?

Yes. It adds new `@Unstable` public Java APIs for creating and reading structured Metric Views.

### How was this patch tested?

- `./gradlew :api:test :api:javadoc :api:spotlessCheck`
