### PR TITLE
[#12493] feat(idp): Add optional comment to idp_group_meta

### DIFF
--- a/design-docs/gravitino-local-authentication.md
+++ b/design-docs/gravitino-local-authentication.md
@@ -201,6 +201,7 @@ CREATE TABLE IF NOT EXISTS `idp_user_meta` (
 CREATE TABLE IF NOT EXISTS `idp_group_meta` (
     `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
     `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `group_comment` VARCHAR(1024) DEFAULT '' COMMENT 'group comment',
     `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
     `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',

--- a/docs/open-api/idp/idp.yaml
+++ b/docs/open-api/idp/idp.yaml
@@ -359,7 +359,7 @@ components:
           description: The name of the local user store group
         comment:
           type: string
-          maxLength: 256
+          maxLength: 1024
           description: Optional description of the local user store group
         users:
           type: array
@@ -413,7 +413,7 @@ components:
           description: The group name to add.
         comment:
           type: string
-          maxLength: 256
+          maxLength: 1024
           description: Optional description of the group.
 
     GroupMembershipChangeRequest:

--- a/docs/open-api/idp/idp.yaml
+++ b/docs/open-api/idp/idp.yaml
@@ -357,6 +357,10 @@ components:
           type: string
           maxLength: 128
           description: The name of the local user store group
+        comment:
+          type: string
+          maxLength: 256
+          description: Optional description of the local user store group
         users:
           type: array
           items:
@@ -407,6 +411,10 @@ components:
           minLength: 1
           maxLength: 128
           description: The group name to add.
+        comment:
+          type: string
+          maxLength: 256
+          description: Optional description of the group.
 
     GroupMembershipChangeRequest:
       type: object
@@ -485,7 +493,8 @@ components:
 
     AddGroupRequest:
       value: {
-        "group": "engineers"
+        "group": "engineers",
+        "comment": "Platform engineering"
       }
 
     GroupMembershipChangeRequest:
@@ -526,6 +535,7 @@ components:
         "code": 0,
         "group": {
           "name": "engineers",
+          "comment": "Platform engineering",
           "users": []
         }
       }
@@ -535,6 +545,7 @@ components:
         "code": 0,
         "group": {
           "name": "engineers",
+          "comment": "Platform engineering",
           "users": ["alice", "bob"]
         }
       }
@@ -544,6 +555,7 @@ components:
         "code": 0,
         "group": {
           "name": "engineers",
+          "comment": "Platform engineering",
           "users": ["alice", "bob"]
         }
       }

--- a/docs/security/local-users-and-groups.md
+++ b/docs/security/local-users-and-groups.md
@@ -103,11 +103,11 @@ curl -s -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 | Operation                | Method | Path                                        | Body                                                       |
 |--------------------------|--------|---------------------------------------------|------------------------------------------------------------|
 | Get a group              | GET    | `/api/idp/groups/{group}`                   | None                                                       |
-| Add a group              | POST   | `/api/idp/groups`                           | `{"group":"engineering"}`                                  |
+| Add a group              | POST   | `/api/idp/groups`                           | `{"group":"engineering","comment":"Platform engineering"}` |
 | Remove a group           | DELETE | `/api/idp/groups/{group}?force={true false}`| None                                                       |
 | Change group membership  | PUT    | `/api/idp/groups/{group}/users`             | `{"usersToAdd":["alice"],"usersToRemove":["carol"]}`       |
 
