### PR TITLE
[#12049] feat(iceberg-rest-server): honor Idempotency-Key on mutation endpoints

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
@@ -128,4 +128,19 @@ public class IcebergConstants {
   public static final String SCAN_PLAN_CACHE_IMPL = "scan-plan-cache-impl";
   public static final String SCAN_PLAN_CACHE_CAPACITY = "scan-plan-cache-capacity";
   public static final String SCAN_PLAN_CACHE_EXPIRE_MINUTES = "scan-plan-cache-expire-minutes";
+
+  /** Whether the Iceberg REST server honors the {@code Idempotency-Key} header. */
+  public static final String ICEBERG_IDEMPOTENCY_ENABLED = "idempotency-enabled";
+
+  /** Client reuse window for an idempotency key, as an ISO-8601 duration. */
+  public static final String ICEBERG_IDEMPOTENCY_KEY_LIFETIME = "idempotency-key-lifetime";
+
+  /** Storage backend holding idempotency records. */
+  public static final String ICEBERG_IDEMPOTENCY_STORE_TYPE = "idempotency-store-type";
+
+  /** Short name of the node-local idempotency store. */
+  public static final String ICEBERG_IDEMPOTENCY_STORE_IN_MEMORY = "in-memory";
+
+  /** Capacity of the in-memory idempotency store. */
+  public static final String ICEBERG_IDEMPOTENCY_MAX_ENTRIES = "idempotency-max-entries";
 }

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -148,6 +148,25 @@ The settings below tune the background workers and are optional.
 | `gravitino.iceberg-rest.async-cleanup.max-attempts`           | Number of failed attempts before a cleanup job is marked `FAILED`.                                   | `5`           | No       |
 | `gravitino.iceberg-rest.async-cleanup.retention-hours`        | Retention time for terminal `SUCCEEDED` or `FAILED` cleanup rows before pruning.                     | `720`         | No       |
 
+#### Idempotency Key
+
+The Iceberg REST spec defines an optional `Idempotency-Key` header on mutation endpoints so that a client can safely retry a request whose response it never saw. When the header is present, the server executes the mutation once, stores the response, and replays that stored response to every retry carrying the same key.
+
+Support is disabled by default. Once enabled, the reuse window is advertised as `idempotency-key-lifetime` in `GET /v1/config`; per the spec, clients must assume idempotency is unsupported when that field is absent.
+
+The header applies to the create, update, drop, register, and rename endpoints for tables, namespaces, and views. Its value must be a UUIDv7 in string form ([RFC 9562](https://www.rfc-editor.org/rfc/rfc9562)); anything else returns `400 Bad Request`. Keys must be globally unique: reusing one for a different operation returns `409 Conflict` rather than replaying an unrelated response, and so does a retry that arrives while the first request is still running (with a `Retry-After` header). Successful and deterministic terminal `4xx` responses are stored and replayed, while `5xx` responses release the key so the client can retry with it.
+
+| Configuration item                                | Description                                                                                                                                                                  | Default value | Required |
+|---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
+| `gravitino.iceberg-rest.idempotency-enabled`      | Whether to honor the `Idempotency-Key` header. When `false`, the header is ignored and no lifetime is advertised.                                                             | `false`       | No       |
+| `gravitino.iceberg-rest.idempotency-key-lifetime` | The client reuse window for a key, an ISO-8601 duration such as `PT30M`. Advertised to clients as `idempotency-key-lifetime`.                                                 | `PT30M`       | No       |
+| `gravitino.iceberg-rest.idempotency-store-type`   | The store holding idempotency records, either the `in-memory` short name or the fully-qualified class name of an `IdempotencyStore` implementation.                           | `in-memory`   | No       |
+| `gravitino.iceberg-rest.idempotency-max-entries`  | The maximum number of records retained by the in-memory store. Records beyond it are evicted before their reuse window elapses.                                               | `10000`       | No       |
+
+:::caution
+The `in-memory` store is node-local and not durable. A retry routed to another replica, or to a replica that restarted, finds no record and re-executes the mutation, and its size bound can evict a record before its reuse window elapses. Use it for single-node deployments, development, and testing.
+:::
+
 ### Catalog Backend Configuration
 
 :::info

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -21,6 +21,8 @@ package org.apache.gravitino.iceberg.common;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -397,6 +399,52 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
           .createWithDefault(720);
 
+  /**
+   * Master switch for {@code Idempotency-Key} support. Disabled by default: when off the header is
+   * ignored and no key lifetime is advertised in {@code GET /v1/config}, which per the Iceberg REST
+   * spec tells clients the server does not support idempotency.
+   */
+  public static final ConfigEntry<Boolean> ICEBERG_IDEMPOTENCY_ENABLED =
+      new ConfigBuilder(IcebergConstants.ICEBERG_IDEMPOTENCY_ENABLED)
+          .doc("Whether to honor the Idempotency-Key header on Iceberg REST mutation endpoints")
+          .version(ConfigConstants.VERSION_2_0_0)
+          .booleanConf()
+          .createWithDefault(false);
+
+  /** Client reuse window for an idempotency key, as an ISO-8601 duration. */
+  public static final ConfigEntry<String> ICEBERG_IDEMPOTENCY_KEY_LIFETIME =
+      new ConfigBuilder(IcebergConstants.ICEBERG_IDEMPOTENCY_KEY_LIFETIME)
+          .doc(
+              "The client reuse window for an Idempotency-Key, an ISO-8601 duration such as PT30M. "
+                  + "Advertised to clients as `idempotency-key-lifetime` in the config response")
+          .version(ConfigConstants.VERSION_2_0_0)
+          .stringConf()
+          .checkValue(
+              IcebergConfig::isPositiveDuration, "The value must be a positive ISO-8601 duration")
+          .createWithDefault("PT30M");
+
+  /** Storage backend holding idempotency records. */
+  public static final ConfigEntry<String> ICEBERG_IDEMPOTENCY_STORE_TYPE =
+      new ConfigBuilder(IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_TYPE)
+          .doc(
+              "The store holding Iceberg idempotency records, either the `in-memory` short name or "
+                  + "the fully-qualified class name of an `IdempotencyStore` implementation")
+          .version(ConfigConstants.VERSION_2_0_0)
+          .stringConf()
+          .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)
+          .createWithDefault(IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_IN_MEMORY);
+
+  /** Capacity of the in-memory idempotency store. */
+  public static final ConfigEntry<Integer> ICEBERG_IDEMPOTENCY_MAX_ENTRIES =
+      new ConfigBuilder(IcebergConstants.ICEBERG_IDEMPOTENCY_MAX_ENTRIES)
+          .doc(
+              "The maximum number of idempotency records retained by the in-memory store, records "
+                  + "beyond it are evicted before their reuse window elapses")
+          .version(ConfigConstants.VERSION_2_0_0)
+          .intConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(10000);
+
   public String getJdbcDriver() {
     return get(JDBC_DRIVER);
   }
@@ -420,6 +468,15 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
         IcebergPropertiesUtils.toIcebergCatalogProperties(config);
     transformedConfig.putAll(config);
     return transformedConfig;
+  }
+
+  private static boolean isPositiveDuration(String value) {
+    try {
+      Duration duration = Duration.parse(value);
+      return !duration.isNegative() && !duration.isZero();
+    } catch (DateTimeParseException e) {
+      return false;
+    }
   }
 
   @Override

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyKeys.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyKeys.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Validation helpers for the {@code Idempotency-Key} header.
+ *
+ * <p>The Iceberg REST spec requires the header value to be a UUIDv7 in string form as defined by <a
+ * href="https://www.rfc-editor.org/rfc/rfc9562">RFC 9562</a>, with a fixed length of 36 characters.
+ * Rejecting malformed keys before touching the store keeps invalid requests off the storage path
+ * and guarantees the key space stays time-ordered, which keeps the primary-key index of a database
+ * backed store insert-friendly.
+ */
+public final class IdempotencyKeys {
+
+  /** Canonical (hyphenated) length of a UUID in string form, mandated by the Iceberg REST spec. */
+  public static final int KEY_LENGTH = 36;
+
+  /** UUID version reported by a UUIDv7 as defined by RFC 9562. */
+  private static final int UUID_VERSION_7 = 7;
+
+  /**
+   * Variant reported by {@link UUID#variant()} for the RFC 9562 variant, whose two most significant
+   * variant bits are {@code 10}.
+   */
+  private static final int RFC_9562_VARIANT = 2;
+
+  private static final Pattern CANONICAL_UUID =
+      Pattern.compile(
+          "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
+  private IdempotencyKeys() {}
+
+  /**
+   * Returns whether the value is a UUIDv7 in canonical string form.
+   *
+   * @param idempotencyKey the raw header value, may be {@code null}
+   * @return {@code true} if the value is a valid RFC 9562 UUIDv7
+   */
+  public static boolean isValid(String idempotencyKey) {
+    if (idempotencyKey == null || idempotencyKey.length() != KEY_LENGTH) {
+      return false;
+    }
+    if (!CANONICAL_UUID.matcher(idempotencyKey).matches()) {
+      return false;
+    }
+    UUID uuid = UUID.fromString(idempotencyKey);
+    return uuid.version() == UUID_VERSION_7 && uuid.variant() == RFC_9562_VARIANT;
+  }
+
+  /**
+   * Validates the value and throws when it is not a UUIDv7 in canonical string form.
+   *
+   * @param idempotencyKey the raw header value, may be {@code null}
+   * @throws IllegalArgumentException if the value is not a valid RFC 9562 UUIDv7, which the Iceberg
+   *     REST server maps to {@code 400 Bad Request}
+   */
+  public static void validate(String idempotencyKey) {
+    if (!isValid(idempotencyKey)) {
+      throw new IllegalArgumentException(
+          "Idempotency-Key: "
+              + idempotencyKey
+              + " is illegal, the Iceberg REST spec requires a UUIDv7 in string form (RFC 9562), "
+              + "for example 017f22e2-79b0-7cc3-98c4-dc0c0c07398f");
+    }
+  }
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyKeys.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyKeys.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.iceberg.common.idempotency;
 
+import java.util.Locale;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -82,5 +83,25 @@ public final class IdempotencyKeys {
               + " is illegal, the Iceberg REST spec requires a UUIDv7 in string form (RFC 9562), "
               + "for example 017f22e2-79b0-7cc3-98c4-dc0c0c07398f");
     }
+  }
+
+  /**
+   * Validates the value and returns it in the lower-case form used for storage and comparison.
+   *
+   * <p>RFC 9562 section 4 defines the hexadecimal digits of a UUID as case-insensitive on input
+   * while specifying lower case on output, so {@code 017F22E2-...} and {@code 017f22e2-...} name
+   * the same key. A client that retries with a differently-cased key is retrying the same logical
+   * operation, and folding the case here is what keeps that retry from being taken for a new
+   * request and re-running the mutation. It also keeps a database-backed store correct under a
+   * case-sensitive collation such as {@code utf8mb4_bin}, since only the folded form is ever
+   * written.
+   *
+   * @param idempotencyKey the raw header value, may be {@code null}
+   * @return the key folded to lower case
+   * @throws IllegalArgumentException if the value is not a valid RFC 9562 UUIDv7
+   */
+  public static String canonicalize(String idempotencyKey) {
+    validate(idempotencyKey);
+    return idempotencyKey.toLowerCase(Locale.ROOT);
   }
 }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyRecord.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyRecord.java
