### PR TITLE
[#12049] feat(iceberg-common): add Idempotency-Key storage SPI and in-memory store

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
@@ -128,4 +128,19 @@ public class IcebergConstants {
   public static final String SCAN_PLAN_CACHE_IMPL = "scan-plan-cache-impl";
   public static final String SCAN_PLAN_CACHE_CAPACITY = "scan-plan-cache-capacity";
   public static final String SCAN_PLAN_CACHE_EXPIRE_MINUTES = "scan-plan-cache-expire-minutes";
+
+  /** Whether the Iceberg REST server honors the {@code Idempotency-Key} header. */
+  public static final String ICEBERG_IDEMPOTENCY_ENABLED = "idempotency-enabled";
+
+  /** Client reuse window for an idempotency key, as an ISO-8601 duration. */
+  public static final String ICEBERG_IDEMPOTENCY_KEY_LIFETIME = "idempotency-key-lifetime";
+
+  /** Storage backend holding idempotency records. */
+  public static final String ICEBERG_IDEMPOTENCY_STORE_TYPE = "idempotency-store-type";
+
+  /** Short name of the node-local idempotency store. */
+  public static final String ICEBERG_IDEMPOTENCY_STORE_IN_MEMORY = "in-memory";
+
+  /** Capacity of the in-memory idempotency store. */
+  public static final String ICEBERG_IDEMPOTENCY_MAX_ENTRIES = "idempotency-max-entries";
 }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -21,6 +21,8 @@ package org.apache.gravitino.iceberg.common;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -397,6 +399,52 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
           .createWithDefault(720);
 
+  /**
+   * Master switch for {@code Idempotency-Key} support. Disabled by default: when off the header is
+   * ignored and no key lifetime is advertised in {@code GET /v1/config}, which per the Iceberg REST
+   * spec tells clients the server does not support idempotency.
+   */
+  public static final ConfigEntry<Boolean> ICEBERG_IDEMPOTENCY_ENABLED =
+      new ConfigBuilder(IcebergConstants.ICEBERG_IDEMPOTENCY_ENABLED)
+          .doc("Whether to honor the Idempotency-Key header on Iceberg REST mutation endpoints")
+          .version(ConfigConstants.VERSION_2_0_0)
+          .booleanConf()
+          .createWithDefault(false);
+
+  /** Client reuse window for an idempotency key, as an ISO-8601 duration. */
+  public static final ConfigEntry<String> ICEBERG_IDEMPOTENCY_KEY_LIFETIME =
+      new ConfigBuilder(IcebergConstants.ICEBERG_IDEMPOTENCY_KEY_LIFETIME)
+          .doc(
+              "The client reuse window for an Idempotency-Key, an ISO-8601 duration such as PT30M. "
+                  + "Advertised to clients as `idempotency-key-lifetime` in the config response")
+          .version(ConfigConstants.VERSION_2_0_0)
+          .stringConf()
+          .checkValue(
+              IcebergConfig::isPositiveDuration, "The value must be a positive ISO-8601 duration")
+          .createWithDefault("PT30M");
+
+  /** Storage backend holding idempotency records. */
+  public static final ConfigEntry<String> ICEBERG_IDEMPOTENCY_STORE_TYPE =
+      new ConfigBuilder(IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_TYPE)
+          .doc(
+              "The store holding Iceberg idempotency records, either the `in-memory` short name or "
+                  + "the fully-qualified class name of an `IdempotencyStore` implementation")
+          .version(ConfigConstants.VERSION_2_0_0)
+          .stringConf()
+          .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)
+          .createWithDefault(IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_IN_MEMORY);
+
+  /** Capacity of the in-memory idempotency store. */
+  public static final ConfigEntry<Integer> ICEBERG_IDEMPOTENCY_MAX_ENTRIES =
+      new ConfigBuilder(IcebergConstants.ICEBERG_IDEMPOTENCY_MAX_ENTRIES)
+          .doc(
+              "The maximum number of idempotency records retained by the in-memory store, records "
+                  + "beyond it are evicted before their reuse window elapses")
+          .version(ConfigConstants.VERSION_2_0_0)
+          .intConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(10000);
+
   public String getJdbcDriver() {
     return get(JDBC_DRIVER);
   }
@@ -420,6 +468,15 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
         IcebergPropertiesUtils.toIcebergCatalogProperties(config);
     transformedConfig.putAll(config);
     return transformedConfig;
+  }
+
+  private static boolean isPositiveDuration(String value) {
+    try {
+      Duration duration = Duration.parse(value);
+      return !duration.isNegative() && !duration.isZero();
+    } catch (DateTimeParseException e) {
+      return false;
+    }
   }
 
   @Override

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyKeys.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyKeys.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Validation helpers for the {@code Idempotency-Key} header.
+ *
+ * <p>The Iceberg REST spec requires the header value to be a UUIDv7 in string form as defined by <a
+ * href="https://www.rfc-editor.org/rfc/rfc9562">RFC 9562</a>, with a fixed length of 36 characters.
+ * Rejecting malformed keys before touching the store keeps invalid requests off the storage path
+ * and guarantees the key space stays time-ordered, which keeps the primary-key index of a database
+ * backed store insert-friendly.
+ */
+public final class IdempotencyKeys {
+
+  /** Canonical (hyphenated) length of a UUID in string form, mandated by the Iceberg REST spec. */
+  public static final int KEY_LENGTH = 36;
+
+  /** UUID version reported by a UUIDv7 as defined by RFC 9562. */
+  private static final int UUID_VERSION_7 = 7;
+
+  /**
+   * Variant reported by {@link UUID#variant()} for the RFC 9562 variant, whose two most significant
+   * variant bits are {@code 10}.
+   */
+  private static final int RFC_9562_VARIANT = 2;
+
+  private static final Pattern CANONICAL_UUID =
+      Pattern.compile(
+          "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
+  private IdempotencyKeys() {}
+
+  /**
+   * Returns whether the value is a UUIDv7 in canonical string form.
+   *
+   * @param idempotencyKey the raw header value, may be {@code null}
+   * @return {@code true} if the value is a valid RFC 9562 UUIDv7
+   */
+  public static boolean isValid(String idempotencyKey) {
+    if (idempotencyKey == null || idempotencyKey.length() != KEY_LENGTH) {
+      return false;
+    }
+    if (!CANONICAL_UUID.matcher(idempotencyKey).matches()) {
+      return false;
+    }
+    UUID uuid = UUID.fromString(idempotencyKey);
+    return uuid.version() == UUID_VERSION_7 && uuid.variant() == RFC_9562_VARIANT;
+  }
+
+  /**
+   * Validates the value and throws when it is not a UUIDv7 in canonical string form.
+   *
+   * @param idempotencyKey the raw header value, may be {@code null}
+   * @throws IllegalArgumentException if the value is not a valid RFC 9562 UUIDv7, which the Iceberg
+   *     REST server maps to {@code 400 Bad Request}
+   */
+  public static void validate(String idempotencyKey) {
+    if (!isValid(idempotencyKey)) {
+      throw new IllegalArgumentException(
+          "Idempotency-Key: "
+              + idempotencyKey
+              + " is illegal, the Iceberg REST spec requires a UUIDv7 in string form (RFC 9562), "
+              + "for example 017f22e2-79b0-7cc3-98c4-dc0c0c07398f");
+    }
+  }
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyKeys.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyKeys.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.iceberg.common.idempotency;
 
+import java.util.Locale;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -82,5 +83,25 @@ public final class IdempotencyKeys {
               + " is illegal, the Iceberg REST spec requires a UUIDv7 in string form (RFC 9562), "
               + "for example 017f22e2-79b0-7cc3-98c4-dc0c0c07398f");
     }
+  }
+
+  /**
+   * Validates the value and returns it in the lower-case form used for storage and comparison.
+   *
+   * <p>RFC 9562 section 4 defines the hexadecimal digits of a UUID as case-insensitive on input
+   * while specifying lower case on output, so {@code 017F22E2-...} and {@code 017f22e2-...} name
+   * the same key. A client that retries with a differently-cased key is retrying the same logical
+   * operation, and folding the case here is what keeps that retry from being taken for a new
+   * request and re-running the mutation. It also keeps a database-backed store correct under a
+   * case-sensitive collation such as {@code utf8mb4_bin}, since only the folded form is ever
+   * written.
+   *
+   * @param idempotencyKey the raw header value, may be {@code null}
+   * @return the key folded to lower case
+   * @throws IllegalArgumentException if the value is not a valid RFC 9562 UUIDv7
+   */
+  public static String canonicalize(String idempotencyKey) {
+    validate(idempotencyKey);
+    return idempotencyKey.toLowerCase(Locale.ROOT);
   }
 }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyRecord.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyRecord.java
