### PR TITLE
[#12437] fix(ci): Trust runner system CA in paths-filter

### DIFF
--- a/.github/workflows/access-control-integration-test.yml
+++ b/.github/workflows/access-control-integration-test.yml
@@ -21,6 +21,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -22,6 +22,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           list-files: shell
           filters: |

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -18,6 +18,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/contrib-catalog-test.yml
+++ b/.github/workflows/contrib-catalog-test.yml
@@ -22,6 +22,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -19,6 +19,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/flink-integration-test.yml
+++ b/.github/workflows/flink-integration-test.yml
@@ -20,6 +20,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -20,6 +20,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/gvfs-fuse-build-test.yml
+++ b/.github/workflows/gvfs-fuse-build-test.yml
@@ -22,6 +22,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/iceberg-rest-trino-integration-test.yml
+++ b/.github/workflows/iceberg-rest-trino-integration-test.yml
@@ -23,6 +23,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/idp-basic-test.yml
+++ b/.github/workflows/idp-basic-test.yml
@@ -20,6 +20,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/maintenance-integration-test.yml
+++ b/.github/workflows/maintenance-integration-test.yml
@@ -20,6 +20,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/mcp-integration-test.yml
+++ b/.github/workflows/mcp-integration-test.yml
@@ -39,6 +39,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             mcp_or_authz_changes:

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -20,6 +20,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/spark-integration-test.yml
+++ b/.github/workflows/spark-integration-test.yml
@@ -20,6 +20,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:

--- a/.github/workflows/trino-integration-test.yml
+++ b/.github/workflows/trino-integration-test.yml
@@ -20,6 +20,8 @@ jobs:
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
+        env:
+          NODE_OPTIONS: --use-system-ca
         with:
           filters: |
             source_changes:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Configure all `dorny/paths-filter` steps with `NODE_OPTIONS: --use-system-ca`.

This keeps the setting scoped to the affected JavaScript action while allowing Node 24 to use certificates trusted by the runner system.

### Why are the changes needed?

A `paths-filter` step failed while querying the GitHub API with:

```text
self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
```

The failure prevents downstream tests from running and can block unrelated pull requests.

Fix: #12437

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Ran `./gradlew spotlessApply`.
- Parsed all 31 workflow YAML files successfully.
- Ran actionlint v1.7.7, excluding one unrelated pre-existing `integrationTest` reference error.
- Verified all 16 `paths-filter` workflows enable the system CA.
- Verified `NODE_OPTIONS=--use-system-ca` with Node 24.
- Ran `git diff --check`.
