### PR TITLE
[#12440] improvement(core): Replace the entity change log listener retry/EXIT policy with a cache-clear fallback

### DIFF
--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/TestFilesetCatalogOperations.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/TestFilesetCatalogOperations.java
@@ -20,8 +20,6 @@ package org.apache.gravitino.catalog.fileset;
 
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -256,8 +254,6 @@ public class TestFilesetCatalogOperations {
     when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     // Fix cache config for test

--- a/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.catalog.kafka;
 import static org.apache.gravitino.Catalog.Type.MESSAGING;
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -165,8 +163,6 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
     when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     // Fix cache config for test

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
@@ -20,8 +20,6 @@ package org.apache.gravitino.catalog.lakehouse.generic;
 
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -110,8 +108,6 @@ public class TestGenericCatalogOperations {
     when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(Configs.CACHE_ENABLED)).thenReturn(false);

--- a/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/TestModelCatalogOperations.java
+++ b/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/TestModelCatalogOperations.java
@@ -20,8 +20,6 @@ package org.apache.gravtitino.catalog.model;
 
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -129,8 +127,6 @@ public class TestModelCatalogOperations {
     when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     // Fix cache config for test

--- a/core/src/jmh/java/org/apache/gravitino/cache/it/AbstractEntityStorageBenchmark.java
+++ b/core/src/jmh/java/org/apache/gravitino/cache/it/AbstractEntityStorageBenchmark.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.cache.it;
 
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -296,8 +294,6 @@ public class AbstractEntityStorageBenchmark<E extends Entity & HasIdentifier> {
     Mockito.when(config.get(ENTITY_RELATIONAL_JDBC_BACKEND_WAIT_MILLISECONDS)).thenReturn(1000L);
     Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     Mockito.when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);

--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -20,7 +20,6 @@ package org.apache.gravitino;
 
 import com.google.common.collect.Lists;
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -30,7 +29,6 @@ import org.apache.gravitino.config.ConfigBuilder;
 import org.apache.gravitino.config.ConfigConstants;
 import org.apache.gravitino.config.ConfigEntry;
 import org.apache.gravitino.stats.storage.JdbcPartitionStatisticStorageFactory;
-import org.apache.gravitino.storage.relational.EntityChangeLogPoller;
 import org.apache.gravitino.utils.FileFetcher;
 import org.apache.gravitino.utils.HierarchicalSchemaUtil;
 
@@ -188,8 +186,6 @@ public class Configs {
           .createWithDefault(60 * 60 * 1000L);
 
   public static final long DEFAULT_ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS = 3L;
-  public static final int DEFAULT_ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES = 10;
-  public static final String DEFAULT_ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION = "EXIT";
   public static final long DEFAULT_ENTITY_CHANGE_LOG_RETENTION_SECS = 30 * 24 * 60 * 60L;
   public static final long DEFAULT_ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS = 24 * 60 * 60L;
 
@@ -200,31 +196,6 @@ public class Configs {
           .longConf()
           .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
           .createWithDefault(DEFAULT_ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS);
-
-  public static final ConfigEntry<Integer> ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES =
-      new ConfigBuilder("gravitino.entityChangeLog.listenerMaxRetries")
-          .doc(
-              "The number of times the poller retries a change log batch for a failing listener"
-                  + " before applying gravitino.entityChangeLog.listenerFailureAction")
-          .version(ConfigConstants.VERSION_2_0_0)
-          .intConf()
-          .checkValue(value -> value >= 0, ConfigConstants.NON_NEGATIVE_NUMBER_ERROR_MSG)
-          .createWithDefault(DEFAULT_ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES);
-
-  public static final ConfigEntry<String> ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION =
-      new ConfigBuilder("gravitino.entityChangeLog.listenerFailureAction")
-          .doc(
-              "What the poller does when a listener exhausted its retries: EXIT stops this server"
-                  + " because its local caches are known to be stale, SKIP drops the batch for that"
-                  + " listener and keeps serving")
-          .version(ConfigConstants.VERSION_2_0_0)
-          .stringConf()
-          .checkValue(
-              value ->
-                  Arrays.stream(EntityChangeLogPoller.ListenerFailureAction.values())
-                      .anyMatch(action -> action.name().equalsIgnoreCase(value)),
-              "The value must be either EXIT or SKIP")
-          .createWithDefault(DEFAULT_ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION);
 
   public static final ConfigEntry<Long> ENTITY_CHANGE_LOG_RETENTION_SECS =
       new ConfigBuilder("gravitino.entityChangeLog.retentionSecs")

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
@@ -35,23 +35,28 @@ import org.slf4j.LoggerFactory;
  * <p>This listener is called <em>synchronously</em> in the poller thread. Implementations must not
  * block or perform expensive I/O; only fast, in-memory cache invalidations are permitted.
  *
- * <p>The poller requires each listener to be self-healing. This one heals within a single record:
- * it retries that record's own eviction (see {@link #invalidateWithRetry}) and then swallows the
- * failure, so one bad record never costs the rest of the batch. It must NOT recover by clearing the
- * catalog cache the way {@code EntityCacheChangeLogListener} and {@code JcasbinChangeListener} do,
- * because evicting a catalog this process still uses closes its in-use {@code IsolatedClassLoader}
- * (#11739). Giving up on one eviction is the cheaper failure: the catalog cache expires on access,
- * so staleness is bounded by {@code gravitino.catalog.cache.evictionIntervalMs}.
+ * <p>The poller requires each listener to be self-healing, and this one recovers the same way
+ * {@code EntityCacheChangeLogListener} and {@code JcasbinChangeListener} do: a failed eviction
+ * clears the whole catalog cache, which is a strict superset of the eviction that failed and of the
+ * rest of the batch. A malformed row is skipped instead, because it names no catalog and so leaves
+ * nothing stale.
+ *
+ * <p>If the clear itself fails the exception reaches the poller, which logs it at {@code ERROR} and
+ * advances its cursor. That is safe now that the poller never replays a batch: a replay would
+ * re-run the single-shot {@link CatalogManager#consumeLocalMutation} probe, classify a local
+ * mutation as remote and tear down a catalog this node just mutated itself.
+ *
+ * <p><b>Cost of the clear:</b> evicting a cached catalog closes its {@code CatalogWrapper}, which
+ * tears down the connection pool and the {@code IsolatedClassLoader}. A whole-cache clear therefore
+ * also closes catalogs this process is actively serving; requests holding classes from a closed
+ * loader can fail with {@code NoClassDefFoundError}, the failure mode of #11739. This is accepted
+ * deliberately so that a stale catalog is never served: the alternative left this node serving the
+ * changed catalog from cache for up to {@code gravitino.catalog.cache.evictionIntervalMs}. The
+ * clear runs only on a failed eviction, which is off the normal path.
  */
 public class CatalogChangeLogListener implements EntityChangeLogListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(CatalogChangeLogListener.class);
-
-  /**
-   * How many times one catalog eviction is attempted. This is the listener's whole self-healing
-   * budget: see {@link #invalidateWithRetry} for why recovery cannot be broadened here.
-   */
-  private static final int MAX_INVALIDATION_ATTEMPTS = 2;
 
   private final CatalogManager catalogManager;
 
@@ -67,98 +72,66 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
   @Override
   public void onEntityChange(List<EntityChangeRecord> changes) {
     for (EntityChangeRecord change : changes) {
-      try {
-        if (!isCatalogChange(change)) {
-          continue;
-        }
-
-        Optional<NameIdentifier> identOpt = catalogIdentifier(change);
-        if (identOpt.isEmpty()) {
-          continue;
-        }
-        NameIdentifier ident = identOpt.get();
-
-        if (catalogManager.consumeLocalMutation(ident)) {
-          LOG.debug(
-              "Skipping catalog cache invalidation for local mutation: {}, change log id {}",
-              ident,
-              change.getId());
-          continue;
-        }
-
-        // Logged at INFO on purpose: this tears down the cached catalog, including its connection
-        // pool and isolated classloader, and it is the main cross-node effect of the change log.
-        // CatalogManager logs the matching "Closing catalog" line when the eviction runs.
-        LOG.info(
-            "Invalidating catalog cache for {} due to a remote {} recorded in change log id {}",
-            ident,
-            change.getOperateType(),
-            change.getId());
-        invalidateWithRetry(ident, change);
-      } catch (RuntimeException e) {
-        // Deliberately not rethrown: see the class javadoc. The poller dispatches a batch once, so
-        // rethrowing would only lose the remaining records of this batch as well.
-        LOG.error(
-            "Failed to process catalog change log record: id={}, fullName={}, entityType={}, "
-                + "operateType={}",
-            change.getId(),
-            change.getFullName(),
-            change.getEntityType(),
-            change.getOperateType(),
-            e);
+      if (!isCatalogChange(change)) {
+        continue;
       }
-    }
-  }
 
-  /**
-   * Evicts one catalog, retrying the eviction itself up to {@link #MAX_INVALIDATION_ATTEMPTS}
-   * times.
-   *
-   * <p>Recovery here is deliberately narrow, and both limits are correctness requirements rather
-   * than tuning choices:
-   *
-   * <ul>
-   *   <li>It is scoped to the single identifier this change log record named. Clearing the whole
-   *       catalog cache - the fallback the entity and JCasbin caches use - would evict catalogs
-   *       this process is actively serving and close their in-use {@code IsolatedClassLoader}s,
-   *       which is the permanent {@code NoClassDefFoundError} of #11739. Only the catalog that
-   *       actually changed on another node may be torn down.
-   *   <li>It retries the eviction only, never the {@link CatalogManager#consumeLocalMutation} probe
-   *       that ran before it. That marker is single-shot, so re-consulting it would classify a
-   *       local mutation as remote and tear down a catalog this node just mutated itself.
-   * </ul>
-   *
-   * <p>If every attempt fails, the record is given up on: this node keeps serving that catalog from
-   * cache until {@code gravitino.catalog.cache.evictionIntervalMs} expires it, so the failure is
-   * logged at {@code ERROR}.
-   */
-  private void invalidateWithRetry(NameIdentifier ident, EntityChangeRecord change) {
-    RuntimeException lastFailure = null;
-    for (int attempt = 1; attempt <= MAX_INVALIDATION_ATTEMPTS; attempt++) {
+      Optional<NameIdentifier> identOpt = catalogIdentifier(change);
+      if (identOpt.isEmpty()) {
+        // Already logged. A row that names no catalog cannot leave a stale entry behind, so it is
+        // skipped rather than escalated to a cache clear.
+        continue;
+      }
+      NameIdentifier ident = identOpt.get();
+
+      boolean localMutation;
+      try {
+        localMutation = catalogManager.consumeLocalMutation(ident);
+      } catch (RuntimeException e) {
+        // The dedup probe decides whether this node caused the change. Without an answer there is
+        // no eviction to attempt, and clearing here would tear down catalogs over a bookkeeping
+        // failure, so the record is skipped.
+        LOG.error(
+            "Failed to check local mutation state for catalog {}, skipping change log record id {}",
+            ident,
+            change.getId(),
+            e);
+        continue;
+      }
+
+      if (localMutation) {
+        LOG.debug(
+            "Skipping catalog cache invalidation for local mutation: {}, change log id {}",
+            ident,
+            change.getId());
+        continue;
+      }
+
+      // Logged at INFO on purpose: this tears down the cached catalog, including its connection
+      // pool and isolated classloader, and it is the main cross-node effect of the change log.
+      // CatalogManager logs the matching "Closing catalog" line when the eviction runs.
+      LOG.info(
+          "Invalidating catalog cache for {} due to a remote {} recorded in change log id {}",
+          ident,
+          change.getOperateType(),
+          change.getId());
+
       try {
         catalogManager.getCatalogCache().invalidate(ident);
-        if (attempt > 1) {
-          LOG.info("Evicted catalog {} on attempt {}", ident, attempt);
-        }
-        return;
       } catch (RuntimeException e) {
-        lastFailure = e;
-        LOG.warn(
-            "Failed to evict catalog {} from the catalog cache on attempt {} of {}",
+        // The poller dispatches a batch once and never replays it, so dropping this eviction would
+        // serve the catalog stale until the eviction interval expires. The whole cache is cleared
+        // instead; see the class javadoc for the classloader cost this accepts.
+        LOG.error(
+            "Failed to evict catalog {} for change log id {}, clearing the whole catalog cache to "
+                + "avoid serving it stale; catalogs in use by this node are closed as a result",
             ident,
-            attempt,
-            MAX_INVALIDATION_ATTEMPTS,
+            change.getId(),
             e);
+        catalogManager.getCatalogCache().invalidateAll();
+        return;
       }
     }
-
-    LOG.error(
-        "Giving up on evicting catalog {} after {} attempt(s) for change log id {}; this node may "
-            + "serve it stale until the catalog cache eviction interval expires it",
-        ident,
-        MAX_INVALIDATION_ATTEMPTS,
-        change.getId(),
-        lastFailure);
   }
 
   private boolean isCatalogChange(EntityChangeRecord change) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
@@ -35,16 +35,23 @@ import org.slf4j.LoggerFactory;
  * <p>This listener is called <em>synchronously</em> in the poller thread. Implementations must not
  * block or perform expensive I/O; only fast, in-memory cache invalidations are permitted.
  *
- * <p>The poller requires each listener to be self-healing, and this one heals by swallowing its own
- * failures per record. It must not recover by clearing the catalog cache the way {@code
- * EntityCacheChangeLogListener} does: invalidating a catalog this process still uses closes its
- * in-use {@code IsolatedClassLoader}. Dropping an invalidation is the cheaper failure: the catalog
- * cache expires on access, so staleness is bounded by {@code
- * gravitino.catalog.cache.evictionIntervalMs}.
+ * <p>The poller requires each listener to be self-healing. This one heals within a single record:
+ * it retries that record's own eviction (see {@link #invalidateWithRetry}) and then swallows the
+ * failure, so one bad record never costs the rest of the batch. It must NOT recover by clearing the
+ * catalog cache the way {@code EntityCacheChangeLogListener} and {@code JcasbinChangeListener} do,
+ * because evicting a catalog this process still uses closes its in-use {@code IsolatedClassLoader}
+ * (#11739). Giving up on one eviction is the cheaper failure: the catalog cache expires on access,
+ * so staleness is bounded by {@code gravitino.catalog.cache.evictionIntervalMs}.
  */
 public class CatalogChangeLogListener implements EntityChangeLogListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(CatalogChangeLogListener.class);
+
+  /**
+   * How many times one catalog eviction is attempted. This is the listener's whole self-healing
+   * budget: see {@link #invalidateWithRetry} for why recovery cannot be broadened here.
+   */
+  private static final int MAX_INVALIDATION_ATTEMPTS = 2;
 
   private final CatalogManager catalogManager;
 
@@ -87,12 +94,11 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
             ident,
             change.getOperateType(),
             change.getId());
-        catalogManager.getCatalogCache().invalidate(ident);
+        invalidateWithRetry(ident, change);
       } catch (RuntimeException e) {
-        // Deliberately not rethrown: see the class javadoc. A dropped invalidation only costs
-        // bounded staleness here, while a retry of an already-applied batch can tear down a
-        // catalog that is still in use.
-        LOG.warn(
+        // Deliberately not rethrown: see the class javadoc. The poller dispatches a batch once, so
+        // rethrowing would only lose the remaining records of this batch as well.
+        LOG.error(
             "Failed to process catalog change log record: id={}, fullName={}, entityType={}, "
                 + "operateType={}",
             change.getId(),
@@ -102,6 +108,57 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
             e);
       }
     }
+  }
+
+  /**
+   * Evicts one catalog, retrying the eviction itself up to {@link #MAX_INVALIDATION_ATTEMPTS}
+   * times.
+   *
+   * <p>Recovery here is deliberately narrow, and both limits are correctness requirements rather
+   * than tuning choices:
+   *
+   * <ul>
+   *   <li>It is scoped to the single identifier this change log record named. Clearing the whole
+   *       catalog cache - the fallback the entity and JCasbin caches use - would evict catalogs
+   *       this process is actively serving and close their in-use {@code IsolatedClassLoader}s,
+   *       which is the permanent {@code NoClassDefFoundError} of #11739. Only the catalog that
+   *       actually changed on another node may be torn down.
+   *   <li>It retries the eviction only, never the {@link CatalogManager#consumeLocalMutation} probe
+   *       that ran before it. That marker is single-shot, so re-consulting it would classify a
+   *       local mutation as remote and tear down a catalog this node just mutated itself.
+   * </ul>
+   *
+   * <p>If every attempt fails, the record is given up on: this node keeps serving that catalog from
+   * cache until {@code gravitino.catalog.cache.evictionIntervalMs} expires it, so the failure is
+   * logged at {@code ERROR}.
+   */
+  private void invalidateWithRetry(NameIdentifier ident, EntityChangeRecord change) {
+    RuntimeException lastFailure = null;
+    for (int attempt = 1; attempt <= MAX_INVALIDATION_ATTEMPTS; attempt++) {
+      try {
+        catalogManager.getCatalogCache().invalidate(ident);
+        if (attempt > 1) {
+          LOG.info("Evicted catalog {} on attempt {}", ident, attempt);
+        }
+        return;
+      } catch (RuntimeException e) {
+        lastFailure = e;
+        LOG.warn(
+            "Failed to evict catalog {} from the catalog cache on attempt {} of {}",
+            ident,
+            attempt,
+            MAX_INVALIDATION_ATTEMPTS,
+            e);
+      }
+    }
+
+    LOG.error(
+        "Giving up on evicting catalog {} after {} attempt(s) for change log id {}; this node may "
+            + "serve it stale until the catalog cache eviction interval expires it",
+        ident,
+        MAX_INVALIDATION_ATTEMPTS,
+        change.getId(),
+        lastFailure);
   }
 
   private boolean isCatalogChange(EntityChangeRecord change) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -41,10 +42,10 @@ import org.slf4j.LoggerFactory;
  * rest of the batch. A malformed row is skipped instead, because it names no catalog and so leaves
  * nothing stale.
  *
- * <p>If the clear itself fails the exception reaches the poller, which logs it at {@code ERROR} and
- * advances its cursor. That is safe now that the poller never replays a batch: a replay would
- * re-run the single-shot {@link CatalogManager#consumeLocalMutation} probe, classify a local
- * mutation as remote and tear down a catalog this node just mutated itself.
+ * <p>The listener consumes local-mutation markers for the whole batch before evicting anything. A
+ * failed eviction or clear therefore cannot strand a marker that would make a later remote change
+ * look local. If the clear itself fails, the exception reaches the poller, which logs it at {@code
+ * ERROR} and advances its cursor; the affected catalog can then remain stale until it expires.
  *
  * <p><b>Cost of the clear:</b> evicting a cached catalog closes its {@code CatalogWrapper}, which
  * tears down the connection pool and the {@code IsolatedClassLoader}. A whole-cache clear therefore
@@ -71,6 +72,7 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
 
   @Override
   public void onEntityChange(List<EntityChangeRecord> changes) {
+    List<CatalogInvalidation> remoteInvalidations = new ArrayList<>();
     for (EntityChangeRecord change : changes) {
       if (!isCatalogChange(change)) {
         continue;
@@ -88,15 +90,16 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
       try {
         localMutation = catalogManager.consumeLocalMutation(ident);
       } catch (RuntimeException e) {
-        // The dedup probe decides whether this node caused the change. Without an answer there is
-        // no eviction to attempt, and clearing here would tear down catalogs over a bookkeeping
-        // failure, so the record is skipped.
+        // The identifier is valid, so this record may name a remote mutation. Treating an unknown
+        // origin as remote can cause an unnecessary eviction, but skipping it can leave a stale
+        // catalog cached after the poller advances its cursor.
         LOG.error(
-            "Failed to check local mutation state for catalog {}, skipping change log record id {}",
+            "Failed to check local mutation state for catalog {}, treating change log record id {} "
+                + "as remote to avoid serving stale metadata",
             ident,
             change.getId(),
             e);
-        continue;
+        localMutation = false;
       }
 
       if (localMutation) {
@@ -107,6 +110,12 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
         continue;
       }
 
+      remoteInvalidations.add(new CatalogInvalidation(change, ident));
+    }
+
+    for (CatalogInvalidation invalidation : remoteInvalidations) {
+      EntityChangeRecord change = invalidation.change;
+      NameIdentifier ident = invalidation.ident;
       // Logged at INFO on purpose: this tears down the cached catalog, including its connection
       // pool and isolated classloader, and it is the main cross-node effect of the change log.
       // CatalogManager logs the matching "Closing catalog" line when the eviction runs.
@@ -131,6 +140,16 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
         catalogManager.getCatalogCache().invalidateAll();
         return;
       }
+    }
+  }
+
+  private static class CatalogInvalidation {
+    private final EntityChangeRecord change;
+    private final NameIdentifier ident;
+
+    private CatalogInvalidation(EntityChangeRecord change, NameIdentifier ident) {
+      this.change = change;
+      this.ident = ident;
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
@@ -35,12 +35,12 @@ import org.slf4j.LoggerFactory;
  * <p>This listener is called <em>synchronously</em> in the poller thread. Implementations must not
  * block or perform expensive I/O; only fast, in-memory cache invalidations are permitted.
  *
- * <p>This listener never propagates a failure to the poller, so the poller never retries a batch
- * for it. That is deliberate: local-mutation de-duplication ({@link
- * CatalogManager#consumeLocalMutation}) is single-shot, so re-delivering an already-applied batch
- * would invalidate a catalog this process mutated itself and close its still-in-use {@code
- * IsolatedClassLoader}. Dropping an invalidation is the cheaper failure: the catalog cache expires
- * on access, so staleness is bounded by {@code gravitino.catalog.cache.evictionIntervalMs}.
+ * <p>The poller requires each listener to be self-healing, and this one heals by swallowing its own
+ * failures per record. It must not recover by clearing the catalog cache the way {@code
+ * EntityCacheChangeLogListener} does: invalidating a catalog this process still uses closes its
+ * in-use {@code IsolatedClassLoader}. Dropping an invalidation is the cheaper failure: the catalog
+ * cache expires on access, so staleness is bounded by {@code
+ * gravitino.catalog.cache.evictionIntervalMs}.
  */
 public class CatalogChangeLogListener implements EntityChangeLogListener {
 

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
@@ -36,24 +36,27 @@ import org.slf4j.LoggerFactory;
  * <p>This listener is called <em>synchronously</em> in the poller thread. Implementations must not
  * block or perform expensive I/O; only fast, in-memory cache invalidations are permitted.
  *
- * <p>The poller requires each listener to be self-healing, and this one recovers the same way
- * {@code EntityCacheChangeLogListener} and {@code JcasbinChangeListener} do: a failed eviction
- * clears the whole catalog cache, which is a strict superset of the eviction that failed and of the
- * rest of the batch. A malformed row is skipped instead, because it names no catalog and so leaves
- * nothing stale.
+ * <p>The poller hands each batch to a listener only once, so a listener has to clean up after
+ * itself when it fails. This one does what {@code EntityCacheChangeLogListener} and {@code
+ * JcasbinChangeListener} do: if removing one catalog from the cache fails, it clears the whole
+ * catalog cache, which also covers the entry it failed to remove and the rest of the batch. A row
+ * that cannot be parsed is simply skipped, because it does not point at any catalog and so cannot
+ * leave anything stale.
  *
- * <p>The listener consumes local-mutation markers for the whole batch before evicting anything. A
- * failed eviction or clear therefore cannot strand a marker that would make a later remote change
- * look local. If the clear itself fails, the exception reaches the poller, which logs it at {@code
- * ERROR} and advances its cursor; the affected catalog can then remain stale until it expires.
+ * <p>Before removing anything, the listener first goes through the whole batch and marks off the
+ * changes this node made itself. Doing it in that order means a later failure cannot leave one of
+ * those marks behind, which would otherwise make a future change from another node look like a
+ * local one. If the clear itself fails, the exception goes up to the poller, which logs it at
+ * {@code ERROR} and moves on, and the catalog stays stale until it expires.
  *
- * <p><b>Cost of the clear:</b> evicting a cached catalog closes its {@code CatalogWrapper}, which
- * tears down the connection pool and the {@code IsolatedClassLoader}. A whole-cache clear therefore
- * also closes catalogs this process is actively serving; requests holding classes from a closed
- * loader can fail with {@code NoClassDefFoundError}, the failure mode of #11739. This is accepted
- * deliberately so that a stale catalog is never served: the alternative left this node serving the
- * changed catalog from cache for up to {@code gravitino.catalog.cache.evictionIntervalMs}. The
- * clear runs only on a failed eviction, which is off the normal path.
+ * <p><b>What clearing costs:</b> dropping a catalog from the cache closes its {@code
+ * CatalogWrapper}, which shuts down its connection pool and its {@code IsolatedClassLoader}.
+ * Clearing the whole cache therefore also closes catalogs this process is serving right now, and
+ * requests still using classes from a closed classloader can fail with {@code NoClassDefFoundError}
+ * (that is the bug in #11739). We accept this on purpose so a changed catalog is never served from
+ * a stale cache; without it, this node would keep serving the old catalog for up to {@code
+ * gravitino.catalog.cache.evictionIntervalMs}. The clear only happens when a normal removal failed,
+ * never during normal operation.
  */
 public class CatalogChangeLogListener implements EntityChangeLogListener {
 
@@ -80,8 +83,8 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
 
       Optional<NameIdentifier> identOpt = catalogIdentifier(change);
       if (identOpt.isEmpty()) {
-        // Already logged. A row that names no catalog cannot leave a stale entry behind, so it is
-        // skipped rather than escalated to a cache clear.
+        // Already logged. This row does not point at any catalog, so there is nothing stale to
+        // clean up. Just skip it instead of clearing the cache.
         continue;
       }
       NameIdentifier ident = identOpt.get();
@@ -90,9 +93,9 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
       try {
         localMutation = catalogManager.consumeLocalMutation(ident);
       } catch (RuntimeException e) {
-        // The identifier is valid, so this record may name a remote mutation. Treating an unknown
-        // origin as remote can cause an unnecessary eviction, but skipping it can leave a stale
-        // catalog cached after the poller advances its cursor.
+        // We could not tell whether this change came from this node or another one. The name is
+        // valid, so assume it came from another node: the worst case is one extra cache removal,
+        // while skipping it could leave an old catalog cached forever.
         LOG.error(
             "Failed to check local mutation state for catalog {}, treating change log record id {} "
                 + "as remote to avoid serving stale metadata",
@@ -116,9 +119,9 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
     for (CatalogInvalidation invalidation : remoteInvalidations) {
       EntityChangeRecord change = invalidation.change;
       NameIdentifier ident = invalidation.ident;
-      // Logged at INFO on purpose: this tears down the cached catalog, including its connection
-      // pool and isolated classloader, and it is the main cross-node effect of the change log.
-      // CatalogManager logs the matching "Closing catalog" line when the eviction runs.
+      // INFO on purpose: dropping the catalog from the cache also closes its connection pool and
+      // its isolated classloader, and this is the main thing the change log does across nodes.
+      // CatalogManager prints the matching "Closing catalog" line when the removal happens.
       LOG.info(
           "Invalidating catalog cache for {} due to a remote {} recorded in change log id {}",
           ident,
@@ -128,9 +131,9 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
       try {
         catalogManager.getCatalogCache().invalidate(ident);
       } catch (RuntimeException e) {
-        // The poller dispatches a batch once and never replays it, so dropping this eviction would
-        // serve the catalog stale until the eviction interval expires. The whole cache is cleared
-        // instead; see the class javadoc for the classloader cost this accepts.
+        // This batch will never be sent again, so giving up here would keep serving the old
+        // catalog until it expires on its own. Clear the whole cache instead; see the class
+        // javadoc for the classloader cost that comes with it.
         LOG.error(
             "Failed to evict catalog {} for change log id {}, clearing the whole catalog cache to "
                 + "avoid serving it stale; catalogs in use by this node are closed as a result",
@@ -169,8 +172,11 @@ public class CatalogChangeLogListener implements EntityChangeLogListener {
     NameIdentifier ident;
     try {
       ident = EntityChangeLogNameIdentifierCodec.decode(change.getFullName());
-    } catch (IllegalArgumentException e) {
-      LOG.warn("Invalid catalog full name in entity change log: {}", change.getFullName());
+    } catch (RuntimeException e) {
+      // Catch every unchecked exception, not just IllegalArgumentException: if a future version of
+      // the codec throws something else, one bad row must still be skipped instead of aborting the
+      // whole batch, which would drop the invalidations already collected for the other rows.
+      LOG.warn("Invalid catalog full name in entity change log: {}", change.getFullName(), e);
       return Optional.empty();
     }
     if (ident.namespace().length() != 1) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityCacheChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityCacheChangeLogListener.java
@@ -52,8 +52,9 @@ import org.slf4j.LoggerFactory;
  *   <li>A <b>failed invalidation</b> means this node may now serve stale metadata indefinitely. The
  *       whole cache is cleared instead, which is strictly stronger than the invalidation that
  *       failed and only costs a cold-cache penalty, since the cache is derived state. If even the
- *       clear fails the exception propagates, and {@link EntityChangeLogPoller} retries the batch
- *       and ultimately applies its configured listener failure action.
+ *       clear fails the exception propagates to {@link EntityChangeLogPoller}, which logs it and
+ *       moves on: the batch is not retried, so this node may keep serving stale entries until they
+ *       expire.
  * </ul>
  */
 public class EntityCacheChangeLogListener implements EntityChangeLogListener {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityCacheChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityCacheChangeLogListener.java
@@ -52,9 +52,9 @@ import org.slf4j.LoggerFactory;
  *   <li>A <b>failed invalidation</b> means this node may now serve stale metadata indefinitely. The
  *       whole cache is cleared instead, which is strictly stronger than the invalidation that
  *       failed and only costs a cold-cache penalty, since the cache is derived state. If even the
- *       clear fails the exception propagates to {@link EntityChangeLogPoller}, which logs it and
- *       moves on: the batch is not retried, so this node may keep serving stale entries until they
- *       expire.
+ *       clear also fails, the exception goes up to {@link EntityChangeLogPoller}, which only logs
+ *       it and moves on. The batch is never sent again, so this node may keep serving stale entries
+ *       until they expire.
  * </ul>
  */
 public class EntityCacheChangeLogListener implements EntityChangeLogListener {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogCleaner.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogCleaner.java
@@ -49,7 +49,7 @@ public class EntityChangeLogCleaner implements AutoCloseable {
   /**
    * How many poll cycles a change record must survive at minimum. A record has to outlive more than
    * one cycle, because a node can miss cycles while it is restarting, stalled in a long GC pause,
-   * or paused retrying a failed listener.
+   * or slow to drain a large backlog.
    */
   private static final long MIN_RETENTION_POLL_CYCLES = 10;
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogListener.java
@@ -28,11 +28,11 @@ public interface EntityChangeLogListener {
   /**
    * Handles a batch of entity changes.
    *
-   * <p>The batch is dispatched exactly once and is never replayed, so implementations must be
-   * self-healing: recover locally from a failure (for example by clearing the whole cache this
-   * listener maintains, which is a superset of any invalidation it missed) rather than relying on
-   * the poller to retry. If this method throws, the poller logs the failure at {@code ERROR} and
-   * advances its cursor, which leaves the listener's state permanently stale.
+   * <p>A batch is handed to the listener only once and is never sent again, so the listener has to
+   * clean up after itself when something goes wrong. The simplest way is to clear the whole cache
+   * this listener keeps, because that also removes whatever entry it failed to remove. Do not count
+   * on the poller retrying. If this method throws, the poller only logs the error at {@code ERROR}
+   * and moves on, and this listener's cache can stay wrong from then on.
    *
    * @param changes the entity changes fetched in one poller cycle
    */

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogListener.java
@@ -28,9 +28,11 @@ public interface EntityChangeLogListener {
   /**
    * Handles a batch of entity changes.
    *
-   * <p>If this method throws, the poller may retry the same batch for this listener.
-   * Implementations must make the callback atomic or tolerate retrying changes that were applied
-   * before the exception.
+   * <p>The batch is dispatched exactly once and is never replayed, so implementations must be
+   * self-healing: recover locally from a failure (for example by clearing the whole cache this
+   * listener maintains, which is a superset of any invalidation it missed) rather than relying on
+   * the poller to retry. If this method throws, the poller logs the failure at {@code ERROR} and
+   * advances its cursor, which leaves the listener's state permanently stale.
    *
    * @param changes the entity changes fetched in one poller cycle
    */

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
@@ -49,10 +49,10 @@ import org.slf4j.LoggerFactory;
  *       the invalidations it missed.
  *   <li>{@code JcasbinChangeListener} clears its whole {@code metadataIdCache} for the same reason;
  *       a stale name&#8594;id mapping there would feed authorization decisions.
- *   <li>{@code CatalogChangeLogListener} retries the single eviction that failed and then swallows
- *       the failure. It must NOT clear its cache, because evicting a catalog this process still
- *       uses closes its in-use {@code IsolatedClassLoader}; it accepts staleness bounded by the
- *       catalog cache eviction interval instead.
+ *   <li>{@code CatalogChangeLogListener} clears its whole catalog cache as well. Note that this
+ *       closes the {@code IsolatedClassLoader} of every cached catalog, including catalogs this
+ *       process is actively serving (the failure mode of #11739); it is accepted so that a changed
+ *       catalog is never served stale. The clear runs only on a failed eviction.
  * </ul>
  *
  * <p>A listener that can do neither must not be registered here.

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
@@ -35,30 +35,31 @@ import org.slf4j.LoggerFactory;
 /**
  * Global poller for {@code entity_change_log}.
  *
- * <p>The poller owns the single high-water mark for a Gravitino server process. Each consumed batch
- * is dispatched once to every registered listener and the cursor then advances unconditionally, so
- * a failing listener never delays the batch for the others: pausing the shared cursor would degrade
- * cache coherence process-wide because of one listener.
+ * <p>There is one poller per Gravitino server process, and it keeps one read position (the id of
+ * the last row it has read). It reads a batch of rows, hands that batch to every listener once, and
+ * then always moves the read position forward, even if a listener failed. The read position is
+ * shared by all listeners, so holding it back to retry one listener would stop every other listener
+ * from seeing new changes, and all the caches in this process would fall behind.
  *
- * <p>Listeners must therefore be self-healing: a listener that cannot apply a batch has to recover
- * locally, because it will not see that batch again. The three registered listeners recover as
- * follows:
+ * <p>Because a batch is handed out only once and is never sent again, every listener must be able
+ * to fix itself when it fails. The usual way to do that is to clear its whole cache: clearing
+ * everything also covers whatever the listener failed to remove, so nothing stale is left behind.
+ * The three listeners registered today do exactly that:
  *
  * <ul>
- *   <li>{@code EntityCacheChangeLogListener} clears its whole entity cache, a strict superset of
- *       the invalidations it missed.
- *   <li>{@code JcasbinChangeListener} clears its whole {@code metadataIdCache} for the same reason;
- *       a stale name&#8594;id mapping there would feed authorization decisions.
- *   <li>{@code CatalogChangeLogListener} clears its whole catalog cache as well. Note that this
- *       closes the {@code IsolatedClassLoader} of every cached catalog, including catalogs this
- *       process is actively serving (the failure mode of #11739); it is accepted so that a changed
- *       catalog is never served stale. The clear runs only on a failed eviction.
+ *   <li>{@code EntityCacheChangeLogListener} clears its whole entity cache.
+ *   <li>{@code JcasbinChangeListener} clears its whole {@code metadataIdCache}. A stale
+ *       name&#8594;id entry there would be used by authorization checks.
+ *   <li>{@code CatalogChangeLogListener} clears its whole catalog cache. Clearing it also closes
+ *       the {@code IsolatedClassLoader} of every cached catalog, including catalogs this process is
+ *       currently serving (that is the bug in #11739). We accept that cost so a changed catalog is
+ *       never served from a stale cache, and the clear only happens when a normal removal failed.
  * </ul>
  *
- * <p>A listener that can do neither must not be registered here.
+ * <p>Do not register a listener here if it cannot recover on its own.
  *
- * <p>Every listener failure is logged at {@code ERROR}, so a listener whose local recovery is
- * failing stays visible in the logs even though the poller keeps making progress.
+ * <p>Every listener failure is logged at {@code ERROR}, so a listener that keeps failing stays
+ * visible in the logs even though the poller keeps going.
  */
 public class EntityChangeLogPoller implements AutoCloseable {
 
@@ -173,7 +174,12 @@ public class EntityChangeLogPoller implements AutoCloseable {
   void pollChanges() {
     try {
       doPollChanges();
-    } catch (Exception e) {
+    } catch (Throwable e) {
+      // Catch Throwable, not Exception: this method is the task handed to
+      // scheduleWithFixedDelay(), and anything that escapes it cancels all future runs for good,
+      // silently. An Error is reachable here, for example a NoClassDefFoundError thrown by a
+      // listener that touched a closed IsolatedClassLoader. Losing the poller would stop cache
+      // invalidation for every listener in this process, so we log and let the next cycle run.
       if (handleInterruptIfAny(e, "Entity change poll")) {
         return;
       }
@@ -284,9 +290,9 @@ public class EntityChangeLogPoller implements AutoCloseable {
   }
 
   /**
-   * Dispatches the batch to every listener that is still registered. A listener failure is logged
-   * and then dropped: the listener is responsible for its own local recovery, and the cursor
-   * advances either way.
+   * Hands the batch to every listener that is still registered. If a listener throws, the error is
+   * only logged: each listener is expected to clean up after itself, and the read position moves
+   * forward either way.
    */
   private void notifyListeners(BatchDelivery delivery) {
     for (EntityChangeLogListener listener : delivery.targetListeners) {
@@ -306,7 +312,10 @@ public class EntityChangeLogPoller implements AutoCloseable {
             listener.getClass().getName(),
             delivery.firstChangeId(),
             delivery.lastChangeId);
-      } catch (Exception e) {
+      } catch (Throwable e) {
+        // Throwable, not Exception: a listener recovering by clearing its cache can close an
+        // IsolatedClassLoader that is still in use and surface a NoClassDefFoundError, which is an
+        // Error. One listener doing that must not take down the whole poller.
         LOG.error(
             "Entity change log listener {} failed to consume batch id range [{}, {}]; the batch is "
                 + "not retried, so the listener is responsible for local recovery",

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
@@ -309,7 +309,7 @@ public class EntityChangeLogPoller implements AutoCloseable {
       } catch (Exception e) {
         LOG.error(
             "Entity change log listener {} failed to consume batch id range [{}, {}]; the batch is "
-                + "not retried, and the listener did not contain the failure locally",
+                + "not retried, so the listener is responsible for local recovery",
             listener.getClass().getName(),
             delivery.firstChangeId(),
             delivery.lastChangeId,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
@@ -20,7 +20,6 @@ package org.apache.gravitino.storage.relational;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
@@ -36,51 +35,33 @@ import org.slf4j.LoggerFactory;
 /**
  * Global poller for {@code entity_change_log}.
  *
- * <p>The poller owns the single high-water mark for a Gravitino server process and dispatches each
- * consumed batch to registered listeners. The cursor advances only after every listener applies the
- * batch. If a listener throws, the immutable batch stays in memory and the next poll retries only
- * the listeners that have not succeeded yet.
+ * <p>The poller owns the single high-water mark for a Gravitino server process. Each consumed batch
+ * is dispatched once to every registered listener and the cursor then advances unconditionally, so
+ * a failing listener never delays the batch for the others: pausing the shared cursor would degrade
+ * cache coherence process-wide because of one listener.
  *
- * <p>A listener that throws after partially applying a batch receives the whole batch again, so
- * listeners must make each callback atomic or tolerate retrying changes they already applied. A
- * listener that cannot satisfy that contract must swallow its own failures, as {@code
- * CatalogChangeLogListener} does.
+ * <p>Listeners must therefore be self-healing: a listener that cannot apply a batch has to recover
+ * locally, because it will not see that batch again. {@code EntityCacheChangeLogListener} clears
+ * its whole cache, which is a strict superset of the invalidations it missed. {@code
+ * CatalogChangeLogListener} swallows its own failures instead - it must NOT clear its cache,
+ * because that closes {@code IsolatedClassLoader}s still in use. A listener that can satisfy
+ * neither must not be registered here.
  *
- * <p>Retries are bounded by {@code maxListenerRetries}. While a batch is paused no new batch is
- * fetched, so a permanently failing listener would otherwise freeze cache invalidation for the
- * whole process. When the bound is reached, {@link ListenerFailureAction} decides what happens:
- * {@code EXIT} stops this server (the local caches are known to be stale, so serving from them
- * would trade correctness for availability), {@code SKIP} drops the failed listeners from the batch
- * and advances the cursor.
+ * <p>Every listener failure is logged at {@code ERROR}, so a listener whose local recovery is
+ * failing stays visible in the logs even though the poller keeps making progress.
  */
 public class EntityChangeLogPoller implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(EntityChangeLogPoller.class);
 
-  /**
-   * Max entity-change rows to fetch per batch. A paused batch is retained in memory until every
-   * listener applies it, so this also bounds the poller's retained heap.
-   */
+  /** Max entity-change rows to fetch per batch. */
   private static final int ENTITY_CHANGE_POLLER_MAX_ROWS = 2000;
 
   /** Max records rendered in a batch summary log line. */
   private static final int MAX_SUMMARIZED_RECORDS = 20;
 
-  /** What the poller does when a listener keeps failing after {@code maxListenerRetries}. */
-  public enum ListenerFailureAction {
-    /** Stop this server process, because its local caches are known to be stale. */
-    EXIT,
-    /** Drop the failing listener from the batch, advance the cursor and keep serving. */
-    SKIP
-  }
-
   private final List<EntityChangeLogListener> listeners = new CopyOnWriteArrayList<>();
   private final long pollIntervalSecs;
-  private final int maxListenerRetries;
-  private final ListenerFailureAction listenerFailureAction;
-  private final Runnable exitHandler;
-
-  @Nullable private BatchDelivery pendingDelivery;
 
   private ScheduledExecutorService scheduler;
   private volatile long entityPollHighWaterId = 0;
@@ -89,39 +70,16 @@ public class EntityChangeLogPoller implements AutoCloseable {
    * Creates an {@link EntityChangeLogPoller}.
    *
    * @param pollIntervalSecs interval between successive polling cycles
-   * @param maxListenerRetries how many times a failing listener is retried for the same batch
-   *     before {@code listenerFailureAction} is applied
-   * @param listenerFailureAction what to do once a listener exhausted its retries
    */
-  public EntityChangeLogPoller(
-      long pollIntervalSecs, int maxListenerRetries, ListenerFailureAction listenerFailureAction) {
-    // System.exit() runs the JVM shutdown hooks, which is where GravitinoServer performs its
-    // graceful stop, so in-flight requests still get a chance to finish.
-    this(pollIntervalSecs, maxListenerRetries, listenerFailureAction, () -> System.exit(1));
-  }
-
-  @VisibleForTesting
-  EntityChangeLogPoller(
-      long pollIntervalSecs,
-      int maxListenerRetries,
-      ListenerFailureAction listenerFailureAction,
-      Runnable exitHandler) {
+  public EntityChangeLogPoller(long pollIntervalSecs) {
     Preconditions.checkArgument(pollIntervalSecs > 0, "pollIntervalSecs must be positive");
-    Preconditions.checkArgument(maxListenerRetries >= 0, "maxListenerRetries must be non-negative");
-    Preconditions.checkArgument(
-        listenerFailureAction != null, "listenerFailureAction cannot be null");
     this.pollIntervalSecs = pollIntervalSecs;
-    this.maxListenerRetries = maxListenerRetries;
-    this.listenerFailureAction = listenerFailureAction;
-    this.exitHandler = exitHandler;
   }
 
   /**
    * Registers a listener to receive future entity change batches.
    *
-   * <p>A listener only receives batches fetched after it was registered. In particular, if a batch
-   * is currently paused by a failing listener, the newly registered listener does not receive that
-   * batch and the cursor moves past it once the batch completes.
+   * <p>A listener only receives batches fetched after it was registered.
    *
    * @param listener the listener to register
    */
@@ -165,12 +123,10 @@ public class EntityChangeLogPoller implements AutoCloseable {
                 EntityChangeLogMapper.class, EntityChangeLogMapper::selectMaxChangeId));
     LOG.info(
         "Starting entity change log poller at high-water id {} with a {} second interval, "
-            + "{} listener(s) registered, maxListenerRetries={}, listenerFailureAction={}",
+            + "{} listener(s) registered",
         entityPollHighWaterId,
         pollIntervalSecs,
-        listeners.size(),
-        maxListenerRetries,
-        listenerFailureAction);
+        listeners.size());
 
     scheduler =
         Executors.newSingleThreadScheduledExecutor(
@@ -200,16 +156,7 @@ public class EntityChangeLogPoller implements AutoCloseable {
 
     // The final cursor tells where this node stopped consuming, which is the starting point when
     // comparing nodes after an incident.
-    LOG.info(
-        "Stopped entity change log poller at high-water id {}{}",
-        entityPollHighWaterId,
-        pendingDelivery == null
-            ? ""
-            : ", with an unapplied batch id range ["
-                + pendingDelivery.firstChangeId()
-                + ", "
-                + pendingDelivery.lastChangeId
-                + "]");
+    LOG.info("Stopped entity change log poller at high-water id {}", entityPollHighWaterId);
   }
 
   @VisibleForTesting
@@ -225,22 +172,7 @@ public class EntityChangeLogPoller implements AutoCloseable {
   }
 
   private synchronized void doPollChanges() {
-    BatchDelivery delivery = pendingDelivery;
-    if (delivery != null) {
-      LOG.info(
-          "Retrying entity change log batch with {} record(s), id range [{}, {}], attempt {} of "
-              + "{}, for {} pending listener(s)",
-          delivery.changes.size(),
-          delivery.firstChangeId(),
-          delivery.lastChangeId,
-          delivery.attempts,
-          maxListenerRetries + 1,
-          delivery.pendingListeners.size());
-      deliver(delivery);
-      return;
-    }
-
-    delivery = fetchNextDelivery();
+    BatchDelivery delivery = fetchNextDelivery();
     if (delivery != null) {
       deliver(delivery);
     }
@@ -256,7 +188,7 @@ public class EntityChangeLogPoller implements AutoCloseable {
     List<EntityChangeRecord> immutableChanges = List.copyOf(changes);
     long lastChangeId = immutableChanges.get(immutableChanges.size() - 1).getId();
     BatchDelivery delivery =
-        new BatchDelivery(immutableChanges, lastChangeId, List.copyOf(listeners), 1);
+        new BatchDelivery(immutableChanges, lastChangeId, List.copyOf(listeners));
     LOG.debug(
         "Fetched {} entity change log record(s) after cursor {}, id range [{}, {}]: {}",
         immutableChanges.size(),
@@ -323,33 +255,13 @@ public class EntityChangeLogPoller implements AutoCloseable {
   }
 
   private void deliver(BatchDelivery delivery) {
-    List<EntityChangeLogListener> failedListeners = notifyListeners(delivery);
-    if (failedListeners.isEmpty()) {
-      advanceCursor(delivery);
-      return;
-    }
-
-    if (delivery.attempts > maxListenerRetries) {
-      handleExhaustedRetries(delivery, failedListeners);
-      return;
-    }
-
-    pendingDelivery = delivery.retryOnly(failedListeners);
-    LOG.error(
-        "Entity change log cursor is paused at id {} because {} listener(s) failed to apply batch "
-            + "id range [{}, {}] (attempt {} of {})",
-        entityPollHighWaterId,
-        failedListeners.size(),
-        delivery.firstChangeId(),
-        delivery.lastChangeId,
-        delivery.attempts,
-        maxListenerRetries + 1);
+    notifyListeners(delivery);
+    advanceCursor(delivery);
   }
 
   private void advanceCursor(BatchDelivery delivery) {
     long previousHighWaterId = entityPollHighWaterId;
     entityPollHighWaterId = delivery.lastChangeId;
-    pendingDelivery = null;
     LOG.info(
         "Consumed {} entity change log record(s), id range [{}, {}]; cursor advanced from {} to {}; "
             + "newest record is ~{} ms old",
@@ -361,38 +273,13 @@ public class EntityChangeLogPoller implements AutoCloseable {
         delivery.approximateLagMs());
   }
 
-  private void handleExhaustedRetries(
-      BatchDelivery delivery, List<EntityChangeLogListener> failedListeners) {
-    List<String> failedListenerNames = new ArrayList<>();
-    for (EntityChangeLogListener listener : failedListeners) {
-      failedListenerNames.add(listener.getClass().getName());
-    }
-
-    if (listenerFailureAction == ListenerFailureAction.EXIT) {
-      LOG.error(
-          "Stopping this server: listener(s) {} failed to apply entity change log batch id range "
-              + "[{}, {}] after {} attempt(s), so local caches are stale and cannot be trusted",
-          failedListenerNames,
-          delivery.firstChangeId(),
-          delivery.lastChangeId,
-          delivery.attempts);
-      exitHandler.run();
-      return;
-    }
-
-    LOG.error(
-        "Dropping entity change log batch id range [{}, {}] for listener(s) {} after {} attempt(s);"
-            + " their local caches may be stale until the affected entries expire",
-        delivery.firstChangeId(),
-        delivery.lastChangeId,
-        failedListenerNames,
-        delivery.attempts);
-    advanceCursor(delivery);
-  }
-
-  private List<EntityChangeLogListener> notifyListeners(BatchDelivery delivery) {
-    List<EntityChangeLogListener> failedListeners = new ArrayList<>();
-    for (EntityChangeLogListener listener : delivery.pendingListeners) {
+  /**
+   * Dispatches the batch to every listener that is still registered. A listener failure is logged
+   * and then dropped: the listener is responsible for its own local recovery, and the cursor
+   * advances either way.
+   */
+  private void notifyListeners(BatchDelivery delivery) {
+    for (EntityChangeLogListener listener : delivery.targetListeners) {
       if (!listeners.contains(listener)) {
         LOG.debug(
             "Skipping unregistered entity change log listener {} for batch id range [{}, {}]",
@@ -410,39 +297,29 @@ public class EntityChangeLogPoller implements AutoCloseable {
             delivery.firstChangeId(),
             delivery.lastChangeId);
       } catch (Exception e) {
-        failedListeners.add(listener);
-        LOG.warn(
-            "Entity change log listener {} failed to consume batch id range [{}, {}]",
+        LOG.error(
+            "Entity change log listener {} failed to consume batch id range [{}, {}]; the batch is "
+                + "not retried, so the listener must have recovered locally",
             listener.getClass().getName(),
             delivery.firstChangeId(),
             delivery.lastChangeId,
             e);
       }
     }
-    return failedListeners;
   }
 
   private static class BatchDelivery {
     private final List<EntityChangeRecord> changes;
     private final long lastChangeId;
-    private final List<EntityChangeLogListener> pendingListeners;
-
-    /** How many times this batch has been dispatched, starting at 1 for the initial dispatch. */
-    private final int attempts;
+    private final List<EntityChangeLogListener> targetListeners;
 
     private BatchDelivery(
         List<EntityChangeRecord> changes,
         long lastChangeId,
-        List<EntityChangeLogListener> pendingListeners,
-        int attempts) {
+        List<EntityChangeLogListener> targetListeners) {
       this.changes = changes;
       this.lastChangeId = lastChangeId;
-      this.pendingListeners = pendingListeners;
-      this.attempts = attempts;
-    }
-
-    private BatchDelivery retryOnly(List<EntityChangeLogListener> failedListeners) {
-      return new BatchDelivery(changes, lastChangeId, List.copyOf(failedListeners), attempts + 1);
+      this.targetListeners = targetListeners;
     }
 
     private long firstChangeId() {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
@@ -309,7 +309,7 @@ public class EntityChangeLogPoller implements AutoCloseable {
       } catch (Exception e) {
         LOG.error(
             "Entity change log listener {} failed to consume batch id range [{}, {}]; the batch is "
-                + "not retried, so the listener must have recovered locally",
+                + "not retried, and the listener did not contain the failure locally",
             listener.getClass().getName(),
             delivery.firstChangeId(),
             delivery.lastChangeId,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
@@ -49,10 +49,10 @@ import org.slf4j.LoggerFactory;
  *       the invalidations it missed.
  *   <li>{@code JcasbinChangeListener} clears its whole {@code metadataIdCache} for the same reason;
  *       a stale name&#8594;id mapping there would feed authorization decisions.
- *   <li>{@code CatalogChangeLogListener} swallows its failures per record and must NOT clear its
- *       cache, because evicting a catalog this process still uses closes its in-use {@code
- *       IsolatedClassLoader}. It accepts staleness bounded by the catalog cache eviction interval
- *       instead.
+ *   <li>{@code CatalogChangeLogListener} retries the single eviction that failed and then swallows
+ *       the failure. It must NOT clear its cache, because evicting a catalog this process still
+ *       uses closes its in-use {@code IsolatedClassLoader}; it accepts staleness bounded by the
+ *       catalog cache eviction interval instead.
  * </ul>
  *
  * <p>A listener that can do neither must not be registered here.

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
@@ -41,11 +41,21 @@ import org.slf4j.LoggerFactory;
  * cache coherence process-wide because of one listener.
  *
  * <p>Listeners must therefore be self-healing: a listener that cannot apply a batch has to recover
- * locally, because it will not see that batch again. {@code EntityCacheChangeLogListener} clears
- * its whole cache, which is a strict superset of the invalidations it missed. {@code
- * CatalogChangeLogListener} swallows its own failures instead - it must NOT clear its cache,
- * because that closes {@code IsolatedClassLoader}s still in use. A listener that can satisfy
- * neither must not be registered here.
+ * locally, because it will not see that batch again. The three registered listeners recover as
+ * follows:
+ *
+ * <ul>
+ *   <li>{@code EntityCacheChangeLogListener} clears its whole entity cache, a strict superset of
+ *       the invalidations it missed.
+ *   <li>{@code JcasbinChangeListener} clears its whole {@code metadataIdCache} for the same reason;
+ *       a stale name&#8594;id mapping there would feed authorization decisions.
+ *   <li>{@code CatalogChangeLogListener} swallows its failures per record and must NOT clear its
+ *       cache, because evicting a catalog this process still uses closes its in-use {@code
+ *       IsolatedClassLoader}. It accepts staleness bounded by the catalog cache eviction interval
+ *       instead.
+ * </ul>
+ *
+ * <p>A listener that can do neither must not be registered here.
  *
  * <p>Every listener failure is logged at {@code ERROR}, so a listener whose local recovery is
  * failing stays visible in the logs even though the poller keeps making progress.

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -108,13 +107,7 @@ public class RelationalEntityStore
     // Polling and cleanup use separate single-threaded schedulers. Polling only dispatches changes
     // to local listeners, while cleanup independently removes records beyond the retention period.
     this.entityChangeLogPoller =
-        new EntityChangeLogPoller(
-            config.get(Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS),
-            config.get(Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES),
-            EntityChangeLogPoller.ListenerFailureAction.valueOf(
-                config
-                    .get(Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)
-                    .toUpperCase(Locale.ROOT)));
+        new EntityChangeLogPoller(config.get(Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS));
     this.entityChangeLogCleaner =
         new EntityChangeLogCleaner(
             TimeUnit.SECONDS.toMillis(config.get(Configs.ENTITY_CHANGE_LOG_RETENTION_SECS)),

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.authorization;
 import static org.apache.gravitino.Configs.CATALOG_CACHE_EVICTION_INTERVAL_MS;
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -138,8 +136,6 @@ public class TestAccessControlManager {
     Mockito.when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     Mockito.when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);

--- a/core/src/test/java/org/apache/gravitino/authorization/TestOwnerManager.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestOwnerManager.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.authorization;
 import static org.apache.gravitino.Configs.CATALOG_CACHE_EVICTION_INTERVAL_MS;
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -116,8 +114,6 @@ public class TestOwnerManager {
     Mockito.when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     Mockito.when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogChangeLogListener.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogChangeLogListener.java
@@ -19,8 +19,10 @@
 package org.apache.gravitino.catalog;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,6 +36,7 @@ import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
 import org.apache.gravitino.storage.relational.po.cache.OperateType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 public class TestCatalogChangeLogListener {
 
@@ -53,16 +56,18 @@ public class TestCatalogChangeLogListener {
 
     CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
 
-    // Nothing is left to try locally. Propagating is safe now that the poller only logs a listener
-    // failure: it never replays the batch, which is what used to be dangerous here, because
-    // consumeLocalMutation() is single-shot and a replay would classify a local mutation as remote.
+    // There is nothing else we can do here, so let the exception go up. That is fine now: the
+    // poller only logs it and never sends the batch again. Re-sending was the dangerous part,
+    // because consumeLocalMutation() works only once and a second pass would mistake a change made
+    // by this node for one made by another node.
     Assertions.assertThrows(
         RuntimeException.class,
         () ->
             listener.onEntityChange(
                 List.of(change(1L, "metalake.failing"), change(2L, "metalake.later_local"))));
 
-    // All markers are consumed before eviction starts, even when both eviction and recovery fail.
+    // The "made by this node" marks are all read before any removal starts, even when both the
+    // removal and the clear fail.
     verify(catalogManager).consumeLocalMutation(laterLocal);
     verify(catalogCache).invalidateAll();
   }
@@ -92,8 +97,8 @@ public class TestCatalogChangeLogListener {
                     change(2L, "metalake.later_remote"),
                     change(3L, "metalake.later_local"))));
 
-    // The later local marker is consumed before eviction starts. The clear is then a superset of
-    // the failed eviction and all remote records, so no additional eviction is needed.
+    // The later local mark is read before any removal starts. Clearing the whole cache then covers
+    // both the removal that failed and every remote record, so nothing else has to be removed.
     verify(catalogManager).consumeLocalMutation(laterLocal);
     verify(catalogCache).invalidateAll();
     verify(catalogCache, never()).invalidate(laterRemote);
@@ -117,7 +122,8 @@ public class TestCatalogChangeLogListener {
 
     verify(catalogCache).invalidate(first);
     verify(catalogCache).invalidate(second);
-    // Clearing closes in-use IsolatedClassLoaders, so it must stay off the normal path.
+    // Clearing closes IsolatedClassLoaders that are still in use, so it must never happen during
+    // normal operation.
     verify(catalogCache, never()).invalidateAll();
   }
 
@@ -133,7 +139,8 @@ public class TestCatalogChangeLogListener {
 
     CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
 
-    // A row that names no catalog leaves nothing stale, so it must not escalate to a clear.
+    // A row that does not point at any catalog leaves nothing stale, so it must not cause a
+    // whole-cache clear.
     Assertions.assertDoesNotThrow(
         () ->
             listener.onEntityChange(
@@ -161,8 +168,8 @@ public class TestCatalogChangeLogListener {
 
     CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
 
-    // An unknown origin is treated as remote: an unnecessary targeted eviction is safer than
-    // permanently skipping a real remote change after the poller advances its cursor.
+    // When we cannot tell which node made the change, assume another node did. Removing one entry
+    // for nothing is cheaper than missing a real remote change, which we would never see again.
     Assertions.assertDoesNotThrow(
         () ->
             listener.onEntityChange(
@@ -210,6 +217,37 @@ public class TestCatalogChangeLogListener {
     listener.onEntityChange(List.of(change(1L, EntityChangeLogNameIdentifierCodec.encode(ident))));
 
     verify(catalogCache).invalidate(ident);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testUnexpectedDecodeFailureSkipsOnlyThatRecord() {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
+    NameIdentifier healthy = NameIdentifier.of("metalake", "healthy");
+
+    when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
+    when(catalogManager.consumeLocalMutation(any())).thenReturn(false);
+
+    CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
+
+    // The codec throws IllegalArgumentException today, but that is an implementation detail two
+    // calls down. If it ever throws something else, one bad row must still be skipped instead of
+    // aborting the batch and dropping the invalidations already collected for the other rows.
+    try (MockedStatic<EntityChangeLogNameIdentifierCodec> codec =
+        mockStatic(EntityChangeLogNameIdentifierCodec.class, CALLS_REAL_METHODS)) {
+      codec
+          .when(() -> EntityChangeLogNameIdentifierCodec.decode("metalake.boom"))
+          .thenThrow(new IllegalStateException("codec blew up"));
+
+      Assertions.assertDoesNotThrow(
+          () ->
+              listener.onEntityChange(
+                  List.of(change(1L, "metalake.boom"), change(2L, "metalake.healthy"))));
+    }
+
+    verify(catalogCache).invalidate(healthy);
+    verify(catalogCache, never()).invalidateAll();
   }
 
   private static EntityChangeRecord change(long id, String fullName) {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogChangeLogListener.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogChangeLogListener.java
@@ -19,8 +19,11 @@
 package org.apache.gravitino.catalog;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,6 +63,61 @@ public class TestCatalogChangeLogListener {
 
     verify(catalogCache).invalidate(successfulIdentifier);
     verify(catalogCache, never()).invalidate(failedIdentifier);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testTransientEvictionFailureIsRetriedForTheSameCatalog() {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
+    NameIdentifier ident = NameIdentifier.of("metalake", "cat");
+
+    when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
+    when(catalogManager.consumeLocalMutation(ident)).thenReturn(false);
+    doThrow(new RuntimeException("eviction failed"))
+        .doNothing()
+        .when(catalogCache)
+        .invalidate(ident);
+
+    CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
+
+    Assertions.assertDoesNotThrow(
+        () -> listener.onEntityChange(List.of(change(1L, "metalake.cat"))));
+
+    // The eviction is retried, so a transient failure no longer leaves this catalog stale.
+    verify(catalogCache, times(2)).invalidate(ident);
+    // The retry must not re-run the single-shot local-mutation probe: doing so would classify a
+    // local mutation as remote and close an IsolatedClassLoader this process is still using.
+    verify(catalogManager, times(1)).consumeLocalMutation(ident);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testPersistentEvictionFailureIsGivenUpWithoutClearingTheCache() {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
+    NameIdentifier failing = NameIdentifier.of("metalake", "failing");
+    NameIdentifier healthy = NameIdentifier.of("metalake", "healthy");
+
+    when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
+    when(catalogManager.consumeLocalMutation(any())).thenReturn(false);
+    doThrow(new RuntimeException("eviction failed")).when(catalogCache).invalidate(failing);
+    doNothing().when(catalogCache).invalidate(healthy);
+
+    CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            listener.onEntityChange(
+                List.of(change(1L, "metalake.failing"), change(2L, "metalake.healthy"))));
+
+    // Retries are bounded, the rest of the batch still applies, and the whole cache is NEVER
+    // cleared: that would evict catalogs this process is serving and close their in-use
+    // IsolatedClassLoaders (#11739).
+    verify(catalogCache, times(2)).invalidate(failing);
+    verify(catalogCache).invalidate(healthy);
+    verify(catalogCache, never()).invalidateAll();
+    verify(catalogCache, never()).invalidateAll(any());
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogChangeLogListener.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogChangeLogListener.java
@@ -19,11 +19,9 @@
 package org.apache.gravitino.catalog;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,83 +39,123 @@ public class TestCatalogChangeLogListener {
 
   @Test
   @SuppressWarnings("unchecked")
-  void testProcessesRemainingChangesAndSwallowsFailure() {
-    CatalogManager catalogManager = mock(CatalogManager.class);
-    Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
-    NameIdentifier failedIdentifier = NameIdentifier.of("metalake", "failed");
-    NameIdentifier successfulIdentifier = NameIdentifier.of("metalake", "successful");
-
-    when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
-    when(catalogManager.consumeLocalMutation(failedIdentifier))
-        .thenThrow(new RuntimeException("invalidation failed"));
-
-    CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
-
-    // The failure must not reach the poller. A retried batch would re-invalidate catalogs this
-    // process mutated itself, because consumeLocalMutation() is single-shot, and closing an
-    // in-use CatalogWrapper also closes its IsolatedClassLoader.
-    Assertions.assertDoesNotThrow(
-        () ->
-            listener.onEntityChange(
-                List.of(change(1L, "metalake.failed"), change(2L, "metalake.successful"))));
-
-    verify(catalogCache).invalidate(successfulIdentifier);
-    verify(catalogCache, never()).invalidate(failedIdentifier);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void testTransientEvictionFailureIsRetriedForTheSameCatalog() {
+  void testFailedClearPropagatesToThePoller() {
     CatalogManager catalogManager = mock(CatalogManager.class);
     Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
     NameIdentifier ident = NameIdentifier.of("metalake", "cat");
 
     when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
     when(catalogManager.consumeLocalMutation(ident)).thenReturn(false);
-    doThrow(new RuntimeException("eviction failed"))
-        .doNothing()
-        .when(catalogCache)
-        .invalidate(ident);
+    doThrow(new RuntimeException("eviction failed")).when(catalogCache).invalidate(ident);
+    doThrow(new RuntimeException("clear failed")).when(catalogCache).invalidateAll();
 
     CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
 
-    Assertions.assertDoesNotThrow(
-        () -> listener.onEntityChange(List.of(change(1L, "metalake.cat"))));
+    // Nothing is left to try locally. Propagating is safe now that the poller only logs a listener
+    // failure: it never replays the batch, which is what used to be dangerous here, because
+    // consumeLocalMutation() is single-shot and a replay would classify a local mutation as remote.
+    Assertions.assertThrows(
+        RuntimeException.class, () -> listener.onEntityChange(List.of(change(1L, "metalake.cat"))));
 
-    // The eviction is retried, so a transient failure no longer leaves this catalog stale.
-    verify(catalogCache, times(2)).invalidate(ident);
-    // The retry must not re-run the single-shot local-mutation probe: doing so would classify a
-    // local mutation as remote and close an IsolatedClassLoader this process is still using.
-    verify(catalogManager, times(1)).consumeLocalMutation(ident);
+    verify(catalogCache).invalidateAll();
   }
 
   @Test
   @SuppressWarnings("unchecked")
-  void testPersistentEvictionFailureIsGivenUpWithoutClearingTheCache() {
+  void testFailedEvictionClearsTheWholeCatalogCache() {
     CatalogManager catalogManager = mock(CatalogManager.class);
     Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
     NameIdentifier failing = NameIdentifier.of("metalake", "failing");
-    NameIdentifier healthy = NameIdentifier.of("metalake", "healthy");
+    NameIdentifier later = NameIdentifier.of("metalake", "later");
 
     when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
     when(catalogManager.consumeLocalMutation(any())).thenReturn(false);
     doThrow(new RuntimeException("eviction failed")).when(catalogCache).invalidate(failing);
-    doNothing().when(catalogCache).invalidate(healthy);
 
     CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
 
     Assertions.assertDoesNotThrow(
         () ->
             listener.onEntityChange(
-                List.of(change(1L, "metalake.failing"), change(2L, "metalake.healthy"))));
+                List.of(change(1L, "metalake.failing"), change(2L, "metalake.later"))));
 
-    // Retries are bounded, the rest of the batch still applies, and the whole cache is NEVER
-    // cleared: that would evict catalogs this process is serving and close their in-use
-    // IsolatedClassLoaders (#11739).
-    verify(catalogCache, times(2)).invalidate(failing);
+    // The clear is a superset of the failed eviction and of the rest of the batch, so the remaining
+    // records need no separate eviction.
+    verify(catalogCache).invalidateAll();
+    verify(catalogCache, never()).invalidate(later);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testSuccessfulBatchDoesNotClearTheCatalogCache() {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
+    NameIdentifier first = NameIdentifier.of("metalake", "cat1");
+    NameIdentifier second = NameIdentifier.of("metalake", "cat2");
+
+    when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
+    when(catalogManager.consumeLocalMutation(any())).thenReturn(false);
+
+    CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
+
+    listener.onEntityChange(List.of(change(1L, "metalake.cat1"), change(2L, "metalake.cat2")));
+
+    verify(catalogCache).invalidate(first);
+    verify(catalogCache).invalidate(second);
+    // Clearing closes in-use IsolatedClassLoaders, so it must stay off the normal path.
+    verify(catalogCache, never()).invalidateAll();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testMalformedRecordIsSkippedWithoutClearingTheCatalogCache() {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
+    NameIdentifier healthy = NameIdentifier.of("metalake", "healthy");
+
+    when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
+    when(catalogManager.consumeLocalMutation(any())).thenReturn(false);
+
+    CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
+
+    // A row that names no catalog leaves nothing stale, so it must not escalate to a clear.
+    Assertions.assertDoesNotThrow(
+        () ->
+            listener.onEntityChange(
+                List.of(
+                    new EntityChangeRecord(1L, "metalake", "CATALOG", null, OperateType.ALTER, 0L),
+                    change(2L, "metalake.cat.schema"),
+                    change(3L, "metalake.healthy"))));
+
     verify(catalogCache).invalidate(healthy);
     verify(catalogCache, never()).invalidateAll();
-    verify(catalogCache, never()).invalidateAll(any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testFailedLocalMutationProbeSkipsTheRecordWithoutClearing() {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
+    NameIdentifier failing = NameIdentifier.of("metalake", "failing");
+    NameIdentifier healthy = NameIdentifier.of("metalake", "healthy");
+
+    when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
+    when(catalogManager.consumeLocalMutation(failing))
+        .thenThrow(new RuntimeException("probe failed"));
+    when(catalogManager.consumeLocalMutation(healthy)).thenReturn(false);
+
+    CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
+
+    // Without a dedup answer there is no eviction to recover, so the record is skipped rather than
+    // tearing down every cached catalog over a bookkeeping failure.
+    Assertions.assertDoesNotThrow(
+        () ->
+            listener.onEntityChange(
+                List.of(change(1L, "metalake.failing"), change(2L, "metalake.healthy"))));
+
+    verify(catalogCache, never()).invalidate(failing);
+    verify(catalogCache).invalidate(healthy);
+    verify(catalogCache, never()).invalidateAll();
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogChangeLogListener.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogChangeLogListener.java
@@ -42,11 +42,13 @@ public class TestCatalogChangeLogListener {
   void testFailedClearPropagatesToThePoller() {
     CatalogManager catalogManager = mock(CatalogManager.class);
     Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
-    NameIdentifier ident = NameIdentifier.of("metalake", "cat");
+    NameIdentifier failing = NameIdentifier.of("metalake", "failing");
+    NameIdentifier laterLocal = NameIdentifier.of("metalake", "later_local");
 
     when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
-    when(catalogManager.consumeLocalMutation(ident)).thenReturn(false);
-    doThrow(new RuntimeException("eviction failed")).when(catalogCache).invalidate(ident);
+    when(catalogManager.consumeLocalMutation(failing)).thenReturn(false);
+    when(catalogManager.consumeLocalMutation(laterLocal)).thenReturn(true);
+    doThrow(new RuntimeException("eviction failed")).when(catalogCache).invalidate(failing);
     doThrow(new RuntimeException("clear failed")).when(catalogCache).invalidateAll();
 
     CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
@@ -55,8 +57,13 @@ public class TestCatalogChangeLogListener {
     // failure: it never replays the batch, which is what used to be dangerous here, because
     // consumeLocalMutation() is single-shot and a replay would classify a local mutation as remote.
     Assertions.assertThrows(
-        RuntimeException.class, () -> listener.onEntityChange(List.of(change(1L, "metalake.cat"))));
+        RuntimeException.class,
+        () ->
+            listener.onEntityChange(
+                List.of(change(1L, "metalake.failing"), change(2L, "metalake.later_local"))));
 
+    // All markers are consumed before eviction starts, even when both eviction and recovery fail.
+    verify(catalogManager).consumeLocalMutation(laterLocal);
     verify(catalogCache).invalidateAll();
   }
 
@@ -66,10 +73,13 @@ public class TestCatalogChangeLogListener {
     CatalogManager catalogManager = mock(CatalogManager.class);
     Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
     NameIdentifier failing = NameIdentifier.of("metalake", "failing");
-    NameIdentifier later = NameIdentifier.of("metalake", "later");
+    NameIdentifier laterRemote = NameIdentifier.of("metalake", "later_remote");
+    NameIdentifier laterLocal = NameIdentifier.of("metalake", "later_local");
 
     when(catalogManager.getCatalogCache()).thenReturn(catalogCache);
-    when(catalogManager.consumeLocalMutation(any())).thenReturn(false);
+    when(catalogManager.consumeLocalMutation(failing)).thenReturn(false);
+    when(catalogManager.consumeLocalMutation(laterRemote)).thenReturn(false);
+    when(catalogManager.consumeLocalMutation(laterLocal)).thenReturn(true);
     doThrow(new RuntimeException("eviction failed")).when(catalogCache).invalidate(failing);
 
     CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
@@ -77,12 +87,17 @@ public class TestCatalogChangeLogListener {
     Assertions.assertDoesNotThrow(
         () ->
             listener.onEntityChange(
-                List.of(change(1L, "metalake.failing"), change(2L, "metalake.later"))));
+                List.of(
+                    change(1L, "metalake.failing"),
+                    change(2L, "metalake.later_remote"),
+                    change(3L, "metalake.later_local"))));
 
-    // The clear is a superset of the failed eviction and of the rest of the batch, so the remaining
-    // records need no separate eviction.
+    // The later local marker is consumed before eviction starts. The clear is then a superset of
+    // the failed eviction and all remote records, so no additional eviction is needed.
+    verify(catalogManager).consumeLocalMutation(laterLocal);
     verify(catalogCache).invalidateAll();
-    verify(catalogCache, never()).invalidate(later);
+    verify(catalogCache, never()).invalidate(laterRemote);
+    verify(catalogCache, never()).invalidate(laterLocal);
   }
 
   @Test
@@ -133,7 +148,7 @@ public class TestCatalogChangeLogListener {
 
   @Test
   @SuppressWarnings("unchecked")
-  void testFailedLocalMutationProbeSkipsTheRecordWithoutClearing() {
+  void testFailedLocalMutationProbeTreatsTheRecordAsRemote() {
     CatalogManager catalogManager = mock(CatalogManager.class);
     Cache<NameIdentifier, CatalogWrapper> catalogCache = mock(Cache.class);
     NameIdentifier failing = NameIdentifier.of("metalake", "failing");
@@ -146,14 +161,14 @@ public class TestCatalogChangeLogListener {
 
     CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
 
-    // Without a dedup answer there is no eviction to recover, so the record is skipped rather than
-    // tearing down every cached catalog over a bookkeeping failure.
+    // An unknown origin is treated as remote: an unnecessary targeted eviction is safer than
+    // permanently skipping a real remote change after the poller advances its cursor.
     Assertions.assertDoesNotThrow(
         () ->
             listener.onEntityChange(
                 List.of(change(1L, "metalake.failing"), change(2L, "metalake.healthy"))));
 
-    verify(catalogCache, never()).invalidate(failing);
+    verify(catalogCache).invalidate(failing);
     verify(catalogCache).invalidate(healthy);
     verify(catalogCache, never()).invalidateAll();
   }

--- a/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.hook;
 import static org.apache.gravitino.Configs.CATALOG_CACHE_EVICTION_INTERVAL_MS;
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -221,8 +219,6 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
           Mockito.when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
           Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
           Mockito.when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-          Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-          Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
           Mockito.when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
           Mockito.when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
           Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);

--- a/core/src/test/java/org/apache/gravitino/policy/TestPolicyManager.java
+++ b/core/src/test/java/org/apache/gravitino/policy/TestPolicyManager.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.policy;
 
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -201,8 +199,6 @@ public class TestPolicyManager {
     Mockito.when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     Mockito.when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);

--- a/core/src/test/java/org/apache/gravitino/stats/TestStatisticManager.java
+++ b/core/src/test/java/org/apache/gravitino/stats/TestStatisticManager.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.stats;
 
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -115,8 +113,6 @@ public class TestStatisticManager {
     Mockito.when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     Mockito.when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);

--- a/core/src/test/java/org/apache/gravitino/storage/AbstractEntityStorageTest.java
+++ b/core/src/test/java/org/apache/gravitino/storage/AbstractEntityStorageTest.java
@@ -21,8 +21,6 @@ package org.apache.gravitino.storage;
 
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -149,8 +147,6 @@ abstract class AbstractEntityStorageTest {
     Mockito.when(config.get(ENTITY_RELATIONAL_JDBC_BACKEND_WAIT_MILLISECONDS)).thenReturn(1000L);
     Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     Mockito.when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestEntityCacheCrossNodeInvalidation.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestEntityCacheCrossNodeInvalidation.java
@@ -45,12 +45,7 @@ public class TestEntityCacheCrossNodeInvalidation extends TestJDBCBackend {
   // A large poll interval so the background scheduler never fires during the test; the test drives
   // node B's poll explicitly via pollChanges().
   private EntityChangeLogPoller newIdlePoller(CaffeineEntityCache nodeBCache) {
-    EntityChangeLogPoller poller =
-        new EntityChangeLogPoller(
-            3600,
-            0,
-            EntityChangeLogPoller.ListenerFailureAction.EXIT,
-            () -> Assertions.fail("The entity cache listener must not exhaust its retries"));
+    EntityChangeLogPoller poller = new EntityChangeLogPoller(3600);
     poller.registerListener(new EntityCacheChangeLogListener(nodeBCache));
     // start() seeds the cursor with the current DB tail, modelling a node whose cache is already
     // warm: only changes written after this point are replayed.

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestEntityChangeLogPoller.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestEntityChangeLogPoller.java
@@ -19,21 +19,15 @@
 package org.apache.gravitino.storage.relational;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import org.apache.gravitino.storage.relational.EntityChangeLogPoller.ListenerFailureAction;
 import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
 import org.apache.gravitino.storage.relational.po.cache.OperateType;
@@ -48,11 +42,8 @@ public class TestEntityChangeLogPoller {
 
   @Test
   void testRejectsInvalidConfiguration() {
-    Assertions.assertThrows(IllegalArgumentException.class, () -> newPoller(0, 10));
-    Assertions.assertThrows(IllegalArgumentException.class, () -> newPoller(-1, 10));
-    Assertions.assertThrows(IllegalArgumentException.class, () -> newPoller(1, -1));
-    Assertions.assertThrows(
-        IllegalArgumentException.class, () -> new EntityChangeLogPoller(1, 10, null));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new EntityChangeLogPoller(0));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new EntityChangeLogPoller(-1));
   }
 
   @Test
@@ -69,7 +60,7 @@ public class TestEntityChangeLogPoller {
     try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
       mockSessionUtils(sessionUtils, mapper);
 
-      EntityChangeLogPoller poller = newPoller(1, 10);
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
       poller.registerListener(firstListenerRecords::addAll);
       poller.registerListener(secondListenerRecords::addAll);
 
@@ -83,26 +74,25 @@ public class TestEntityChangeLogPoller {
   }
 
   @Test
-  void testRetriesOnlyFailedListenersBeforeAdvancingCursor() {
+  void testThrowingListenerNeitherPausesCursorNorBlocksOtherListeners() {
     EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
-    EntityChangeRecord change = change(1L, "CATALOG", "ml1.cat1");
-    when(mapper.selectEntityChanges(0L, MAX_ROWS)).thenReturn(List.of(change));
-    when(mapper.selectEntityChanges(1L, MAX_ROWS)).thenReturn(List.of());
+    EntityChangeRecord first = change(1L, "CATALOG", "ml1.cat1");
+    EntityChangeRecord second = change(2L, "CATALOG", "ml1.cat2");
+    when(mapper.selectEntityChanges(0L, MAX_ROWS)).thenReturn(List.of(first));
+    when(mapper.selectEntityChanges(1L, MAX_ROWS)).thenReturn(List.of(second));
+    when(mapper.selectEntityChanges(2L, MAX_ROWS)).thenReturn(List.of());
 
+    AtomicInteger throwingListenerCalls = new AtomicInteger();
     List<EntityChangeRecord> received = new ArrayList<>();
-    AtomicInteger failingListenerCalls = new AtomicInteger();
-    AtomicBoolean firstCall = new AtomicBoolean(true);
 
     try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
       mockSessionUtils(sessionUtils, mapper);
 
-      EntityChangeLogPoller poller = newPoller(1, 10);
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
       poller.registerListener(
           changes -> {
-            failingListenerCalls.incrementAndGet();
-            if (firstCall.getAndSet(false)) {
-              throw new RuntimeException("listener failed");
-            }
+            throwingListenerCalls.incrementAndGet();
+            throw new RuntimeException("listener failed");
           });
       poller.registerListener(received::addAll);
 
@@ -111,127 +101,38 @@ public class TestEntityChangeLogPoller {
       poller.pollChanges();
     }
 
-    // The healthy listener is not re-notified, the failed one is retried once and then succeeds.
-    Assertions.assertEquals(2, failingListenerCalls.get());
-    Assertions.assertEquals(List.of(change), received);
-    verify(mapper).selectEntityChanges(0L, MAX_ROWS);
+    // Each batch is dispatched exactly once: the throwing listener never sees a batch again, the
+    // healthy listener sees every batch, and the cursor keeps advancing past both batches.
+    Assertions.assertEquals(2, throwingListenerCalls.get());
+    Assertions.assertEquals(List.of(first, second), received);
     verify(mapper).selectEntityChanges(1L, MAX_ROWS);
+    verify(mapper).selectEntityChanges(2L, MAX_ROWS);
   }
 
   @Test
-  void testUnregisteredFailedListenerDoesNotBlockCursor() {
-    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
-    EntityChangeRecord change = change(1L, "CATALOG", "ml1.cat1");
-    when(mapper.selectEntityChanges(0L, MAX_ROWS)).thenReturn(List.of(change));
-    when(mapper.selectEntityChanges(1L, MAX_ROWS)).thenReturn(List.of());
-
-    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
-      mockSessionUtils(sessionUtils, mapper);
-
-      EntityChangeLogPoller poller = newPoller(1, 10);
-      EntityChangeLogListener failedListener =
-          changes -> {
-            throw new RuntimeException("listener failed");
-          };
-      poller.registerListener(failedListener);
-
-      poller.pollChanges();
-      poller.unregisterListener(failedListener);
-      poller.pollChanges();
-      poller.pollChanges();
-    }
-
-    verify(mapper).selectEntityChanges(1L, MAX_ROWS);
-  }
-
-  @Test
-  void testPausedBatchBlocksFetchingNewBatches() {
-    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
-    EntityChangeRecord change = change(1L, "CATALOG", "ml1.cat1");
-    when(mapper.selectEntityChanges(0L, MAX_ROWS)).thenReturn(List.of(change));
-
-    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
-      mockSessionUtils(sessionUtils, mapper);
-
-      EntityChangeLogPoller poller = newPoller(1, 10);
-      poller.registerListener(
-          changes -> {
-            throw new RuntimeException("listener failed");
-          });
-
-      poller.pollChanges();
-      poller.pollChanges();
-    }
-
-    // Only the very first fetch happened: the second poll retried the paused batch instead.
-    verify(mapper).selectEntityChanges(0L, MAX_ROWS);
-    verify(mapper, times(1)).selectEntityChanges(anyLong(), anyInt());
-  }
-
-  @Test
-  void testStopsServerAfterListenerExhaustsRetries() {
-    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
-    EntityChangeRecord change = change(1L, "CATALOG", "ml1.cat1");
-    when(mapper.selectEntityChanges(0L, MAX_ROWS)).thenReturn(List.of(change));
-
-    AtomicInteger listenerCalls = new AtomicInteger();
-    AtomicInteger exitCalls = new AtomicInteger();
-
-    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
-      mockSessionUtils(sessionUtils, mapper);
-
-      EntityChangeLogPoller poller =
-          new EntityChangeLogPoller(1, 1, ListenerFailureAction.EXIT, exitCalls::incrementAndGet);
-      poller.registerListener(
-          changes -> {
-            listenerCalls.incrementAndGet();
-            throw new RuntimeException("listener failed");
-          });
-
-      poller.pollChanges();
-      Assertions.assertEquals(0, exitCalls.get());
-      poller.pollChanges();
-    }
-
-    // One initial dispatch plus one retry, then the server is stopped and the cursor never moves.
-    Assertions.assertEquals(2, listenerCalls.get());
-    Assertions.assertEquals(1, exitCalls.get());
-    verify(mapper, never()).selectEntityChanges(1L, MAX_ROWS);
-  }
-
-  @Test
-  void testSkipActionDropsFailedListenerAndAdvancesCursor() {
+  void testUnregisteredListenerIsSkipped() {
     EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
     EntityChangeRecord first = change(1L, "CATALOG", "ml1.cat1");
     EntityChangeRecord second = change(2L, "CATALOG", "ml1.cat2");
     when(mapper.selectEntityChanges(0L, MAX_ROWS)).thenReturn(List.of(first));
     when(mapper.selectEntityChanges(1L, MAX_ROWS)).thenReturn(List.of(second));
-    when(mapper.selectEntityChanges(2L, MAX_ROWS)).thenReturn(List.of());
 
-    AtomicInteger listenerCalls = new AtomicInteger();
+    List<EntityChangeRecord> received = new ArrayList<>();
 
     try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
       mockSessionUtils(sessionUtils, mapper);
 
-      EntityChangeLogPoller poller =
-          new EntityChangeLogPoller(
-              1, 0, ListenerFailureAction.SKIP, TestEntityChangeLogPoller::failOnExit);
-      poller.registerListener(
-          changes -> {
-            listenerCalls.incrementAndGet();
-            throw new RuntimeException("listener failed");
-          });
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
+      EntityChangeLogListener listener = received::addAll;
+      poller.registerListener(listener);
 
       poller.pollChanges();
-      poller.pollChanges();
+      poller.unregisterListener(listener);
       poller.pollChanges();
     }
 
-    // No retry with maxListenerRetries=0: each batch is dropped for the listener after one
-    // attempt, and the cursor keeps moving.
-    Assertions.assertEquals(2, listenerCalls.get());
+    Assertions.assertEquals(List.of(first), received);
     verify(mapper).selectEntityChanges(1L, MAX_ROWS);
-    verify(mapper).selectEntityChanges(2L, MAX_ROWS);
   }
 
   @Test
@@ -246,7 +147,7 @@ public class TestEntityChangeLogPoller {
     try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
       mockSessionUtils(sessionUtils, mapper);
 
-      EntityChangeLogPoller poller = newPoller(1, 10);
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
       poller.registerListener(received::addAll);
 
       poller.pollChanges();
@@ -265,7 +166,7 @@ public class TestEntityChangeLogPoller {
     try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
       mockSessionUtils(sessionUtils, mapper);
 
-      EntityChangeLogPoller poller = newPoller(1, 10);
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
 
       Assertions.assertDoesNotThrow(poller::pollChanges);
     }
@@ -284,7 +185,7 @@ public class TestEntityChangeLogPoller {
     try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
       mockSessionUtils(sessionUtils, mapper);
 
-      EntityChangeLogPoller poller = newPoller(1, 10);
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
       poller.registerListener(
           changes -> Assertions.assertThrows(UnsupportedOperationException.class, changes::clear));
       poller.registerListener(received::addAll);
@@ -293,19 +194,6 @@ public class TestEntityChangeLogPoller {
     }
 
     Assertions.assertEquals(List.of(first, second), received);
-  }
-
-  /** Fails the test instead of stopping the JVM when the poller decides to exit. */
-  private static void failOnExit() {
-    Assertions.fail("the poller must not stop the server in this scenario");
-  }
-
-  private static EntityChangeLogPoller newPoller(long pollIntervalSecs, int maxListenerRetries) {
-    return new EntityChangeLogPoller(
-        pollIntervalSecs,
-        maxListenerRetries,
-        ListenerFailureAction.EXIT,
-        TestEntityChangeLogPoller::failOnExit);
   }
 
   private static EntityChangeRecord change(long id, String type, String fullName) {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestEntityChangeLogPoller.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestEntityChangeLogPoller.java
@@ -101,9 +101,44 @@ public class TestEntityChangeLogPoller {
       poller.pollChanges();
     }
 
-    // Each batch is dispatched exactly once: the throwing listener never sees a batch again, the
-    // healthy listener sees every batch, and the cursor keeps advancing past both batches.
+    // Each batch is handed out exactly once: the failing listener never gets a batch a second
+    // time, the healthy listener still gets every batch, and the read position moves past both.
     Assertions.assertEquals(2, throwingListenerCalls.get());
+    Assertions.assertEquals(List.of(first, second), received);
+    verify(mapper).selectEntityChanges(1L, MAX_ROWS);
+    verify(mapper).selectEntityChanges(2L, MAX_ROWS);
+  }
+
+  @Test
+  void testListenerThrowingErrorDoesNotKillThePoller() {
+    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
+    EntityChangeRecord first = change(1L, "CATALOG", "ml1.cat1");
+    EntityChangeRecord second = change(2L, "CATALOG", "ml1.cat2");
+    when(mapper.selectEntityChanges(0L, MAX_ROWS)).thenReturn(List.of(first));
+    when(mapper.selectEntityChanges(1L, MAX_ROWS)).thenReturn(List.of(second));
+    when(mapper.selectEntityChanges(2L, MAX_ROWS)).thenReturn(List.of());
+
+    List<EntityChangeRecord> received = new ArrayList<>();
+
+    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
+      mockSessionUtils(sessionUtils, mapper);
+
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
+      // A listener that clears its catalog cache can close an IsolatedClassLoader that is still in
+      // use, and a request holding a class from it then fails with NoClassDefFoundError, an Error
+      // rather than an Exception. pollChanges() is the task given to scheduleWithFixedDelay(), so
+      // anything escaping it would cancel every future poll and freeze invalidation process-wide.
+      poller.registerListener(
+          changes -> {
+            throw new NoClassDefFoundError("closed isolated classloader");
+          });
+      poller.registerListener(received::addAll);
+
+      Assertions.assertDoesNotThrow(poller::pollChanges);
+      Assertions.assertDoesNotThrow(poller::pollChanges);
+      Assertions.assertDoesNotThrow(poller::pollChanges);
+    }
+
     Assertions.assertEquals(List.of(first, second), received);
     verify(mapper).selectEntityChanges(1L, MAX_ROWS);
     verify(mapper).selectEntityChanges(2L, MAX_ROWS);

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestRelationalEntityStoreHierarchicalCache.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestRelationalEntityStoreHierarchicalCache.java
@@ -162,8 +162,6 @@ public class TestRelationalEntityStoreHierarchicalCache {
     Mockito.when(config.get(Configs.STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     Mockito.when(config.get(Configs.VERSION_RETENTION_COUNT)).thenReturn(1L);
     Mockito.when(config.get(Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    Mockito.when(config.get(Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    Mockito.when(config.get(Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     Mockito.when(config.get(Configs.ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     Mockito.when(config.get(Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(Configs.CACHE_ENABLED)).thenReturn(true);

--- a/core/src/test/java/org/apache/gravitino/tag/TestTagManager.java
+++ b/core/src/test/java/org/apache/gravitino/tag/TestTagManager.java
@@ -20,8 +20,6 @@ package org.apache.gravitino.tag;
 
 import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION;
-import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS;
 import static org.apache.gravitino.Configs.ENTITY_CHANGE_LOG_RETENTION_SECS;
 import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
@@ -157,8 +155,6 @@ public class TestTagManager {
     Mockito.when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
     Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS)).thenReturn(3L);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_MAX_RETRIES)).thenReturn(10);
-    Mockito.when(config.get(ENTITY_CHANGE_LOG_LISTENER_FAILURE_ACTION)).thenReturn("SKIP");
     Mockito.when(config.get(ENTITY_CHANGE_LOG_RETENTION_SECS)).thenReturn(24 * 60 * 60L);
     Mockito.when(config.get(ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)).thenReturn(60 * 60L);
     Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);

--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -307,13 +307,11 @@ Caches are local to each server, so a metalake modified on one server would othe
 its neighbors. Every server writes its changes to an entity change log table and polls that table
 to invalidate what other servers have touched. A separate cleaner trims old rows.
 
-| Configuration Item                                | Description                                                                                                                                                           | Default Value       |
-|---------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
-| `gravitino.entityChangeLog.pollIntervalSecs`      | Interval in seconds between polls. Must be positive.                                                                                                                  | `3`                 |
-| `gravitino.entityChangeLog.listenerMaxRetries`    | Times a batch is retried for a failing listener before `listenerFailureAction` applies. Must be non-negative.                                                         | `10`                |
-| `gravitino.entityChangeLog.listenerFailureAction` | What happens when a listener exhausts its retries. `EXIT` stops the server, on the grounds that its caches are known stale; `SKIP` drops the batch and keeps serving. | `EXIT`              |
-| `gravitino.entityChangeLog.retentionSecs`         | How long in seconds change log rows are kept, measured by database time. `0` disables cleanup; otherwise use at least ten times `pollIntervalSecs`.                   | `2592000` (30 days) |
-| `gravitino.entityChangeLog.cleanupIntervalSecs`   | Interval in seconds between cleaner runs. Must be positive.                                                                                                           | `86400` (1 day)     |
+| Configuration Item                              | Description                                                                                                                                         | Default Value       |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| `gravitino.entityChangeLog.pollIntervalSecs`    | Interval in seconds between polls. Must be positive.                                                                                                | `3`                 |
+| `gravitino.entityChangeLog.retentionSecs`       | How long in seconds change log rows are kept, measured by database time. `0` disables cleanup; otherwise use at least ten times `pollIntervalSecs`. | `2592000` (30 days) |
+| `gravitino.entityChangeLog.cleanupIntervalSecs` | Interval in seconds between cleaner runs. Must be positive.                                                                                         | `86400` (1 day)     |
 
 #### Tree Lock
 

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinChangeListener.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinChangeListener.java
@@ -225,15 +225,16 @@ public class JcasbinChangeListener implements EntityChangeLogListener, AutoClose
    * change starts emitting the new post-rename name, this invalidation will silently miss and stale
    * entries will only clear via LRU eviction.
    *
-   * <p><b>Poison-row tolerance:</b> a record this listener cannot map is logged and skipped rather
-   * than propagated. Such a row names no cache key, so skipping it leaves no stale entry behind.
+   * <p><b>Bad rows:</b> a record this listener cannot understand is logged and skipped instead of
+   * being thrown up. Such a row does not point at any cache key, so skipping it leaves nothing
+   * stale behind.
    *
-   * <p><b>Self-healing:</b> the poller dispatches each batch once and never replays it, so a failed
-   * invalidation must be recovered here or {@code metadataIdCache} would serve a stale name→id
-   * mapping to authorization decisions until the entry's TTL expires. The whole {@code
-   * metadataIdCache} is therefore cleared instead: it is pure derived state, a strict superset of
-   * the invalidation that failed and of the rest of the batch, and repopulating it only costs the
-   * name→id lookups it caches.
+   * <p><b>Recovering from a failure:</b> the poller hands each batch over only once and never sends
+   * it again, so a failed removal has to be handled here. Otherwise {@code metadataIdCache} would
+   * keep an out-of-date name&#8594;id entry and hand it to authorization checks until that entry's
+   * TTL runs out. So the whole {@code metadataIdCache} is cleared instead. That is safe: everything
+   * in it can be looked up again, and clearing it also covers the entry that failed plus the rest
+   * of the batch. The only cost is redoing those name&#8594;id lookups.
    *
    * <p>The {@code synchronized} modifier is defensive — see the note on {@link #pollOwnerChanges()}
    * for the rationale. The single-threaded scheduler already prevents overlapping runs in
@@ -330,9 +331,9 @@ public class JcasbinChangeListener implements EntityChangeLogListener, AutoClose
     if (prefixes.isEmpty() && leafKeys.isEmpty()) {
       return;
     }
-    // Hold the cache's exclusive invalidation lock for the whole batch so readers never observe
-    // a half-applied state. If an individual invalidation fails, clear the whole cache before
-    // releasing that lock. Fall back to an unlocked clear only if the batch callback never starts.
+    // Take the cache's exclusive lock for the whole batch, so a reader never sees a state where
+    // part of the batch has been removed and part has not. If removing one key fails, clear the
+    // whole cache while we still hold the lock. If we never got the lock at all, clear without it.
     boolean[] batchStarted = {false};
     try {
       metadataIdCache.runInvalidationBatch(

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinChangeListener.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinChangeListener.java
@@ -226,9 +226,14 @@ public class JcasbinChangeListener implements EntityChangeLogListener, AutoClose
    * entries will only clear via LRU eviction.
    *
    * <p><b>Poison-row tolerance:</b> a record this listener cannot map is logged and skipped rather
-   * than propagated. The poller treats a listener throw as a batch failure and, after exhausting
-   * retries, its default action is to stop the server — so one unmappable row must never be able to
-   * take the node down.
+   * than propagated. Such a row names no cache key, so skipping it leaves no stale entry behind.
+   *
+   * <p><b>Self-healing:</b> the poller dispatches each batch once and never replays it, so a failed
+   * invalidation must be recovered here or {@code metadataIdCache} would serve a stale name→id
+   * mapping to authorization decisions until the entry's TTL expires. The whole {@code
+   * metadataIdCache} is therefore cleared instead: it is pure derived state, a strict superset of
+   * the invalidation that failed and of the rest of the batch, and repopulating it only costs the
+   * name→id lookups it caches.
    *
    * <p>The {@code synchronized} modifier is defensive — see the note on {@link #pollOwnerChanges()}
    * for the rationale. The single-threaded scheduler already prevents overlapping runs in
@@ -275,7 +280,17 @@ public class JcasbinChangeListener implements EntityChangeLogListener, AutoClose
         leafKeys.add(cacheKey);
       }
     }
-    invalidateCoalescedKeys(containerPrefixes, leafKeys);
+    try {
+      invalidateCoalescedKeys(containerPrefixes, leafKeys);
+    } catch (RuntimeException e) {
+      LOG.error(
+          "Failed to invalidate {} prefix(es) and {} leaf key(s) from the entity change log, "
+              + "clearing the whole metadata id cache to stay coherent",
+          containerPrefixes.size(),
+          leafKeys.size(),
+          e);
+      metadataIdCache.invalidateAll();
+    }
   }
 
   @Override

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinChangeListener.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinChangeListener.java
@@ -280,17 +280,7 @@ public class JcasbinChangeListener implements EntityChangeLogListener, AutoClose
         leafKeys.add(cacheKey);
       }
     }
-    try {
-      invalidateCoalescedKeys(containerPrefixes, leafKeys);
-    } catch (RuntimeException e) {
-      LOG.error(
-          "Failed to invalidate {} prefix(es) and {} leaf key(s) from the entity change log, "
-              + "clearing the whole metadata id cache to stay coherent",
-          containerPrefixes.size(),
-          leafKeys.size(),
-          e);
-      metadataIdCache.invalidateAll();
-    }
+    invalidateCoalescedKeys(containerPrefixes, leafKeys);
   }
 
   @Override
@@ -341,17 +331,43 @@ public class JcasbinChangeListener implements EntityChangeLogListener, AutoClose
       return;
     }
     // Hold the cache's exclusive invalidation lock for the whole batch so readers never observe
-    // a half-applied state where some prefix/leaf keys have been evicted and others have not.
-    metadataIdCache.runInvalidationBatch(
-        () -> {
-          for (String prefix : prefixes) {
-            metadataIdCache.invalidateByPrefix(prefix);
-          }
-          for (String leafKey : leafKeys) {
-            if (prefixes.stream().noneMatch(leafKey::startsWith)) {
-              metadataIdCache.invalidate(leafKey);
+    // a half-applied state. If an individual invalidation fails, clear the whole cache before
+    // releasing that lock. Fall back to an unlocked clear only if the batch callback never starts.
+    boolean[] batchStarted = {false};
+    try {
+      metadataIdCache.runInvalidationBatch(
+          () -> {
+            batchStarted[0] = true;
+            try {
+              for (String prefix : prefixes) {
+                metadataIdCache.invalidateByPrefix(prefix);
+              }
+              for (String leafKey : leafKeys) {
+                if (prefixes.stream().noneMatch(leafKey::startsWith)) {
+                  metadataIdCache.invalidate(leafKey);
+                }
+              }
+            } catch (RuntimeException e) {
+              LOG.error(
+                  "Failed to invalidate {} prefix(es) and {} leaf key(s) from the entity change "
+                      + "log, clearing the whole metadata id cache to stay coherent",
+                  prefixes.size(),
+                  leafKeys.size(),
+                  e);
+              metadataIdCache.invalidateAll();
             }
-          }
-        });
+          });
+    } catch (RuntimeException e) {
+      if (batchStarted[0]) {
+        throw e;
+      }
+      LOG.error(
+          "Failed to start an invalidation batch for {} prefix(es) and {} leaf key(s), clearing "
+              + "the whole metadata id cache without the batch lock",
+          prefixes.size(),
+          leafKeys.size(),
+          e);
+      metadataIdCache.invalidateAll();
+    }
   }
 }

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinChangePoller.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinChangePoller.java
@@ -150,8 +150,8 @@ public class TestJcasbinChangePoller {
 
     JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
 
-    // A record whose full name cannot be turned into a MetadataObject of the declared type must be
-    // logged and skipped; a poison row must never take the node down via the poller's EXIT action.
+    // A record whose full name cannot be turned into a MetadataObject of the declared type names no
+    // cache key, so it must be logged and skipped without discarding the rest of the batch.
     Assertions.assertDoesNotThrow(
         () ->
             poller.onEntityChange(
@@ -164,6 +164,102 @@ public class TestJcasbinChangePoller {
         List.of(key("ml1", "CATALOG", "cat1", "SCHEMA", "sch1", "TABLE", "tbl1", "")),
         metadataIdCache.invalidatedPrefixes);
     Assertions.assertEquals(List.of(), metadataIdCache.invalidatedKeys);
+  }
+
+  @Test
+  void testLeafTypesAreInvalidatedByExactKey() {
+    RecordingCache<String, Long> metadataIdCache = new RecordingCache<>();
+    RecordingCache<Long, Optional<OwnerInfo>> ownerRelCache = new RecordingCache<>();
+
+    JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
+    poller.onEntityChange(List.of(change(1L, MetadataObject.Type.FILESET, "ml1.cat1.sch1.fs1")));
+
+    // A FILESET has no nested metadata objects, so it is removed by exact key, not by prefix.
+    Assertions.assertEquals(
+        List.of(key("ml1", "CATALOG", "cat1", "SCHEMA", "sch1", "FILESET", "fs1")),
+        metadataIdCache.invalidatedKeys);
+    Assertions.assertEquals(List.of(), metadataIdCache.invalidatedPrefixes);
+    Assertions.assertEquals(0, metadataIdCache.invalidateAllCalls);
+  }
+
+  @Test
+  void testSuccessfulBatchDoesNotClearTheCache() {
+    RecordingCache<String, Long> metadataIdCache = new RecordingCache<>();
+    RecordingCache<Long, Optional<OwnerInfo>> ownerRelCache = new RecordingCache<>();
+
+    JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
+    poller.onEntityChange(
+        List.of(
+            change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"),
+            change(2L, MetadataObject.Type.FILESET, "ml1.cat2.sch1.fs1")));
+
+    Assertions.assertEquals(0, metadataIdCache.invalidateAllCalls);
+    Assertions.assertEquals(0, ownerRelCache.invalidateAllCalls);
+  }
+
+  @Test
+  void testFailedPrefixInvalidationClearsTheWholeMetadataIdCache() {
+    RecordingCache<String, Long> metadataIdCache = new RecordingCache<>();
+    metadataIdCache.failPrefixInvalidation = true;
+    RecordingCache<Long, Optional<OwnerInfo>> ownerRelCache = new RecordingCache<>();
+
+    JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
+
+    // The poller dispatches a batch once and never replays it, so the listener must recover here.
+    Assertions.assertDoesNotThrow(
+        () -> poller.onEntityChange(List.of(change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"))));
+
+    Assertions.assertEquals(1, metadataIdCache.invalidateAllCalls);
+    // The owner cache is driven by its own poller, so a change-log failure must not clear it.
+    Assertions.assertEquals(0, ownerRelCache.invalidateAllCalls);
+  }
+
+  @Test
+  void testFailedLeafInvalidationClearsTheWholeMetadataIdCache() {
+    RecordingCache<String, Long> metadataIdCache = new RecordingCache<>();
+    metadataIdCache.failKeyInvalidation = true;
+    RecordingCache<Long, Optional<OwnerInfo>> ownerRelCache = new RecordingCache<>();
+
+    JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            poller.onEntityChange(
+                List.of(change(1L, MetadataObject.Type.FILESET, "ml1.cat1.sch1.fs1"))));
+
+    Assertions.assertEquals(1, metadataIdCache.invalidateAllCalls);
+  }
+
+  @Test
+  void testFailedInvalidationBatchClearsTheWholeMetadataIdCache() {
+    RecordingCache<String, Long> metadataIdCache = new RecordingCache<>();
+    metadataIdCache.failInvalidationBatch = true;
+    RecordingCache<Long, Optional<OwnerInfo>> ownerRelCache = new RecordingCache<>();
+
+    JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
+
+    // The failure can also come from the cache's batch lock itself, before any key is touched.
+    Assertions.assertDoesNotThrow(
+        () -> poller.onEntityChange(List.of(change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"))));
+
+    Assertions.assertEquals(1, metadataIdCache.invalidateAllCalls);
+  }
+
+  @Test
+  void testFailedClearPropagatesToThePoller() {
+    RecordingCache<String, Long> metadataIdCache = new RecordingCache<>();
+    metadataIdCache.failPrefixInvalidation = true;
+    metadataIdCache.failInvalidateAll = true;
+    RecordingCache<Long, Optional<OwnerInfo>> ownerRelCache = new RecordingCache<>();
+
+    JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
+
+    // Nothing is left to try locally, so the poller logs it and keeps the cursor moving.
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> poller.onEntityChange(List.of(change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"))));
+
+    Assertions.assertEquals(1, metadataIdCache.invalidateAllCalls);
   }
 
   @Test
@@ -188,6 +284,12 @@ public class TestJcasbinChangePoller {
     private final List<K> invalidatedKeys = new ArrayList<>();
     private final List<String> invalidatedPrefixes = new ArrayList<>();
 
+    private int invalidateAllCalls;
+    private boolean failKeyInvalidation;
+    private boolean failPrefixInvalidation;
+    private boolean failInvalidationBatch;
+    private boolean failInvalidateAll;
+
     @Override
     public Optional<V> getIfPresent(K key) {
       return Optional.empty();
@@ -198,15 +300,34 @@ public class TestJcasbinChangePoller {
 
     @Override
     public void invalidate(K key) {
+      if (failKeyInvalidation) {
+        throw new RuntimeException("invalidate failed");
+      }
       invalidatedKeys.add(key);
     }
 
     @Override
-    public void invalidateAll() {}
+    public void invalidateAll() {
+      invalidateAllCalls++;
+      if (failInvalidateAll) {
+        throw new RuntimeException("invalidateAll failed");
+      }
+    }
 
     @Override
     public void invalidateByPrefix(String prefix) {
+      if (failPrefixInvalidation) {
+        throw new RuntimeException("invalidateByPrefix failed");
+      }
       invalidatedPrefixes.add(prefix);
+    }
+
+    @Override
+    public void runInvalidationBatch(Runnable batch) {
+      if (failInvalidationBatch) {
+        throw new RuntimeException("invalidation batch failed");
+      }
+      batch.run();
     }
 
     @Override

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinChangePoller.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinChangePoller.java
@@ -150,8 +150,8 @@ public class TestJcasbinChangePoller {
 
     JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
 
-    // A record whose full name cannot be turned into a MetadataObject of the declared type names no
-    // cache key, so it must be logged and skipped without discarding the rest of the batch.
+    // If the full name does not match the type in the record, we cannot build a cache key from it.
+    // Log it, skip it, and keep handling the rest of the batch.
     Assertions.assertDoesNotThrow(
         () ->
             poller.onEntityChange(
@@ -174,7 +174,7 @@ public class TestJcasbinChangePoller {
     JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
     poller.onEntityChange(List.of(change(1L, MetadataObject.Type.FILESET, "ml1.cat1.sch1.fs1")));
 
-    // A FILESET has no nested metadata objects, so it is removed by exact key, not by prefix.
+    // A FILESET has nothing nested under it, so it is removed by its exact key, not by prefix.
     Assertions.assertEquals(
         List.of(key("ml1", "CATALOG", "cat1", "SCHEMA", "sch1", "FILESET", "fs1")),
         metadataIdCache.invalidatedKeys);
@@ -205,13 +205,13 @@ public class TestJcasbinChangePoller {
 
     JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
 
-    // The poller dispatches a batch once and never replays it, so the listener must recover here.
+    // The batch is handed out once and never sent again, so the listener has to fix things here.
     Assertions.assertDoesNotThrow(
         () -> poller.onEntityChange(List.of(change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"))));
 
     Assertions.assertEquals(1, metadataIdCache.invalidateAllCalls);
     Assertions.assertEquals(1, metadataIdCache.invalidateAllInsideBatchCalls);
-    // The owner cache is driven by its own poller, so a change-log failure must not clear it.
+    // The owner cache has its own poller, so a change-log failure must not wipe it as well.
     Assertions.assertEquals(0, ownerRelCache.invalidateAllCalls);
   }
 
@@ -240,7 +240,7 @@ public class TestJcasbinChangePoller {
 
     JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
 
-    // The failure can also come from the cache's batch lock itself, before any key is touched.
+    // The failure can also happen while taking the cache's batch lock, before any key is touched.
     Assertions.assertDoesNotThrow(
         () -> poller.onEntityChange(List.of(change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"))));
 
@@ -257,7 +257,7 @@ public class TestJcasbinChangePoller {
 
     JcasbinChangeListener poller = new JcasbinChangeListener(metadataIdCache, ownerRelCache, 1);
 
-    // Nothing is left to try locally, so the poller logs it and keeps the cursor moving.
+    // There is nothing else to try here, so the poller just logs it and keeps reading.
     Assertions.assertThrows(
         RuntimeException.class,
         () -> poller.onEntityChange(List.of(change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"))));

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinChangePoller.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinChangePoller.java
@@ -210,6 +210,7 @@ public class TestJcasbinChangePoller {
         () -> poller.onEntityChange(List.of(change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"))));
 
     Assertions.assertEquals(1, metadataIdCache.invalidateAllCalls);
+    Assertions.assertEquals(1, metadataIdCache.invalidateAllInsideBatchCalls);
     // The owner cache is driven by its own poller, so a change-log failure must not clear it.
     Assertions.assertEquals(0, ownerRelCache.invalidateAllCalls);
   }
@@ -228,6 +229,7 @@ public class TestJcasbinChangePoller {
                 List.of(change(1L, MetadataObject.Type.FILESET, "ml1.cat1.sch1.fs1"))));
 
     Assertions.assertEquals(1, metadataIdCache.invalidateAllCalls);
+    Assertions.assertEquals(1, metadataIdCache.invalidateAllInsideBatchCalls);
   }
 
   @Test
@@ -243,6 +245,7 @@ public class TestJcasbinChangePoller {
         () -> poller.onEntityChange(List.of(change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"))));
 
     Assertions.assertEquals(1, metadataIdCache.invalidateAllCalls);
+    Assertions.assertEquals(0, metadataIdCache.invalidateAllInsideBatchCalls);
   }
 
   @Test
@@ -285,6 +288,8 @@ public class TestJcasbinChangePoller {
     private final List<String> invalidatedPrefixes = new ArrayList<>();
 
     private int invalidateAllCalls;
+    private int invalidateAllInsideBatchCalls;
+    private boolean invalidationBatchActive;
     private boolean failKeyInvalidation;
     private boolean failPrefixInvalidation;
     private boolean failInvalidationBatch;
@@ -309,6 +314,9 @@ public class TestJcasbinChangePoller {
     @Override
     public void invalidateAll() {
       invalidateAllCalls++;
+      if (invalidationBatchActive) {
+        invalidateAllInsideBatchCalls++;
+      }
       if (failInvalidateAll) {
         throw new RuntimeException("invalidateAll failed");
       }
@@ -327,7 +335,12 @@ public class TestJcasbinChangePoller {
       if (failInvalidationBatch) {
         throw new RuntimeException("invalidation batch failed");
       }
-      batch.run();
+      invalidationBatchActive = true;
+      try {
+        batch.run();
+      } finally {
+        invalidationBatchActive = false;
+      }
     }
 
     @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make "dispatch once, always advance the cursor, listeners are self-healing" the entity change log contract, and let each listener recover locally.

Poller and configs:

- `EntityChangeLogPoller`: remove `ListenerFailureAction`, `exitHandler`, `pendingDelivery`, `BatchDelivery.retryOnly`/`attempts` and `handleExhaustedRetries`. Each batch is dispatched once and the cursor always advances; every listener failure is logged at `ERROR`. The self-healing contract is stated in the poller and `EntityChangeLogListener` javadoc, so a listener that cannot contain its own failures is not added silently.
- Remove `gravitino.entityChangeLog.listenerMaxRetries` and `gravitino.entityChangeLog.listenerFailureAction` from `Configs`, their wiring in `RelationalEntityStore`, and their entries in `docs/gravitino-server-config.md`.
- Clean up the removed config stubs in 13 test/benchmark classes.

All three registered listeners now recover by clearing the cache they maintain, which is a strict superset of the invalidation that failed and of the rest of the batch:

| Listener | Cache | Recovery |
|-------------------------------|-------------------|--------------------------------------------------|
| `EntityCacheChangeLogListener` | entity cache      | clears the whole cache (already did)             |
| `JcasbinChangeListener`        | `metadataIdCache` | clears the whole cache (new)                     |
| `CatalogChangeLogListener`     | catalog cache     | clears the whole cache (new)                     |

Notes on the two listeners that changed:

- `JcasbinChangeListener` is a third change-log listener that the issue did not account for. It tolerated poison rows but propagated a failed invalidation, so under the dispatch-once contract its `metadataIdCache` would feed a stale name→id mapping to authorization decisions until the entry's TTL expired.
- `CatalogChangeLogListener` clears the catalog cache on a failed eviction. This is a deliberate tradeoff, documented in its javadoc: clearing closes the `CatalogWrapper` of every cached catalog, including catalogs this process is actively serving, so in-flight requests can hit `NoClassDefFoundError` from a closed `IsolatedClassLoader` (the failure mode of #11739). It is accepted so that a changed catalog is never served stale, and the clear runs only on a failed eviction, off the normal path. Malformed rows and a failed `consumeLocalMutation` probe are still skipped rather than escalated, since they name no eviction to recover.

Caches deliberately left alone: `ownerRelCache` is driven by `JcasbinChangeListener`'s own `owner_meta` poller, whose cursor only advances after a successful invalidation batch, so it already retries; `userRoleCache`, `groupRoleCache` and `loadedRoles` are version-validated on every read and cannot go stale from a missed batch.

### Why are the changes needed?

After #12374 every registered listener can recover locally, so the retry/`EXIT` path is effectively unreachable while carrying real cost:

1. `EXIT` trades the whole server for a condition a local cache clear already resolves. Killing a node to fix a stale cache entry is a heavy, surprising failure mode for operators.
2. A paused cursor blocks cache invalidation for **every** listener in the process while one listener retries, so a single misbehaving listener degrades cluster-wide coherence for up to 10 poll intervals.
3. The retained batch, `pendingDelivery`, `BatchDelivery.retryOnly`, `attempts` tracking and `handleExhaustedRetries` add machinery and two public configs for a path no listener reaches.

Fix: #12440

### Does this PR introduce _any_ user-facing change?

Yes:

- Removed config keys `gravitino.entityChangeLog.listenerMaxRetries` and `gravitino.entityChangeLog.listenerFailureAction`. Both are `VERSION_2_0_0` and 2.0.0 is unreleased, so no deprecation cycle is needed.
- A node no longer stops itself (`System.exit(1)`) when a listener keeps failing to apply a change log batch.

### How was this patch tested?

New and reworked unit tests:

- `TestEntityChangeLogPoller`: the four retry/pause/EXIT/SKIP cases are replaced by `testThrowingListenerNeitherPausesCursorNorBlocksOtherListeners` (each batch dispatched exactly once, the healthy listener sees every batch, the cursor advances past both) and `testUnregisteredListenerIsSkipped`.
- `TestJcasbinChangePoller` (7 → 14): the `metadataIdCache` clear fallback on prefix, leaf-key and batch-lock failures; a failed clear propagating to the poller; the happy path clearing nothing; `ownerRelCache` not cleared as collateral; plus leaf-vs-prefix keying, which had no coverage.
- `TestCatalogChangeLogListener` (3 → 7): the clear on a failed eviction; no clear on the happy path; malformed rows and a failed `consumeLocalMutation` probe skipped without clearing; a failed clear propagating.

Suites run locally: `:core:test` (1657 tests) and `:server-common:test` (272 tests) with `--rerun-tasks`, both green, plus the unit tests of the four catalog modules whose config stubs changed. `:core:javadoc` reports no new warnings on the touched files. Docker was not available locally, so docker-tagged tests and integration tests were not run.