@@ -34,6 +34,7 @@ public final class IdempotencyRecord {
 
   private final String idempotencyKey;
   private final String operationBinding;
+  private final long claim;
   @Nullable private final Integer httpStatus;
   @Nullable private final String responseSummary;
   private final long createdAtMs;
@@ -42,12 +43,14 @@ public final class IdempotencyRecord {
   private IdempotencyRecord(
       String idempotencyKey,
       String operationBinding,
+      long claim,
       @Nullable Integer httpStatus,
       @Nullable String responseSummary,
       long createdAtMs,
       long expiresAtMs) {
     this.idempotencyKey = idempotencyKey;
     this.operationBinding = operationBinding;
+    this.claim = claim;
     this.httpStatus = httpStatus;
     this.responseSummary = responseSummary;
     this.createdAtMs = createdAtMs;
@@ -60,16 +63,21 @@ public final class IdempotencyRecord {
    * @param idempotencyKey the client-provided UUIDv7 key
    * @param operationBinding request identity, for example {@code POST
    *     /v1/cat1/namespaces/ns1/tables}
+   * @param claim the reserving caller's fencing token
    * @param createdAtMs reservation time in unix epoch millis
    * @param expiresAtMs time after which the record may be purged, in unix epoch millis
    * @return a record in the reserved state
    */
   public static IdempotencyRecord reserved(
-      String idempotencyKey, String operationBinding, long createdAtMs, long expiresAtMs) {
+      String idempotencyKey,
+      String operationBinding,
+      long claim,
+      long createdAtMs,
+      long expiresAtMs) {
     Preconditions.checkArgument(idempotencyKey != null, "idempotencyKey should not be null");
     Preconditions.checkArgument(operationBinding != null, "operationBinding should not be null");
     return new IdempotencyRecord(
-        idempotencyKey, operationBinding, null, null, createdAtMs, expiresAtMs);
+        idempotencyKey, operationBinding, claim, null, null, createdAtMs, expiresAtMs);
   }
 
   /**
@@ -81,7 +89,20 @@ public final class IdempotencyRecord {
    */
   public IdempotencyRecord withResponse(int status, @Nullable String summary) {
     return new IdempotencyRecord(
-        idempotencyKey, operationBinding, status, summary, createdAtMs, expiresAtMs);
+        idempotencyKey, operationBinding, claim, status, summary, createdAtMs, expiresAtMs);
+  }
+
+  /**
+   * Returns the fencing token of the caller that reserved this record.
+   *
+   * <p>A store accepts a finalize or release only from the caller holding this token, so a caller
+   * whose reservation was already dropped cannot disturb the record of whoever reserved the key
+   * next.
+   *
+   * @return the reserving caller's claim
+   */
+  public long claim() {
+    return claim;
   }
 
   /**
@@ -162,6 +183,7 @@ public final class IdempotencyRecord {
     IdempotencyRecord that = (IdempotencyRecord) other;
     return createdAtMs == that.createdAtMs
         && expiresAtMs == that.expiresAtMs
+        && claim == that.claim
         && Objects.equals(idempotencyKey, that.idempotencyKey)
         && Objects.equals(operationBinding, that.operationBinding)
         && Objects.equals(httpStatus, that.httpStatus)
@@ -171,7 +193,13 @@ public final class IdempotencyRecord {
   @Override
   public int hashCode() {
     return Objects.hash(
-        idempotencyKey, operationBinding, httpStatus, responseSummary, createdAtMs, expiresAtMs);
+        idempotencyKey,
+        operationBinding,
+        claim,
+        httpStatus,
+        responseSummary,
+        createdAtMs,
+        expiresAtMs);
   }
 
   @Override

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyRecord.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyRecord.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * One stored idempotency record: the reservation for an in-flight mutation, and after finalization
+ * the response replayed to retries carrying the same key.
+ *
+ * <p>Instances are immutable; {@link #withResponse(int, String)} returns a new record rather than
+ * mutating this one. Timestamps are unix epoch milliseconds so that a database backed store can map
+ * them onto the {@code BIGINT} columns used by Gravitino's other metadata tables.
+ */
+public final class IdempotencyRecord {
+
+  private final String idempotencyKey;
+  private final String operationBinding;
+  @Nullable private final Integer httpStatus;
+  @Nullable private final String responseSummary;
+  private final long createdAtMs;
+  private final long expiresAtMs;
+
+  private IdempotencyRecord(
+      String idempotencyKey,
+      String operationBinding,
+      @Nullable Integer httpStatus,
+      @Nullable String responseSummary,
+      long createdAtMs,
+      long expiresAtMs) {
+    this.idempotencyKey = idempotencyKey;
+    this.operationBinding = operationBinding;
+    this.httpStatus = httpStatus;
+    this.responseSummary = responseSummary;
+    this.createdAtMs = createdAtMs;
+    this.expiresAtMs = expiresAtMs;
+  }
+
+  /**
+   * Creates a reserved (not yet finalized) record.
+   *
+   * @param idempotencyKey the client-provided UUIDv7 key
+   * @param operationBinding request identity, for example {@code POST
+   *     /v1/cat1/namespaces/ns1/tables}
+   * @param createdAtMs reservation time in unix epoch millis
+   * @param expiresAtMs time after which the record may be purged, in unix epoch millis
+   * @return a record in the reserved state
+   */
+  public static IdempotencyRecord reserved(
+      String idempotencyKey, String operationBinding, long createdAtMs, long expiresAtMs) {
+    Preconditions.checkArgument(idempotencyKey != null, "idempotencyKey should not be null");
+    Preconditions.checkArgument(operationBinding != null, "operationBinding should not be null");
+    return new IdempotencyRecord(
+        idempotencyKey, operationBinding, null, null, createdAtMs, expiresAtMs);
+  }
+
+  /**
+   * Returns a copy of this record in the finalized state, carrying the response to replay.
+   *
+   * @param status HTTP status of the original response
+   * @param summary serialized response body, {@code null} for responses without a body
+   * @return a new finalized record
+   */
+  public IdempotencyRecord withResponse(int status, @Nullable String summary) {
+    return new IdempotencyRecord(
+        idempotencyKey, operationBinding, status, summary, createdAtMs, expiresAtMs);
+  }
+
+  /**
+   * Returns the client-provided idempotency key.
+   *
+   * @return the UUIDv7 key in canonical string form
+   */
+  public String idempotencyKey() {
+    return idempotencyKey;
+  }
+
+  /**
+   * Returns the request identity this key was first used for. Retries that present the same key for
+   * a different operation violate the Iceberg REST spec and are rejected instead of replayed.
+   *
+   * @return the operation binding
+   */
+  public String operationBinding() {
+    return operationBinding;
+  }
+
+  /**
+   * Returns the HTTP status of the finalized response.
+   *
+   * @return the status code, or {@code null} while the record is still reserved
+   */
+  @Nullable
+  public Integer httpStatus() {
+    return httpStatus;
+  }
+
+  /**
+   * Returns the serialized response body replayed to retries.
+   *
+   * @return the response body, or {@code null} while the record is reserved or for responses
+   *     without a body
+   */
+  @Nullable
+  public String responseSummary() {
+    return responseSummary;
+  }
+
+  /**
+   * Returns when the key was reserved.
+   *
+   * @return reservation time in unix epoch millis
+   */
+  public long createdAtMs() {
+    return createdAtMs;
+  }
+
+  /**
+   * Returns when the record becomes eligible for purging.
+   *
+   * @return expiry time in unix epoch millis
+   */
+  public long expiresAtMs() {
+    return expiresAtMs;
+  }
+
+  /**
+   * Returns whether the mutation finished and its response can be replayed.
+   *
+   * @return {@code true} once the record carries a response
+   */
+  public boolean isFinalized() {
+    return httpStatus != null;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof IdempotencyRecord)) {
+      return false;
+    }
+    IdempotencyRecord that = (IdempotencyRecord) other;
+    return createdAtMs == that.createdAtMs
+        && expiresAtMs == that.expiresAtMs
+        && Objects.equals(idempotencyKey, that.idempotencyKey)
+        && Objects.equals(operationBinding, that.operationBinding)
+        && Objects.equals(httpStatus, that.httpStatus)
+        && Objects.equals(responseSummary, that.responseSummary);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        idempotencyKey, operationBinding, httpStatus, responseSummary, createdAtMs, expiresAtMs);
+  }
+
+  @Override
+  public String toString() {
+    return "IdempotencyRecord{idempotencyKey="
+        + idempotencyKey
+        + ", operationBinding="
+        + operationBinding
+        + ", httpStatus="
+        + httpStatus
+        + ", createdAtMs="
+        + createdAtMs
+        + ", expiresAtMs="
+        + expiresAtMs
+        + "}";
+  }
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStore.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStore.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Storage for {@code Idempotency-Key} records, pluggable so that a deployment can trade durability
+ * for latency.
+ *
+ * <p>The server drives a store through a reserve-execute-finalize cycle: exactly one caller wins
+ * {@link #reserve}, executes the mutation, and then either {@link #finalizeRecord finalizes} the
+ * response for later replay or {@link #release releases} the reservation so the client can retry
+ * with the same key. Implementations must make {@link #reserve} atomic across every caller that can
+ * see the same storage, since that is the only thing standing between a retried request and a
+ * duplicate mutation.
+ *
+ * <p>Implementations must be thread-safe and are expected to have a public no-argument constructor
+ * so they can be loaded by class name.
+ */
+public interface IdempotencyStore extends Closeable {
+
+  /** Outcome of an attempt to claim a key. */
+  enum ReserveResult {
+    /** The key was newly claimed by this caller, which now owns the mutation. */
+    RESERVED,
+    /** The key is already reserved or finalized, so the request is a retry. */
+    DUPLICATE
+  }
+
+  /**
+   * Initializes the store from the Iceberg REST server configuration.
+   *
+   * @param properties the full Iceberg REST server configuration
+   */
+  void initialize(Map<String, String> properties);
+
+  /**
+   * Atomically attempts to claim a key.
+   *
+   * @param idempotencyKey the client-provided UUIDv7 key
+   * @param operationBinding request identity, for example {@code POST
+   *     /v1/cat1/namespaces/ns1/tables}
+   * @param expiresAtMs time after which the record may be purged, in unix epoch millis
+   * @return {@link ReserveResult#RESERVED} if newly claimed, {@link ReserveResult#DUPLICATE} if a
+   *     record for this key already exists
+   */
+  ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs);
+
+  /**
+   * Loads a finalized record for replay.
+   *
+   * @param idempotencyKey the client-provided key
+   * @return the record, or {@link Optional#empty()} if the key is unknown or still reserved by an
+   *     in-flight request
+   */
+  Optional<IdempotencyRecord> load(String idempotencyKey);
+
+  /**
+   * Marks a reserved key finalized, storing the response replayed to later retries.
+   *
+   * <p>A record that has already expired or been purged is not resurrected; the call is a no-op.
+   *
+   * @param idempotencyKey the client-provided key
+   * @param httpStatus HTTP status of the original response
+   * @param responseSummary serialized response body, {@code null} for responses without a body
+   */
+  void finalizeRecord(String idempotencyKey, int httpStatus, @Nullable String responseSummary);
+
+  /**
+   * Releases a reservation so the client can retry with the same key. Called when the mutation
+   * failed in a way the Iceberg REST spec treats as retryable, which is any {@code 5xx} response.
+   *
+   * @param idempotencyKey the client-provided key
+   */
+  void release(String idempotencyKey);
+
+  /**
+   * Purges records whose reuse window has elapsed.
+   *
+   * @param beforeMs cutoff in unix epoch millis; records expiring before this time are removed
+   * @return the number of records purged
+   */
+  int purgeExpired(long beforeMs);
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStore.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStore.java
@@ -34,6 +34,17 @@ import javax.annotation.Nullable;
  * see the same storage, since that is the only thing standing between a retried request and a
  * duplicate mutation.
  *
+ * <p>A reservation does not always survive until its owner finishes: a bounded store can drop it
+ * under memory pressure, and a purge can remove it once it expires. The key is then free, and
+ * another caller can reserve it while the first is still running. Every call that mutates an
+ * existing record therefore carries the {@code claim} its caller reserved with, and implementations
+ * must ignore the call when the stored claim differs, so a caller that has lost its reservation
+ * cannot finalize or release a record that now belongs to someone else.
+ *
+ * <p>Keys are compared in the folded form returned by {@link IdempotencyKeys#canonicalize}, so
+ * implementations must canonicalize before reading or writing storage rather than trusting the
+ * caller to have done it.
+ *
  * <p>Implementations must be thread-safe and are expected to have a public no-argument constructor
  * so they can be loaded by class name.
  */
@@ -60,11 +71,14 @@ public interface IdempotencyStore extends Closeable {
    * @param idempotencyKey the client-provided UUIDv7 key
    * @param operationBinding request identity, for example {@code POST
    *     /v1/cat1/namespaces/ns1/tables}
+   * @param claim a fencing token identifying this attempt, which the caller must generate afresh
+   *     for every reservation and pass back to {@link #finalizeRecord} and {@link #release}
    * @param expiresAtMs time after which the record may be purged, in unix epoch millis
    * @return {@link ReserveResult#RESERVED} if newly claimed, {@link ReserveResult#DUPLICATE} if a
    *     record for this key already exists
    */
-  ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs);
+  ReserveResult reserve(
+      String idempotencyKey, String operationBinding, long claim, long expiresAtMs);
 
   /**
    * Loads a finalized record for replay.
@@ -78,21 +92,29 @@ public interface IdempotencyStore extends Closeable {
   /**
    * Marks a reserved key finalized, storing the response replayed to later retries.
    *
-   * <p>A record that has already expired or been purged is not resurrected; the call is a no-op.
+   * <p>The call is a no-op when the record has already expired or been purged, so it is not
+   * resurrected, and when the stored claim differs, so a caller that has lost its reservation
+   * cannot overwrite the record of whoever holds the key now.
    *
    * @param idempotencyKey the client-provided key
+   * @param claim the claim this caller reserved with
    * @param httpStatus HTTP status of the original response
    * @param responseSummary serialized response body, {@code null} for responses without a body
    */
-  void finalizeRecord(String idempotencyKey, int httpStatus, @Nullable String responseSummary);
+  void finalizeRecord(
+      String idempotencyKey, long claim, int httpStatus, @Nullable String responseSummary);
 
   /**
    * Releases a reservation so the client can retry with the same key. Called when the mutation
    * failed in a way the Iceberg REST spec treats as retryable, which is any {@code 5xx} response.
    *
+   * <p>The call is a no-op when the stored claim differs, so a caller that has lost its reservation
+   * cannot free a key another caller is currently executing under.
+   *
    * @param idempotencyKey the client-provided key
+   * @param claim the claim this caller reserved with
    */
-  void release(String idempotencyKey);
+  void release(String idempotencyKey, long claim);
 
   /**
    * Purges records whose reuse window has elapsed.

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStoreFactory.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStoreFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Loads the {@link IdempotencyStore} named by {@code idempotency-store-type}. */
+public class IdempotencyStoreFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IdempotencyStoreFactory.class);
+
+  /**
+   * Short names for the built-in stores, so that a deployment does not have to spell out a
+   * fully-qualified class name for them.
+   */
+  private static final ImmutableMap<String, String> STORE_CLASS_NAMES =
+      ImmutableMap.of(
+          IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_IN_MEMORY,
+          InMemoryIdempotencyStore.class.getCanonicalName());
+
+  private IdempotencyStoreFactory() {}
+
+  /**
+   * Creates and initializes the configured store.
+   *
+   * @param icebergConfig the Iceberg REST server configuration
+   * @return an initialized store
+   * @throws RuntimeException if the store cannot be instantiated or initialized
+   */
+  public static IdempotencyStore create(IcebergConfig icebergConfig) {
+    String storeType = icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_STORE_TYPE);
+    String storeClassName = STORE_CLASS_NAMES.getOrDefault(storeType, storeType);
+    LOG.info("Load Iceberg idempotency store: {}.", storeClassName);
+    try {
+      IdempotencyStore store =
+          (IdempotencyStore) Class.forName(storeClassName).getDeclaredConstructor().newInstance();
+      store.initialize(icebergConfig.getAllConfig());
+      return store;
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to create Iceberg idempotency store by name " + storeType, e);
+    }
+  }
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/InMemoryIdempotencyStore.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/InMemoryIdempotencyStore.java
@@ -20,13 +20,16 @@ package org.apache.gravitino.iceberg.common.idempotency;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.annotations.VisibleForTesting;
-import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import javax.annotation.Nullable;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.slf4j.Logger;
@@ -40,6 +43,11 @@ import org.slf4j.LoggerFactory;
  * node that restarted, finds no record and re-executes the mutation. Its size bound can also evict
  * a record before its reuse window elapses. Production deployments that run more than one replica
  * should use a shared, durable store instead.
+ *
+ * <p>Each record's own {@code expiresAtMs} decides whether it still counts, so a record past its
+ * deadline reads as absent whether or not the cache has reclaimed it yet. Caffeine's expiry only
+ * reclaims memory, which keeps behavior independent of when maintenance runs and matches how a
+ * database-backed store compares {@code expires_at} in its queries.
  */
 public class InMemoryIdempotencyStore implements IdempotencyStore {
 
@@ -49,18 +57,55 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
   private static final long EVICTION_LOG_INTERVAL = 1000;
 
   private final AtomicLong sizeEvictions = new AtomicLong();
+  private final LongSupplier clock;
 
   private Cache<String, IdempotencyRecord> cache;
+
+  /** Creates a store reading wall-clock time. */
+  public InMemoryIdempotencyStore() {
+    this(System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  InMemoryIdempotencyStore(LongSupplier clock) {
+    this.clock = clock;
+  }
 
   @Override
   public void initialize(Map<String, String> properties) {
     IcebergConfig icebergConfig = new IcebergConfig(properties);
-    Duration lifetime =
-        Duration.parse(icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_KEY_LIFETIME));
     int maxEntries = icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_MAX_ENTRIES);
     this.cache =
         Caffeine.newBuilder()
-            .expireAfterWrite(lifetime)
+            // Expiry off each record's own deadline rather than expireAfterWrite, which restarts on
+            // every write: finalizing a record is a write, and would otherwise push a record
+            // finalized late in its window well past the lifetime advertised to clients.
+            .expireAfter(
+                new Expiry<String, IdempotencyRecord>() {
+                  @Override
+                  public long expireAfterCreate(
+                      String key, IdempotencyRecord record, long currentTimeNanos) {
+                    return remainingNanos(record);
+                  }
+
+                  @Override
+                  public long expireAfterUpdate(
+                      String key,
+                      IdempotencyRecord record,
+                      long currentTimeNanos,
+                      long currentDurationNanos) {
+                    return remainingNanos(record);
+                  }
+
+                  @Override
+                  public long expireAfterRead(
+                      String key,
+                      IdempotencyRecord record,
+                      long currentTimeNanos,
+                      long currentDurationNanos) {
+                    return remainingNanos(record);
+                  }
+                })
             .maximumSize(maxEntries)
             .removalListener(
                 (String key, IdempotencyRecord record, RemovalCause cause) -> {
@@ -69,44 +114,64 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
                   }
                 })
             .build();
-    LOG.info(
-        "Initialized in-memory Iceberg idempotency store, key lifetime: {}, max entries: {}.",
-        lifetime,
-        maxEntries);
+    LOG.info("Initialized in-memory Iceberg idempotency store, max entries: {}.", maxEntries);
   }
 
   @Override
-  public ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs) {
+  public ReserveResult reserve(
+      String idempotencyKey, String operationBinding, long claim, long expiresAtMs) {
+    String key = IdempotencyKeys.canonicalize(idempotencyKey);
     IdempotencyRecord reserved =
-        IdempotencyRecord.reserved(
-            idempotencyKey, operationBinding, System.currentTimeMillis(), expiresAtMs);
-    IdempotencyRecord existing = cache.asMap().putIfAbsent(idempotencyKey, reserved);
-    return existing == null ? ReserveResult.RESERVED : ReserveResult.DUPLICATE;
+        IdempotencyRecord.reserved(key, operationBinding, claim, clock.getAsLong(), expiresAtMs);
+    // A record past its deadline is treated as absent rather than waiting for the cache to reclaim
+    // it, so behavior turns on the record's own expiry instead of when maintenance happens to run.
+    AtomicBoolean claimed = new AtomicBoolean();
+    cache
+        .asMap()
+        .compute(
+            key,
+            (cacheKey, existing) -> {
+              if (existing == null || isExpired(existing)) {
+                claimed.set(true);
+                return reserved;
+              }
+              return existing;
+            });
+    return claimed.get() ? ReserveResult.RESERVED : ReserveResult.DUPLICATE;
   }
 
   @Override
   public Optional<IdempotencyRecord> load(String idempotencyKey) {
-    return Optional.ofNullable(cache.getIfPresent(idempotencyKey))
+    return Optional.ofNullable(cache.getIfPresent(IdempotencyKeys.canonicalize(idempotencyKey)))
+        .filter(record -> !isExpired(record))
         .filter(IdempotencyRecord::isFinalized);
   }
 
   @Override
   public void finalizeRecord(
-      String idempotencyKey, int httpStatus, @Nullable String responseSummary) {
-    // computeIfPresent, so a record purged while the mutation was running is not resurrected.
+      String idempotencyKey, long claim, int httpStatus, @Nullable String responseSummary) {
+    // computeIfPresent, so a record purged while the mutation was running is not resurrected. The
+    // claim check leaves a record reserved by someone else untouched.
     cache
         .asMap()
         .computeIfPresent(
-            idempotencyKey, (key, record) -> record.withResponse(httpStatus, responseSummary));
+            IdempotencyKeys.canonicalize(idempotencyKey),
+            (key, record) ->
+                record.claim() == claim && !isExpired(record)
+                    ? record.withResponse(httpStatus, responseSummary)
+                    : record);
   }
 
   @Override
-  public void release(String idempotencyKey) {
-    // Returning null removes the entry; a finalized record is left alone so that a late release
-    // cannot drop a response another request may still replay.
+  public void release(String idempotencyKey, long claim) {
+    // Returning null removes the entry. A finalized record is left alone so that a late release
+    // cannot drop a response another request may still replay, and so is a record whose claim has
+    // moved on, so a caller that lost its reservation cannot free a key someone else is executing.
     cache
         .asMap()
-        .computeIfPresent(idempotencyKey, (key, record) -> record.isFinalized() ? record : null);
+        .computeIfPresent(
+            IdempotencyKeys.canonicalize(idempotencyKey),
+            (key, record) -> record.isFinalized() || record.claim() != claim ? record : null);
   }
 
   @Override
@@ -134,6 +199,15 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
   long size() {
     cache.cleanUp();
     return cache.estimatedSize();
+  }
+
+  private boolean isExpired(IdempotencyRecord record) {
+    return record.expiresAtMs() <= clock.getAsLong();
+  }
+
+  private long remainingNanos(IdempotencyRecord record) {
+    long remainingMs = record.expiresAtMs() - clock.getAsLong();
+    return remainingMs <= 0 ? 0 : TimeUnit.MILLISECONDS.toNanos(remainingMs);
   }
 
   private void onSizeEviction(int maxEntries) {

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/InMemoryIdempotencyStore.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/InMemoryIdempotencyStore.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Node-local {@link IdempotencyStore} backed by a Caffeine cache.
+ *
+ * <p>This store is best-effort and intended for single-node deployments, development, and tests. It
+ * is not durable, and it is not shared between replicas: a retry routed to another node, or to a
+ * node that restarted, finds no record and re-executes the mutation. Its size bound can also evict
+ * a record before its reuse window elapses. Production deployments that run more than one replica
+ * should use a shared, durable store instead.
+ */
+public class InMemoryIdempotencyStore implements IdempotencyStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InMemoryIdempotencyStore.class);
+
+  /** Evictions between two warnings, so an undersized cache is visible without flooding the log. */
+  private static final long EVICTION_LOG_INTERVAL = 1000;
+
+  private final AtomicLong sizeEvictions = new AtomicLong();
+
+  private Cache<String, IdempotencyRecord> cache;
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    IcebergConfig icebergConfig = new IcebergConfig(properties);
+    Duration lifetime =
+        Duration.parse(icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_KEY_LIFETIME));
+    int maxEntries = icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_MAX_ENTRIES);
+    this.cache =
+        Caffeine.newBuilder()
+            .expireAfterWrite(lifetime)
+            .maximumSize(maxEntries)
+            .removalListener(
+                (String key, IdempotencyRecord record, RemovalCause cause) -> {
+                  if (cause == RemovalCause.SIZE) {
+                    onSizeEviction(maxEntries);
+                  }
+                })
+            .build();
+    LOG.info(
+        "Initialized in-memory Iceberg idempotency store, key lifetime: {}, max entries: {}.",
+        lifetime,
+        maxEntries);
+  }
+
+  @Override
+  public ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs) {
+    IdempotencyRecord reserved =
+        IdempotencyRecord.reserved(
+            idempotencyKey, operationBinding, System.currentTimeMillis(), expiresAtMs);
+    IdempotencyRecord existing = cache.asMap().putIfAbsent(idempotencyKey, reserved);
+    return existing == null ? ReserveResult.RESERVED : ReserveResult.DUPLICATE;
+  }
+
+  @Override
+  public Optional<IdempotencyRecord> load(String idempotencyKey) {
+    return Optional.ofNullable(cache.getIfPresent(idempotencyKey))
+        .filter(IdempotencyRecord::isFinalized);
+  }
+
+  @Override
+  public void finalizeRecord(
+      String idempotencyKey, int httpStatus, @Nullable String responseSummary) {
+    // computeIfPresent, so a record purged while the mutation was running is not resurrected.
+    cache
+        .asMap()
+        .computeIfPresent(
+            idempotencyKey, (key, record) -> record.withResponse(httpStatus, responseSummary));
+  }
+
+  @Override
+  public void release(String idempotencyKey) {
+    // Returning null removes the entry; a finalized record is left alone so that a late release
+    // cannot drop a response another request may still replay.
+    cache
+        .asMap()
+        .computeIfPresent(idempotencyKey, (key, record) -> record.isFinalized() ? record : null);
+  }
+
+  @Override
+  public int purgeExpired(long beforeMs) {
+    int purged = 0;
+    Iterator<Map.Entry<String, IdempotencyRecord>> entries = cache.asMap().entrySet().iterator();
+    while (entries.hasNext()) {
+      Map.Entry<String, IdempotencyRecord> entry = entries.next();
+      if (entry.getValue().expiresAtMs() < beforeMs
+          && cache.asMap().remove(entry.getKey(), entry.getValue())) {
+        purged += 1;
+      }
+    }
+    return purged;
+  }
+
+  @Override
+  public void close() {
+    if (cache != null) {
+      cache.invalidateAll();
+    }
+  }
+
+  @VisibleForTesting
+  long size() {
+    cache.cleanUp();
+    return cache.estimatedSize();
+  }
+
+  private void onSizeEviction(int maxEntries) {
+    long evictions = sizeEvictions.incrementAndGet();
+    if (evictions % EVICTION_LOG_INTERVAL == 1) {
+      LOG.warn(
+          "In-memory Iceberg idempotency store evicted {} record(s) before their reuse window "
+              + "elapsed; retries for evicted keys re-execute the mutation. Raise "
+              + "`idempotency-max-entries` (currently {}) or use a shared, durable store.",
+          evictions,
+          maxEntries);
+    }
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyKeys.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyKeys.java
@@ -74,4 +74,20 @@ public class TestIdempotencyKeys {
   void testNilUuidIsRejected() {
     Assertions.assertFalse(IdempotencyKeys.isValid("00000000-0000-0000-0000-000000000000"));
   }
+
+  @Test
+  void testCanonicalizeFoldsCase() {
+    String expected = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+    Assertions.assertEquals(
+        expected, IdempotencyKeys.canonicalize("017F22E2-79B0-7CC3-98C4-DC0C0C07398F"));
+    Assertions.assertEquals(expected, IdempotencyKeys.canonicalize(expected));
+    Assertions.assertEquals(
+        expected, IdempotencyKeys.canonicalize("017f22E2-79b0-7CC3-98c4-DC0c0c07398F"));
+  }
+
+  @Test
+  void testCanonicalizeRejectsAnInvalidKey() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> IdempotencyKeys.canonicalize("not-a-uuid"));
+  }
 }

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyKeys.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyKeys.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestIdempotencyKeys {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // The example from the Iceberg REST spec, in both cases.
+        "017F22E2-79B0-7CC3-98C4-DC0C0C07398F",
+        "017f22e2-79b0-7cc3-98c4-dc0c0c07398f",
+        // Variant octet 0b10xx, covering the whole RFC 9562 variant range.
+        "017f22e2-79b0-7cc3-88c4-dc0c0c07398f",
+        "017f22e2-79b0-7cc3-b8c4-dc0c0c07398f"
+      })
+  void testAcceptsUuidV7(String idempotencyKey) {
+    Assertions.assertTrue(IdempotencyKeys.isValid(idempotencyKey));
+    Assertions.assertDoesNotThrow(() -> IdempotencyKeys.validate(idempotencyKey));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(
+      strings = {
+        // UUIDv4, the version nibble must be 7.
+        "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        // UUIDv1.
+        "c232ab00-9414-11ec-b3c8-9f6bdeced846",
+        // RFC 9562 requires the variant bits to be 10; this is the NCS variant.
+        "017f22e2-79b0-7cc3-28c4-dc0c0c07398f",
+        // The Microsoft variant.
+        "017f22e2-79b0-7cc3-c8c4-dc0c0c07398f",
+        // Not the canonical 36-character form.
+        "017f22e279b07cc398c4dc0c0c07398f",
+        "017f22e2-79b0-7cc3-98c4-dc0c0c07398",
+        "017f22e2-79b0-7cc3-98c4-dc0c0c07398ff",
+        "  017f22e2-79b0-7cc3-98c4-dc0c0c07398f  ",
+        // Right length, but not hexadecimal.
+        "017f22e2-79b0-7cc3-98c4-dc0c0c0739zz",
+        "not-a-uuid"
+      })
+  void testRejectsAnythingElse(String idempotencyKey) {
+    Assertions.assertFalse(IdempotencyKeys.isValid(idempotencyKey));
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> IdempotencyKeys.validate(idempotencyKey));
+    Assertions.assertTrue(exception.getMessage().contains("UUIDv7"), exception.getMessage());
+  }
+
+  @Test
+  void testNilUuidIsRejected() {
+    Assertions.assertFalse(IdempotencyKeys.isValid("00000000-0000-0000-0000-000000000000"));
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyStoreFactory.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyStoreFactory.java
@@ -85,7 +85,8 @@ public class TestIdempotencyStoreFactory {
     }
 
     @Override
-    public ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs) {
+    public ReserveResult reserve(
+        String idempotencyKey, String operationBinding, long claim, long expiresAtMs) {
       return ReserveResult.RESERVED;
     }
 
@@ -95,10 +96,11 @@ public class TestIdempotencyStoreFactory {
     }
 
     @Override
-    public void finalizeRecord(String idempotencyKey, int httpStatus, String responseSummary) {}
+    public void finalizeRecord(
+        String idempotencyKey, long claim, int httpStatus, String responseSummary) {}
 
     @Override
-    public void release(String idempotencyKey) {}
+    public void release(String idempotencyKey, long claim) {}
 
     @Override
     public int purgeExpired(long beforeMs) {

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyStoreFactory.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyStoreFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestIdempotencyStoreFactory {
+
+  @Test
+  void testCreateDefaultsToInMemoryStore() throws IOException {
+    try (IdempotencyStore store = IdempotencyStoreFactory.create(new IcebergConfig())) {
+      Assertions.assertInstanceOf(InMemoryIdempotencyStore.class, store);
+    }
+  }
+
+  @Test
+  void testCreateResolvesShortName() throws IOException {
+    IcebergConfig config =
+        new IcebergConfig(
+            ImmutableMap.of(
+                IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_TYPE,
+                IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_IN_MEMORY));
+    try (IdempotencyStore store = IdempotencyStoreFactory.create(config)) {
+      Assertions.assertInstanceOf(InMemoryIdempotencyStore.class, store);
+    }
+  }
+
+  @Test
+  void testCreateResolvesCustomClassNameAndInitializesIt() throws IOException {
+    IcebergConfig config =
+        new IcebergConfig(
+            ImmutableMap.of(
+                IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_TYPE,
+                // Binary name, since Class.forName cannot resolve a nested class by canonical name.
+                RecordingIdempotencyStore.class.getName()));
+    try (IdempotencyStore store = IdempotencyStoreFactory.create(config)) {
+      Assertions.assertInstanceOf(RecordingIdempotencyStore.class, store);
+      Assertions.assertTrue(((RecordingIdempotencyStore) store).initialized);
+    }
+  }
+
+  @Test
+  void testCreateFailsForUnknownStore() {
+    IcebergConfig config =
+        new IcebergConfig(
+            ImmutableMap.of(
+                IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_TYPE, "com.example.NoSuchStore"));
+    Exception exception =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> IdempotencyStoreFactory.create(config));
+    Assertions.assertTrue(exception.getMessage().contains("com.example.NoSuchStore"));
+  }
+
+  /** Store loaded by class name, asserting the factory initializes what it constructs. */
+  public static class RecordingIdempotencyStore implements IdempotencyStore {
+
+    private boolean initialized = false;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      this.initialized = true;
+    }
+
+    @Override
+    public ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs) {
+      return ReserveResult.RESERVED;
+    }
+
+    @Override
+    public Optional<IdempotencyRecord> load(String idempotencyKey) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void finalizeRecord(String idempotencyKey, int httpStatus, String responseSummary) {}
+
+    @Override
+    public void release(String idempotencyKey) {}
+
+    @Override
+    public int purgeExpired(long beforeMs) {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestInMemoryIdempotencyStore.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestInMemoryIdempotencyStore.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStore.ReserveResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestInMemoryIdempotencyStore {
+
+  private static final String KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+  private static final String OTHER_KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c073990";
+  private static final String BINDING = "POST v1/cat1/namespaces/ns1/tables";
+  private static final long FAR_FUTURE_MS = Long.MAX_VALUE;
+
+  private InMemoryIdempotencyStore store;
+
+  @BeforeEach
+  void setUp() {
+    store = newStore(ImmutableMap.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    store.close();
+  }
+
+  @Test
+  void testReserveClaimsKeyOnlyOnce() {
+    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(OTHER_KEY, BINDING, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testLoadReturnsEmptyUntilFinalized() {
+    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    Assertions.assertEquals(Optional.empty(), store.load(KEY));
+
+    store.finalizeRecord(KEY, 200, "{\"a\":1}");
+
+    IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
+    Assertions.assertTrue(record.isFinalized());
+    Assertions.assertEquals(KEY, record.idempotencyKey());
+    Assertions.assertEquals(BINDING, record.operationBinding());
+    Assertions.assertEquals(200, record.httpStatus().intValue());
+    Assertions.assertEquals("{\"a\":1}", record.responseSummary());
+  }
+
+  @Test
+  void testLoadUnknownKeyReturnsEmpty() {
+    Assertions.assertEquals(Optional.empty(), store.load(KEY));
+  }
+
+  @Test
+  void testFinalizeWithoutBodyIsReplayable() {
+    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    store.finalizeRecord(KEY, 204, null);
+
+    IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
+    Assertions.assertEquals(204, record.httpStatus().intValue());
+    Assertions.assertNull(record.responseSummary());
+  }
+
+  @Test
+  void testFinalizeDoesNotResurrectAPurgedRecord() {
+    store.finalizeRecord(KEY, 200, "{}");
+    Assertions.assertEquals(Optional.empty(), store.load(KEY));
+    Assertions.assertEquals(0, store.size());
+  }
+
+  @Test
+  void testReleaseFreesTheKeyForRetry() {
+    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    store.release(KEY);
+
+    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testReleaseKeepsAFinalizedRecord() {
+    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    store.finalizeRecord(KEY, 200, "{}");
+    store.release(KEY);
+
+    Assertions.assertTrue(store.load(KEY).isPresent());
+    Assertions.assertEquals(ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testPurgeExpiredRemovesOnlyElapsedRecords() {
+    long now = System.currentTimeMillis();
+    store.reserve(KEY, BINDING, now - 1);
+    store.reserve(OTHER_KEY, BINDING, now + 60_000);
+
+    Assertions.assertEquals(1, store.purgeExpired(now));
+    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(OTHER_KEY, BINDING, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testSizeBoundEvictsRecords() throws InterruptedException {
+    InMemoryIdempotencyStore boundedStore =
+        newStore(ImmutableMap.of(IcebergConstants.ICEBERG_IDEMPOTENCY_MAX_ENTRIES, "2"));
+    try {
+      for (int i = 0; i < 50; i++) {
+        boundedStore.reserve(String.format("key-%d", i), BINDING, FAR_FUTURE_MS);
+      }
+      // Caffeine evicts during maintenance, so the bound is reached shortly after the writes
+      // rather than synchronously with them.
+      long retained = boundedStore.size();
+      for (int attempt = 0; attempt < 100 && retained > 2; attempt++) {
+        Thread.sleep(20);
+        retained = boundedStore.size();
+      }
+      Assertions.assertTrue(retained <= 2, "expected at most 2 retained records, got " + retained);
+    } finally {
+      boundedStore.close();
+    }
+  }
+
+  @Test
+  void testConcurrentReserveHasASingleWinner() throws InterruptedException {
+    int threads = 16;
+    ExecutorService executor = Executors.newFixedThreadPool(threads);
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threads);
+    AtomicInteger reserved = new AtomicInteger();
+    try {
+      for (int i = 0; i < threads; i++) {
+        executor.submit(
+            () -> {
+              try {
+                start.await();
+                if (store.reserve(KEY, BINDING, FAR_FUTURE_MS) == ReserveResult.RESERVED) {
+                  reserved.incrementAndGet();
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              } finally {
+                done.countDown();
+              }
+            });
+      }
+      start.countDown();
+      Assertions.assertTrue(done.await(30, TimeUnit.SECONDS));
+      Assertions.assertEquals(1, reserved.get());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static InMemoryIdempotencyStore newStore(Map<String, String> properties) {
+    InMemoryIdempotencyStore store = new InMemoryIdempotencyStore();
+    store.initialize(properties);
+    return store;
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestInMemoryIdempotencyStore.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestInMemoryIdempotencyStore.java
@@ -19,13 +19,19 @@
 package org.apache.gravitino.iceberg.common.idempotency;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStore.ReserveResult;
 import org.junit.jupiter.api.AfterEach;
@@ -36,9 +42,11 @@ import org.junit.jupiter.api.Test;
 public class TestInMemoryIdempotencyStore {
 
   private static final String KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+  private static final String KEY_UPPER = "017F22E2-79B0-7CC3-98C4-DC0C0C07398F";
   private static final String OTHER_KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c073990";
   private static final String BINDING = "POST v1/cat1/namespaces/ns1/tables";
   private static final long FAR_FUTURE_MS = Long.MAX_VALUE;
+  private static final long CLAIM = 1L;
 
   private InMemoryIdempotencyStore store;
 
@@ -54,18 +62,36 @@ public class TestInMemoryIdempotencyStore {
 
   @Test
   void testReserveClaimsKeyOnlyOnce() {
-    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
-    Assertions.assertEquals(ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
     Assertions.assertEquals(
-        ReserveResult.RESERVED, store.reserve(OTHER_KEY, BINDING, FAR_FUTURE_MS));
+        ReserveResult.RESERVED, store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, CLAIM + 1, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(OTHER_KEY, BINDING, CLAIM, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testKeyCaseVariantsAddressTheSameRecord() {
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(KEY_UPPER, BINDING, CLAIM, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, CLAIM + 1, FAR_FUTURE_MS));
+    Assertions.assertEquals(1, store.size());
+
+    // Finalizing under one casing has to be replayable under the other, otherwise a retry that
+    // changes case re-executes the mutation.
+    store.finalizeRecord(KEY_UPPER, CLAIM, 200, "{\"a\":1}");
+    IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
+    Assertions.assertEquals(KEY, record.idempotencyKey());
+    Assertions.assertEquals(200, record.httpStatus().intValue());
   }
 
   @Test
   void testLoadReturnsEmptyUntilFinalized() {
-    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS);
     Assertions.assertEquals(Optional.empty(), store.load(KEY));
 
-    store.finalizeRecord(KEY, 200, "{\"a\":1}");
+    store.finalizeRecord(KEY, CLAIM, 200, "{\"a\":1}");
 
     IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
     Assertions.assertTrue(record.isFinalized());
@@ -82,8 +108,8 @@ public class TestInMemoryIdempotencyStore {
 
   @Test
   void testFinalizeWithoutBodyIsReplayable() {
-    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
-    store.finalizeRecord(KEY, 204, null);
+    store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS);
+    store.finalizeRecord(KEY, CLAIM, 204, null);
 
     IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
     Assertions.assertEquals(204, record.httpStatus().intValue());
@@ -92,39 +118,115 @@ public class TestInMemoryIdempotencyStore {
 
   @Test
   void testFinalizeDoesNotResurrectAPurgedRecord() {
-    store.finalizeRecord(KEY, 200, "{}");
+    store.finalizeRecord(KEY, CLAIM, 200, "{}");
     Assertions.assertEquals(Optional.empty(), store.load(KEY));
     Assertions.assertEquals(0, store.size());
   }
 
   @Test
   void testReleaseFreesTheKeyForRetry() {
-    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
-    store.release(KEY);
+    store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS);
+    store.release(KEY, CLAIM);
 
-    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS));
   }
 
   @Test
   void testReleaseKeepsAFinalizedRecord() {
-    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
-    store.finalizeRecord(KEY, 200, "{}");
-    store.release(KEY);
+    store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS);
+    store.finalizeRecord(KEY, CLAIM, 200, "{}");
+    store.release(KEY, CLAIM);
 
     Assertions.assertTrue(store.load(KEY).isPresent());
-    Assertions.assertEquals(ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testStaleFinalizeAfterReReservationIsIgnored() {
+    long staleClaim = 1L;
+    long currentClaim = 2L;
+    store.reserve(KEY, BINDING, staleClaim, FAR_FUTURE_MS);
+    // The first reservation goes away underneath its owner, as a size eviction or a purge would do,
+    // and a second caller takes the key.
+    store.release(KEY, staleClaim);
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(KEY, BINDING, currentClaim, FAR_FUTURE_MS));
+
+    store.finalizeRecord(KEY, staleClaim, 200, "{\"stale\":true}");
+
+    // The current owner is still mid-flight: nothing to replay, and the key stays taken.
+    Assertions.assertEquals(Optional.empty(), store.load(KEY));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, 3L, FAR_FUTURE_MS));
+
+    // And the current owner can still finalize its own response.
+    store.finalizeRecord(KEY, currentClaim, 201, "{\"stale\":false}");
+    Assertions.assertEquals(
+        "{\"stale\":false}", store.load(KEY).orElseThrow(AssertionError::new).responseSummary());
+  }
+
+  @Test
+  void testStaleReleaseAfterReReservationIsIgnored() {
+    long staleClaim = 1L;
+    long currentClaim = 2L;
+    store.reserve(KEY, BINDING, staleClaim, FAR_FUTURE_MS);
+    store.release(KEY, staleClaim);
+    store.reserve(KEY, BINDING, currentClaim, FAR_FUTURE_MS);
+
+    store.release(KEY, staleClaim);
+
+    // Releasing on a lost claim must not free a key the current owner is executing under, which
+    // would let a third request run the mutation a second time.
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, 3L, FAR_FUTURE_MS));
   }
 
   @Test
   void testPurgeExpiredRemovesOnlyElapsedRecords() {
-    long now = System.currentTimeMillis();
-    store.reserve(KEY, BINDING, now - 1);
-    store.reserve(OTHER_KEY, BINDING, now + 60_000);
+    AtomicLong now = new AtomicLong(1_000_000L);
+    InMemoryIdempotencyStore clockedStore = newStore(ImmutableMap.of(), now::get);
+    try {
+      clockedStore.reserve(KEY, BINDING, CLAIM, now.get() + 1_000L);
+      clockedStore.reserve(OTHER_KEY, BINDING, CLAIM, now.get() + 60_000L);
 
-    Assertions.assertEquals(1, store.purgeExpired(now));
-    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
-    Assertions.assertEquals(
-        ReserveResult.DUPLICATE, store.reserve(OTHER_KEY, BINDING, FAR_FUTURE_MS));
+      // Only the first record's window has elapsed.
+      now.addAndGet(1_001L);
+      Assertions.assertEquals(1, clockedStore.purgeExpired(now.get()));
+
+      Assertions.assertEquals(
+          ReserveResult.RESERVED, clockedStore.reserve(KEY, BINDING, CLAIM, now.get() + 1_000L));
+      Assertions.assertEquals(
+          ReserveResult.DUPLICATE,
+          clockedStore.reserve(OTHER_KEY, BINDING, CLAIM, now.get() + 60_000L));
+    } finally {
+      clockedStore.close();
+    }
+  }
+
+  @Test
+  void testRecordExpiresAtItsDeadlineAndFinalizeDoesNotExtendIt() {
+    AtomicLong now = new AtomicLong(1_000_000L);
+    InMemoryIdempotencyStore clockedStore = newStore(ImmutableMap.of(), now::get);
+    try {
+      long deadline = now.get() + 1_000L;
+      Assertions.assertEquals(
+          ReserveResult.RESERVED, clockedStore.reserve(KEY, BINDING, CLAIM, deadline));
+
+      // Finalize halfway through the window. A cache expiring on last-write would restart the
+      // clock here and keep the record past the lifetime advertised to clients.
+      now.set(deadline - 500L);
+      clockedStore.finalizeRecord(KEY, CLAIM, 200, "{}");
+      Assertions.assertTrue(clockedStore.load(KEY).isPresent());
+
+      now.set(deadline);
+      Assertions.assertEquals(Optional.empty(), clockedStore.load(KEY));
+      Assertions.assertEquals(
+          ReserveResult.RESERVED, clockedStore.reserve(KEY, BINDING, CLAIM, now.get() + 1_000L));
+    } finally {
+      clockedStore.close();
+    }
   }
 
   @Test
@@ -133,7 +235,7 @@ public class TestInMemoryIdempotencyStore {
         newStore(ImmutableMap.of(IcebergConstants.ICEBERG_IDEMPOTENCY_MAX_ENTRIES, "2"));
     try {
       for (int i = 0; i < 50; i++) {
-        boundedStore.reserve(String.format("key-%d", i), BINDING, FAR_FUTURE_MS);
+        boundedStore.reserve(uuidKey(i), BINDING, CLAIM, FAR_FUTURE_MS);
       }
       // Caffeine evicts during maintenance, so the bound is reached shortly after the writes
       // rather than synchronously with them.
@@ -154,18 +256,18 @@ public class TestInMemoryIdempotencyStore {
     ExecutorService executor = Executors.newFixedThreadPool(threads);
     CountDownLatch start = new CountDownLatch(1);
     CountDownLatch done = new CountDownLatch(threads);
-    AtomicInteger reserved = new AtomicInteger();
+    List<ReserveResult> results = Collections.synchronizedList(new ArrayList<>());
+    AtomicReference<Throwable> failure = new AtomicReference<>();
     try {
       for (int i = 0; i < threads; i++) {
+        long claim = i;
         executor.submit(
             () -> {
               try {
                 start.await();
-                if (store.reserve(KEY, BINDING, FAR_FUTURE_MS) == ReserveResult.RESERVED) {
-                  reserved.incrementAndGet();
-                }
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                results.add(store.reserve(KEY, BINDING, claim, FAR_FUTURE_MS));
+              } catch (Throwable t) {
+                failure.compareAndSet(null, t);
               } finally {
                 done.countDown();
               }
@@ -173,14 +275,29 @@ public class TestInMemoryIdempotencyStore {
       }
       start.countDown();
       Assertions.assertTrue(done.await(30, TimeUnit.SECONDS));
-      Assertions.assertEquals(1, reserved.get());
+      Assertions.assertNull(failure.get(), "no reserve should fail");
+      Map<ReserveResult, Long> counts =
+          results.stream().collect(Collectors.groupingBy(result -> result, Collectors.counting()));
+      Assertions.assertEquals(threads, results.size(), "every caller should report a result");
+      Assertions.assertEquals(1L, counts.getOrDefault(ReserveResult.RESERVED, 0L));
+      Assertions.assertEquals(threads - 1L, counts.getOrDefault(ReserveResult.DUPLICATE, 0L));
     } finally {
       executor.shutdownNow();
     }
   }
 
+  /** Builds distinct valid UUIDv7 keys, since the store rejects anything else. */
+  private static String uuidKey(int index) {
+    return String.format("017f22e2-79b0-7cc3-98c4-%012x", index);
+  }
+
   private static InMemoryIdempotencyStore newStore(Map<String, String> properties) {
-    InMemoryIdempotencyStore store = new InMemoryIdempotencyStore();
+    return newStore(properties, System::currentTimeMillis);
+  }
+
+  private static InMemoryIdempotencyStore newStore(
+      Map<String, String> properties, LongSupplier clock) {
+    InMemoryIdempotencyStore store = new InMemoryIdempotencyStore(clock);
     store.initialize(properties);
     return store;
   }


### PR DESCRIPTION
> Split out of the original single PR per review feedback: this one is the storage seam only (~1000 lines), the endpoint wiring follows in a stacked PR.

### What changes were proposed in this pull request?

First half of phase 1 of the Idempotency-Key design (`design-docs/iceberg-idempotency-key.md`): the pluggable storage seam and its node-local implementation. No endpoint is wired yet, so this change has no runtime effect on its own.

- **`IdempotencyStore`** SPI built around reserve, execute, finalize. An implementation only has to make `reserve` atomic across the callers that share its storage; that single guarantee is what keeps a retried request from re-running a mutation. `release` hands a key back after a retryable failure, and `purgeExpired` drops records whose reuse window has elapsed.
- **`IdempotencyRecord`**, immutable, carrying the operation binding and the response replayed to retries. Timestamps are epoch millis so a database-backed store maps them onto `BIGINT` columns like Gravitino's other metadata tables.
- **`IdempotencyKeys`** validates the header as an RFC 9562 UUIDv7, rejecting malformed keys before they reach storage.
- **`InMemoryIdempotencyStore`**, a Caffeine cache bounded by the key lifetime and a max entry count. Its Javadoc is explicit that it is best-effort and single-node, and it warns when the size bound evicts a record before its window elapses.
- **`IdempotencyStoreFactory`** resolves the configured store, by short name or by class name.
- Config entries for enablement, key lifetime, store type, and capacity, all inert until the endpoints are wired.

Follow-ups, each its own PR:

1. The manager and endpoint wiring, which turns this into a working feature. Already prepared and stacked on this branch.
2. The durable, multi-node JDBC store on Gravitino's relational backend (phase 2 of the design).

### Why are the changes needed?

Epic #12049. Without idempotency support, a client retry after a network failure re-executes the mutation and produces duplicate table/namespace/view creates and drops. Splitting the storage seam out first keeps each change small enough to review properly, and it is the interface the JDBC store in phase 2 plugs into.

Supersedes #10751, which used a node-local Caffeine cache with no storage seam.

Fix: #12049

### Does this PR introduce _any_ user-facing change?

No behavior change. It adds four properties that do nothing until the endpoints are wired in the follow-up: `gravitino.iceberg-rest.idempotency-enabled` (`false`), `idempotency-key-lifetime` (`PT30M`), `idempotency-store-type` (`in-memory`), `idempotency-max-entries` (`10000`). They are documented alongside the feature in the follow-up PR.

### How was this patch tested?

New unit tests:

- `TestIdempotencyKeys` - accepts UUIDv7 in both cases and across the RFC 9562 variant range; rejects UUIDv1/v4, the NCS and Microsoft variants, the nil UUID, non-canonical lengths, and non-hex input.
- `TestInMemoryIdempotencyStore` - single-winner `reserve` under 16 concurrent threads, `load` empty until finalized, `release` freeing a reservation but preserving a finalized record, no resurrection of a record purged while its mutation ran, `purgeExpired` removing only elapsed rows, size-bound eviction.
- `TestIdempotencyStoreFactory` - default and short-name resolution, a store loaded by class name and initialized, and a clear failure for an unknown store.

`iceberg-common` suite passes on JDK 17: 95 tests, 0 failures.

```bash
./gradlew :iceberg:iceberg-common:test -PskipITs
```