@@ -34,6 +34,7 @@ public final class IdempotencyRecord {
 
   private final String idempotencyKey;
   private final String operationBinding;
+  private final long claim;
   @Nullable private final Integer httpStatus;
   @Nullable private final String responseSummary;
   private final long createdAtMs;
@@ -42,12 +43,14 @@ public final class IdempotencyRecord {
   private IdempotencyRecord(
       String idempotencyKey,
       String operationBinding,
+      long claim,
       @Nullable Integer httpStatus,
       @Nullable String responseSummary,
       long createdAtMs,
       long expiresAtMs) {
     this.idempotencyKey = idempotencyKey;
     this.operationBinding = operationBinding;
+    this.claim = claim;
     this.httpStatus = httpStatus;
     this.responseSummary = responseSummary;
     this.createdAtMs = createdAtMs;
@@ -60,16 +63,21 @@ public final class IdempotencyRecord {
    * @param idempotencyKey the client-provided UUIDv7 key
    * @param operationBinding request identity, for example {@code POST
    *     /v1/cat1/namespaces/ns1/tables}
+   * @param claim the reserving caller's fencing token
    * @param createdAtMs reservation time in unix epoch millis
    * @param expiresAtMs time after which the record may be purged, in unix epoch millis
    * @return a record in the reserved state
    */
   public static IdempotencyRecord reserved(
-      String idempotencyKey, String operationBinding, long createdAtMs, long expiresAtMs) {
+      String idempotencyKey,
+      String operationBinding,
+      long claim,
+      long createdAtMs,
+      long expiresAtMs) {
     Preconditions.checkArgument(idempotencyKey != null, "idempotencyKey should not be null");
     Preconditions.checkArgument(operationBinding != null, "operationBinding should not be null");
     return new IdempotencyRecord(
-        idempotencyKey, operationBinding, null, null, createdAtMs, expiresAtMs);
+        idempotencyKey, operationBinding, claim, null, null, createdAtMs, expiresAtMs);
   }
 
   /**
@@ -81,7 +89,20 @@ public final class IdempotencyRecord {
    */
   public IdempotencyRecord withResponse(int status, @Nullable String summary) {
     return new IdempotencyRecord(
-        idempotencyKey, operationBinding, status, summary, createdAtMs, expiresAtMs);
+        idempotencyKey, operationBinding, claim, status, summary, createdAtMs, expiresAtMs);
+  }
+
+  /**
+   * Returns the fencing token of the caller that reserved this record.
+   *
+   * <p>A store accepts a finalize or release only from the caller holding this token, so a caller
+   * whose reservation was already dropped cannot disturb the record of whoever reserved the key
+   * next.
+   *
+   * @return the reserving caller's claim
+   */
+  public long claim() {
+    return claim;
   }
 
   /**
@@ -162,6 +183,7 @@ public final class IdempotencyRecord {
     IdempotencyRecord that = (IdempotencyRecord) other;
     return createdAtMs == that.createdAtMs
         && expiresAtMs == that.expiresAtMs
+        && claim == that.claim
         && Objects.equals(idempotencyKey, that.idempotencyKey)
         && Objects.equals(operationBinding, that.operationBinding)
         && Objects.equals(httpStatus, that.httpStatus)
@@ -171,7 +193,13 @@ public final class IdempotencyRecord {
   @Override
   public int hashCode() {
     return Objects.hash(
-        idempotencyKey, operationBinding, httpStatus, responseSummary, createdAtMs, expiresAtMs);
+        idempotencyKey,
+        operationBinding,
+        claim,
+        httpStatus,
+        responseSummary,
+        createdAtMs,
+        expiresAtMs);
   }
 
   @Override

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyRecord.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyRecord.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * One stored idempotency record: the reservation for an in-flight mutation, and after finalization
+ * the response replayed to retries carrying the same key.
+ *
+ * <p>Instances are immutable; {@link #withResponse(int, String)} returns a new record rather than
+ * mutating this one. Timestamps are unix epoch milliseconds so that a database backed store can map
+ * them onto the {@code BIGINT} columns used by Gravitino's other metadata tables.
+ */
+public final class IdempotencyRecord {
+
+  private final String idempotencyKey;
+  private final String operationBinding;
+  @Nullable private final Integer httpStatus;
+  @Nullable private final String responseSummary;
+  private final long createdAtMs;
+  private final long expiresAtMs;
+
+  private IdempotencyRecord(
+      String idempotencyKey,
+      String operationBinding,
+      @Nullable Integer httpStatus,
+      @Nullable String responseSummary,
+      long createdAtMs,
+      long expiresAtMs) {
+    this.idempotencyKey = idempotencyKey;
+    this.operationBinding = operationBinding;
+    this.httpStatus = httpStatus;
+    this.responseSummary = responseSummary;
+    this.createdAtMs = createdAtMs;
+    this.expiresAtMs = expiresAtMs;
+  }
+
+  /**
+   * Creates a reserved (not yet finalized) record.
+   *
+   * @param idempotencyKey the client-provided UUIDv7 key
+   * @param operationBinding request identity, for example {@code POST
+   *     /v1/cat1/namespaces/ns1/tables}
+   * @param createdAtMs reservation time in unix epoch millis
+   * @param expiresAtMs time after which the record may be purged, in unix epoch millis
+   * @return a record in the reserved state
+   */
+  public static IdempotencyRecord reserved(
+      String idempotencyKey, String operationBinding, long createdAtMs, long expiresAtMs) {
+    Preconditions.checkArgument(idempotencyKey != null, "idempotencyKey should not be null");
+    Preconditions.checkArgument(operationBinding != null, "operationBinding should not be null");
+    return new IdempotencyRecord(
+        idempotencyKey, operationBinding, null, null, createdAtMs, expiresAtMs);
+  }
+
+  /**
+   * Returns a copy of this record in the finalized state, carrying the response to replay.
+   *
+   * @param status HTTP status of the original response
+   * @param summary serialized response body, {@code null} for responses without a body
+   * @return a new finalized record
+   */
+  public IdempotencyRecord withResponse(int status, @Nullable String summary) {
+    return new IdempotencyRecord(
+        idempotencyKey, operationBinding, status, summary, createdAtMs, expiresAtMs);
+  }
+
+  /**
+   * Returns the client-provided idempotency key.
+   *
+   * @return the UUIDv7 key in canonical string form
+   */
+  public String idempotencyKey() {
+    return idempotencyKey;
+  }
+
+  /**
+   * Returns the request identity this key was first used for. Retries that present the same key for
+   * a different operation violate the Iceberg REST spec and are rejected instead of replayed.
+   *
+   * @return the operation binding
+   */
+  public String operationBinding() {
+    return operationBinding;
+  }
+
+  /**
+   * Returns the HTTP status of the finalized response.
+   *
+   * @return the status code, or {@code null} while the record is still reserved
+   */
+  @Nullable
+  public Integer httpStatus() {
+    return httpStatus;
+  }
+
+  /**
+   * Returns the serialized response body replayed to retries.
+   *
+   * @return the response body, or {@code null} while the record is reserved or for responses
+   *     without a body
+   */
+  @Nullable
+  public String responseSummary() {
+    return responseSummary;
+  }
+
+  /**
+   * Returns when the key was reserved.
+   *
+   * @return reservation time in unix epoch millis
+   */
+  public long createdAtMs() {
+    return createdAtMs;
+  }
+
+  /**
+   * Returns when the record becomes eligible for purging.
+   *
+   * @return expiry time in unix epoch millis
+   */
+  public long expiresAtMs() {
+    return expiresAtMs;
+  }
+
+  /**
+   * Returns whether the mutation finished and its response can be replayed.
+   *
+   * @return {@code true} once the record carries a response
+   */
+  public boolean isFinalized() {
+    return httpStatus != null;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof IdempotencyRecord)) {
+      return false;
+    }
+    IdempotencyRecord that = (IdempotencyRecord) other;
+    return createdAtMs == that.createdAtMs
+        && expiresAtMs == that.expiresAtMs
+        && Objects.equals(idempotencyKey, that.idempotencyKey)
+        && Objects.equals(operationBinding, that.operationBinding)
+        && Objects.equals(httpStatus, that.httpStatus)
+        && Objects.equals(responseSummary, that.responseSummary);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        idempotencyKey, operationBinding, httpStatus, responseSummary, createdAtMs, expiresAtMs);
+  }
+
+  @Override
+  public String toString() {
+    return "IdempotencyRecord{idempotencyKey="
+        + idempotencyKey
+        + ", operationBinding="
+        + operationBinding
+        + ", httpStatus="
+        + httpStatus
+        + ", createdAtMs="
+        + createdAtMs
+        + ", expiresAtMs="
+        + expiresAtMs
+        + "}";
+  }
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStore.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStore.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Storage for {@code Idempotency-Key} records, pluggable so that a deployment can trade durability
+ * for latency.
+ *
+ * <p>The server drives a store through a reserve-execute-finalize cycle: exactly one caller wins
+ * {@link #reserve}, executes the mutation, and then either {@link #finalizeRecord finalizes} the
+ * response for later replay or {@link #release releases} the reservation so the client can retry
+ * with the same key. Implementations must make {@link #reserve} atomic across every caller that can
+ * see the same storage, since that is the only thing standing between a retried request and a
+ * duplicate mutation.
+ *
+ * <p>Implementations must be thread-safe and are expected to have a public no-argument constructor
+ * so they can be loaded by class name.
+ */
+public interface IdempotencyStore extends Closeable {
+
+  /** Outcome of an attempt to claim a key. */
+  enum ReserveResult {
+    /** The key was newly claimed by this caller, which now owns the mutation. */
+    RESERVED,
+    /** The key is already reserved or finalized, so the request is a retry. */
+    DUPLICATE
+  }
+
+  /**
+   * Initializes the store from the Iceberg REST server configuration.
+   *
+   * @param properties the full Iceberg REST server configuration
+   */
+  void initialize(Map<String, String> properties);
+
+  /**
+   * Atomically attempts to claim a key.
+   *
+   * @param idempotencyKey the client-provided UUIDv7 key
+   * @param operationBinding request identity, for example {@code POST
+   *     /v1/cat1/namespaces/ns1/tables}
+   * @param expiresAtMs time after which the record may be purged, in unix epoch millis
+   * @return {@link ReserveResult#RESERVED} if newly claimed, {@link ReserveResult#DUPLICATE} if a
+   *     record for this key already exists
+   */
+  ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs);
+
+  /**
+   * Loads a finalized record for replay.
+   *
+   * @param idempotencyKey the client-provided key
+   * @return the record, or {@link Optional#empty()} if the key is unknown or still reserved by an
+   *     in-flight request
+   */
+  Optional<IdempotencyRecord> load(String idempotencyKey);
+
+  /**
+   * Marks a reserved key finalized, storing the response replayed to later retries.
+   *
+   * <p>A record that has already expired or been purged is not resurrected; the call is a no-op.
+   *
+   * @param idempotencyKey the client-provided key
+   * @param httpStatus HTTP status of the original response
+   * @param responseSummary serialized response body, {@code null} for responses without a body
+   */
+  void finalizeRecord(String idempotencyKey, int httpStatus, @Nullable String responseSummary);
+
+  /**
+   * Releases a reservation so the client can retry with the same key. Called when the mutation
+   * failed in a way the Iceberg REST spec treats as retryable, which is any {@code 5xx} response.
+   *
+   * @param idempotencyKey the client-provided key
+   */
+  void release(String idempotencyKey);
+
+  /**
+   * Purges records whose reuse window has elapsed.
+   *
+   * @param beforeMs cutoff in unix epoch millis; records expiring before this time are removed
+   * @return the number of records purged
+   */
+  int purgeExpired(long beforeMs);
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStore.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStore.java
@@ -34,6 +34,17 @@ import javax.annotation.Nullable;
  * see the same storage, since that is the only thing standing between a retried request and a
  * duplicate mutation.
  *
+ * <p>A reservation does not always survive until its owner finishes: a bounded store can drop it
+ * under memory pressure, and a purge can remove it once it expires. The key is then free, and
+ * another caller can reserve it while the first is still running. Every call that mutates an
+ * existing record therefore carries the {@code claim} its caller reserved with, and implementations
+ * must ignore the call when the stored claim differs, so a caller that has lost its reservation
+ * cannot finalize or release a record that now belongs to someone else.
+ *
+ * <p>Keys are compared in the folded form returned by {@link IdempotencyKeys#canonicalize}, so
+ * implementations must canonicalize before reading or writing storage rather than trusting the
+ * caller to have done it.
+ *
  * <p>Implementations must be thread-safe and are expected to have a public no-argument constructor
  * so they can be loaded by class name.
  */
@@ -60,11 +71,14 @@ public interface IdempotencyStore extends Closeable {
    * @param idempotencyKey the client-provided UUIDv7 key
    * @param operationBinding request identity, for example {@code POST
    *     /v1/cat1/namespaces/ns1/tables}
+   * @param claim a fencing token identifying this attempt, which the caller must generate afresh
+   *     for every reservation and pass back to {@link #finalizeRecord} and {@link #release}
    * @param expiresAtMs time after which the record may be purged, in unix epoch millis
    * @return {@link ReserveResult#RESERVED} if newly claimed, {@link ReserveResult#DUPLICATE} if a
    *     record for this key already exists
    */
-  ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs);
+  ReserveResult reserve(
+      String idempotencyKey, String operationBinding, long claim, long expiresAtMs);
 
   /**
    * Loads a finalized record for replay.
@@ -78,21 +92,29 @@ public interface IdempotencyStore extends Closeable {
   /**
    * Marks a reserved key finalized, storing the response replayed to later retries.
    *
-   * <p>A record that has already expired or been purged is not resurrected; the call is a no-op.
+   * <p>The call is a no-op when the record has already expired or been purged, so it is not
+   * resurrected, and when the stored claim differs, so a caller that has lost its reservation
+   * cannot overwrite the record of whoever holds the key now.
    *
    * @param idempotencyKey the client-provided key
+   * @param claim the claim this caller reserved with
    * @param httpStatus HTTP status of the original response
    * @param responseSummary serialized response body, {@code null} for responses without a body
    */
-  void finalizeRecord(String idempotencyKey, int httpStatus, @Nullable String responseSummary);
+  void finalizeRecord(
+      String idempotencyKey, long claim, int httpStatus, @Nullable String responseSummary);
 
   /**
    * Releases a reservation so the client can retry with the same key. Called when the mutation
    * failed in a way the Iceberg REST spec treats as retryable, which is any {@code 5xx} response.
    *
+   * <p>The call is a no-op when the stored claim differs, so a caller that has lost its reservation
+   * cannot free a key another caller is currently executing under.
+   *
    * @param idempotencyKey the client-provided key
+   * @param claim the claim this caller reserved with
    */
-  void release(String idempotencyKey);
+  void release(String idempotencyKey, long claim);
 
   /**
    * Purges records whose reuse window has elapsed.

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStoreFactory.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/IdempotencyStoreFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Loads the {@link IdempotencyStore} named by {@code idempotency-store-type}. */
+public class IdempotencyStoreFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IdempotencyStoreFactory.class);
+
+  /**
+   * Short names for the built-in stores, so that a deployment does not have to spell out a
+   * fully-qualified class name for them.
+   */
+  private static final ImmutableMap<String, String> STORE_CLASS_NAMES =
+      ImmutableMap.of(
+          IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_IN_MEMORY,
+          InMemoryIdempotencyStore.class.getCanonicalName());
+
+  private IdempotencyStoreFactory() {}
+
+  /**
+   * Creates and initializes the configured store.
+   *
+   * @param icebergConfig the Iceberg REST server configuration
+   * @return an initialized store
+   * @throws RuntimeException if the store cannot be instantiated or initialized
+   */
+  public static IdempotencyStore create(IcebergConfig icebergConfig) {
+    String storeType = icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_STORE_TYPE);
+    String storeClassName = STORE_CLASS_NAMES.getOrDefault(storeType, storeType);
+    LOG.info("Load Iceberg idempotency store: {}.", storeClassName);
+    try {
+      IdempotencyStore store =
+          (IdempotencyStore) Class.forName(storeClassName).getDeclaredConstructor().newInstance();
+      store.initialize(icebergConfig.getAllConfig());
+      return store;
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to create Iceberg idempotency store by name " + storeType, e);
+    }
+  }
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/InMemoryIdempotencyStore.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/InMemoryIdempotencyStore.java
@@ -20,13 +20,16 @@ package org.apache.gravitino.iceberg.common.idempotency;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.annotations.VisibleForTesting;
-import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import javax.annotation.Nullable;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.slf4j.Logger;
@@ -40,6 +43,11 @@ import org.slf4j.LoggerFactory;
  * node that restarted, finds no record and re-executes the mutation. Its size bound can also evict
  * a record before its reuse window elapses. Production deployments that run more than one replica
  * should use a shared, durable store instead.
+ *
+ * <p>Each record's own {@code expiresAtMs} decides whether it still counts, so a record past its
+ * deadline reads as absent whether or not the cache has reclaimed it yet. Caffeine's expiry only
+ * reclaims memory, which keeps behavior independent of when maintenance runs and matches how a
+ * database-backed store compares {@code expires_at} in its queries.
  */
 public class InMemoryIdempotencyStore implements IdempotencyStore {
 
@@ -49,18 +57,55 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
   private static final long EVICTION_LOG_INTERVAL = 1000;
 
   private final AtomicLong sizeEvictions = new AtomicLong();
+  private final LongSupplier clock;
 
   private Cache<String, IdempotencyRecord> cache;
+
+  /** Creates a store reading wall-clock time. */
+  public InMemoryIdempotencyStore() {
+    this(System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  InMemoryIdempotencyStore(LongSupplier clock) {
+    this.clock = clock;
+  }
 
   @Override
   public void initialize(Map<String, String> properties) {
     IcebergConfig icebergConfig = new IcebergConfig(properties);
-    Duration lifetime =
-        Duration.parse(icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_KEY_LIFETIME));
     int maxEntries = icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_MAX_ENTRIES);
     this.cache =
         Caffeine.newBuilder()
-            .expireAfterWrite(lifetime)
+            // Expiry off each record's own deadline rather than expireAfterWrite, which restarts on
+            // every write: finalizing a record is a write, and would otherwise push a record
+            // finalized late in its window well past the lifetime advertised to clients.
+            .expireAfter(
+                new Expiry<String, IdempotencyRecord>() {
+                  @Override
+                  public long expireAfterCreate(
+                      String key, IdempotencyRecord record, long currentTimeNanos) {
+                    return remainingNanos(record);
+                  }
+
+                  @Override
+                  public long expireAfterUpdate(
+                      String key,
+                      IdempotencyRecord record,
+                      long currentTimeNanos,
+                      long currentDurationNanos) {
+                    return remainingNanos(record);
+                  }
+
+                  @Override
+                  public long expireAfterRead(
+                      String key,
+                      IdempotencyRecord record,
+                      long currentTimeNanos,
+                      long currentDurationNanos) {
+                    return remainingNanos(record);
+                  }
+                })
             .maximumSize(maxEntries)
             .removalListener(
                 (String key, IdempotencyRecord record, RemovalCause cause) -> {
@@ -69,44 +114,64 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
                   }
                 })
             .build();
-    LOG.info(
-        "Initialized in-memory Iceberg idempotency store, key lifetime: {}, max entries: {}.",
-        lifetime,
-        maxEntries);
+    LOG.info("Initialized in-memory Iceberg idempotency store, max entries: {}.", maxEntries);
   }
 
   @Override
-  public ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs) {
+  public ReserveResult reserve(
+      String idempotencyKey, String operationBinding, long claim, long expiresAtMs) {
+    String key = IdempotencyKeys.canonicalize(idempotencyKey);
     IdempotencyRecord reserved =
-        IdempotencyRecord.reserved(
-            idempotencyKey, operationBinding, System.currentTimeMillis(), expiresAtMs);
-    IdempotencyRecord existing = cache.asMap().putIfAbsent(idempotencyKey, reserved);
-    return existing == null ? ReserveResult.RESERVED : ReserveResult.DUPLICATE;
+        IdempotencyRecord.reserved(key, operationBinding, claim, clock.getAsLong(), expiresAtMs);
+    // A record past its deadline is treated as absent rather than waiting for the cache to reclaim
+    // it, so behavior turns on the record's own expiry instead of when maintenance happens to run.
+    AtomicBoolean claimed = new AtomicBoolean();
+    cache
+        .asMap()
+        .compute(
+            key,
+            (cacheKey, existing) -> {
+              if (existing == null || isExpired(existing)) {
+                claimed.set(true);
+                return reserved;
+              }
+              return existing;
+            });
+    return claimed.get() ? ReserveResult.RESERVED : ReserveResult.DUPLICATE;
   }
 
   @Override
   public Optional<IdempotencyRecord> load(String idempotencyKey) {
-    return Optional.ofNullable(cache.getIfPresent(idempotencyKey))
+    return Optional.ofNullable(cache.getIfPresent(IdempotencyKeys.canonicalize(idempotencyKey)))
+        .filter(record -> !isExpired(record))
         .filter(IdempotencyRecord::isFinalized);
   }
 
   @Override
   public void finalizeRecord(
-      String idempotencyKey, int httpStatus, @Nullable String responseSummary) {
-    // computeIfPresent, so a record purged while the mutation was running is not resurrected.
+      String idempotencyKey, long claim, int httpStatus, @Nullable String responseSummary) {
+    // computeIfPresent, so a record purged while the mutation was running is not resurrected. The
+    // claim check leaves a record reserved by someone else untouched.
     cache
         .asMap()
         .computeIfPresent(
-            idempotencyKey, (key, record) -> record.withResponse(httpStatus, responseSummary));
+            IdempotencyKeys.canonicalize(idempotencyKey),
+            (key, record) ->
+                record.claim() == claim && !isExpired(record)
+                    ? record.withResponse(httpStatus, responseSummary)
+                    : record);
   }
 
   @Override
-  public void release(String idempotencyKey) {
-    // Returning null removes the entry; a finalized record is left alone so that a late release
-    // cannot drop a response another request may still replay.
+  public void release(String idempotencyKey, long claim) {
+    // Returning null removes the entry. A finalized record is left alone so that a late release
+    // cannot drop a response another request may still replay, and so is a record whose claim has
+    // moved on, so a caller that lost its reservation cannot free a key someone else is executing.
     cache
         .asMap()
-        .computeIfPresent(idempotencyKey, (key, record) -> record.isFinalized() ? record : null);
+        .computeIfPresent(
+            IdempotencyKeys.canonicalize(idempotencyKey),
+            (key, record) -> record.isFinalized() || record.claim() != claim ? record : null);
   }
 
   @Override
@@ -134,6 +199,15 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
   long size() {
     cache.cleanUp();
     return cache.estimatedSize();
+  }
+
+  private boolean isExpired(IdempotencyRecord record) {
+    return record.expiresAtMs() <= clock.getAsLong();
+  }
+
+  private long remainingNanos(IdempotencyRecord record) {
+    long remainingMs = record.expiresAtMs() - clock.getAsLong();
+    return remainingMs <= 0 ? 0 : TimeUnit.MILLISECONDS.toNanos(remainingMs);
   }
 
   private void onSizeEviction(int maxEntries) {

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/InMemoryIdempotencyStore.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/idempotency/InMemoryIdempotencyStore.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Node-local {@link IdempotencyStore} backed by a Caffeine cache.
+ *
+ * <p>This store is best-effort and intended for single-node deployments, development, and tests. It
+ * is not durable, and it is not shared between replicas: a retry routed to another node, or to a
+ * node that restarted, finds no record and re-executes the mutation. Its size bound can also evict
+ * a record before its reuse window elapses. Production deployments that run more than one replica
+ * should use a shared, durable store instead.
+ */
+public class InMemoryIdempotencyStore implements IdempotencyStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InMemoryIdempotencyStore.class);
+
+  /** Evictions between two warnings, so an undersized cache is visible without flooding the log. */
+  private static final long EVICTION_LOG_INTERVAL = 1000;
+
+  private final AtomicLong sizeEvictions = new AtomicLong();
+
+  private Cache<String, IdempotencyRecord> cache;
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    IcebergConfig icebergConfig = new IcebergConfig(properties);
+    Duration lifetime =
+        Duration.parse(icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_KEY_LIFETIME));
+    int maxEntries = icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_MAX_ENTRIES);
+    this.cache =
+        Caffeine.newBuilder()
+            .expireAfterWrite(lifetime)
+            .maximumSize(maxEntries)
+            .removalListener(
+                (String key, IdempotencyRecord record, RemovalCause cause) -> {
+                  if (cause == RemovalCause.SIZE) {
+                    onSizeEviction(maxEntries);
+                  }
+                })
+            .build();
+    LOG.info(
+        "Initialized in-memory Iceberg idempotency store, key lifetime: {}, max entries: {}.",
+        lifetime,
+        maxEntries);
+  }
+
+  @Override
+  public ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs) {
+    IdempotencyRecord reserved =
+        IdempotencyRecord.reserved(
+            idempotencyKey, operationBinding, System.currentTimeMillis(), expiresAtMs);
+    IdempotencyRecord existing = cache.asMap().putIfAbsent(idempotencyKey, reserved);
+    return existing == null ? ReserveResult.RESERVED : ReserveResult.DUPLICATE;
+  }
+
+  @Override
+  public Optional<IdempotencyRecord> load(String idempotencyKey) {
+    return Optional.ofNullable(cache.getIfPresent(idempotencyKey))
+        .filter(IdempotencyRecord::isFinalized);
+  }
+
+  @Override
+  public void finalizeRecord(
+      String idempotencyKey, int httpStatus, @Nullable String responseSummary) {
+    // computeIfPresent, so a record purged while the mutation was running is not resurrected.
+    cache
+        .asMap()
+        .computeIfPresent(
+            idempotencyKey, (key, record) -> record.withResponse(httpStatus, responseSummary));
+  }
+
+  @Override
+  public void release(String idempotencyKey) {
+    // Returning null removes the entry; a finalized record is left alone so that a late release
+    // cannot drop a response another request may still replay.
+    cache
+        .asMap()
+        .computeIfPresent(idempotencyKey, (key, record) -> record.isFinalized() ? record : null);
+  }
+
+  @Override
+  public int purgeExpired(long beforeMs) {
+    int purged = 0;
+    Iterator<Map.Entry<String, IdempotencyRecord>> entries = cache.asMap().entrySet().iterator();
+    while (entries.hasNext()) {
+      Map.Entry<String, IdempotencyRecord> entry = entries.next();
+      if (entry.getValue().expiresAtMs() < beforeMs
+          && cache.asMap().remove(entry.getKey(), entry.getValue())) {
+        purged += 1;
+      }
+    }
+    return purged;
+  }
+
+  @Override
+  public void close() {
+    if (cache != null) {
+      cache.invalidateAll();
+    }
+  }
+
+  @VisibleForTesting
+  long size() {
+    cache.cleanUp();
+    return cache.estimatedSize();
+  }
+
+  private void onSizeEviction(int maxEntries) {
+    long evictions = sizeEvictions.incrementAndGet();
+    if (evictions % EVICTION_LOG_INTERVAL == 1) {
+      LOG.warn(
+          "In-memory Iceberg idempotency store evicted {} record(s) before their reuse window "
+              + "elapsed; retries for evicted keys re-execute the mutation. Raise "
+              + "`idempotency-max-entries` (currently {}) or use a shared, durable store.",
+          evictions,
+          maxEntries);
+    }
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyKeys.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyKeys.java
@@ -74,4 +74,20 @@ public class TestIdempotencyKeys {
   void testNilUuidIsRejected() {
     Assertions.assertFalse(IdempotencyKeys.isValid("00000000-0000-0000-0000-000000000000"));
   }
+
+  @Test
+  void testCanonicalizeFoldsCase() {
+    String expected = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+    Assertions.assertEquals(
+        expected, IdempotencyKeys.canonicalize("017F22E2-79B0-7CC3-98C4-DC0C0C07398F"));
+    Assertions.assertEquals(expected, IdempotencyKeys.canonicalize(expected));
+    Assertions.assertEquals(
+        expected, IdempotencyKeys.canonicalize("017f22E2-79b0-7CC3-98c4-DC0c0c07398F"));
+  }
+
+  @Test
+  void testCanonicalizeRejectsAnInvalidKey() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> IdempotencyKeys.canonicalize("not-a-uuid"));
+  }
 }

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyKeys.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyKeys.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestIdempotencyKeys {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // The example from the Iceberg REST spec, in both cases.
+        "017F22E2-79B0-7CC3-98C4-DC0C0C07398F",
+        "017f22e2-79b0-7cc3-98c4-dc0c0c07398f",
+        // Variant octet 0b10xx, covering the whole RFC 9562 variant range.
+        "017f22e2-79b0-7cc3-88c4-dc0c0c07398f",
+        "017f22e2-79b0-7cc3-b8c4-dc0c0c07398f"
+      })
+  void testAcceptsUuidV7(String idempotencyKey) {
+    Assertions.assertTrue(IdempotencyKeys.isValid(idempotencyKey));
+    Assertions.assertDoesNotThrow(() -> IdempotencyKeys.validate(idempotencyKey));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(
+      strings = {
+        // UUIDv4, the version nibble must be 7.
+        "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        // UUIDv1.
+        "c232ab00-9414-11ec-b3c8-9f6bdeced846",
+        // RFC 9562 requires the variant bits to be 10; this is the NCS variant.
+        "017f22e2-79b0-7cc3-28c4-dc0c0c07398f",
+        // The Microsoft variant.
+        "017f22e2-79b0-7cc3-c8c4-dc0c0c07398f",
+        // Not the canonical 36-character form.
+        "017f22e279b07cc398c4dc0c0c07398f",
+        "017f22e2-79b0-7cc3-98c4-dc0c0c07398",
+        "017f22e2-79b0-7cc3-98c4-dc0c0c07398ff",
+        "  017f22e2-79b0-7cc3-98c4-dc0c0c07398f  ",
+        // Right length, but not hexadecimal.
+        "017f22e2-79b0-7cc3-98c4-dc0c0c0739zz",
+        "not-a-uuid"
+      })
+  void testRejectsAnythingElse(String idempotencyKey) {
+    Assertions.assertFalse(IdempotencyKeys.isValid(idempotencyKey));
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> IdempotencyKeys.validate(idempotencyKey));
+    Assertions.assertTrue(exception.getMessage().contains("UUIDv7"), exception.getMessage());
+  }
+
+  @Test
+  void testNilUuidIsRejected() {
+    Assertions.assertFalse(IdempotencyKeys.isValid("00000000-0000-0000-0000-000000000000"));
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyStoreFactory.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyStoreFactory.java
@@ -85,7 +85,8 @@ public class TestIdempotencyStoreFactory {
     }
 
     @Override
-    public ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs) {
+    public ReserveResult reserve(
+        String idempotencyKey, String operationBinding, long claim, long expiresAtMs) {
       return ReserveResult.RESERVED;
     }
 
@@ -95,10 +96,11 @@ public class TestIdempotencyStoreFactory {
     }
 
     @Override
-    public void finalizeRecord(String idempotencyKey, int httpStatus, String responseSummary) {}
+    public void finalizeRecord(
+        String idempotencyKey, long claim, int httpStatus, String responseSummary) {}
 
     @Override
-    public void release(String idempotencyKey) {}
+    public void release(String idempotencyKey, long claim) {}
 
     @Override
     public int purgeExpired(long beforeMs) {

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyStoreFactory.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestIdempotencyStoreFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestIdempotencyStoreFactory {
+
+  @Test
+  void testCreateDefaultsToInMemoryStore() throws IOException {
+    try (IdempotencyStore store = IdempotencyStoreFactory.create(new IcebergConfig())) {
+      Assertions.assertInstanceOf(InMemoryIdempotencyStore.class, store);
+    }
+  }
+
+  @Test
+  void testCreateResolvesShortName() throws IOException {
+    IcebergConfig config =
+        new IcebergConfig(
+            ImmutableMap.of(
+                IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_TYPE,
+                IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_IN_MEMORY));
+    try (IdempotencyStore store = IdempotencyStoreFactory.create(config)) {
+      Assertions.assertInstanceOf(InMemoryIdempotencyStore.class, store);
+    }
+  }
+
+  @Test
+  void testCreateResolvesCustomClassNameAndInitializesIt() throws IOException {
+    IcebergConfig config =
+        new IcebergConfig(
+            ImmutableMap.of(
+                IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_TYPE,
+                // Binary name, since Class.forName cannot resolve a nested class by canonical name.
+                RecordingIdempotencyStore.class.getName()));
+    try (IdempotencyStore store = IdempotencyStoreFactory.create(config)) {
+      Assertions.assertInstanceOf(RecordingIdempotencyStore.class, store);
+      Assertions.assertTrue(((RecordingIdempotencyStore) store).initialized);
+    }
+  }
+
+  @Test
+  void testCreateFailsForUnknownStore() {
+    IcebergConfig config =
+        new IcebergConfig(
+            ImmutableMap.of(
+                IcebergConstants.ICEBERG_IDEMPOTENCY_STORE_TYPE, "com.example.NoSuchStore"));
+    Exception exception =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> IdempotencyStoreFactory.create(config));
+    Assertions.assertTrue(exception.getMessage().contains("com.example.NoSuchStore"));
+  }
+
+  /** Store loaded by class name, asserting the factory initializes what it constructs. */
+  public static class RecordingIdempotencyStore implements IdempotencyStore {
+
+    private boolean initialized = false;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      this.initialized = true;
+    }
+
+    @Override
+    public ReserveResult reserve(String idempotencyKey, String operationBinding, long expiresAtMs) {
+      return ReserveResult.RESERVED;
+    }
+
+    @Override
+    public Optional<IdempotencyRecord> load(String idempotencyKey) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void finalizeRecord(String idempotencyKey, int httpStatus, String responseSummary) {}
+
+    @Override
+    public void release(String idempotencyKey) {}
+
+    @Override
+    public int purgeExpired(long beforeMs) {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestInMemoryIdempotencyStore.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestInMemoryIdempotencyStore.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.idempotency;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStore.ReserveResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestInMemoryIdempotencyStore {
+
+  private static final String KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+  private static final String OTHER_KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c073990";
+  private static final String BINDING = "POST v1/cat1/namespaces/ns1/tables";
+  private static final long FAR_FUTURE_MS = Long.MAX_VALUE;
+
+  private InMemoryIdempotencyStore store;
+
+  @BeforeEach
+  void setUp() {
+    store = newStore(ImmutableMap.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    store.close();
+  }
+
+  @Test
+  void testReserveClaimsKeyOnlyOnce() {
+    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(OTHER_KEY, BINDING, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testLoadReturnsEmptyUntilFinalized() {
+    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    Assertions.assertEquals(Optional.empty(), store.load(KEY));
+
+    store.finalizeRecord(KEY, 200, "{\"a\":1}");
+
+    IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
+    Assertions.assertTrue(record.isFinalized());
+    Assertions.assertEquals(KEY, record.idempotencyKey());
+    Assertions.assertEquals(BINDING, record.operationBinding());
+    Assertions.assertEquals(200, record.httpStatus().intValue());
+    Assertions.assertEquals("{\"a\":1}", record.responseSummary());
+  }
+
+  @Test
+  void testLoadUnknownKeyReturnsEmpty() {
+    Assertions.assertEquals(Optional.empty(), store.load(KEY));
+  }
+
+  @Test
+  void testFinalizeWithoutBodyIsReplayable() {
+    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    store.finalizeRecord(KEY, 204, null);
+
+    IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
+    Assertions.assertEquals(204, record.httpStatus().intValue());
+    Assertions.assertNull(record.responseSummary());
+  }
+
+  @Test
+  void testFinalizeDoesNotResurrectAPurgedRecord() {
+    store.finalizeRecord(KEY, 200, "{}");
+    Assertions.assertEquals(Optional.empty(), store.load(KEY));
+    Assertions.assertEquals(0, store.size());
+  }
+
+  @Test
+  void testReleaseFreesTheKeyForRetry() {
+    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    store.release(KEY);
+
+    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testReleaseKeepsAFinalizedRecord() {
+    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    store.finalizeRecord(KEY, 200, "{}");
+    store.release(KEY);
+
+    Assertions.assertTrue(store.load(KEY).isPresent());
+    Assertions.assertEquals(ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testPurgeExpiredRemovesOnlyElapsedRecords() {
+    long now = System.currentTimeMillis();
+    store.reserve(KEY, BINDING, now - 1);
+    store.reserve(OTHER_KEY, BINDING, now + 60_000);
+
+    Assertions.assertEquals(1, store.purgeExpired(now));
+    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(OTHER_KEY, BINDING, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testSizeBoundEvictsRecords() throws InterruptedException {
+    InMemoryIdempotencyStore boundedStore =
+        newStore(ImmutableMap.of(IcebergConstants.ICEBERG_IDEMPOTENCY_MAX_ENTRIES, "2"));
+    try {
+      for (int i = 0; i < 50; i++) {
+        boundedStore.reserve(String.format("key-%d", i), BINDING, FAR_FUTURE_MS);
+      }
+      // Caffeine evicts during maintenance, so the bound is reached shortly after the writes
+      // rather than synchronously with them.
+      long retained = boundedStore.size();
+      for (int attempt = 0; attempt < 100 && retained > 2; attempt++) {
+        Thread.sleep(20);
+        retained = boundedStore.size();
+      }
+      Assertions.assertTrue(retained <= 2, "expected at most 2 retained records, got " + retained);
+    } finally {
+      boundedStore.close();
+    }
+  }
+
+  @Test
+  void testConcurrentReserveHasASingleWinner() throws InterruptedException {
+    int threads = 16;
+    ExecutorService executor = Executors.newFixedThreadPool(threads);
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threads);
+    AtomicInteger reserved = new AtomicInteger();
+    try {
+      for (int i = 0; i < threads; i++) {
+        executor.submit(
+            () -> {
+              try {
+                start.await();
+                if (store.reserve(KEY, BINDING, FAR_FUTURE_MS) == ReserveResult.RESERVED) {
+                  reserved.incrementAndGet();
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              } finally {
+                done.countDown();
+              }
+            });
+      }
+      start.countDown();
+      Assertions.assertTrue(done.await(30, TimeUnit.SECONDS));
+      Assertions.assertEquals(1, reserved.get());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static InMemoryIdempotencyStore newStore(Map<String, String> properties) {
+    InMemoryIdempotencyStore store = new InMemoryIdempotencyStore();
+    store.initialize(properties);
+    return store;
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestInMemoryIdempotencyStore.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/idempotency/TestInMemoryIdempotencyStore.java
@@ -19,13 +19,19 @@
 package org.apache.gravitino.iceberg.common.idempotency;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStore.ReserveResult;
 import org.junit.jupiter.api.AfterEach;
@@ -36,9 +42,11 @@ import org.junit.jupiter.api.Test;
 public class TestInMemoryIdempotencyStore {
 
   private static final String KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+  private static final String KEY_UPPER = "017F22E2-79B0-7CC3-98C4-DC0C0C07398F";
   private static final String OTHER_KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c073990";
   private static final String BINDING = "POST v1/cat1/namespaces/ns1/tables";
   private static final long FAR_FUTURE_MS = Long.MAX_VALUE;
+  private static final long CLAIM = 1L;
 
   private InMemoryIdempotencyStore store;
 
@@ -54,18 +62,36 @@ public class TestInMemoryIdempotencyStore {
 
   @Test
   void testReserveClaimsKeyOnlyOnce() {
-    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
-    Assertions.assertEquals(ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
     Assertions.assertEquals(
-        ReserveResult.RESERVED, store.reserve(OTHER_KEY, BINDING, FAR_FUTURE_MS));
+        ReserveResult.RESERVED, store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, CLAIM + 1, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(OTHER_KEY, BINDING, CLAIM, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testKeyCaseVariantsAddressTheSameRecord() {
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(KEY_UPPER, BINDING, CLAIM, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, CLAIM + 1, FAR_FUTURE_MS));
+    Assertions.assertEquals(1, store.size());
+
+    // Finalizing under one casing has to be replayable under the other, otherwise a retry that
+    // changes case re-executes the mutation.
+    store.finalizeRecord(KEY_UPPER, CLAIM, 200, "{\"a\":1}");
+    IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
+    Assertions.assertEquals(KEY, record.idempotencyKey());
+    Assertions.assertEquals(200, record.httpStatus().intValue());
   }
 
   @Test
   void testLoadReturnsEmptyUntilFinalized() {
-    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
+    store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS);
     Assertions.assertEquals(Optional.empty(), store.load(KEY));
 
-    store.finalizeRecord(KEY, 200, "{\"a\":1}");
+    store.finalizeRecord(KEY, CLAIM, 200, "{\"a\":1}");
 
     IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
     Assertions.assertTrue(record.isFinalized());
@@ -82,8 +108,8 @@ public class TestInMemoryIdempotencyStore {
 
   @Test
   void testFinalizeWithoutBodyIsReplayable() {
-    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
-    store.finalizeRecord(KEY, 204, null);
+    store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS);
+    store.finalizeRecord(KEY, CLAIM, 204, null);
 
     IdempotencyRecord record = store.load(KEY).orElseThrow(AssertionError::new);
     Assertions.assertEquals(204, record.httpStatus().intValue());
@@ -92,39 +118,115 @@ public class TestInMemoryIdempotencyStore {
 
   @Test
   void testFinalizeDoesNotResurrectAPurgedRecord() {
-    store.finalizeRecord(KEY, 200, "{}");
+    store.finalizeRecord(KEY, CLAIM, 200, "{}");
     Assertions.assertEquals(Optional.empty(), store.load(KEY));
     Assertions.assertEquals(0, store.size());
   }
 
   @Test
   void testReleaseFreesTheKeyForRetry() {
-    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
-    store.release(KEY);
+    store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS);
+    store.release(KEY, CLAIM);
 
-    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS));
   }
 
   @Test
   void testReleaseKeepsAFinalizedRecord() {
-    store.reserve(KEY, BINDING, FAR_FUTURE_MS);
-    store.finalizeRecord(KEY, 200, "{}");
-    store.release(KEY);
+    store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS);
+    store.finalizeRecord(KEY, CLAIM, 200, "{}");
+    store.release(KEY, CLAIM);
 
     Assertions.assertTrue(store.load(KEY).isPresent());
-    Assertions.assertEquals(ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, CLAIM, FAR_FUTURE_MS));
+  }
+
+  @Test
+  void testStaleFinalizeAfterReReservationIsIgnored() {
+    long staleClaim = 1L;
+    long currentClaim = 2L;
+    store.reserve(KEY, BINDING, staleClaim, FAR_FUTURE_MS);
+    // The first reservation goes away underneath its owner, as a size eviction or a purge would do,
+    // and a second caller takes the key.
+    store.release(KEY, staleClaim);
+    Assertions.assertEquals(
+        ReserveResult.RESERVED, store.reserve(KEY, BINDING, currentClaim, FAR_FUTURE_MS));
+
+    store.finalizeRecord(KEY, staleClaim, 200, "{\"stale\":true}");
+
+    // The current owner is still mid-flight: nothing to replay, and the key stays taken.
+    Assertions.assertEquals(Optional.empty(), store.load(KEY));
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, 3L, FAR_FUTURE_MS));
+
+    // And the current owner can still finalize its own response.
+    store.finalizeRecord(KEY, currentClaim, 201, "{\"stale\":false}");
+    Assertions.assertEquals(
+        "{\"stale\":false}", store.load(KEY).orElseThrow(AssertionError::new).responseSummary());
+  }
+
+  @Test
+  void testStaleReleaseAfterReReservationIsIgnored() {
+    long staleClaim = 1L;
+    long currentClaim = 2L;
+    store.reserve(KEY, BINDING, staleClaim, FAR_FUTURE_MS);
+    store.release(KEY, staleClaim);
+    store.reserve(KEY, BINDING, currentClaim, FAR_FUTURE_MS);
+
+    store.release(KEY, staleClaim);
+
+    // Releasing on a lost claim must not free a key the current owner is executing under, which
+    // would let a third request run the mutation a second time.
+    Assertions.assertEquals(
+        ReserveResult.DUPLICATE, store.reserve(KEY, BINDING, 3L, FAR_FUTURE_MS));
   }
 
   @Test
   void testPurgeExpiredRemovesOnlyElapsedRecords() {
-    long now = System.currentTimeMillis();
-    store.reserve(KEY, BINDING, now - 1);
-    store.reserve(OTHER_KEY, BINDING, now + 60_000);
+    AtomicLong now = new AtomicLong(1_000_000L);
+    InMemoryIdempotencyStore clockedStore = newStore(ImmutableMap.of(), now::get);
+    try {
+      clockedStore.reserve(KEY, BINDING, CLAIM, now.get() + 1_000L);
+      clockedStore.reserve(OTHER_KEY, BINDING, CLAIM, now.get() + 60_000L);
 
-    Assertions.assertEquals(1, store.purgeExpired(now));
-    Assertions.assertEquals(ReserveResult.RESERVED, store.reserve(KEY, BINDING, FAR_FUTURE_MS));
-    Assertions.assertEquals(
-        ReserveResult.DUPLICATE, store.reserve(OTHER_KEY, BINDING, FAR_FUTURE_MS));
+      // Only the first record's window has elapsed.
+      now.addAndGet(1_001L);
+      Assertions.assertEquals(1, clockedStore.purgeExpired(now.get()));
+
+      Assertions.assertEquals(
+          ReserveResult.RESERVED, clockedStore.reserve(KEY, BINDING, CLAIM, now.get() + 1_000L));
+      Assertions.assertEquals(
+          ReserveResult.DUPLICATE,
+          clockedStore.reserve(OTHER_KEY, BINDING, CLAIM, now.get() + 60_000L));
+    } finally {
+      clockedStore.close();
+    }
+  }
+
+  @Test
+  void testRecordExpiresAtItsDeadlineAndFinalizeDoesNotExtendIt() {
+    AtomicLong now = new AtomicLong(1_000_000L);
+    InMemoryIdempotencyStore clockedStore = newStore(ImmutableMap.of(), now::get);
+    try {
+      long deadline = now.get() + 1_000L;
+      Assertions.assertEquals(
+          ReserveResult.RESERVED, clockedStore.reserve(KEY, BINDING, CLAIM, deadline));
+
+      // Finalize halfway through the window. A cache expiring on last-write would restart the
+      // clock here and keep the record past the lifetime advertised to clients.
+      now.set(deadline - 500L);
+      clockedStore.finalizeRecord(KEY, CLAIM, 200, "{}");
+      Assertions.assertTrue(clockedStore.load(KEY).isPresent());
+
+      now.set(deadline);
+      Assertions.assertEquals(Optional.empty(), clockedStore.load(KEY));
+      Assertions.assertEquals(
+          ReserveResult.RESERVED, clockedStore.reserve(KEY, BINDING, CLAIM, now.get() + 1_000L));
+    } finally {
+      clockedStore.close();
+    }
   }
 
   @Test
@@ -133,7 +235,7 @@ public class TestInMemoryIdempotencyStore {
         newStore(ImmutableMap.of(IcebergConstants.ICEBERG_IDEMPOTENCY_MAX_ENTRIES, "2"));
     try {
       for (int i = 0; i < 50; i++) {
-        boundedStore.reserve(String.format("key-%d", i), BINDING, FAR_FUTURE_MS);
+        boundedStore.reserve(uuidKey(i), BINDING, CLAIM, FAR_FUTURE_MS);
       }
       // Caffeine evicts during maintenance, so the bound is reached shortly after the writes
       // rather than synchronously with them.
@@ -154,18 +256,18 @@ public class TestInMemoryIdempotencyStore {
     ExecutorService executor = Executors.newFixedThreadPool(threads);
     CountDownLatch start = new CountDownLatch(1);
     CountDownLatch done = new CountDownLatch(threads);
-    AtomicInteger reserved = new AtomicInteger();
+    List<ReserveResult> results = Collections.synchronizedList(new ArrayList<>());
+    AtomicReference<Throwable> failure = new AtomicReference<>();
     try {
       for (int i = 0; i < threads; i++) {
+        long claim = i;
         executor.submit(
             () -> {
               try {
                 start.await();
-                if (store.reserve(KEY, BINDING, FAR_FUTURE_MS) == ReserveResult.RESERVED) {
-                  reserved.incrementAndGet();
-                }
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                results.add(store.reserve(KEY, BINDING, claim, FAR_FUTURE_MS));
+              } catch (Throwable t) {
+                failure.compareAndSet(null, t);
               } finally {
                 done.countDown();
               }
@@ -173,14 +275,29 @@ public class TestInMemoryIdempotencyStore {
       }
       start.countDown();
       Assertions.assertTrue(done.await(30, TimeUnit.SECONDS));
-      Assertions.assertEquals(1, reserved.get());
+      Assertions.assertNull(failure.get(), "no reserve should fail");
+      Map<ReserveResult, Long> counts =
+          results.stream().collect(Collectors.groupingBy(result -> result, Collectors.counting()));
+      Assertions.assertEquals(threads, results.size(), "every caller should report a result");
+      Assertions.assertEquals(1L, counts.getOrDefault(ReserveResult.RESERVED, 0L));
+      Assertions.assertEquals(threads - 1L, counts.getOrDefault(ReserveResult.DUPLICATE, 0L));
     } finally {
       executor.shutdownNow();
     }
   }
 
+  /** Builds distinct valid UUIDv7 keys, since the store rejects anything else. */
+  private static String uuidKey(int index) {
+    return String.format("017f22e2-79b0-7cc3-98c4-%012x", index);
+  }
+
   private static InMemoryIdempotencyStore newStore(Map<String, String> properties) {
-    InMemoryIdempotencyStore store = new InMemoryIdempotencyStore();
+    return newStore(properties, System::currentTimeMillis);
+  }
+
+  private static InMemoryIdempotencyStore newStore(
+      Map<String, String> properties, LongSupplier clock) {
+    InMemoryIdempotencyStore store = new InMemoryIdempotencyStore(clock);
     store.initialize(properties);
     return store;
   }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -48,6 +48,7 @@ import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewEventDispatche
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewHookDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationExecutor;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 import org.apache.gravitino.iceberg.service.provider.IcebergConfigProvider;
 import org.apache.gravitino.iceberg.service.provider.IcebergConfigProviderFactory;
@@ -82,6 +83,7 @@ public class RESTService implements GravitinoAuxiliaryService {
 
   private IcebergCatalogWrapperManager icebergCatalogWrapperManager;
   private IcebergMetricsManager icebergMetricsManager;
+  private IcebergIdempotencyManager icebergIdempotencyManager;
   private Optional<IcebergCleanupManager> cleanupManager;
   private IcebergConfigProvider configProvider;
   private boolean auxMode;
@@ -126,6 +128,7 @@ public class RESTService implements GravitinoAuxiliaryService {
             skipAuthorizationForRestBackend,
             icebergCatalogWrapperManager);
     this.icebergMetricsManager = new IcebergMetricsManager(icebergConfig);
+    this.icebergIdempotencyManager = new IcebergIdempotencyManager(icebergConfig);
     if (auxMode) {
       // Async cleanup reuses the entity store's shared relational backend (connection pool +
       // per-backend SQL), which is only available when running embedded in the Gravitino server
@@ -192,6 +195,7 @@ public class RESTService implements GravitinoAuxiliaryService {
             }
             bind(icebergCatalogWrapperManager).to(IcebergCatalogWrapperManager.class).ranked(1);
             bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(1);
+            bind(icebergIdempotencyManager).to(IcebergIdempotencyManager.class).ranked(1);
             cleanupManager.ifPresent(
                 manager -> bind(manager).to(IcebergCleanupManager.class).ranked(1));
             bind(icebergTableDispatcher).to(IcebergTableOperationDispatcher.class).ranked(1);
@@ -244,6 +248,7 @@ public class RESTService implements GravitinoAuxiliaryService {
         // Stop the components we already started so they don't outlive a failed startup.
         cleanupManager.ifPresent(IcebergCleanupManager::close);
         icebergMetricsManager.close();
+        icebergIdempotencyManager.close();
         throw new RuntimeException(e);
       }
     }
@@ -263,6 +268,9 @@ public class RESTService implements GravitinoAuxiliaryService {
     }
     if (icebergMetricsManager != null) {
       icebergMetricsManager.close();
+    }
+    if (icebergIdempotencyManager != null) {
+      icebergIdempotencyManager.close();
     }
     cleanupManager.ifPresent(IcebergCleanupManager::close);
   }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/idempotency/IcebergIdempotencyManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/idempotency/IcebergIdempotencyManager.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.idempotency;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyKeys;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyRecord;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStore;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStore.ReserveResult;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStoreFactory;
+import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
+import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies {@code Idempotency-Key} semantics to Iceberg REST mutation endpoints.
+ *
+ * <p>Each mutation runs through {@link #replayOrExecute}, which claims the key, executes the
+ * mutation exactly once, and stores its response so that retries carrying the same key get the
+ * original answer back instead of a second mutation. Idempotency is off by default; when it is off,
+ * or when a request carries no key, the mutation runs directly and nothing is stored.
+ *
+ * <p>A replayed response carries the original status and body. Response headers are not stored, so
+ * a replayed create or update does not carry the {@code ETag} the first response did; clients that
+ * rely on it simply load the table again.
+ */
+public class IcebergIdempotencyManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergIdempotencyManager.class);
+
+  /** The idempotency key header defined by the Iceberg REST spec. */
+  public static final String IDEMPOTENCY_KEY = "Idempotency-Key";
+
+  /** Cap on the stored operation binding, matching the width a database backed store can hold. */
+  @VisibleForTesting static final int MAX_OPERATION_BINDING_LENGTH = 512;
+
+  /** Seconds a client should wait before retrying a request whose key is still in flight. */
+  private static final int RETRY_AFTER_SECONDS = 1;
+
+  /**
+   * Statuses that are terminal for the request but not for the key. Authentication and
+   * authorization outcomes depend on the caller's credentials rather than on catalog state, so
+   * replaying them would keep failing a retry that has since obtained valid credentials.
+   */
+  private static final Set<Integer> NON_FINALIZABLE_STATUSES = ImmutableSet.of(401, 403, 419);
+
+  private final boolean enabled;
+  private final Duration keyLifetime;
+  private final ObjectMapper icebergObjectMapper;
+  private final Optional<IdempotencyStore> store;
+
+  /**
+   * Creates a manager, loading the configured store when idempotency is enabled.
+   *
+   * @param icebergConfig the Iceberg REST server configuration
+   */
+  public IcebergIdempotencyManager(IcebergConfig icebergConfig) {
+    this(
+        icebergConfig,
+        icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_ENABLED)
+            ? Optional.of(IdempotencyStoreFactory.create(icebergConfig))
+            : Optional.empty());
+  }
+
+  @VisibleForTesting
+  IcebergIdempotencyManager(IcebergConfig icebergConfig, Optional<IdempotencyStore> store) {
+    this.enabled = icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_ENABLED);
+    this.keyLifetime =
+        Duration.parse(icebergConfig.get(IcebergConfig.ICEBERG_IDEMPOTENCY_KEY_LIFETIME));
+    this.icebergObjectMapper = IcebergObjectMapper.getInstance();
+    this.store = store;
+  }
+
+  /**
+   * Returns the key reuse window to advertise to clients.
+   *
+   * @return the lifetime as an ISO-8601 duration, or {@link Optional#empty()} when idempotency is
+   *     disabled. The Iceberg REST spec reads the absence of {@code idempotency-key-lifetime} in
+   *     the config response as "this server does not support idempotency".
+   */
+  public Optional<String> advertisedKeyLifetime() {
+    return enabled ? Optional.of(keyLifetime.toString()) : Optional.empty();
+  }
+
+  /**
+   * Runs a mutation under the given idempotency key.
+   *
+   * <p>Without a key, or with idempotency disabled, this just runs {@code action}. With a key, the
+   * first request claims it and stores the response; retries carrying the same key replay that
+   * response. A retry that arrives while the first request is still running, or that reuses a key
+   * already spent on a different operation, gets {@code 409 Conflict}.
+   *
+   * @param idempotencyKey the raw {@code Idempotency-Key} header value, may be {@code null}
+   * @param operationBinding request identity, see {@link #operationBinding(String, UriInfo)}
+   * @param action the mutation, which is expected to return its own error responses rather than
+   *     throw
+   * @return the response to send to the client
+   */
+  public Response replayOrExecute(
+      @Nullable String idempotencyKey, String operationBinding, Supplier<Response> action) {
+    if (!enabled || StringUtils.isBlank(idempotencyKey) || !store.isPresent()) {
+      return action.get();
+    }
+
+    try {
+      IdempotencyKeys.validate(idempotencyKey);
+    } catch (IllegalArgumentException e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
+
+    IdempotencyStore idempotencyStore = store.get();
+    String binding = truncate(operationBinding);
+    long expiresAtMs = System.currentTimeMillis() + keyLifetime.toMillis();
+    if (idempotencyStore.reserve(idempotencyKey, binding, expiresAtMs) == ReserveResult.DUPLICATE) {
+      return replay(idempotencyStore, idempotencyKey, binding);
+    }
+
+    boolean finalized = false;
+    try {
+      Response response = action.get();
+      if (isFinalizable(response.getStatus())) {
+        finalized = tryFinalize(idempotencyStore, idempotencyKey, response);
+      }
+      return response;
+    } finally {
+      if (!finalized) {
+        // The mutation failed in a way the spec treats as retryable, or its response could not be
+        // stored. Either way the key must go back so the client can retry with it.
+        idempotencyStore.release(idempotencyKey);
+      }
+    }
+  }
+
+  /**
+   * Builds the request identity stored alongside a key. Retries of the same logical operation
+   * produce the same binding, while a key reused for a different request does not.
+   *
+   * <p>The identity covers the method, path, and query parameters, not the request body. A client
+   * that reuses one key for two different bodies on the same endpoint gets the first response
+   * replayed, which is exactly what the header promises; the spec already requires a fresh key per
+   * operation.
+   *
+   * @param httpMethod the HTTP method of the endpoint
+   * @param uriInfo the request URI, may be {@code null} outside a request context
+   * @return the operation binding, for example {@code POST v1/cat1/namespaces/ns1/tables}
+   */
+  public static String operationBinding(String httpMethod, @Nullable UriInfo uriInfo) {
+    if (uriInfo == null) {
+      return httpMethod;
+    }
+    StringBuilder binding = new StringBuilder(httpMethod).append(' ').append(uriInfo.getPath());
+    MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
+    if (queryParameters != null && !queryParameters.isEmpty()) {
+      // Sorted, so that clients that order query parameters differently between a request and its
+      // retry still land on the same binding.
+      StringJoiner query = new StringJoiner("&", "?", "");
+      for (Map.Entry<String, List<String>> parameter : new TreeMap<>(queryParameters).entrySet()) {
+        for (String value : parameter.getValue()) {
+          query.add(parameter.getKey() + "=" + value);
+        }
+      }
+      binding.append(query);
+    }
+    return binding.toString();
+  }
+
+  /** Closes the underlying store. */
+  public void close() {
+    store.ifPresent(
+        idempotencyStore -> {
+          try {
+            idempotencyStore.close();
+          } catch (IOException e) {
+            LOG.warn("Close Iceberg idempotency store failed.", e);
+          }
+        });
+  }
+
+  private Response replay(
+      IdempotencyStore idempotencyStore, String idempotencyKey, String binding) {
+    Optional<IdempotencyRecord> record = idempotencyStore.load(idempotencyKey);
+    if (!record.isPresent()) {
+      // Reserved but not finalized: the first request is still running, here or on another node.
+      return conflict(
+          "Idempotency-Key: "
+              + idempotencyKey
+              + " is being processed by another request, retry later",
+          true);
+    }
+
+    IdempotencyRecord found = record.get();
+    if (!found.operationBinding().equals(binding)) {
+      // Replaying here would hand the client the response of an unrelated operation.
+      return conflict(
+          "Idempotency-Key: "
+              + idempotencyKey
+              + " was already used for `"
+              + found.operationBinding()
+              + "`, the Iceberg REST spec requires a new key for a different operation",
+          false);
+    }
+
+    LOG.info(
+        "Replaying the stored response for Idempotency-Key: {}, operation: {}, http status: {}.",
+        idempotencyKey,
+        binding,
+        found.httpStatus());
+    Response.ResponseBuilder builder = Response.status(found.httpStatus());
+    if (found.responseSummary() != null) {
+      builder.entity(found.responseSummary()).type(MediaType.APPLICATION_JSON);
+    }
+    return builder.build();
+  }
+
+  private boolean tryFinalize(
+      IdempotencyStore idempotencyStore, String idempotencyKey, Response response) {
+    String responseSummary;
+    try {
+      responseSummary = serializeEntity(response.getEntity());
+    } catch (JsonProcessingException e) {
+      LOG.warn(
+          "Failed to serialize the response for Idempotency-Key: {}, it will not be replayed.",
+          idempotencyKey,
+          e);
+      return false;
+    }
+    idempotencyStore.finalizeRecord(idempotencyKey, response.getStatus(), responseSummary);
+    return true;
+  }
+
+  @Nullable
+  private String serializeEntity(@Nullable Object entity) throws JsonProcessingException {
+    if (entity == null) {
+      return null;
+    }
+    if (entity instanceof String) {
+      return (String) entity;
+    }
+    return icebergObjectMapper.writeValueAsString(entity);
+  }
+
+  private static Response conflict(String message, boolean retryable) {
+    Response response =
+        IcebergRESTUtils.errorResponse(
+            new IdempotencyConflictException(message), Response.Status.CONFLICT.getStatusCode());
+    if (!retryable) {
+      return response;
+    }
+    return Response.fromResponse(response)
+        .header(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS)
+        .build();
+  }
+
+  /**
+   * Returns whether a response finalizes the key. Per the Iceberg REST spec, {@code 5xx} responses
+   * are retryable and must not be stored, while {@code 2xx} and deterministic terminal {@code 4xx}
+   * responses are replayed.
+   */
+  private static boolean isFinalizable(int httpStatus) {
+    return httpStatus < Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()
+        && !NON_FINALIZABLE_STATUSES.contains(httpStatus);
+  }
+
+  private static String truncate(String operationBinding) {
+    return operationBinding.length() <= MAX_OPERATION_BINDING_LENGTH
+        ? operationBinding
+        : operationBinding.substring(0, MAX_OPERATION_BINDING_LENGTH);
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/idempotency/IcebergIdempotencyManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/idempotency/IcebergIdempotencyManager.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.TreeMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.HttpHeaders;
@@ -140,8 +141,9 @@ public class IcebergIdempotencyManager {
       return action.get();
     }
 
+    String key;
     try {
-      IdempotencyKeys.validate(idempotencyKey);
+      key = IdempotencyKeys.canonicalize(idempotencyKey);
     } catch (IllegalArgumentException e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -149,22 +151,25 @@ public class IcebergIdempotencyManager {
     IdempotencyStore idempotencyStore = store.get();
     String binding = truncate(operationBinding);
     long expiresAtMs = System.currentTimeMillis() + keyLifetime.toMillis();
-    if (idempotencyStore.reserve(idempotencyKey, binding, expiresAtMs) == ReserveResult.DUPLICATE) {
-      return replay(idempotencyStore, idempotencyKey, binding);
+    // A fresh claim per attempt, so that if this reservation is dropped underneath us and another
+    // request takes the key, our finalize or release lands on nothing instead of on its record.
+    long claim = ThreadLocalRandom.current().nextLong();
+    if (idempotencyStore.reserve(key, binding, claim, expiresAtMs) == ReserveResult.DUPLICATE) {
+      return replay(idempotencyStore, key, binding);
     }
 
     boolean finalized = false;
     try {
       Response response = action.get();
       if (isFinalizable(response.getStatus())) {
-        finalized = tryFinalize(idempotencyStore, idempotencyKey, response);
+        finalized = tryFinalize(idempotencyStore, key, claim, response);
       }
       return response;
     } finally {
       if (!finalized) {
         // The mutation failed in a way the spec treats as retryable, or its response could not be
         // stored. Either way the key must go back so the client can retry with it.
-        idempotencyStore.release(idempotencyKey);
+        idempotencyStore.release(key, claim);
       }
     }
   }
@@ -251,7 +256,7 @@ public class IcebergIdempotencyManager {
   }
 
   private boolean tryFinalize(
-      IdempotencyStore idempotencyStore, String idempotencyKey, Response response) {
+      IdempotencyStore idempotencyStore, String idempotencyKey, long claim, Response response) {
     String responseSummary;
     try {
       responseSummary = serializeEntity(response.getEntity());
@@ -262,7 +267,7 @@ public class IcebergIdempotencyManager {
           e);
       return false;
     }
-    idempotencyStore.finalizeRecord(idempotencyKey, response.getStatus(), responseSummary);
+    idempotencyStore.finalizeRecord(idempotencyKey, claim, response.getStatus(), responseSummary);
     return true;
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/idempotency/IdempotencyConflictException.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/idempotency/IdempotencyConflictException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.idempotency;
+
+/**
+ * Thrown when an {@code Idempotency-Key} cannot be honored: the first request using it is still
+ * running, or the key was already used for a different operation. Both cases are reported to the
+ * client as {@code 409 Conflict}.
+ */
+public class IdempotencyConflictException extends RuntimeException {
+
+  /**
+   * Creates a conflict exception.
+   *
+   * @param message the message returned to the client
+   */
+  public IdempotencyConflictException(String message) {
+    super(message);
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
@@ -42,6 +42,7 @@ import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.service.CatalogWrapperForREST;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.responses.ConfigResponse;
@@ -56,6 +57,7 @@ public class IcebergConfigOperations {
   private HttpServletRequest httpRequest;
 
   private final IcebergCatalogWrapperManager catalogWrapperManager;
+  private final IcebergIdempotencyManager idempotencyManager;
 
   private static final List<Endpoint> DEFAULT_ENDPOINTS =
       ImmutableList.<Endpoint>builder()
@@ -91,8 +93,11 @@ public class IcebergConfigOperations {
           .build();
 
   @Inject
-  public IcebergConfigOperations(IcebergCatalogWrapperManager catalogWrapperManager) {
+  public IcebergConfigOperations(
+      IcebergCatalogWrapperManager catalogWrapperManager,
+      IcebergIdempotencyManager idempotencyManager) {
     this.catalogWrapperManager = catalogWrapperManager;
+    this.idempotencyManager = idempotencyManager;
   }
 
   @GET
@@ -107,6 +112,9 @@ public class IcebergConfigOperations {
     if (StringUtils.isNotBlank(warehouse)) {
       builder.withDefault("prefix", warehouse);
     }
+    // Advertised only when idempotency is enabled: the Iceberg REST spec reads the absence of this
+    // field as "the server does not support Idempotency-Key semantics".
+    idempotencyManager.advertisedKeyLifetime().ifPresent(builder::withIdempotencyKeyLifetime);
     return IcebergRESTUtils.ok(builder.build());
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
@@ -36,6 +36,7 @@ import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
 import javax.ws.rs.HeaderParam;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -44,6 +45,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
@@ -52,6 +54,7 @@ import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.gravitino.server.authorization.MetadataAuthzHelper;
@@ -85,13 +88,16 @@ public class IcebergNamespaceOperations {
 
   private ObjectMapper icebergObjectMapper;
   private IcebergNamespaceOperationDispatcher namespaceOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Context private HttpServletRequest httpRequest;
 
   @Inject
   public IcebergNamespaceOperations(
-      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher) {
+      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.namespaceOperationDispatcher = namespaceOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -217,7 +223,16 @@ public class IcebergNamespaceOperations {
   public Response dropNamespace(
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
-          String namespace) {
+          String namespace,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.DELETE, uriInfo),
+        () -> doDropNamespace(prefix, namespace));
+  }
+
+  private Response doDropNamespace(String prefix, String namespace) {
     // todo check if table exists in namespace after table ops is added
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
@@ -248,7 +263,16 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @IcebergAuthorizationMetadata(
               type = IcebergAuthorizationMetadata.RequestType.CREATE_NAMESPACE)
-          CreateNamespaceRequest createNamespaceRequest) {
+          CreateNamespaceRequest createNamespaceRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doCreateNamespace(prefix, createNamespaceRequest));
+  }
+
+  private Response doCreateNamespace(String prefix, CreateNamespaceRequest createNamespaceRequest) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     LOG.info(
         "Create Iceberg namespace, catalog: {}, createNamespaceRequest: {}",
@@ -281,6 +305,18 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
+      UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doUpdateNamespace(prefix, namespace, updateNamespacePropertiesRequest));
+  }
+
+  private Response doUpdateNamespace(
+      String prefix,
+      String namespace,
       UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
@@ -322,7 +358,20 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
       RegisterTableRequest registerTableRequest,
-      @HeaderParam(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION) String accessDelegation) {
+      @HeaderParam(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION) String accessDelegation,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doRegisterTable(prefix, namespace, registerTableRequest, accessDelegation));
+  }
+
+  private Response doRegisterTable(
+      String prefix,
+      String namespace,
+      RegisterTableRequest registerTableRequest,
+      String accessDelegation) {
     boolean isCredentialVending = IcebergTableOperations.isCredentialVending(accessDelegation);
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
@@ -363,7 +412,17 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      RegisterViewRequest registerViewRequest) {
+      RegisterViewRequest registerViewRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doRegisterView(prefix, namespace, registerViewRequest));
+  }
+
+  private Response doRegisterView(
+      String prefix, String namespace, RegisterViewRequest registerViewRequest) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -38,6 +38,7 @@ import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
 import javax.ws.rs.HeaderParam;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -47,6 +48,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.Entity.EntityType;
@@ -58,6 +60,7 @@ import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
@@ -101,15 +104,18 @@ public class IcebergTableOperations {
 
   private ObjectMapper icebergObjectMapper;
   private IcebergTableOperationDispatcher tableOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Context private HttpServletRequest httpRequest;
 
   @Inject
   public IcebergTableOperations(
       IcebergMetricsManager icebergMetricsManager,
-      IcebergTableOperationDispatcher tableOperationDispatcher) {
+      IcebergTableOperationDispatcher tableOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.icebergMetricsManager = icebergMetricsManager;
     this.tableOperationDispatcher = tableOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -172,7 +178,20 @@ public class IcebergTableOperations {
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
       CreateTableRequest createTableRequest,
-      @HeaderParam(X_ICEBERG_ACCESS_DELEGATION) String accessDelegation) {
+      @HeaderParam(X_ICEBERG_ACCESS_DELEGATION) String accessDelegation,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doCreateTable(prefix, namespace, createTableRequest, accessDelegation));
+  }
+
+  private Response doCreateTable(
+      String prefix,
+      String namespace,
+      CreateTableRequest createTableRequest,
+      String accessDelegation) {
     boolean isCredentialVending = isCredentialVending(accessDelegation);
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
@@ -217,7 +236,17 @@ public class IcebergTableOperations {
           String namespace,
       @AuthorizationMetadata(type = Entity.EntityType.TABLE) @Encoded() @PathParam("table")
           String table,
-      UpdateTableRequest updateTableRequest) {
+      UpdateTableRequest updateTableRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doUpdateTable(prefix, namespace, table, updateTableRequest));
+  }
+
+  private Response doUpdateTable(
+      String prefix, String namespace, String table, UpdateTableRequest updateTableRequest) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -263,7 +292,17 @@ public class IcebergTableOperations {
           String namespace,
       @AuthorizationMetadata(type = Entity.EntityType.TABLE) @Encoded() @PathParam("table")
           String table,
-      @DefaultValue("false") @QueryParam("purgeRequested") boolean purgeRequested) {
+      @DefaultValue("false") @QueryParam("purgeRequested") boolean purgeRequested,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.DELETE, uriInfo),
+        () -> doDropTable(prefix, namespace, table, purgeRequested));
+  }
+
+  private Response doDropTable(
+      String prefix, String namespace, String table, boolean purgeRequested) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
@@ -24,6 +24,8 @@ import com.google.common.annotations.VisibleForTesting;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -31,11 +33,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
@@ -56,10 +60,14 @@ public class IcebergTableRenameOperations {
   @Context private HttpServletRequest httpRequest;
 
   private IcebergTableOperationDispatcher tableOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Inject
-  public IcebergTableRenameOperations(IcebergTableOperationDispatcher tableOperationDispatcher) {
+  public IcebergTableRenameOperations(
+      IcebergTableOperationDispatcher tableOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.tableOperationDispatcher = tableOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
   }
 
   @POST
@@ -75,7 +83,16 @@ public class IcebergTableRenameOperations {
   public Response renameTable(
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @IcebergAuthorizationMetadata(type = RequestType.RENAME_TABLE)
-          RenameTableRequest renameTableRequest) {
+          RenameTableRequest renameTableRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doRenameTable(prefix, renameTableRequest));
+  }
+
+  private Response doRenameTable(String prefix, RenameTableRequest renameTableRequest) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     LOG.info(
         "Rename Iceberg tables, catalog: {}, source: {}, destination: {}.",

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
@@ -33,6 +33,8 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -41,6 +43,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.Entity.EntityType;
 import org.apache.gravitino.MetadataObject;
@@ -51,6 +54,7 @@ import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.gravitino.server.authorization.MetadataAuthzHelper;
@@ -80,12 +84,16 @@ public class IcebergViewOperations {
 
   private ObjectMapper icebergObjectMapper;
   private IcebergViewOperationDispatcher viewOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Context private HttpServletRequest httpRequest;
 
   @Inject
-  public IcebergViewOperations(IcebergViewOperationDispatcher viewOperationDispatcher) {
+  public IcebergViewOperations(
+      IcebergViewOperationDispatcher viewOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.viewOperationDispatcher = viewOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -144,7 +152,17 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      CreateViewRequest createViewRequest) {
+      CreateViewRequest createViewRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doCreateView(prefix, namespace, createViewRequest));
+  }
+
+  private Response doCreateView(
+      String prefix, String namespace, CreateViewRequest createViewRequest) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -226,7 +244,17 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
       @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view,
-      UpdateTableRequest replaceViewRequest) {
+      UpdateTableRequest replaceViewRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doReplaceView(prefix, namespace, view, replaceViewRequest));
+  }
+
+  private Response doReplaceView(
+      String prefix, String namespace, String view, UpdateTableRequest replaceViewRequest) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -265,7 +293,16 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view) {
+      @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.DELETE, uriInfo),
+        () -> doDropView(prefix, namespace, view));
+  }
+
+  private Response doDropView(String prefix, String namespace, String view) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewRenameOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewRenameOperations.java
@@ -24,6 +24,8 @@ import com.google.common.annotations.VisibleForTesting;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -31,11 +33,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
@@ -57,10 +61,14 @@ public class IcebergViewRenameOperations {
   @Context private HttpServletRequest httpRequest;
 
   private IcebergViewOperationDispatcher viewOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Inject
-  public IcebergViewRenameOperations(IcebergViewOperationDispatcher viewOperationDispatcher) {
+  public IcebergViewRenameOperations(
+      IcebergViewOperationDispatcher viewOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.viewOperationDispatcher = viewOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
   }
 
   @POST
@@ -73,7 +81,16 @@ public class IcebergViewRenameOperations {
   public Response renameView(
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @IcebergAuthorizationMetadata(type = RequestType.RENAME_VIEW)
-          RenameTableRequest renameViewRequest) {
+          RenameTableRequest renameViewRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY) String idempotencyKey,
+      @Context UriInfo uriInfo) {
+    return idempotencyManager.replayOrExecute(
+        idempotencyKey,
+        IcebergIdempotencyManager.operationBinding(HttpMethod.POST, uriInfo),
+        () -> doRenameView(prefix, renameViewRequest));
+  }
+
+  private Response doRenameView(String prefix, RenameTableRequest renameViewRequest) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     LOG.info(
         "Rename Iceberg view, catalog: {}, source: {}, destination: {}.",

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/idempotency/TestIcebergIdempotencyManager.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/idempotency/TestIcebergIdempotencyManager.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.idempotency;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStore;
+import org.apache.gravitino.iceberg.common.idempotency.IdempotencyStore.ReserveResult;
+import org.apache.gravitino.iceberg.common.idempotency.InMemoryIdempotencyStore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestIcebergIdempotencyManager {
+
+  private static final String KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+  private static final String OTHER_KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c073990";
+  private static final String BINDING = "POST v1/cat1/namespaces/ns1/tables";
+
+  @Test
+  void testDisabledManagerRunsEveryRequest() {
+    IcebergIdempotencyManager manager = newDisabledManager();
+    AtomicInteger executions = new AtomicInteger();
+
+    Assertions.assertEquals(200, execute(manager, KEY, executions).getStatus());
+    Assertions.assertEquals(200, execute(manager, KEY, executions).getStatus());
+
+    Assertions.assertEquals(2, executions.get());
+    Assertions.assertEquals(Optional.empty(), manager.advertisedKeyLifetime());
+  }
+
+  @Test
+  void testEnabledManagerAdvertisesTheConfiguredLifetime() {
+    IcebergIdempotencyManager manager =
+        newManager(ImmutableMap.of(IcebergConstants.ICEBERG_IDEMPOTENCY_KEY_LIFETIME, "PT2H"));
+    Assertions.assertEquals(Optional.of("PT2H"), manager.advertisedKeyLifetime());
+  }
+
+  @Test
+  void testRequestWithoutKeyIsNotDeduplicated() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    execute(manager, null, executions);
+    execute(manager, "", executions);
+
+    Assertions.assertEquals(2, executions.get());
+  }
+
+  @Test
+  void testRetryReplaysTheStoredResponse() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    Response first = execute(manager, KEY, executions);
+    Response replayed = execute(manager, KEY, executions);
+
+    Assertions.assertEquals(1, executions.get(), "the mutation must run exactly once");
+    Assertions.assertEquals(first.getStatus(), replayed.getStatus());
+    Assertions.assertEquals("{\"payload\":1}", replayed.getEntity());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, replayed.getMediaType());
+  }
+
+  @Test
+  void testDifferentKeyExecutesAgain() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    execute(manager, KEY, executions);
+    execute(manager, OTHER_KEY, executions);
+
+    Assertions.assertEquals(2, executions.get());
+  }
+
+  @Test
+  void testResponseWithoutBodyIsReplayed() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    manager.replayOrExecute(
+        KEY,
+        BINDING,
+        () -> {
+          executions.incrementAndGet();
+          return Response.noContent().build();
+        });
+    Response replayed =
+        manager.replayOrExecute(
+            KEY,
+            BINDING,
+            () -> {
+              executions.incrementAndGet();
+              return Response.noContent().build();
+            });
+
+    Assertions.assertEquals(1, executions.get());
+    Assertions.assertEquals(204, replayed.getStatus());
+    Assertions.assertNull(replayed.getEntity());
+  }
+
+  @Test
+  void testTerminalClientErrorIsReplayed() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    Response first = respondWith(manager, 409, executions);
+    Response replayed = respondWith(manager, 409, executions);
+
+    Assertions.assertEquals(1, executions.get());
+    Assertions.assertEquals(409, first.getStatus());
+    Assertions.assertEquals(409, replayed.getStatus());
+  }
+
+  @Test
+  void testServerErrorReleasesTheKey() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    Assertions.assertEquals(500, respondWith(manager, 500, executions).getStatus());
+    // The spec treats 5xx as retryable, so the same key must be usable again.
+    Assertions.assertEquals(503, respondWith(manager, 503, executions).getStatus());
+    Assertions.assertEquals(2, executions.get());
+  }
+
+  @Test
+  void testUnauthorizedResponseReleasesTheKey() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    respondWith(manager, 401, executions);
+    respondWith(manager, 401, executions);
+
+    Assertions.assertEquals(2, executions.get());
+  }
+
+  @Test
+  void testThrownExceptionReleasesTheKey() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        () ->
+            manager.replayOrExecute(
+                KEY,
+                BINDING,
+                () -> {
+                  executions.incrementAndGet();
+                  throw new IllegalStateException("boom");
+                }));
+
+    Assertions.assertEquals(200, execute(manager, KEY, executions).getStatus());
+    Assertions.assertEquals(2, executions.get());
+  }
+
+  @Test
+  void testInvalidKeyIsRejectedWithoutExecuting() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    Response response = execute(manager, "not-a-uuid-v7", executions);
+
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(0, executions.get());
+  }
+
+  @Test
+  void testKeyReusedForAnotherOperationIsRejected() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    execute(manager, KEY, executions);
+    Response response =
+        manager.replayOrExecute(
+            KEY,
+            "DELETE v1/cat1/namespaces/ns1/tables/t1",
+            () -> {
+              executions.incrementAndGet();
+              return Response.ok().build();
+            });
+
+    Assertions.assertEquals(409, response.getStatus());
+    Assertions.assertEquals(1, executions.get(), "the second operation must not run");
+    Assertions.assertNull(response.getHeaderString(HttpHeaders.RETRY_AFTER));
+  }
+
+  @Test
+  void testRetryWhileTheFirstRequestIsRunningIsRetryable() {
+    IdempotencyStore store = Mockito.mock(IdempotencyStore.class);
+    Mockito.when(store.reserve(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong()))
+        .thenReturn(ReserveResult.DUPLICATE);
+    Mockito.when(store.load(KEY)).thenReturn(Optional.empty());
+    IcebergIdempotencyManager manager =
+        new IcebergIdempotencyManager(enabledConfig(ImmutableMap.of()), Optional.of(store));
+    AtomicInteger executions = new AtomicInteger();
+
+    Response response = execute(manager, KEY, executions);
+
+    Assertions.assertEquals(409, response.getStatus());
+    Assertions.assertEquals(0, executions.get());
+    Assertions.assertEquals("1", response.getHeaderString(HttpHeaders.RETRY_AFTER));
+  }
+
+  @Test
+  void testOperationBindingIncludesSortedQueryParameters() {
+    MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<>();
+    queryParameters.putSingle("purgeRequested", "true");
+    queryParameters.putSingle("mode", "async");
+    UriInfo uriInfo = Mockito.mock(UriInfo.class);
+    Mockito.when(uriInfo.getPath()).thenReturn("v1/cat1/namespaces/ns1/tables/t1");
+    Mockito.when(uriInfo.getQueryParameters()).thenReturn(queryParameters);
+
+    Assertions.assertEquals(
+        "DELETE v1/cat1/namespaces/ns1/tables/t1?mode=async&purgeRequested=true",
+        IcebergIdempotencyManager.operationBinding("DELETE", uriInfo));
+  }
+
+  @Test
+  void testOperationBindingWithoutUriInfoFallsBackToTheMethod() {
+    Assertions.assertEquals("POST", IcebergIdempotencyManager.operationBinding("POST", null));
+  }
+
+  private static Response execute(
+      IcebergIdempotencyManager manager, String idempotencyKey, AtomicInteger executions) {
+    return manager.replayOrExecute(
+        idempotencyKey,
+        BINDING,
+        () -> {
+          executions.incrementAndGet();
+          return Response.ok("{\"payload\":1}", MediaType.APPLICATION_JSON_TYPE).build();
+        });
+  }
+
+  private static Response respondWith(
+      IcebergIdempotencyManager manager, int status, AtomicInteger executions) {
+    return manager.replayOrExecute(
+        KEY,
+        BINDING,
+        () -> {
+          executions.incrementAndGet();
+          return Response.status(status).build();
+        });
+  }
+
+  private static IcebergIdempotencyManager newManager(Map<String, String> properties) {
+    IcebergConfig icebergConfig = enabledConfig(properties);
+    InMemoryIdempotencyStore store = new InMemoryIdempotencyStore();
+    store.initialize(icebergConfig.getAllConfig());
+    return new IcebergIdempotencyManager(icebergConfig, Optional.of(store));
+  }
+
+  private static IcebergIdempotencyManager newDisabledManager() {
+    return new IcebergIdempotencyManager(new IcebergConfig(ImmutableMap.of()), Optional.empty());
+  }
+
+  private static IcebergConfig enabledConfig(Map<String, String> properties) {
+    Map<String, String> merged = new HashMap<>(properties);
+    merged.put(IcebergConstants.ICEBERG_IDEMPOTENCY_ENABLED, "true");
+    return new IcebergConfig(merged);
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/idempotency/TestIcebergIdempotencyManager.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/idempotency/TestIcebergIdempotencyManager.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 public class TestIcebergIdempotencyManager {
 
   private static final String KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+  private static final String KEY_UPPER = "017F22E2-79B0-7CC3-98C4-DC0C0C07398F";
   private static final String OTHER_KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c073990";
   private static final String BINDING = "POST v1/cat1/namespaces/ns1/tables";
 
@@ -212,9 +213,25 @@ public class TestIcebergIdempotencyManager {
   }
 
   @Test
+  void testRetryWithADifferentlyCasedKeyReplays() {
+    IcebergIdempotencyManager manager = newManager(ImmutableMap.of());
+    AtomicInteger executions = new AtomicInteger();
+
+    Response first = execute(manager, KEY_UPPER, executions);
+    Response retry = execute(manager, KEY, executions);
+
+    Assertions.assertEquals(200, first.getStatus());
+    Assertions.assertEquals(200, retry.getStatus());
+    Assertions.assertEquals(1, executions.get(), "a case variant is the same key, not a new one");
+    Assertions.assertEquals(first.getEntity(), retry.getEntity());
+  }
+
+  @Test
   void testRetryWhileTheFirstRequestIsRunningIsRetryable() {
     IdempotencyStore store = Mockito.mock(IdempotencyStore.class);
-    Mockito.when(store.reserve(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong()))
+    Mockito.when(
+            store.reserve(
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong()))
         .thenReturn(ReserveResult.DUPLICATE);
     Mockito.when(store.load(KEY)).thenReturn(Optional.empty());
     IcebergIdempotencyManager manager =

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewEventDispatche
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationExecutor;
 import org.apache.gravitino.iceberg.service.extension.DummyCredentialProvider;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 import org.apache.gravitino.iceberg.service.provider.IcebergConfigProvider;
 import org.apache.gravitino.iceberg.service.provider.IcebergConfigProviderFactory;
@@ -95,10 +96,38 @@ public class IcebergRestTestUtil {
 
   public static ResourceConfig getIcebergResourceConfig(
       Class c, boolean bindIcebergTableOps, List<EventListenerPlugin> eventListenerPlugins) {
+    return getIcebergResourceConfig(
+        c, bindIcebergTableOps, eventListenerPlugins, Collections.emptyMap());
+  }
+
+  /**
+   * Builds a test resource config.
+   *
+   * @param c the resource class under test
+   * @param bindIcebergTableOps whether to bind the catalog and dispatcher stack
+   * @param eventListenerPlugins event listeners to attach to the event bus
+   * @param serverConf extra Iceberg REST server configuration, for example to enable idempotency
+   * @return the configured Jersey resource config
+   */
+  public static ResourceConfig getIcebergResourceConfig(
+      Class c,
+      boolean bindIcebergTableOps,
+      List<EventListenerPlugin> eventListenerPlugins,
+      Map<String, String> serverConf) {
     ResourceConfig resourceConfig = new ResourceConfig();
     resourceConfig.register(c);
     resourceConfig.register(IcebergObjectMapperProvider.class).register(JacksonFeature.class);
     resourceConfig.register(IcebergExceptionMapper.class);
+
+    IcebergIdempotencyManager icebergIdempotencyManager =
+        new IcebergIdempotencyManager(new IcebergConfig(serverConf));
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            bind(icebergIdempotencyManager).to(IcebergIdempotencyManager.class).ranked(2);
+          }
+        });
 
     if (DEBUG_SERVER_LOG_ENABLED) {
       resourceConfig.register(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergNamespaceOperations.java
@@ -22,13 +22,15 @@ package org.apache.gravitino.iceberg.service.rest;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 
 public class MockIcebergNamespaceOperations extends IcebergNamespaceOperations {
 
   @Inject
   public MockIcebergNamespaceOperations(
-      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher) {
-    super(namespaceOperationDispatcher);
+      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
+    super(namespaceOperationDispatcher, idempotencyManager);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergTableOperations.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.iceberg.service.rest;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 
 public class MockIcebergTableOperations extends IcebergTableOperations {
@@ -29,8 +30,9 @@ public class MockIcebergTableOperations extends IcebergTableOperations {
   @Inject
   public MockIcebergTableOperations(
       IcebergMetricsManager icebergMetricsManager,
-      IcebergTableOperationDispatcher tableOperationDispatcher) {
-    super(icebergMetricsManager, tableOperationDispatcher);
+      IcebergTableOperationDispatcher tableOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
+    super(icebergMetricsManager, tableOperationDispatcher, idempotencyManager);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergTableRenameOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergTableRenameOperations.java
@@ -22,12 +22,14 @@ package org.apache.gravitino.iceberg.service.rest;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 
 public class MockIcebergTableRenameOperations extends IcebergTableRenameOperations {
   @Inject
   public MockIcebergTableRenameOperations(
-      IcebergTableOperationDispatcher tableOperationDispatcher) {
-    super(tableOperationDispatcher);
+      IcebergTableOperationDispatcher tableOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
+    super(tableOperationDispatcher, idempotencyManager);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergViewOperations.java
@@ -22,12 +22,15 @@ package org.apache.gravitino.iceberg.service.rest;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 
 public class MockIcebergViewOperations extends IcebergViewOperations {
 
   @Inject
-  public MockIcebergViewOperations(IcebergViewOperationDispatcher viewOperationDispatcher) {
-    super(viewOperationDispatcher);
+  public MockIcebergViewOperations(
+      IcebergViewOperationDispatcher viewOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
+    super(viewOperationDispatcher, idempotencyManager);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergViewRenameOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergViewRenameOperations.java
@@ -22,11 +22,14 @@ package org.apache.gravitino.iceberg.service.rest;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
 
 public class MockIcebergViewRenameOperations extends IcebergViewRenameOperations {
   @Inject
-  public MockIcebergViewRenameOperations(IcebergViewOperationDispatcher viewOperationDispatcher) {
-    super(viewOperationDispatcher);
+  public MockIcebergViewRenameOperations(
+      IcebergViewOperationDispatcher viewOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
+    super(viewOperationDispatcher, idempotencyManager);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergConfig.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergConfig.java
@@ -50,6 +50,15 @@ public class TestIcebergConfig extends IcebergTestBase {
   }
 
   @Test
+  public void testConfigOmitsIdempotencyKeyLifetimeWhenDisabled() {
+    // Idempotency is disabled by default, and per the Iceberg REST spec the absence of
+    // `idempotency-key-lifetime` tells clients the server does not support Idempotency-Key.
+    Response resp = getConfigClientBuilder().get();
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    Assertions.assertNull(resp.readEntity(ConfigResponse.class).idempotencyKeyLifetime());
+  }
+
+  @Test
   public void testConfigWithEmptyWarehouse() {
     Map<String, String> queryParams = ImmutableMap.of("warehouse", "");
     Response resp =

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergIdempotencyKey.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergIdempotencyKey.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.service.idempotency.IcebergIdempotencyManager;
+import org.apache.gravitino.listener.api.event.IcebergCreateTableEvent;
+import org.apache.gravitino.server.ServerConfig;
+import org.apache.gravitino.server.authorization.GravitinoAuthorizerProvider;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/** End-to-end coverage of the {@code Idempotency-Key} header on mutation endpoints. */
+@SuppressWarnings("deprecation")
+public class TestIcebergIdempotencyKey extends IcebergNamespaceTestBase {
+
+  private static final Namespace NAMESPACE = Namespace.of("idempotency_test");
+
+  private static final String KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f";
+  private static final String OTHER_KEY = "017f22e2-79b0-7cc3-98c4-dc0c0c073990";
+
+  private static final Schema TABLE_SCHEMA =
+      new Schema(NestedField.of(1, false, "foo_string", StringType.get()));
+
+  private DummyEventListener dummyEventListener;
+
+  @Override
+  protected Application configure() {
+    this.dummyEventListener = new DummyEventListener();
+    ResourceConfig resourceConfig =
+        IcebergRestTestUtil.getIcebergResourceConfig(
+            MockIcebergTableOperations.class,
+            true,
+            Arrays.asList(dummyEventListener),
+            ImmutableMap.of(IcebergConstants.ICEBERG_IDEMPOTENCY_ENABLED, "true"));
+    resourceConfig.register(MockIcebergNamespaceOperations.class);
+    resourceConfig.register(IcebergConfigOperations.class);
+
+    // register a mock HttpServletRequest with user info
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+            Mockito.when(mockRequest.getUserPrincipal()).thenReturn(() -> "test-user");
+            bind(mockRequest).to(HttpServletRequest.class);
+          }
+        });
+
+    GravitinoAuthorizerProvider.getInstance().initialize(new ServerConfig());
+    return resourceConfig;
+  }
+
+  @Test
+  void testConfigAdvertisesTheKeyLifetime() {
+    Response response = getConfigClientBuilder().get();
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    // The Iceberg REST spec puts the lifetime at the top level of CatalogConfig, next to
+    // `defaults` and `overrides`, not inside them.
+    Assertions.assertEquals(
+        "PT30M", response.readEntity(JsonNode.class).get("idempotency-key-lifetime").asText());
+  }
+
+  @Test
+  void testRetryWithTheSameKeyReplaysTheOriginalResponse() {
+    Assertions.assertEquals(Status.OK.getStatusCode(), doCreateNamespace(NAMESPACE).getStatus());
+
+    Response first = createTable("replayed_table", KEY);
+    Assertions.assertEquals(Status.OK.getStatusCode(), first.getStatus());
+    String firstMetadataLocation = first.readEntity(LoadTableResponse.class).metadataLocation();
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergCreateTableEvent);
+    dummyEventListener.clearEvent();
+
+    Response retry = createTable("replayed_table", KEY);
+    Assertions.assertEquals(Status.OK.getStatusCode(), retry.getStatus());
+    Assertions.assertEquals(
+        firstMetadataLocation, retry.readEntity(LoadTableResponse.class).metadataLocation());
+    Assertions.assertTrue(
+        dummyEventListener.postEvents.isEmpty(),
+        "a replayed request must not re-run the mutation: " + dummyEventListener.postEvents);
+  }
+
+  @Test
+  void testRetryWithANewKeyReExecutesAndConflicts() {
+    Assertions.assertEquals(Status.OK.getStatusCode(), doCreateNamespace(NAMESPACE).getStatus());
+
+    Assertions.assertEquals(
+        Status.OK.getStatusCode(), createTable("fresh_key_table", KEY).getStatus());
+    // A new key means a new logical operation, so the mutation runs and hits the existing table.
+    Assertions.assertEquals(
+        Status.CONFLICT.getStatusCode(), createTable("fresh_key_table", OTHER_KEY).getStatus());
+  }
+
+  @Test
+  void testTerminalErrorIsReplayed() {
+    Assertions.assertEquals(Status.OK.getStatusCode(), doCreateNamespace(NAMESPACE).getStatus());
+    Assertions.assertEquals(
+        Status.OK.getStatusCode(), createTable("conflict_table", OTHER_KEY).getStatus());
+
+    Assertions.assertEquals(
+        Status.CONFLICT.getStatusCode(), createTable("conflict_table", KEY).getStatus());
+    // The stored 409 is replayed rather than re-running the create.
+    Assertions.assertEquals(
+        Status.CONFLICT.getStatusCode(), createTable("conflict_table", KEY).getStatus());
+  }
+
+  @Test
+  void testInvalidKeyIsRejected() {
+    Assertions.assertEquals(Status.OK.getStatusCode(), doCreateNamespace(NAMESPACE).getStatus());
+
+    // A UUIDv4 is well-formed but the spec requires UUIDv7.
+    Response response = createTable("rejected_table", "f47ac10b-58cc-4372-a567-0e02b2c3d479");
+    Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+
+    // The mutation must not have run.
+    Assertions.assertEquals(
+        Status.OK.getStatusCode(), createTable("rejected_table", KEY).getStatus());
+  }
+
+  @Test
+  void testKeyReusedForAnotherOperationIsRejected() {
+    Assertions.assertEquals(Status.OK.getStatusCode(), doCreateNamespace(NAMESPACE).getStatus());
+    Assertions.assertEquals(
+        Status.OK.getStatusCode(), createTable("reused_table", KEY).getStatus());
+
+    Response response =
+        getTableClientBuilder(NAMESPACE, Optional.of("reused_table"))
+            .header(IcebergIdempotencyManager.IDEMPOTENCY_KEY, KEY)
+            .delete();
+
+    Assertions.assertEquals(Status.CONFLICT.getStatusCode(), response.getStatus());
+    Assertions.assertNull(response.getHeaderString(HttpHeaders.RETRY_AFTER));
+    // The table is still there: the drop never ran.
+    Assertions.assertEquals(
+        Status.OK.getStatusCode(),
+        getTableClientBuilder(NAMESPACE, Optional.of("reused_table")).get().getStatus());
+  }
+
+  @Test
+  void testRequestWithoutAKeyIsUnaffected() {
+    Assertions.assertEquals(Status.OK.getStatusCode(), doCreateNamespace(NAMESPACE).getStatus());
+
+    Assertions.assertEquals(
+        Status.OK.getStatusCode(), createTable("no_key_table", null).getStatus());
+    Assertions.assertEquals(
+        Status.CONFLICT.getStatusCode(), createTable("no_key_table", null).getStatus());
+  }
+
+  @Test
+  void testDropIsReplayed() {
+    Assertions.assertEquals(Status.OK.getStatusCode(), doCreateNamespace(NAMESPACE).getStatus());
+    Assertions.assertEquals(
+        Status.OK.getStatusCode(), createTable("dropped_table", OTHER_KEY).getStatus());
+
+    Assertions.assertEquals(Status.NO_CONTENT.getStatusCode(), dropTable("dropped_table", KEY));
+    // Without idempotency the retry would be a 404; the stored 204 is replayed instead.
+    Assertions.assertEquals(Status.NO_CONTENT.getStatusCode(), dropTable("dropped_table", KEY));
+  }
+
+  private Response createTable(String name, String idempotencyKey) {
+    CreateTableRequest request =
+        CreateTableRequest.builder().withName(name).withSchema(TABLE_SCHEMA).build();
+    Invocation.Builder builder = getTableClientBuilder(NAMESPACE, Optional.empty());
+    if (idempotencyKey != null) {
+      builder = builder.header(IcebergIdempotencyManager.IDEMPOTENCY_KEY, idempotencyKey);
+    }
+    return builder.post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private int dropTable(String name, String idempotencyKey) {
+    return getTableClientBuilder(NAMESPACE, Optional.of(name))
+        .header(IcebergIdempotencyManager.IDEMPOTENCY_KEY, idempotencyKey)
+        .delete()
+        .getStatus();
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/authorization/TestIcebergViewAuthorizationExpression.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/authorization/TestIcebergViewAuthorizationExpression.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import javax.ws.rs.core.UriInfo;
 import ognl.OgnlException;
 import org.apache.gravitino.iceberg.service.rest.IcebergViewOperations;
 import org.apache.gravitino.iceberg.service.rest.IcebergViewRenameOperations;
@@ -46,7 +47,12 @@ public class TestIcebergViewAuthorizationExpression {
   public void testCreateView() throws NoSuchMethodException, OgnlException {
     Method method =
         IcebergViewOperations.class.getMethod(
-            "createView", String.class, String.class, CreateViewRequest.class);
+            "createView",
+            String.class,
+            String.class,
+            CreateViewRequest.class,
+            String.class,
+            UriInfo.class);
     AuthorizationExpression annotation = method.getAnnotation(AuthorizationExpression.class);
     String expression = annotation.expression();
     MockAuthorizationExpressionEvaluator mockEvaluator =
@@ -253,7 +259,13 @@ public class TestIcebergViewAuthorizationExpression {
   public void testReplaceView() throws NoSuchMethodException, OgnlException {
     Method method =
         IcebergViewOperations.class.getMethod(
-            "replaceView", String.class, String.class, String.class, UpdateTableRequest.class);
+            "replaceView",
+            String.class,
+            String.class,
+            String.class,
+            UpdateTableRequest.class,
+            String.class,
+            UriInfo.class);
     AuthorizationExpression annotation = method.getAnnotation(AuthorizationExpression.class);
     String expression = annotation.expression();
     MockAuthorizationExpressionEvaluator mockEvaluator =
@@ -300,7 +312,8 @@ public class TestIcebergViewAuthorizationExpression {
   @Test
   public void testDropView() throws NoSuchMethodException, OgnlException {
     Method method =
-        IcebergViewOperations.class.getMethod("dropView", String.class, String.class, String.class);
+        IcebergViewOperations.class.getMethod(
+            "dropView", String.class, String.class, String.class, String.class, UriInfo.class);
     AuthorizationExpression annotation = method.getAnnotation(AuthorizationExpression.class);
     String expression = annotation.expression();
     MockAuthorizationExpressionEvaluator mockEvaluator =
@@ -388,7 +401,7 @@ public class TestIcebergViewAuthorizationExpression {
   public void testRenameView() throws NoSuchMethodException, OgnlException {
     Method method =
         IcebergViewRenameOperations.class.getMethod(
-            "renameView", String.class, RenameTableRequest.class);
+            "renameView", String.class, RenameTableRequest.class, String.class, UriInfo.class);
     AuthorizationExpression annotation = method.getAnnotation(AuthorizationExpression.class);
     String expression = annotation.expression();
     MockAuthorizationExpressionEvaluator mockEvaluator =


### PR DESCRIPTION
> Second half of the split. Stacked on #12470 - the first commit here belongs to that PR, so review the second commit (`+1143/-32`) only. I'll rebase onto main and undraft once #12470 merges.

### What changes were proposed in this pull request?

Puts the storage seam from #12470 behind the REST endpoints.

- **`IcebergIdempotencyManager`** runs reserve, execute, finalize around a mutation. Retries replay the stored response; a key reused for another operation, or one whose first request is still in flight, gets `409 Conflict` (the latter with `Retry-After`); `5xx` releases the key so the client can retry with it.
- **Endpoint wiring** for create, update, drop, register, and rename across tables, namespaces, and views (13 endpoints). Each endpoint delegates to a private method holding its original body, so the idempotency seam is visible at the call site and the mutation itself reads unchanged.
- **`GET /v1/config`** advertises `idempotency-key-lifetime` as the top-level `CatalogConfig` field the spec defines, not a `defaults` entry as the design document's example showed, and only when enabled, since the spec reads its absence as no support. Iceberg 1.11's `ConfigResponse.Builder.withIdempotencyKeyLifetime()` already supports it.

One deliberate deviation from the spec: `401`, `403`, and `419` **release** the key rather than finalizing it. The spec finalizes deterministic terminal `4xx`, but auth outcomes depend on the caller's credentials rather than catalog state, so replaying them would keep failing a retry that has since obtained a valid token.

Known limitation, documented in the manager's Javadoc: a replayed response carries the original status and body but not headers, so a replayed create/update does not carry the `ETag` the first response did.

### Why are the changes needed?

Epic #12049. Completes phase 1 of the design. Phase 2, the durable multi-node JDBC store, follows separately.

Fix: #12049

### Does this PR introduce _any_ user-facing change?

Yes. Clients can send `Idempotency-Key: <UUIDv7>` on mutation requests for safe retries, and `GET /v1/config` includes `idempotency-key-lifetime` when enabled. Documents the four properties added in #12470. Off by default, so default behavior is unchanged.

### How was this patch tested?

- `TestIcebergIdempotencyManager` - replay, distinct keys, bodiless `204` replay, terminal `4xx` replay, `5xx`/`401`/thrown-exception release, invalid key rejected without executing, operation-binding mismatch, in-flight `409` with `Retry-After`, query-parameter-sorted bindings.
- `TestIcebergIdempotencyKey` - end-to-end through Jersey: a replayed create fires no second `IcebergCreateTableEvent`, a fresh key re-executes into `409 AlreadyExists`, a stored `409` replays, a key reused on `DELETE` is rejected and the table survives, a drop replays `204` where a retry would otherwise `404`, and `GET /v1/config` carries `PT30M`.
- `TestIcebergConfig` - the lifetime is absent when disabled.

`iceberg-rest-server` suite passes on JDK 17: 418 tests, 0 failures.

```bash
./gradlew :iceberg:iceberg-rest-server:test -PskipITs
```