-The add-group body uses the field name `group` rather than `name`. Removing a group that still has members fails unless `force=true`. A membership change requires at least one of `usersToAdd` or `usersToRemove`, and accepts both in a single request.
+The add-group body uses the field name `group` rather than `name`. `comment` is optional and stored as the group description. Removing a group that still has members fails unless `force=true`. A membership change requires at least one of `usersToAdd` or `usersToRemove`, and accepts both in a single request.
 
 ```shell
 curl -s -X PUT -H "Accept: application/vnd.gravitino.v1+json" \

--- a/docs/security/local-users-and-groups.md
+++ b/docs/security/local-users-and-groups.md
@@ -107,7 +107,7 @@ curl -s -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 | Remove a group           | DELETE | `/api/idp/groups/{group}?force={true false}`| None                                                       |
 | Change group membership  | PUT    | `/api/idp/groups/{group}/users`             | `{"usersToAdd":["alice"],"usersToRemove":["carol"]}`       |
 
-The add-group body uses the field name `group` rather than `name`. `comment` is optional and stored as the group description. Removing a group that still has members fails unless `force=true`. A membership change requires at least one of `usersToAdd` or `usersToRemove`, and accepts both in a single request.
+The add-group body uses the field name `group` rather than `name`. `comment` is optional (max 1024 characters, utf8mb4) and stored as the group description. Removing a group that still has members fails unless `force=true`. A membership change requires at least one of `usersToAdd` or `usersToRemove`, and accepts both in a single request.
 
 ```shell
 curl -s -X PUT -H "Accept: application/vnd.gravitino.v1+json" \

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/IdpUserGroupManager.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/IdpUserGroupManager.java
@@ -194,6 +194,7 @@ public class IdpUserGroupManager implements Closeable {
    * @return The created built-in IdP group.
    */
   public IdpGroup addGroup(String groupName, String comment) throws IOException {
+    IdpCredentialValidator.validateGroupComment(comment);
     String normalizedComment = comment == null ? "" : comment;
     GROUP_SERVICE.insertIdpGroup(newGroupPO(groupName, normalizedComment));
     return new IdpGroup(groupName, Collections.emptyList(), normalizedComment);

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/IdpUserGroupManager.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/IdpUserGroupManager.java
@@ -183,8 +183,20 @@ public class IdpUserGroupManager implements Closeable {
    * @return The created built-in IdP group.
    */
   public IdpGroup addGroup(String groupName) throws IOException {
-    GROUP_SERVICE.insertIdpGroup(newGroupPO(groupName));
-    return new IdpGroup(groupName, Collections.emptyList());
+    return addGroup(groupName, "");
+  }
+
+  /**
+   * Adds a built-in IdP group.
+   *
+   * @param groupName The group name.
+   * @param comment The optional group comment.
+   * @return The created built-in IdP group.
+   */
+  public IdpGroup addGroup(String groupName, String comment) throws IOException {
+    String normalizedComment = comment == null ? "" : comment;
+    GROUP_SERVICE.insertIdpGroup(newGroupPO(groupName, normalizedComment));
+    return new IdpGroup(groupName, Collections.emptyList(), normalizedComment);
   }
 
   /**
@@ -254,10 +266,11 @@ public class IdpUserGroupManager implements Closeable {
     }
   }
 
-  private IdpGroupPO newGroupPO(String groupName) {
+  private IdpGroupPO newGroupPO(String groupName, String comment) {
     return IdpGroupPO.builder()
         .withGroupId(idGenerator.nextId())
         .withGroupName(groupName)
+        .withGroupComment(comment == null ? "" : comment)
         .withCurrentVersion(POConverters.INIT_VERSION)
         .withLastVersion(POConverters.INIT_VERSION)
         .withDeletedAt(POConverters.DEFAULT_DELETED_AT)

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/basic/IdpCredentialValidator.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/basic/IdpCredentialValidator.java
@@ -32,8 +32,12 @@ public final class IdpCredentialValidator {
   /** Matches {@code idp_user_meta.user_name} and {@code idp_group_meta.group_name} column size. */
   private static final int MAX_NAME_LENGTH = 128;
 
-  /** Matches {@code idp_group_meta.group_comment} column size. */
-  private static final int MAX_COMMENT_LENGTH = 256;
+  /**
+   * Matches {@code idp_group_meta.group_comment} (utf8mb4 VARCHAR(1024)). Same character limit as
+   * Microsoft Entra ID / Azure AD and Okta group description (Keycloak DESCRIPTION is
+   * VARCHAR(255)).
+   */
+  private static final int MAX_COMMENT_LENGTH = 1024;
 
   private IdpCredentialValidator() {}
 
@@ -61,7 +65,7 @@ public final class IdpCredentialValidator {
       return;
     }
     Preconditions.checkArgument(
-        comment.length() <= MAX_COMMENT_LENGTH,
+        comment.codePointCount(0, comment.length()) <= MAX_COMMENT_LENGTH,
         "Group comment must not exceed %s characters",
         MAX_COMMENT_LENGTH);
   }

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/basic/IdpCredentialValidator.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/basic/IdpCredentialValidator.java
@@ -32,6 +32,9 @@ public final class IdpCredentialValidator {
   /** Matches {@code idp_user_meta.user_name} and {@code idp_group_meta.group_name} column size. */
   private static final int MAX_NAME_LENGTH = 128;
 
+  /** Matches {@code idp_group_meta.group_comment} column size. */
+  private static final int MAX_COMMENT_LENGTH = 256;
+
   private IdpCredentialValidator() {}
 
   public static void validateUsername(String username) {
@@ -51,6 +54,16 @@ public final class IdpCredentialValidator {
         groupName.length() <= MAX_NAME_LENGTH,
         "Group name must not exceed %s characters",
         MAX_NAME_LENGTH);
+  }
+
+  public static void validateGroupComment(String comment) {
+    if (comment == null) {
+      return;
+    }
+    Preconditions.checkArgument(
+        comment.length() <= MAX_COMMENT_LENGTH,
+        "Group comment must not exceed %s characters",
+        MAX_COMMENT_LENGTH);
   }
 
   public static void validatePassword(String password) {

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/basic/IdpCredentialValidator.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/basic/IdpCredentialValidator.java
@@ -32,11 +32,7 @@ public final class IdpCredentialValidator {
   /** Matches {@code idp_user_meta.user_name} and {@code idp_group_meta.group_name} column size. */
   private static final int MAX_NAME_LENGTH = 128;
 
-  /**
-   * Matches {@code idp_group_meta.group_comment} (utf8mb4 VARCHAR(1024)). Same character limit as
-   * Microsoft Entra ID / Azure AD and Okta group description (Keycloak DESCRIPTION is
-   * VARCHAR(255)).
-   */
+  /** Matches {@code idp_group_meta.group_comment} column size (utf8mb4 VARCHAR(1024)). */
   private static final int MAX_COMMENT_LENGTH = 1024;
 
   private IdpCredentialValidator() {}

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/dto/IdpGroupDTO.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/dto/IdpGroupDTO.java
@@ -42,6 +42,7 @@ public class IdpGroupDTO {
   private String name;
 
   @JsonProperty("comment")
+  @JsonSetter(nulls = Nulls.AS_EMPTY)
   private String comment = "";
 
   @JsonProperty("users")
@@ -80,7 +81,7 @@ public class IdpGroupDTO {
    * @return The comment of the built-in IdP group DTO, or an empty string if none.
    */
   public String comment() {
-    return comment;
+    return comment == null ? "" : comment;
   }
 
   /**

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/dto/IdpGroupDTO.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/dto/IdpGroupDTO.java
@@ -41,6 +41,9 @@ public class IdpGroupDTO {
   @JsonProperty("name")
   private String name;
 
+  @JsonProperty("comment")
+  private String comment = "";
+
   @JsonProperty("users")
   @JsonSetter(nulls = Nulls.AS_EMPTY)
   private List<String> users = Collections.emptyList();
@@ -49,10 +52,11 @@ public class IdpGroupDTO {
    * Creates a new instance of IdpGroupDTO.
    *
    * @param name The name of the built-in IdP group DTO.
+   * @param comment The comment of the built-in IdP group DTO.
    * @param users The users of the built-in IdP group DTO.
    */
   @Builder(setterPrefix = "with")
-  protected IdpGroupDTO(String name, List<String> users) {
+  protected IdpGroupDTO(String name, String comment, List<String> users) {
     Preconditions.checkArgument(StringUtils.isNotBlank(name), "name cannot be null or empty");
     if (users != null) {
       users.forEach(
@@ -61,6 +65,7 @@ public class IdpGroupDTO {
                   StringUtils.isNotBlank(user), "users cannot contain null or empty user names"));
     }
     this.name = name;
+    this.comment = comment == null ? "" : comment;
     this.users = users == null ? Collections.emptyList() : users;
   }
 
@@ -69,6 +74,13 @@ public class IdpGroupDTO {
    */
   public String name() {
     return name;
+  }
+
+  /**
+   * @return The comment of the built-in IdP group DTO, or an empty string if none.
+   */
+  public String comment() {
+    return comment;
   }
 
   /**

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/dto/requests/AddGroupRequest.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/dto/requests/AddGroupRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.idp.dto.requests;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -40,6 +41,7 @@ public class AddGroupRequest implements RESTRequest {
   private final String group;
 
   @JsonProperty("comment")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String comment;
 
   /** Default constructor for AddGroupRequest. (Used for Jackson deserialization.) */

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/dto/requests/AddGroupRequest.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/dto/requests/AddGroupRequest.java
@@ -39,9 +39,12 @@ public class AddGroupRequest implements RESTRequest {
   @JsonProperty("group")
   private final String group;
 
+  @JsonProperty("comment")
+  private final String comment;
+
   /** Default constructor for AddGroupRequest. (Used for Jackson deserialization.) */
   public AddGroupRequest() {
-    this(null);
+    this(null, null);
   }
 
   /**
@@ -50,8 +53,19 @@ public class AddGroupRequest implements RESTRequest {
    * @param group The group name of the built-in IdP group.
    */
   public AddGroupRequest(String group) {
+    this(group, null);
+  }
+
+  /**
+   * Creates a new AddGroupRequest.
+   *
+   * @param group The group name of the built-in IdP group.
+   * @param comment The optional group comment.
+   */
+  public AddGroupRequest(String group, String comment) {
     super();
     this.group = group;
+    this.comment = comment;
   }
 
   /**
@@ -62,5 +76,6 @@ public class AddGroupRequest implements RESTRequest {
   @Override
   public void validate() throws IllegalArgumentException {
     IdpCredentialValidator.validateGroupName(group);
+    IdpCredentialValidator.validateGroupComment(comment);
   }
 }

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/model/IdpGroup.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/model/IdpGroup.java
@@ -26,6 +26,7 @@ import org.apache.gravitino.idp.dto.IdpGroupDTO;
 public class IdpGroup {
 
   private final String name;
+  private final String comment;
   private final List<String> usernames;
 
   /**
@@ -35,13 +36,30 @@ public class IdpGroup {
    * @param usernames The usernames in the group.
    */
   public IdpGroup(String name, List<String> usernames) {
+    this(name, usernames, "");
+  }
+
+  /**
+   * Creates a built-in IdP group.
+   *
+   * @param name The group name.
+   * @param usernames The usernames in the group.
+   * @param comment The group comment, or empty if none.
+   */
+  public IdpGroup(String name, List<String> usernames, String comment) {
     this.name = name;
     this.usernames = usernames;
+    this.comment = comment == null ? "" : comment;
   }
 
   /** Returns the group name. */
   public String name() {
     return name;
+  }
+
+  /** Returns the group comment, or an empty string if none. */
+  public String comment() {
+    return comment;
   }
 
   /** Returns the usernames in the group. */
@@ -55,7 +73,7 @@ public class IdpGroup {
    * @return the group DTO
    */
   public IdpGroupDTO toDTO() {
-    return IdpGroupDTO.builder().withName(name).withUsers(usernames).build();
+    return IdpGroupDTO.builder().withName(name).withComment(comment).withUsers(usernames).build();
   }
 
   @Override
@@ -67,16 +85,18 @@ public class IdpGroup {
       return false;
     }
     IdpGroup that = (IdpGroup) other;
-    return Objects.equals(name, that.name) && Objects.equals(usernames, that.usernames);
+    return Objects.equals(name, that.name)
+        && Objects.equals(comment, that.comment)
+        && Objects.equals(usernames, that.usernames);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, usernames);
+    return Objects.hash(name, comment, usernames);
   }
 
   @Override
   public String toString() {
-    return "IdpGroup{name='" + name + "', usernames=" + usernames + '}';
+    return "IdpGroup{name='" + name + "', comment='" + comment + "', usernames=" + usernames + '}';
   }
 }

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/base/IdpGroupMetaBaseSQLProvider.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/base/IdpGroupMetaBaseSQLProvider.java
@@ -29,6 +29,7 @@ public class IdpGroupMetaBaseSQLProvider {
 
   public String selectIdpGroup(@Param("groupName") String groupName) {
     return "SELECT group_id as groupId, group_name as groupName,"
+        + " COALESCE(group_comment, '') as groupComment,"
         + " current_version as currentVersion,"
         + " last_version as lastVersion, deleted_at as deletedAt"
         + " FROM "
@@ -38,6 +39,7 @@ public class IdpGroupMetaBaseSQLProvider {
 
   public String selectIdpGroupWithUsers(@Param("groupName") String groupName) {
     return "SELECT g.group_name as name,"
+        + " COALESCE(g.group_comment, '') as comment,"
         + " COALESCE(JSON_ARRAYAGG(u.user_name), JSON_ARRAY()) as usernames"
         + " FROM "
         + IdpGroupMetaMapper.IDP_GROUP_TABLE_NAME
@@ -48,16 +50,17 @@ public class IdpGroupMetaBaseSQLProvider {
         + IdpUserMetaMapper.IDP_USER_TABLE_NAME
         + " u ON u.user_id = r.user_id AND u.deleted_at = 0"
         + " WHERE g.group_name = #{groupName} AND g.deleted_at = 0"
-        + " GROUP BY g.group_id, g.group_name";
+        + " GROUP BY g.group_id, g.group_name, g.group_comment";
   }
 
   public String insertIdpGroup(@Param("groupMeta") IdpGroupPO groupPO) {
     return "INSERT INTO "
         + IdpGroupMetaMapper.IDP_GROUP_TABLE_NAME
-        + " (group_id, group_name, current_version, last_version, deleted_at)"
+        + " (group_id, group_name, group_comment, current_version, last_version, deleted_at)"
         + " VALUES ("
         + " #{groupMeta.groupId},"
         + " #{groupMeta.groupName},"
+        + " COALESCE(#{groupMeta.groupComment}, ''),"
         + " #{groupMeta.currentVersion},"
         + " #{groupMeta.lastVersion},"
         + " #{groupMeta.deletedAt}"

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/h2/IdpGroupMetaH2Provider.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/h2/IdpGroupMetaH2Provider.java
@@ -31,6 +31,7 @@ public class IdpGroupMetaH2Provider extends IdpGroupMetaBaseSQLProvider {
   @Override
   public String selectIdpGroupWithUsers(@Param("groupName") String groupName) {
     return "SELECT g.group_name as name,"
+        + " COALESCE(g.group_comment, '') as comment,"
         + " '['"
         + " || COALESCE(GROUP_CONCAT('\"' || u.user_name || '\"'), '')"
         + " || ']' as usernames"
@@ -43,7 +44,7 @@ public class IdpGroupMetaH2Provider extends IdpGroupMetaBaseSQLProvider {
         + IdpUserMetaMapper.IDP_USER_TABLE_NAME
         + " u ON u.user_id = r.user_id AND u.deleted_at = 0"
         + " WHERE g.group_name = #{groupName} AND g.deleted_at = 0"
-        + " GROUP BY g.group_id, g.group_name";
+        + " GROUP BY g.group_id, g.group_name, g.group_comment";
   }
 
   @Override

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/postgresql/IdpGroupMetaPostgreSQLProvider.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/postgresql/IdpGroupMetaPostgreSQLProvider.java
@@ -30,6 +30,7 @@ public class IdpGroupMetaPostgreSQLProvider extends IdpGroupMetaBaseSQLProvider 
   @Override
   public String selectIdpGroupWithUsers(@Param("groupName") String groupName) {
     return "SELECT g.group_name as name,"
+        + " COALESCE(g.group_comment, '') as comment,"
         + " COALESCE(JSON_AGG(u.user_name), '[]'::json) as usernames"
         + " FROM "
         + IdpGroupMetaMapper.IDP_GROUP_TABLE_NAME
@@ -40,7 +41,7 @@ public class IdpGroupMetaPostgreSQLProvider extends IdpGroupMetaBaseSQLProvider 
         + IdpUserMetaMapper.IDP_USER_TABLE_NAME
         + " u ON u.user_id = r.user_id AND u.deleted_at = 0"
         + " WHERE g.group_name = #{groupName} AND g.deleted_at = 0"
-        + " GROUP BY g.group_id, g.group_name";
+        + " GROUP BY g.group_id, g.group_name, g.group_comment";
   }
 
   @Override

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/po/IdpGroupPO.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/po/IdpGroupPO.java
@@ -35,6 +35,7 @@ import lombok.ToString;
 public class IdpGroupPO {
   private Long groupId;
   private String groupName;
+  private String groupComment;
   private Long currentVersion;
   private Long lastVersion;
   private Long deletedAt;

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/po/IdpGroupWithUsersPO.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/po/IdpGroupWithUsersPO.java
@@ -38,5 +38,6 @@ import lombok.ToString;
 @Builder(setterPrefix = "with")
 public class IdpGroupWithUsersPO {
   private String name;
+  private String comment;
   private String usernames;
 }

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/relational/utils/IdpPOConverters.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/relational/utils/IdpPOConverters.java
@@ -56,7 +56,8 @@ public final class IdpPOConverters {
    */
   public static IdpGroup fromIdpGroupWithUsersPO(IdpGroupWithUsersPO groupPO) {
     Preconditions.checkNotNull(groupPO, "groupPO must not be null");
-    return new IdpGroup(groupPO.getName(), parseJsonStringList(groupPO.getUsernames()));
+    return new IdpGroup(
+        groupPO.getName(), parseJsonStringList(groupPO.getUsernames()), groupPO.getComment());
   }
 
   @SuppressWarnings("unchecked")

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/web/rest/IdpGroupOperations.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/web/rest/IdpGroupOperations.java
@@ -82,7 +82,8 @@ public class IdpGroupOperations {
         () -> {
           request.validate();
           return IdpRESTUtils.ok(
-              new IdpGroupResponse(userGroupManager.addGroup(request.getGroup()).toDTO()));
+              new IdpGroupResponse(
+                  userGroupManager.addGroup(request.getGroup(), request.getComment()).toDTO()));
         },
         "group",
         IdpOperationType.ADD,

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
@@ -137,7 +137,12 @@ public class TestIdpUserGroupManager {
   public void testAddGroup() throws IOException {
     IdpGroup group = manager.addGroup("testAddGroup");
     Assertions.assertEquals("testAddGroup", group.name());
+    Assertions.assertEquals("", group.comment());
     Assertions.assertTrue(group.usernames().isEmpty());
+
+    IdpGroup commented = manager.addGroup("testAddGroupComment", "on-call rotation");
+    Assertions.assertEquals("on-call rotation", commented.comment());
+    Assertions.assertEquals("on-call rotation", manager.getGroup("testAddGroupComment").comment());
 
     Assertions.assertThrows(AlreadyExistsException.class, () -> manager.addGroup("testAddGroup"));
   }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
@@ -144,6 +144,12 @@ public class TestIdpUserGroupManager {
     Assertions.assertEquals("on-call rotation", commented.comment());
     Assertions.assertEquals("on-call rotation", manager.getGroup("testAddGroupComment").comment());
 
+    Assertions.assertDoesNotThrow(
+        () -> manager.addGroup("testAddGroupMaxComment", "a".repeat(1024)));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> manager.addGroup("testAddGroupTooLongComment", "a".repeat(1025)));
+
     Assertions.assertThrows(AlreadyExistsException.class, () -> manager.addGroup("testAddGroup"));
   }
 

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/dto/TestIdpGroupDTO.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/dto/TestIdpGroupDTO.java
@@ -64,6 +64,12 @@ public class TestIdpGroupDTO {
     Assertions.assertEquals(
         "IdpGroupDTO(name=test_group, comment=, users=[])", deserializedWithNullUsers.toString());
 
+    IdpGroupDTO deserializedNullComment =
+        JsonUtils.objectMapper()
+            .readValue("{\"name\":\"test_group\",\"comment\":null}", IdpGroupDTO.class);
+    Assertions.assertEquals("", deserializedNullComment.comment());
+    Assertions.assertEquals(groupDTO1, deserializedNullComment);
+
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> IdpGroupDTO.builder().withName(" ").build());
     IllegalArgumentException invalidUserException =

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/dto/TestIdpGroupDTO.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/dto/TestIdpGroupDTO.java
@@ -52,14 +52,17 @@ public class TestIdpGroupDTO {
     Assertions.assertEquals(groupDTO1, deserialized1);
     Assertions.assertEquals("test_group", deserialized1.name());
     Assertions.assertTrue(deserialized1.users().isEmpty());
-    Assertions.assertEquals("IdpGroupDTO(name=test_group, users=[])", deserialized1.toString());
+    Assertions.assertEquals("", deserialized1.comment());
+    Assertions.assertEquals(
+        "IdpGroupDTO(name=test_group, comment=, users=[])", deserialized1.toString());
 
     IdpGroupDTO deserializedWithNullUsers =
         JsonUtils.objectMapper()
             .readValue("{\"name\":\"test_group\",\"users\":null}", IdpGroupDTO.class);
     Assertions.assertTrue(deserializedWithNullUsers.users().isEmpty());
+    Assertions.assertEquals("", deserializedWithNullUsers.comment());
     Assertions.assertEquals(
-        "IdpGroupDTO(name=test_group, users=[])", deserializedWithNullUsers.toString());
+        "IdpGroupDTO(name=test_group, comment=, users=[])", deserializedWithNullUsers.toString());
 
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> IdpGroupDTO.builder().withName(" ").build());

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/dto/requests/TestAddGroupRequest.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/dto/requests/TestAddGroupRequest.java
@@ -67,9 +67,9 @@ public class TestAddGroupRequest {
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> new AddGroupRequest("a".repeat(129)).validate());
     Assertions.assertDoesNotThrow(
-        () -> new AddGroupRequest("test_group", "a".repeat(256)).validate());
+        () -> new AddGroupRequest("test_group", "a".repeat(1024)).validate());
     Assertions.assertThrows(
         IllegalArgumentException.class,
-        () -> new AddGroupRequest("test_group", "a".repeat(257)).validate());
+        () -> new AddGroupRequest("test_group", "a".repeat(1025)).validate());
   }
 }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/dto/requests/TestAddGroupRequest.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/dto/requests/TestAddGroupRequest.java
@@ -36,6 +36,16 @@ public class TestAddGroupRequest {
 
     Assertions.assertEquals(request, deserRequest);
     Assertions.assertEquals("test_group", deserRequest.getGroup());
+    Assertions.assertNull(deserRequest.getComment());
+
+    AddGroupRequest requestWithComment = new AddGroupRequest("test_group", "engineering team");
+    AddGroupRequest deserWithComment =
+        JsonUtils.objectMapper()
+            .readValue(
+                JsonUtils.objectMapper().writeValueAsString(requestWithComment),
+                AddGroupRequest.class);
+    Assertions.assertEquals(requestWithComment, deserWithComment);
+    Assertions.assertEquals("engineering team", deserWithComment.getComment());
 
     // Test with null group
     AddGroupRequest request1 = new AddGroupRequest();
@@ -56,5 +66,10 @@ public class TestAddGroupRequest {
         IllegalArgumentException.class, () -> new AddGroupRequest(" ").validate());
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> new AddGroupRequest("a".repeat(129)).validate());
+    Assertions.assertDoesNotThrow(
+        () -> new AddGroupRequest("test_group", "a".repeat(256)).validate());
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new AddGroupRequest("test_group", "a".repeat(257)).validate());
   }
 }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/integration/test/IdpRESTApiIT.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/integration/test/IdpRESTApiIT.java
@@ -191,13 +191,23 @@ public class IdpRESTApiIT extends BaseIT {
 
     IdpGroupResponse group = postGroup(GROUP1);
     Assertions.assertEquals(GROUP1, group.getGroup().name());
+    Assertions.assertEquals("", group.getGroup().comment());
     Assertions.assertTrue(group.getGroup().users().isEmpty());
+
+    IdpGroupResponse commented = postGroup("commented-group", "on-call rotation");
+    Assertions.assertEquals("on-call rotation", commented.getGroup().comment());
+    Assertions.assertEquals("on-call rotation", getGroup("commented-group").getGroup().comment());
+    Assertions.assertTrue(deleteGroup("commented-group", false));
 
     assertError(
         409, post("/idp/groups", new AddGroupRequest(GROUP1)), ErrorConstants.ALREADY_EXISTS_CODE);
     assertError(
         400,
         post("/idp/groups", new AddGroupRequest("a".repeat(129))),
+        ErrorConstants.ILLEGAL_ARGUMENTS_CODE);
+    assertError(
+        400,
+        post("/idp/groups", new AddGroupRequest("too-long-comment", "a".repeat(1025))),
         ErrorConstants.ILLEGAL_ARGUMENTS_CODE);
     assertError(
         404,
@@ -304,7 +314,20 @@ public class IdpRESTApiIT extends BaseIT {
   }
 
   private static IdpGroupResponse postGroup(String groupName) throws Exception {
-    HttpResponse<String> response = post("/idp/groups", new AddGroupRequest(groupName));
+    return postGroup(groupName, null);
+  }
+
+  private static IdpGroupResponse postGroup(String groupName, String comment) throws Exception {
+    HttpResponse<String> response = post("/idp/groups", new AddGroupRequest(groupName, comment));
+    Assertions.assertEquals(200, response.statusCode(), response.body());
+    IdpGroupResponse groupResponse =
+        JsonUtils.objectMapper().readValue(response.body(), IdpGroupResponse.class);
+    groupResponse.validate();
+    return groupResponse;
+  }
+
+  private static IdpGroupResponse getGroup(String groupName) throws Exception {
+    HttpResponse<String> response = get("/idp/groups/" + groupName, ADMIN, ADMIN_PASSWORD);
     Assertions.assertEquals(200, response.statusCode(), response.body());
     IdpGroupResponse groupResponse =
         JsonUtils.objectMapper().readValue(response.body(), IdpGroupResponse.class);

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/mapper/TestIdpGroupMetaStorage.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/mapper/TestIdpGroupMetaStorage.java
@@ -49,6 +49,7 @@ class TestIdpGroupMetaStorage extends AbstractIdpMetaStorageTest {
         IdpGroupPO.builder()
             .withGroupId(1L)
             .withGroupName("dev")
+            .withGroupComment("")
             .withCurrentVersion(1L)
             .withLastVersion(0L)
             .withDeletedAt(0L)
@@ -61,12 +62,33 @@ class TestIdpGroupMetaStorage extends AbstractIdpMetaStorageTest {
 
   @ParameterizedTest
   @MethodSource("storageProvider")
+  void testInsertIdpGroupPersistsComment(String type) throws IOException {
+    init(type);
+    IdpGroupPO group =
+        IdpGroupPO.builder()
+            .withGroupId(1L)
+            .withGroupName("dev")
+            .withGroupComment("on-call rotation")
+            .withCurrentVersion(1L)
+            .withLastVersion(0L)
+            .withDeletedAt(0L)
+            .build();
+    idpGroupMetaMapper.insertIdpGroup(group);
+
+    assertEquals(group, idpGroupMetaMapper.selectIdpGroup("dev"));
+    assertEquals(
+        "on-call rotation", idpGroupMetaMapper.selectIdpGroupWithUsers("dev").getComment());
+  }
+
+  @ParameterizedTest
+  @MethodSource("storageProvider")
   void testSelectIdpGroupWithUsers(String type) throws IOException {
     init(type);
     idpGroupMetaMapper.insertIdpGroup(
         IdpGroupPO.builder()
             .withGroupId(1L)
             .withGroupName("dev")
+            .withGroupComment("")
             .withCurrentVersion(1L)
             .withLastVersion(0L)
             .withDeletedAt(0L)
@@ -113,6 +135,7 @@ class TestIdpGroupMetaStorage extends AbstractIdpMetaStorageTest {
 
     var groupWithUsers = idpGroupMetaMapper.selectIdpGroupWithUsers("dev");
     assertEquals("dev", groupWithUsers.getName());
+    assertEquals("", groupWithUsers.getComment());
     assertTrue(groupWithUsers.getUsernames().contains("alice"));
     assertTrue(groupWithUsers.getUsernames().contains("bob"));
     assertNull(idpGroupMetaMapper.selectIdpGroupWithUsers("unknown"));
@@ -126,6 +149,7 @@ class TestIdpGroupMetaStorage extends AbstractIdpMetaStorageTest {
         IdpGroupPO.builder()
             .withGroupId(1L)
             .withGroupName("dev")
+            .withGroupComment("")
             .withCurrentVersion(1L)
             .withLastVersion(0L)
             .withDeletedAt(0L)
@@ -152,6 +176,7 @@ class TestIdpGroupMetaStorage extends AbstractIdpMetaStorageTest {
         IdpGroupPO.builder()
             .withGroupId(1L)
             .withGroupName("dev")
+            .withGroupComment("")
             .withCurrentVersion(1L)
             .withLastVersion(0L)
             .withDeletedAt(0L)

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/po/TestIdpGroupPO.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/po/TestIdpGroupPO.java
@@ -29,6 +29,7 @@ public class TestIdpGroupPO {
         IdpGroupPO.builder()
             .withGroupId(1L)
             .withGroupName("engineering")
+            .withGroupComment("platform engineering")
             .withCurrentVersion(1L)
             .withLastVersion(1L)
             .withDeletedAt(0L)
@@ -36,6 +37,7 @@ public class TestIdpGroupPO {
 
     Assertions.assertEquals(1L, groupPO.getGroupId());
     Assertions.assertEquals("engineering", groupPO.getGroupName());
+    Assertions.assertEquals("platform engineering", groupPO.getGroupComment());
     Assertions.assertEquals(1L, groupPO.getCurrentVersion());
     Assertions.assertEquals(1L, groupPO.getLastVersion());
     Assertions.assertEquals(0L, groupPO.getDeletedAt());
@@ -47,6 +49,7 @@ public class TestIdpGroupPO {
         IdpGroupPO.builder()
             .withGroupId(1L)
             .withGroupName("engineering")
+            .withGroupComment("platform engineering")
             .withCurrentVersion(1L)
             .withLastVersion(1L)
             .withDeletedAt(0L)
@@ -56,6 +59,7 @@ public class TestIdpGroupPO {
         IdpGroupPO.builder()
             .withGroupId(1L)
             .withGroupName("engineering")
+            .withGroupComment("platform engineering")
             .withCurrentVersion(1L)
             .withLastVersion(1L)
             .withDeletedAt(0L)
@@ -71,6 +75,7 @@ public class TestIdpGroupPO {
         IdpGroupPO.builder()
             .withGroupId(1L)
             .withGroupName("engineering")
+            .withGroupComment("platform engineering")
             .withCurrentVersion(1L)
             .withLastVersion(1L)
             .withDeletedAt(0L);

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/web/rest/TestIdpOperations.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/web/rest/TestIdpOperations.java
@@ -42,6 +42,7 @@ import org.apache.gravitino.dto.responses.RemoveResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.idp.IdpUserGroupManager;
+import org.apache.gravitino.idp.dto.IdpGroupDTO;
 import org.apache.gravitino.idp.dto.requests.AddGroupRequest;
 import org.apache.gravitino.idp.dto.requests.AddUserRequest;
 import org.apache.gravitino.idp.dto.requests.ChangePasswordRequest;
@@ -145,9 +146,24 @@ class TestIdpOperations extends JerseyTest {
     doReturn(buildGroup("group1")).when(MANAGER).addGroup(eq("group1"), nullable(String.class));
     when(MANAGER.getGroup("group1")).thenReturn(buildGroup("group1"));
 
-    assertStatus(Response.Status.OK, post("/idp/groups", req));
+    IdpGroupDTO created = post("/idp/groups", req).readEntity(IdpGroupResponse.class).getGroup();
+    Assertions.assertEquals("group1", created.name());
+    Assertions.assertEquals("", created.comment());
     Assertions.assertEquals(
-        "group1", get("/idp/groups/group1").readEntity(IdpGroupResponse.class).getGroup().name());
+        "", get("/idp/groups/group1").readEntity(IdpGroupResponse.class).getGroup().comment());
+
+    AddGroupRequest withComment = new AddGroupRequest("group2", "platform engineering");
+    doReturn(buildGroup("group2", "platform engineering"))
+        .when(MANAGER)
+        .addGroup(eq("group2"), eq("platform engineering"));
+    Assertions.assertEquals(
+        "platform engineering",
+        post("/idp/groups", withComment).readEntity(IdpGroupResponse.class).getGroup().comment());
+
+    assertError(
+        Response.Status.BAD_REQUEST,
+        post("/idp/groups", new AddGroupRequest("group3", "a".repeat(1025))),
+        ErrorConstants.ILLEGAL_ARGUMENTS_CODE);
 
     doThrow(new AlreadyExistsException("mock error"))
         .when(MANAGER)
@@ -224,10 +240,18 @@ class TestIdpOperations extends JerseyTest {
   }
 
   private IdpGroup buildGroup(String group) {
-    return buildGroup(group, Collections.emptyList());
+    return buildGroup(group, Collections.emptyList(), "");
+  }
+
+  private IdpGroup buildGroup(String group, String comment) {
+    return buildGroup(group, Collections.emptyList(), comment);
   }
 
   private IdpGroup buildGroup(String group, List<String> users) {
-    return new IdpGroup(group, users);
+    return buildGroup(group, users, "");
+  }
+
+  private IdpGroup buildGroup(String group, List<String> users, String comment) {
+    return new IdpGroup(group, users, comment);
   }
 }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/web/rest/TestIdpOperations.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/web/rest/TestIdpOperations.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.idp.web.rest;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -140,14 +142,16 @@ class TestIdpOperations extends JerseyTest {
   @Test
   void testAddAndGetGroup() throws Exception {
     AddGroupRequest req = new AddGroupRequest("group1");
-    doReturn(buildGroup("group1")).when(MANAGER).addGroup("group1");
+    doReturn(buildGroup("group1")).when(MANAGER).addGroup(eq("group1"), nullable(String.class));
     when(MANAGER.getGroup("group1")).thenReturn(buildGroup("group1"));
 
     assertStatus(Response.Status.OK, post("/idp/groups", req));
     Assertions.assertEquals(
         "group1", get("/idp/groups/group1").readEntity(IdpGroupResponse.class).getGroup().name());
 
-    doThrow(new AlreadyExistsException("mock error")).when(MANAGER).addGroup("group1");
+    doThrow(new AlreadyExistsException("mock error"))
+        .when(MANAGER)
+        .addGroup(eq("group1"), nullable(String.class));
     assertStatus(Response.Status.CONFLICT, post("/idp/groups", req));
   }
 

--- a/scripts/h2/schema-2.0.0-h2.sql
+++ b/scripts/h2/schema-2.0.0-h2.sql
@@ -269,6 +269,7 @@ CREATE TABLE IF NOT EXISTS `idp_user_meta` (
 CREATE TABLE IF NOT EXISTS `idp_group_meta` (
     `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'idp group id',
     `group_name` VARCHAR(128) NOT NULL COMMENT 'idp group name',
+    `group_comment` VARCHAR(256) DEFAULT '' COMMENT 'idp group comment',
     `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'idp group current version',
     `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'idp group last version',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'idp group deleted at',

--- a/scripts/h2/schema-2.0.0-h2.sql
+++ b/scripts/h2/schema-2.0.0-h2.sql
@@ -269,7 +269,7 @@ CREATE TABLE IF NOT EXISTS `idp_user_meta` (
 CREATE TABLE IF NOT EXISTS `idp_group_meta` (
     `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'idp group id',
     `group_name` VARCHAR(128) NOT NULL COMMENT 'idp group name',
-    `group_comment` VARCHAR(256) DEFAULT '' COMMENT 'idp group comment',
+    `group_comment` VARCHAR(1024) DEFAULT '' COMMENT 'idp group comment',
     `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'idp group current version',
     `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'idp group last version',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'idp group deleted at',

--- a/scripts/h2/upgrade-1.3.0-to-2.0.0-h2.sql
+++ b/scripts/h2/upgrade-1.3.0-to-2.0.0-h2.sql
@@ -34,5 +34,7 @@ ALTER TABLE `tag_relation_meta` DROP INDEX `uk_ti_mi_del`;
 
 ALTER TABLE `tag_relation_meta` ADD COLUMN `tag_value` VARCHAR(256) NOT NULL DEFAULT '' COMMENT 'tag assignment value, empty string means no value' AFTER `metadata_object_type`;
 
+ALTER TABLE `idp_group_meta` ADD COLUMN `group_comment` VARCHAR(256) DEFAULT '' COMMENT 'idp group comment' AFTER `group_name`;
+
 CREATE UNIQUE INDEX IF NOT EXISTS `uk_ti_mi_mo_tv_del` ON `tag_relation_meta` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `tag_value`, `deleted_at`);
 CREATE INDEX IF NOT EXISTS `idx_tid_value` ON `tag_relation_meta` (`tag_id`, `tag_value`);

--- a/scripts/h2/upgrade-1.3.0-to-2.0.0-h2.sql
+++ b/scripts/h2/upgrade-1.3.0-to-2.0.0-h2.sql
@@ -34,7 +34,7 @@ ALTER TABLE `tag_relation_meta` DROP INDEX `uk_ti_mi_del`;
 
 ALTER TABLE `tag_relation_meta` ADD COLUMN `tag_value` VARCHAR(256) NOT NULL DEFAULT '' COMMENT 'tag assignment value, empty string means no value' AFTER `metadata_object_type`;
 
-ALTER TABLE `idp_group_meta` ADD COLUMN `group_comment` VARCHAR(256) DEFAULT '' COMMENT 'idp group comment' AFTER `group_name`;
+ALTER TABLE `idp_group_meta` ADD COLUMN `group_comment` VARCHAR(1024) DEFAULT '' COMMENT 'idp group comment' AFTER `group_name`;
 
 CREATE UNIQUE INDEX IF NOT EXISTS `uk_ti_mi_mo_tv_del` ON `tag_relation_meta` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `tag_value`, `deleted_at`);
 CREATE INDEX IF NOT EXISTS `idx_tid_value` ON `tag_relation_meta` (`tag_id`, `tag_value`);

--- a/scripts/mysql/schema-2.0.0-mysql.sql
+++ b/scripts/mysql/schema-2.0.0-mysql.sql
@@ -260,7 +260,7 @@ CREATE TABLE IF NOT EXISTS `idp_user_meta` (
 CREATE TABLE IF NOT EXISTS `idp_group_meta` (
     `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'idp group id',
     `group_name` VARCHAR(128) NOT NULL COMMENT 'idp group name',
-    `group_comment` VARCHAR(256) DEFAULT '' COMMENT 'idp group comment',
+    `group_comment` VARCHAR(1024) DEFAULT '' COMMENT 'idp group comment',
     `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'idp group current version',
     `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'idp group last version',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'idp group deleted at',

--- a/scripts/mysql/schema-2.0.0-mysql.sql
+++ b/scripts/mysql/schema-2.0.0-mysql.sql
@@ -260,6 +260,7 @@ CREATE TABLE IF NOT EXISTS `idp_user_meta` (
 CREATE TABLE IF NOT EXISTS `idp_group_meta` (
     `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'idp group id',
     `group_name` VARCHAR(128) NOT NULL COMMENT 'idp group name',
+    `group_comment` VARCHAR(256) DEFAULT '' COMMENT 'idp group comment',
     `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'idp group current version',
     `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'idp group last version',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'idp group deleted at',

--- a/scripts/mysql/upgrade-1.3.0-to-2.0.0-mysql.sql
+++ b/scripts/mysql/upgrade-1.3.0-to-2.0.0-mysql.sql
@@ -40,7 +40,7 @@ ALTER TABLE `tag_relation_meta`
     ADD COLUMN `tag_value` VARCHAR(256) NOT NULL DEFAULT '' COMMENT 'tag assignment value, empty string means no value' AFTER `metadata_object_type`;
 
 ALTER TABLE `idp_group_meta`
-    ADD COLUMN `group_comment` VARCHAR(256) DEFAULT '' COMMENT 'idp group comment' AFTER `group_name`;
+    ADD COLUMN `group_comment` VARCHAR(1024) DEFAULT '' COMMENT 'idp group comment' AFTER `group_name`;
 
 CREATE UNIQUE INDEX `uk_ti_mi_mo_tv_del` ON `tag_relation_meta` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `tag_value`, `deleted_at`);
 CREATE INDEX `idx_tid_value` ON `tag_relation_meta` (`tag_id`, `tag_value`);

--- a/scripts/mysql/upgrade-1.3.0-to-2.0.0-mysql.sql
+++ b/scripts/mysql/upgrade-1.3.0-to-2.0.0-mysql.sql
@@ -39,5 +39,8 @@ ALTER TABLE `tag_relation_meta`
 ALTER TABLE `tag_relation_meta`
     ADD COLUMN `tag_value` VARCHAR(256) NOT NULL DEFAULT '' COMMENT 'tag assignment value, empty string means no value' AFTER `metadata_object_type`;
 
+ALTER TABLE `idp_group_meta`
+    ADD COLUMN `group_comment` VARCHAR(256) DEFAULT '' COMMENT 'idp group comment' AFTER `group_name`;
+
 CREATE UNIQUE INDEX `uk_ti_mi_mo_tv_del` ON `tag_relation_meta` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `tag_value`, `deleted_at`);
 CREATE INDEX `idx_tid_value` ON `tag_relation_meta` (`tag_id`, `tag_value`);

--- a/scripts/postgresql/schema-2.0.0-postgresql.sql
+++ b/scripts/postgresql/schema-2.0.0-postgresql.sql
@@ -459,7 +459,7 @@ COMMENT ON COLUMN idp_user_meta.deleted_at IS 'idp user deleted at';
 CREATE TABLE IF NOT EXISTS idp_group_meta (
     group_id BIGINT NOT NULL,
     group_name VARCHAR(128) NOT NULL,
-    group_comment VARCHAR(256) DEFAULT '',
+    group_comment VARCHAR(1024) DEFAULT '',
     current_version INT NOT NULL DEFAULT 1,
     last_version INT NOT NULL DEFAULT 1,
     deleted_at BIGINT NOT NULL DEFAULT 0,

--- a/scripts/postgresql/schema-2.0.0-postgresql.sql
+++ b/scripts/postgresql/schema-2.0.0-postgresql.sql
@@ -459,6 +459,7 @@ COMMENT ON COLUMN idp_user_meta.deleted_at IS 'idp user deleted at';
 CREATE TABLE IF NOT EXISTS idp_group_meta (
     group_id BIGINT NOT NULL,
     group_name VARCHAR(128) NOT NULL,
+    group_comment VARCHAR(256) DEFAULT '',
     current_version INT NOT NULL DEFAULT 1,
     last_version INT NOT NULL DEFAULT 1,
     deleted_at BIGINT NOT NULL DEFAULT 0,
@@ -469,6 +470,7 @@ COMMENT ON TABLE idp_group_meta IS 'local IdP group metadata';
 
 COMMENT ON COLUMN idp_group_meta.group_id IS 'idp group id';
 COMMENT ON COLUMN idp_group_meta.group_name IS 'idp group name';
+COMMENT ON COLUMN idp_group_meta.group_comment IS 'idp group comment';
 COMMENT ON COLUMN idp_group_meta.current_version IS 'idp group current version';
 COMMENT ON COLUMN idp_group_meta.last_version IS 'idp group last version';
 COMMENT ON COLUMN idp_group_meta.deleted_at IS 'idp group deleted at';

--- a/scripts/postgresql/upgrade-1.3.0-to-2.0.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-1.3.0-to-2.0.0-postgresql.sql
@@ -38,6 +38,9 @@ COMMENT ON COLUMN tag_meta.allowed_values IS 'tag allowed values as a JSON strin
 ALTER TABLE tag_relation_meta ADD COLUMN IF NOT EXISTS tag_value VARCHAR(256) NOT NULL DEFAULT '';
 COMMENT ON COLUMN tag_relation_meta.tag_value IS 'tag assignment value, empty string means no value';
 
+ALTER TABLE idp_group_meta ADD COLUMN IF NOT EXISTS group_comment VARCHAR(256) DEFAULT '';
+COMMENT ON COLUMN idp_group_meta.group_comment IS 'idp group comment';
+
 ALTER TABLE tag_relation_meta DROP CONSTRAINT IF EXISTS tag_relation_meta_tag_id_metadata_object_id_metadata_object_key;
 
 CREATE UNIQUE INDEX IF NOT EXISTS uk_ti_mi_mo_tv_del ON tag_relation_meta (tag_id, metadata_object_id, metadata_object_type, tag_value, deleted_at);

--- a/scripts/postgresql/upgrade-1.3.0-to-2.0.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-1.3.0-to-2.0.0-postgresql.sql
@@ -38,7 +38,7 @@ COMMENT ON COLUMN tag_meta.allowed_values IS 'tag allowed values as a JSON strin
 ALTER TABLE tag_relation_meta ADD COLUMN IF NOT EXISTS tag_value VARCHAR(256) NOT NULL DEFAULT '';
 COMMENT ON COLUMN tag_relation_meta.tag_value IS 'tag assignment value, empty string means no value';
 
-ALTER TABLE idp_group_meta ADD COLUMN IF NOT EXISTS group_comment VARCHAR(256) DEFAULT '';
+ALTER TABLE idp_group_meta ADD COLUMN IF NOT EXISTS group_comment VARCHAR(1024) DEFAULT '';
 COMMENT ON COLUMN idp_group_meta.group_comment IS 'idp group comment';
 
 ALTER TABLE tag_relation_meta DROP CONSTRAINT IF EXISTS tag_relation_meta_tag_id_metadata_object_id_metadata_object_key;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an optional description for built-in IdP groups.

- Persist `group_comment VARCHAR(1024) DEFAULT ''` on `idp_group_meta` (utf8mb4, 1024 Unicode characters).
- Expose optional REST JSON field `comment` on group create (`POST /api/idp/groups`) and get.
  - Omit or `null` on create → store empty string.
  - Existing rows get `''` via column default / 1.3.0 → 2.0.0 upgrade.
- Schema: 2.0.0 CREATE + 1.3.0 → 2.0.0 ALTER for MySQL, PostgreSQL, and H2. Released 1.3.0 schema is unchanged.
- OpenAPI, `docs/security/local-users-and-groups.md`, and the local-auth design doc table snippet updated.

Update-group REST (`PUT /api/idp/groups/{group}`) is out of scope; create writes the comment and GET returns it.

### Why are the changes needed?

Local IdP groups currently store only `group_name`. Operators have no place to record a short description (purpose, owner, etc.) when creating a group.

Fix: #12493

### Does this PR introduce _any_ user-facing change?

- Optional `comment` on `POST /api/idp/groups` request body (max 1024 characters).
- `comment` returned on group GET responses (`null` JSON normalizes to `""`).
- New `idp_group_meta.group_comment` column after upgrade to 2.0.0.

### How was this patch tested?

- Unit tests: `TestIdpUserGroupManager`, `TestAddGroupRequest`, `TestIdpGroupDTO`, `TestIdpGroupPO`, `TestIdpGroupMetaStorage`, `TestIdpOperations`.
- REST IT: `IdpRESTApiIT` create/get comment round-trip and 1025-character rejection.