### PR TITLE
[#11284] fix(iceberg-rest): Order planned file scan tasks deterministically

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/CatalogWrapperForREST.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/CatalogWrapperForREST.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -451,6 +452,34 @@ public class CatalogWrapperForREST extends IcebergCatalogWrapper {
               "Scan planning returned no tasks for table: {}. Table may be empty or fully filtered.",
               tableIdentifier);
         }
+
+        // Iceberg plans manifests in parallel, so the order tasks come back in is not reproducible:
+        // planning one snapshot twice can return the same tasks in a different order, and so can
+        // two servers planning it at the same time. Order them totally, so that an identical scan
+        // of an identical snapshot produces an identical response.
+        //
+        // Data file location, offset and length do not order tasks totally on their own, because
+        // one path can be referenced by several manifest entries - the same file appended in two
+        // snapshots, for instance - and those entries carry different sequence numbers and delete
+        // files. A manifest entry is unique within a snapshot, identified by its manifest and its
+        // position in it, so comparing that as well makes the order total. Sequence numbers come
+        // first because they survive a rewrite into new manifests; when a reader leaves the
+        // manifest fields unset they are also the last discriminator, and tasks that tie on every
+        // key are interchangeable.
+        fileScanTasks.sort(
+            Comparator.comparing((FileScanTask task) -> task.file().location())
+                .thenComparingLong(FileScanTask::start)
+                .thenComparingLong(FileScanTask::length)
+                .thenComparing(
+                    task -> task.file().dataSequenceNumber(),
+                    Comparator.nullsFirst(Long::compareTo))
+                .thenComparing(
+                    task -> task.file().fileSequenceNumber(),
+                    Comparator.nullsFirst(Long::compareTo))
+                .thenComparing(
+                    task -> task.file().manifestLocation(),
+                    Comparator.nullsFirst(String::compareTo))
+                .thenComparing(task -> task.file().pos(), Comparator.nullsFirst(Long::compareTo)));
 
         try {
           response = buildCompletedPlanTableScanResponse(table, fileScanTasks);

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestScanPlanTaskOrdering.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestScanPlanTaskOrdering.java
@@ -1,0 +1,160 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.service;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.requests.PlanTableScanRequest;
+import org.apache.iceberg.rest.responses.PlanTableScanResponse;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Covers the order of {@code file-scan-tasks} in a scan planning response: an identical scan of an
+ * identical snapshot must produce an identical response, whichever order Iceberg happened to plan
+ * the manifests in.
+ */
+@SuppressWarnings("deprecation")
+public class TestScanPlanTaskOrdering {
+
+  private static final Namespace NAMESPACE = Namespace.of("db");
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+  private static final PlanTableScanRequest SCAN_ALL = PlanTableScanRequest.builder().build();
+
+  @TempDir private Path warehouse;
+
+  @Test
+  void testTasksAreOrderedByDataFileLocation() {
+    CatalogWrapperForREST wrapper = newWrapper("ordering");
+    TableIdentifier tableId = createTable(wrapper, "tbl");
+    // Appended in an order that does not match the sort order.
+    appendDataFile(wrapper, tableId, dataFileLocation("c"));
+    appendDataFile(wrapper, tableId, dataFileLocation("a"));
+    appendDataFile(wrapper, tableId, dataFileLocation("b"));
+
+    List<String> locations = dataFileLocations(planTableScan(wrapper, tableId));
+
+    Assertions.assertEquals(
+        ImmutableList.of(dataFileLocation("a"), dataFileLocation("b"), dataFileLocation("c")),
+        locations);
+  }
+
+  @Test
+  void testTasksOverTheSameFileAreOrderedByManifestEntry() {
+    // Data file location, offset and length do not order tasks totally: appending one path twice
+    // leaves two manifest entries that tie on all three, and only the entry itself tells them
+    // apart. Without a further tie-break the two keep whichever order Iceberg planned them in.
+    CatalogWrapperForREST wrapper = newWrapper("duplicate-path");
+    TableIdentifier tableId = createTable(wrapper, "tbl");
+    String duplicated = dataFileLocation("dup");
+    appendDataFile(wrapper, tableId, duplicated);
+    appendDataFile(wrapper, tableId, duplicated);
+
+    List<FileScanTask> tasks = planTableScan(wrapper, tableId);
+
+    Assertions.assertEquals(ImmutableList.of(duplicated, duplicated), dataFileLocations(tasks));
+    Assertions.assertEquals(
+        ImmutableList.of(1L, 2L),
+        tasks.stream().map(task -> task.file().dataSequenceNumber()).collect(Collectors.toList()),
+        "The older manifest entry of the duplicated file must come first");
+  }
+
+  @Test
+  void testPlanningTheSameSnapshotTwiceReturnsTheSameOrder() {
+    CatalogWrapperForREST wrapper = newWrapper("repeatable");
+    TableIdentifier tableId = createTable(wrapper, "tbl");
+    for (int i = 0; i < 5; i++) {
+      appendDataFile(wrapper, tableId, dataFileLocation("f" + i));
+    }
+
+    Assertions.assertEquals(
+        dataFileLocations(planTableScan(wrapper, tableId)),
+        dataFileLocations(planTableScan(wrapper, tableId)));
+  }
+
+  private List<FileScanTask> planTableScan(CatalogWrapperForREST wrapper, TableIdentifier tableId) {
+    PlanTableScanResponse response = wrapper.planTableScan(tableId, SCAN_ALL);
+    return response.fileScanTasks();
+  }
+
+  private CatalogWrapperForREST newWrapper(String catalogName) {
+    return new CatalogWrapperForREST(
+        catalogName,
+        new IcebergConfig(
+            ImmutableMap.of(
+                IcebergConstants.CATALOG_BACKEND,
+                "memory",
+                IcebergConstants.WAREHOUSE,
+                warehouse.toString())));
+  }
+
+  private TableIdentifier createTable(CatalogWrapperForREST wrapper, String tableName) {
+    Catalog catalog = wrapper.getCatalog();
+    ((SupportsNamespaces) catalog).createNamespace(NAMESPACE);
+    TableIdentifier tableId = TableIdentifier.of(NAMESPACE, tableName);
+    catalog.createTable(tableId, SCHEMA, PartitionSpec.unpartitioned(), Collections.emptyMap());
+    return tableId;
+  }
+
+  /**
+   * Appends one data file. The file itself is never read: scan planning only reads the manifests
+   * that describe it.
+   */
+  private void appendDataFile(
+      CatalogWrapperForREST wrapper, TableIdentifier tableId, String location) {
+    Table table = wrapper.getCatalog().loadTable(tableId);
+    DataFile dataFile =
+        DataFiles.builder(table.spec())
+            .withPath(location)
+            .withFormat(FileFormat.PARQUET)
+            .withRecordCount(1)
+            .withFileSizeInBytes(1L)
+            .build();
+    table.newFastAppend().appendFile(dataFile).commit();
+  }
+
+  private String dataFileLocation(String name) {
+    return warehouse.resolve(name + ".parquet").toUri().toString();
+  }
+
+  private static List<String> dataFileLocations(List<FileScanTask> fileScanTasks) {
+    return fileScanTasks.stream().map(task -> task.file().location()).collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Sort the file scan tasks a scan plan produces, so that an identical scan of an identical snapshot produces an identical `POST .../tables/{table}/plan` response.

Tasks are ordered by:

```
(data file location, start, length,
 data sequence number, file sequence number,
 manifest location, manifest entry position)
```

The first three fields are the obvious key, and they are not enough. One data file path can be referenced by several manifest entries - the same file appended in two snapshots, for instance - and those entries tie on location, offset and length while carrying different sequence numbers and delete files:

```
location=…/dup.parquet start=0 length=10  dataSeq=2  manifest=…-m0.avro pos=0
location=…/dup.parquet start=0 length=10  dataSeq=1  manifest=…-m0.avro pos=0
```

A manifest entry is unique within a snapshot, identified by its manifest and its position in that manifest, so comparing those makes the order total for any two tasks that are not interchangeable. Sequence numbers are compared before the manifest fields because they survive a rewrite into new manifests, and they remain the discriminator if a reader leaves the manifest fields unset.

This is the first PR of the stack that implements [#11284](https://github.com/apache/gravitino/issues/11284); see the plan in [#12194](https://github.com/apache/gravitino/pull/12194).

### Why are the changes needed?

Iceberg plans manifests in parallel, so `planFiles()` does not return tasks in a reproducible order: planning one snapshot twice can return the same tasks in a different order, and so can two Gravitino replicas planning it at the same time.

That matters on its own - an identical request should give an identical response, which makes the scan plan cache and any client-side comparison of two plans behave predictably - and it is a prerequisite for the rest of #11284. Server-side scan planning hands a client one batch of a plan at a time and identifies a batch by position, so positions have to mean the same thing every time a plan is computed.

Fix: #11284

### Does this PR introduce _any_ user-facing change?

The `file-scan-tasks` array in a scan planning response is now ordered rather than arbitrary. No field is added, removed or changed, and the set of tasks returned is the same as before; a client that treats the array as an unordered collection, as the Iceberg REST specification allows, sees no difference.

### How was this patch tested?

New `TestScanPlanTaskOrdering`:

- tasks are ordered by data file location, for files appended in a different order;
- two manifest entries of the same data file path are ordered by their sequence numbers - this fails without the sequence number and manifest entry comparisons, since sorting is stable and the two tasks otherwise keep the order Iceberg planned them in;
- planning the same snapshot twice returns the same order.

```bash
./gradlew :iceberg:iceberg-rest-server:check -PskipITs
```
