### PR TITLE
[#12506] feat(secret): Add secret-properties delivery for remote connectors

### DIFF
--- a/api/src/main/java/org/apache/gravitino/Catalog.java
+++ b/api/src/main/java/org/apache/gravitino/Catalog.java
@@ -30,6 +30,7 @@ import org.apache.gravitino.model.ModelCatalog;
 import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.rel.TableCatalog;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.secret.SupportsSecretProperties;
 import org.apache.gravitino.tag.SupportsTags;
 
 /**
@@ -285,5 +286,16 @@ public interface Catalog extends Auditable {
    */
   default SupportsCredentials supportsCredentials() throws UnsupportedOperationException {
     throw new UnsupportedOperationException("Catalog does not support credential operations");
+  }
+
+  /**
+   * @return the {@link SupportsSecretProperties} if the catalog supports secret-properties
+   *     operations.
+   * @throws UnsupportedOperationException if the catalog does not support secret-properties
+   *     operations.
+   */
+  default SupportsSecretProperties supportsSecretProperties() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException(
+        "Catalog does not support secret-properties operations");
   }
 }

--- a/api/src/main/java/org/apache/gravitino/file/Fileset.java
+++ b/api/src/main/java/org/apache/gravitino/file/Fileset.java
@@ -27,6 +27,7 @@ import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.authorization.SupportsRoles;
 import org.apache.gravitino.credential.SupportsCredentials;
 import org.apache.gravitino.policy.SupportsPolicies;
+import org.apache.gravitino.secret.SupportsSecretProperties;
 import org.apache.gravitino.tag.SupportsTags;
 
 /**
@@ -271,5 +272,16 @@ public interface Fileset extends Auditable {
    */
   default SupportsCredentials supportsCredentials() {
     throw new UnsupportedOperationException("Fileset does not support credential operations.");
+  }
+
+  /**
+   * @return The {@link SupportsSecretProperties} if the fileset supports secret-properties
+   *     operations.
+   * @throws UnsupportedOperationException If the fileset does not support secret-properties
+   *     operations.
+   */
+  default SupportsSecretProperties supportsSecretProperties() {
+    throw new UnsupportedOperationException(
+        "Fileset does not support secret-properties operations.");
   }
 }

--- a/api/src/main/java/org/apache/gravitino/secret/SupportsSecretProperties.java
+++ b/api/src/main/java/org/apache/gravitino/secret/SupportsSecretProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import java.util.Map;
+import org.apache.gravitino.annotation.Evolving;
+
+/**
+ * Interface to fetch entity properties whose values are stored as Gravitino secret URNs, resolved
+ * to plaintext.
+ *
+ * <p>Unlike {@link org.apache.gravitino.Catalog#properties()} (and schema/fileset load), which omit
+ * secret-backed keys, this API returns only those secret keys with plaintext values for connectors
+ * that need Vault-backed custom configuration. Credential vending remains on {@link
+ * org.apache.gravitino.credential.SupportsCredentials}.
+ *
+ * <p>UI clients must not call this API; it is intended for trusted engine connectors.
+ */
+@Evolving
+public interface SupportsSecretProperties {
+
+  /**
+   * Returns secret-backed property keys mapped to their plaintext values.
+   *
+   * <p>Non-secret properties are not included. The map may be empty when the entity has no secret
+   * URN properties.
+   *
+   * @return secret key to plaintext value map; never null
+   */
+  Map<String, String> getSecretProperties();
+}

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/BaseSchemaCatalog.java
@@ -56,6 +56,7 @@ import org.apache.gravitino.function.FunctionType;
 import org.apache.gravitino.policy.Policy;
 import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.rest.RESTUtils;
+import org.apache.gravitino.secret.SupportsSecretProperties;
 import org.apache.gravitino.tag.SupportsTags;
 import org.apache.gravitino.tag.Tag;
 import org.apache.gravitino.tag.TagValue;
@@ -83,6 +84,7 @@ abstract class BaseSchemaCatalog extends CatalogDTO
   private final MetadataObjectPolicyOperations objectPolicyOperations;
   private final MetadataObjectRoleOperations objectRoleOperations;
   protected final MetadataObjectCredentialOperations objectCredentialOperations;
+  protected final MetadataObjectSecretPropertiesOperations objectSecretPropertiesOperations;
   private final FunctionCatalogOperations functionOperations;
 
   BaseSchemaCatalog(
@@ -114,6 +116,9 @@ abstract class BaseSchemaCatalog extends CatalogDTO
     this.objectCredentialOperations =
         new MetadataObjectCredentialOperations(
             catalogNamespace.level(0), metadataObject, restClient);
+    this.objectSecretPropertiesOperations =
+        new MetadataObjectSecretPropertiesOperations(
+            catalogNamespace.level(0), metadataObject, restClient);
     this.functionOperations =
         new FunctionCatalogOperations(restClient, catalogNamespace, this.name());
   }
@@ -136,6 +141,11 @@ abstract class BaseSchemaCatalog extends CatalogDTO
   @Override
   public SupportsRoles supportsRoles() throws UnsupportedOperationException {
     return this;
+  }
+
+  @Override
+  public SupportsSecretProperties supportsSecretProperties() throws UnsupportedOperationException {
+    return objectSecretPropertiesOperations;
   }
 
   /**

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -248,6 +248,15 @@ public class ErrorHandlers {
   }
 
   /**
+   * Creates an error handler specific to secret-properties operations.
+   *
+   * @return A Consumer representing the secret-properties error handler.
+   */
+  public static Consumer<ErrorResponse> secretPropertiesErrorHandler() {
+    return SecretPropertiesErrorHandler.INSTANCE;
+  }
+
+  /**
    * Creates an error handler specific to Owner operations.
    *
    * @return A Consumer representing the Owner error handler.
@@ -1026,6 +1035,42 @@ public class ErrorHandlers {
 
         case ErrorConstants.NOT_IN_USE_CODE:
           throw new MetalakeNotInUseException(errorMessage);
+
+        case ErrorConstants.INTERNAL_ERROR_CODE:
+          throw new RuntimeException(errorMessage);
+
+        default:
+          super.accept(errorResponse);
+      }
+    }
+  }
+
+  /** Error handler specific to secret-properties operations. */
+  @SuppressWarnings("FormatStringAnnotation")
+  private static class SecretPropertiesErrorHandler extends RestErrorHandler {
+
+    private static final SecretPropertiesErrorHandler INSTANCE = new SecretPropertiesErrorHandler();
+
+    @Override
+    public void accept(ErrorResponse errorResponse) {
+      String errorMessage = formatErrorMessage(errorResponse);
+
+      switch (errorResponse.getCode()) {
+        case ErrorConstants.ILLEGAL_ARGUMENTS_CODE:
+          throw new IllegalArgumentException(errorMessage);
+
+        case ErrorConstants.NOT_FOUND_CODE:
+          if (errorResponse.getType().equals(NoSuchMetalakeException.class.getSimpleName())) {
+            throw new NoSuchMetalakeException(errorMessage);
+          } else {
+            throw new NotFoundException(errorMessage);
+          }
+
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new MetalakeNotInUseException(errorMessage);
+
+        case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
+          throw new UnsupportedOperationException(errorMessage);
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericFileset.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericFileset.java
@@ -36,19 +36,26 @@ import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.policy.Policy;
 import org.apache.gravitino.policy.SupportsPolicies;
+import org.apache.gravitino.secret.SupportsSecretProperties;
 import org.apache.gravitino.tag.SupportsTags;
 import org.apache.gravitino.tag.Tag;
 import org.apache.gravitino.tag.TagValue;
 
 /** Represents a generic fileset. */
 class GenericFileset
-    implements Fileset, SupportsTags, SupportsRoles, SupportsCredentials, SupportsPolicies {
+    implements Fileset,
+        SupportsTags,
+        SupportsRoles,
+        SupportsCredentials,
+        SupportsSecretProperties,
+        SupportsPolicies {
 
   private final FilesetDTO filesetDTO;
 
   private final MetadataObjectTagOperations objectTagOperations;
   private final MetadataObjectRoleOperations objectRoleOperations;
   private final MetadataObjectCredentialOperations objectCredentialOperations;
+  private final MetadataObjectSecretPropertiesOperations objectSecretPropertiesOperations;
   private final MetadataObjectPolicyOperations objectPolicyOperations;
 
   GenericFileset(FilesetDTO filesetDTO, RESTClient restClient, Namespace filesetNs) {
@@ -62,6 +69,8 @@ class GenericFileset
         new MetadataObjectRoleOperations(filesetNs.level(0), filesetObject, restClient);
     this.objectCredentialOperations =
         new MetadataObjectCredentialOperations(filesetNs.level(0), filesetObject, restClient);
+    this.objectSecretPropertiesOperations =
+        new MetadataObjectSecretPropertiesOperations(filesetNs.level(0), filesetObject, restClient);
     this.objectPolicyOperations =
         new MetadataObjectPolicyOperations(filesetNs.level(0), filesetObject, restClient);
   }
@@ -115,6 +124,16 @@ class GenericFileset
   @Override
   public SupportsCredentials supportsCredentials() {
     return this;
+  }
+
+  @Override
+  public SupportsSecretProperties supportsSecretProperties() {
+    return this;
+  }
+
+  @Override
+  public Map<String, String> getSecretProperties() {
+    return objectSecretPropertiesOperations.getSecretProperties();
   }
 
   @Override

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/MetadataObjectSecretPropertiesOperations.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/MetadataObjectSecretPropertiesOperations.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.client;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.dto.responses.SecretPropertiesResponse;
+import org.apache.gravitino.rest.RESTUtils;
+import org.apache.gravitino.secret.SupportsSecretProperties;
+
+/**
+ * The implementation of {@link SupportsSecretProperties}. Composited into catalog and fileset
+ * clients to fetch secret-backed properties as plaintext.
+ */
+class MetadataObjectSecretPropertiesOperations implements SupportsSecretProperties {
+
+  private final RESTClient restClient;
+
+  private final String secretPropertiesRequestPath;
+
+  MetadataObjectSecretPropertiesOperations(
+      String metalakeName, MetadataObject metadataObject, RESTClient restClient) {
+    this.restClient = restClient;
+    this.secretPropertiesRequestPath =
+        String.format(
+            "api/metalakes/%s/objects/%s/%s/secret-properties",
+            RESTUtils.encodeString(metalakeName),
+            metadataObject.type().name().toLowerCase(Locale.ROOT),
+            RESTUtils.encodeString(metadataObject.fullName()));
+  }
+
+  @Override
+  public Map<String, String> getSecretProperties() {
+    SecretPropertiesResponse resp =
+        restClient.get(
+            secretPropertiesRequestPath,
+            SecretPropertiesResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.secretPropertiesErrorHandler());
+    resp.validate();
+    return resp.getSecretProperties();
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/responses/SecretPropertiesResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/SecretPropertiesResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/** Represents a response for secret properties (secret keys resolved to plaintext). */
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class SecretPropertiesResponse extends BaseResponse {
+
+  @JsonProperty("secretProperties")
+  private final Map<String, String> secretProperties;
+
+  /**
+   * Creates a new SecretPropertiesResponse.
+   *
+   * @param secretProperties secret key to plaintext value map
+   */
+  public SecretPropertiesResponse(Map<String, String> secretProperties) {
+    super(0);
+    this.secretProperties = secretProperties;
+  }
+
+  /**
+   * This is the constructor that is used by Jackson deserializer to create an instance of
+   * SecretPropertiesResponse.
+   */
+  public SecretPropertiesResponse() {
+    super();
+    this.secretProperties = Collections.emptyMap();
+  }
+
+  @Override
+  public void validate() throws IllegalArgumentException {
+    super.validate();
+    Preconditions.checkArgument(secretProperties != null, "\"secretProperties\" must not be null");
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/secret/CatalogSecretProperties.java
+++ b/common/src/main/java/org/apache/gravitino/secret/CatalogSecretProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.Catalog;
+
+/** Helpers for applying catalog secret-properties in engine connectors. */
+public final class CatalogSecretProperties {
+
+  private CatalogSecretProperties() {}
+
+  /**
+   * Fetches secret-backed catalog properties as plaintext, or an empty map when unsupported.
+   *
+   * @param catalog Gravitino catalog client
+   * @return secret key to plaintext map; never null
+   */
+  public static Map<String, String> getSecretProperties(Catalog catalog) {
+    try {
+      Map<String, String> props = catalog.supportsSecretProperties().getSecretProperties();
+      return props == null ? Collections.emptyMap() : props;
+    } catch (UnsupportedOperationException e) {
+      return Collections.emptyMap();
+    }
+  }
+
+  /**
+   * Merges secret-backed catalog properties into {@code target}. Existing keys in {@code target}
+   * are overwritten when present in secret properties.
+   *
+   * @param catalog Gravitino catalog client
+   * @param target mutable configuration map
+   */
+  public static void applySecretProperties(Catalog catalog, Map<String, String> target) {
+    target.putAll(getSecretProperties(catalog));
+  }
+}

--- a/common/src/test/java/org/apache/gravitino/secret/TestCatalogSecretProperties.java
+++ b/common/src/test/java/org/apache/gravitino/secret/TestCatalogSecretProperties.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.gravitino.Audit;
+import org.apache.gravitino.Catalog;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestCatalogSecretProperties {
+
+  @Test
+  public void testGetSecretPropertiesUnsupported() {
+    Catalog catalog =
+        new Catalog() {
+          @Override
+          public String name() {
+            return "c";
+          }
+
+          @Override
+          public Type type() {
+            return Type.RELATIONAL;
+          }
+
+          @Override
+          public String provider() {
+            return "jdbc-mysql";
+          }
+
+          @Override
+          public String comment() {
+            return null;
+          }
+
+          @Override
+          public Map<String, String> properties() {
+            return Map.of();
+          }
+
+          @Override
+          public Audit auditInfo() {
+            return null;
+          }
+        };
+    Assertions.assertTrue(CatalogSecretProperties.getSecretProperties(catalog).isEmpty());
+  }
+
+  @Test
+  public void testApplySecretProperties() {
+    Catalog catalog =
+        new Catalog() {
+          @Override
+          public String name() {
+            return "c";
+          }
+
+          @Override
+          public Type type() {
+            return Type.RELATIONAL;
+          }
+
+          @Override
+          public String provider() {
+            return "jdbc-mysql";
+          }
+
+          @Override
+          public String comment() {
+            return null;
+          }
+
+          @Override
+          public Map<String, String> properties() {
+            return Map.of();
+          }
+
+          @Override
+          public Audit auditInfo() {
+            return null;
+          }
+
+          @Override
+          public SupportsSecretProperties supportsSecretProperties() {
+            return () -> Map.of("custom.secret", "plaintext");
+          }
+        };
+
+    Map<String, String> target = new HashMap<>();
+    target.put("existing", "value");
+    CatalogSecretProperties.applySecretProperties(catalog, target);
+
+    Assertions.assertEquals("value", target.get("existing"));
+    Assertions.assertEquals("plaintext", target.get("custom.secret"));
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -99,6 +99,7 @@ import org.apache.gravitino.metrics.source.JVMMetricsSource;
 import org.apache.gravitino.policy.PolicyDispatcher;
 import org.apache.gravitino.policy.PolicyManager;
 import org.apache.gravitino.secret.SecretManager;
+import org.apache.gravitino.secret.SecretPropertiesOperationDispatcher;
 import org.apache.gravitino.secret.SecretProviderRegistry;
 import org.apache.gravitino.stats.StatisticDispatcher;
 import org.apache.gravitino.stats.StatisticManager;
@@ -156,6 +157,8 @@ public class GravitinoEnv {
   private MetalakeDispatcher metalakeDispatcher;
 
   private CredentialOperationDispatcher credentialOperationDispatcher;
+
+  private SecretPropertiesOperationDispatcher secretPropertiesOperationDispatcher;
 
   private KmsClientRegistry kmsClientRegistry;
 
@@ -423,6 +426,15 @@ public class GravitinoEnv {
    */
   public CredentialOperationDispatcher credentialOperationDispatcher() {
     return credentialOperationDispatcher;
+  }
+
+  /**
+   * Get the {@link SecretPropertiesOperationDispatcher} associated with the Gravitino environment.
+   *
+   * @return The {@link SecretPropertiesOperationDispatcher} instance.
+   */
+  public SecretPropertiesOperationDispatcher secretPropertiesOperationDispatcher() {
+    return secretPropertiesOperationDispatcher;
   }
 
   /**
@@ -744,6 +756,10 @@ public class GravitinoEnv {
 
     this.credentialOperationDispatcher =
         new CredentialOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
+
+    this.secretPropertiesOperationDispatcher =
+        new SecretPropertiesOperationDispatcher(
+            catalogManager, entityStore, idGenerator, secretManager);
 
     SchemaOperationDispatcher schemaOperationDispatcher =
         new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);

--- a/core/src/main/java/org/apache/gravitino/secret/SecretPropertiesOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/secret/SecretPropertiesOperationDispatcher.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.NotSupportedException;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.catalog.CatalogManager;
+import org.apache.gravitino.catalog.OperationDispatcher;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
+import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.meta.FilesetEntity;
+import org.apache.gravitino.meta.SchemaEntity;
+import org.apache.gravitino.storage.IdGenerator;
+
+/**
+ * Loads entity properties from the store and resolves secret URN values to plaintext for remote
+ * connectors.
+ */
+public class SecretPropertiesOperationDispatcher extends OperationDispatcher {
+
+  /**
+   * Creates a dispatcher for secret-properties operations.
+   *
+   * @param catalogManager catalog manager
+   * @param store entity store
+   * @param idGenerator id generator
+   * @param secretManager secret manager
+   */
+  public SecretPropertiesOperationDispatcher(
+      CatalogManager catalogManager,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
+  }
+
+  /**
+   * Returns only secret-backed properties for the given metadata object, with URN values replaced
+   * by plaintext.
+   *
+   * @param identifier entity name identifier
+   * @param type entity type (CATALOG, SCHEMA, or FILESET)
+   * @return secret key to plaintext map; never null
+   * @throws NoSuchMetadataObjectException if the entity does not exist
+   * @throws NotSupportedException if the entity type is not supported
+   */
+  public Map<String, String> getSecretProperties(
+      NameIdentifier identifier, Entity.EntityType type) {
+    Map<String, String> properties = loadEntityProperties(identifier, type);
+    return resolveSecretProperties(properties);
+  }
+
+  private Map<String, String> loadEntityProperties(
+      NameIdentifier identifier, Entity.EntityType type) {
+    try {
+      switch (type) {
+        case CATALOG:
+          CatalogEntity catalog = store.get(identifier, type, CatalogEntity.class);
+          return catalog.getProperties() == null ? Collections.emptyMap() : catalog.getProperties();
+        case SCHEMA:
+          SchemaEntity schema = store.get(identifier, type, SchemaEntity.class);
+          return schema.properties() == null ? Collections.emptyMap() : schema.properties();
+        case FILESET:
+          FilesetEntity fileset = store.get(identifier, type, FilesetEntity.class);
+          return fileset.properties() == null ? Collections.emptyMap() : fileset.properties();
+        default:
+          throw new NotSupportedException(
+              "Doesn't support secret-properties operations for entity type: " + type);
+      }
+    } catch (NoSuchEntityException e) {
+      throw new NoSuchMetadataObjectException(
+          "Metadata object %s of type %s does not exist", identifier, type);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          String.format("Failed to load properties for %s of type %s", identifier, type), e);
+    }
+  }
+
+  private Map<String, String> resolveSecretProperties(Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, String> secretOnly = new HashMap<>();
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      if (SecretPropertyUtils.isSecretProperty(entry.getKey(), entry.getValue())) {
+        secretOnly.put(entry.getKey(), entry.getValue());
+      }
+    }
+    if (secretOnly.isEmpty()) {
+      return Map.of();
+    }
+    return secretManager.toPlaintextProperties(secretOnly);
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/secret/TestSecretPropertiesOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/secret/TestSecretPropertiesOperationDispatcher.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.CatalogManager;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.storage.IdGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestSecretPropertiesOperationDispatcher {
+
+  @Test
+  public void testGetSecretPropertiesResolvesOnlySecretKeys() throws Exception {
+    EntityStore store = mock(EntityStore.class);
+    SecretManager secretManager = mock(SecretManager.class);
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    IdGenerator idGenerator = mock(IdGenerator.class);
+
+    String urn = "urn:gravitino-secret:memory:default:jdbc-password";
+    CatalogEntity entity =
+        CatalogEntity.builder()
+            .withId(1L)
+            .withName("c1")
+            .withNamespace(Namespace.of("ml"))
+            .withType(org.apache.gravitino.Catalog.Type.RELATIONAL)
+            .withProvider("jdbc-mysql")
+            .withProperties(
+                Map.of("jdbc-url", "jdbc:mysql://localhost:3306/db", "jdbc-password", urn))
+            .withAuditInfo(
+                AuditInfo.builder()
+                    .withCreator("test")
+                    .withCreateTime(java.time.Instant.now())
+                    .build())
+            .build();
+
+    when(store.get(any(), any(), any())).thenReturn(entity);
+    when(secretManager.toPlaintextProperties(any()))
+        .thenAnswer(
+            invocation -> {
+              Map<String, String> input = invocation.getArgument(0);
+              Assertions.assertEquals(1, input.size());
+              Assertions.assertEquals(urn, input.get("jdbc-password"));
+              return Map.of("jdbc-password", "plaintext-password");
+            });
+
+    SecretPropertiesOperationDispatcher dispatcher =
+        new SecretPropertiesOperationDispatcher(catalogManager, store, idGenerator, secretManager);
+
+    Map<String, String> result =
+        dispatcher.getSecretProperties(NameIdentifier.of("ml", "c1"), Entity.EntityType.CATALOG);
+
+    Assertions.assertEquals(Map.of("jdbc-password", "plaintext-password"), result);
+  }
+}

--- a/docs/open-api/openapi.yaml
+++ b/docs/open-api/openapi.yaml
@@ -99,6 +99,9 @@ paths:
   /metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectFullName}/credentials:
     $ref: "./credentials.yaml#/paths/~1metalakes~1%7Bmetalake%7D~1objects~1%7BmetadataObjectType%7D~1%7BmetadataObjectFullName%7D~1credentials"
 
+  /metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectFullName}/secret-properties:
+    $ref: "./secret-properties.yaml#/paths/~1metalakes~1%7Bmetalake%7D~1objects~1%7BmetadataObjectType%7D~1%7BmetadataObjectFullName%7D~1secret-properties"
+
   /metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectFullName}/tags/{tag}:
     $ref: "./tags.yaml#/paths/~1metalakes~1%7Bmetalake%7D~1objects~1%7BmetadataObjectType%7D~1%7BmetadataObjectFullName%7D~1tags~1%7Btag%7D"
 

--- a/docs/open-api/secret-properties.yaml
+++ b/docs/open-api/secret-properties.yaml
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+
+paths:
+
+  /metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectFullName}/secret-properties:
+    parameters:
+      - $ref: "./openapi.yaml#/components/parameters/metalake"
+      - $ref: "./openapi.yaml#/components/parameters/metadataObjectType"
+      - $ref: "./openapi.yaml#/components/parameters/metadataObjectFullName"
+    get:
+      tags:
+        - secret-properties
+      summary: Get secret properties
+      description: |
+        Returns secret-backed entity properties with URN values resolved to plaintext.
+        Intended for trusted engine connectors (Spark/Flink/Trino). UI clients should not
+        call this endpoint; load catalog/schema/fileset omits secret keys.
+        Supported metadata object types: catalog, schema, fileset.
+      operationId: getSecretProperties
+      responses:
+        "200":
+          description: Returns secret key to plaintext value map for the metadata object.
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "#/components/responses/SecretPropertiesResponse"
+              examples:
+                SecretPropertiesResponse:
+                  $ref: "#/components/examples/SecretPropertiesResponse"
+        "400":
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "404":
+          description: Not Found - The specified metalake or metadata object does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NoSuchMetalakeException:
+                  $ref: "./metalakes.yaml#/components/examples/NoSuchMetalakeException"
+        "5xx":
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+
+
+components:
+  responses:
+    SecretPropertiesResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Status code of the response
+          enum:
+            - 0
+        secretProperties:
+          type: object
+          description: Secret-backed property keys mapped to plaintext values
+          additionalProperties:
+            type: string
+
+  examples:
+    SecretPropertiesResponse:
+      value: {
+        "code": 0,
+        "secretProperties": {
+          "jdbc-password": "plaintext-password",
+          "custom.vault.key": "resolved-secret-value"
+        }
+      }

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/GravitinoJdbcCatalog.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/GravitinoJdbcCatalog.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.flink.connector.PartitionConverter;
 import org.apache.gravitino.flink.connector.SchemaAndTablePropertiesConverter;
 import org.apache.gravitino.flink.connector.catalog.BaseCatalog;
+import org.apache.gravitino.secret.CatalogSecretProperties;
 
 /**
  * The GravitinoJdbcCatalog class is an implementation of the BaseCatalog class that is used to
@@ -99,6 +100,7 @@ public class GravitinoJdbcCatalog extends BaseCatalog {
     }
     try {
       applyJdbcCredential(catalog(), mutableOptions);
+      CatalogSecretProperties.applySecretProperties(catalog(), mutableOptions);
     } catch (NoSuchCatalogException ignored) {
       // During CREATE CATALOG, open() is called before the catalog is stored in Gravitino.
       // In this case credentials are already present in the user-provided options.

--- a/server/src/main/java/org/apache/gravitino/server/GravitinoServer.java
+++ b/server/src/main/java/org/apache/gravitino/server/GravitinoServer.java
@@ -46,6 +46,7 @@ import org.apache.gravitino.metalake.MetalakeDispatcher;
 import org.apache.gravitino.metrics.MetricsSystem;
 import org.apache.gravitino.metrics.source.MetricsSource;
 import org.apache.gravitino.policy.PolicyDispatcher;
+import org.apache.gravitino.secret.SecretPropertiesOperationDispatcher;
 import org.apache.gravitino.server.authentication.ServerAuthenticator;
 import org.apache.gravitino.server.authorization.GravitinoAuthorizerProvider;
 import org.apache.gravitino.server.web.ConfigServlet;
@@ -155,6 +156,9 @@ public class GravitinoServer extends ResourceConfig {
             bind(gravitinoEnv.policyDispatcher()).to(PolicyDispatcher.class).ranked(1);
             bind(gravitinoEnv.credentialOperationDispatcher())
                 .to(CredentialOperationDispatcher.class)
+                .ranked(1);
+            bind(gravitinoEnv.secretPropertiesOperationDispatcher())
+                .to(SecretPropertiesOperationDispatcher.class)
                 .ranked(1);
             bind(gravitinoEnv.modelDispatcher()).to(ModelDispatcher.class).ranked(1);
             bind(gravitinoEnv.functionDispatcher()).to(FunctionDispatcher.class).ranked(1);

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
@@ -61,6 +61,7 @@ import org.apache.gravitino.server.web.rest.GroupOperations;
 import org.apache.gravitino.server.web.rest.JobOperations;
 import org.apache.gravitino.server.web.rest.MetadataObjectCredentialOperations;
 import org.apache.gravitino.server.web.rest.MetadataObjectPolicyOperations;
+import org.apache.gravitino.server.web.rest.MetadataObjectSecretPropertiesOperations;
 import org.apache.gravitino.server.web.rest.MetadataObjectTagOperations;
 import org.apache.gravitino.server.web.rest.MetalakeOperations;
 import org.apache.gravitino.server.web.rest.ModelOperations;
@@ -113,7 +114,8 @@ public class GravitinoInterceptionService implements InterceptionService {
             PolicyOperations.class.getName(),
             MetadataObjectPolicyOperations.class.getName(),
             JobOperations.class.getName(),
-            MetadataObjectCredentialOperations.class.getName()));
+            MetadataObjectCredentialOperations.class.getName(),
+            MetadataObjectSecretPropertiesOperations.class.getName()));
   }
 
   @Override

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -145,6 +145,11 @@ public class ExceptionHandlers {
     return CredentialExceptionHandler.INSTANCE.handle(op, metadataObjectName, "", e);
   }
 
+  public static Response handleSecretPropertiesException(
+      OperationType op, String metadataObjectName, Exception e) {
+    return SecretPropertiesExceptionHandler.INSTANCE.handle(op, metadataObjectName, "", e);
+  }
+
   public static Response handleModelException(
       OperationType op, String model, String schema, Exception e) {
     return ModelExceptionHandler.INSTANCE.handle(op, model, schema, e);
@@ -745,6 +750,38 @@ public class ExceptionHandlers {
 
       } else {
         return super.handle(op, credential, parent, e);
+      }
+    }
+  }
+
+  private static class SecretPropertiesExceptionHandler extends BaseExceptionHandler {
+
+    private static final ExceptionHandler INSTANCE = new SecretPropertiesExceptionHandler();
+
+    private static String getSecretPropertiesErrorMsg(String parent, String reason) {
+      return String.format(
+          "Failed to get secret-properties under object [%s], reason [%s]", parent, reason);
+    }
+
+    @Override
+    public Response handle(OperationType op, String secretProperties, String parent, Exception e) {
+      String errorMsg = getSecretPropertiesErrorMsg(parent, getErrorMsg(e));
+      LOG.warn(errorMsg, e);
+
+      if (e instanceof IllegalArgumentException) {
+        return Utils.illegalArguments(errorMsg, e);
+
+      } else if (e instanceof NotFoundException) {
+        return Utils.notFound(errorMsg, e);
+
+      } else if (e instanceof NotInUseException) {
+        return Utils.notInUse(errorMsg, e);
+
+      } else if (e instanceof UnsupportedOperationException) {
+        return Utils.unsupportedOperation(errorMsg, e);
+
+      } else {
+        return super.handle(op, secretProperties, parent, e);
       }
     }
   }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetadataObjectSecretPropertiesOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetadataObjectSecretPropertiesOperations.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.web.rest;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.MetadataObjects;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.dto.responses.SecretPropertiesResponse;
+import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.secret.SecretPropertiesOperationDispatcher;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationFullName;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationMetadata;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationObjectType;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
+import org.apache.gravitino.server.web.Utils;
+import org.apache.gravitino.utils.MetadataObjectUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * REST endpoint to fetch secret-backed entity properties as plaintext for trusted connectors.
+ *
+ * <p>This is intentionally separate from Load Catalog/Schema/Fileset so UI clients that only load
+ * metadata never receive secret plaintext.
+ */
+@Path("/metalakes/{metalake}/objects/{type}/{fullName}/secret-properties")
+public class MetadataObjectSecretPropertiesOperations {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MetadataObjectSecretPropertiesOperations.class);
+
+  private static final Set<MetadataObject.Type> SUPPORTS_SECRET_PROPERTIES_TYPES =
+      ImmutableSet.of(
+          MetadataObject.Type.CATALOG, MetadataObject.Type.SCHEMA, MetadataObject.Type.FILESET);
+
+  private final SecretPropertiesOperationDispatcher secretPropertiesOperationDispatcher;
+
+  @SuppressWarnings("unused")
+  @Context
+  private HttpServletRequest httpRequest;
+
+  @Inject
+  public MetadataObjectSecretPropertiesOperations(SecretPropertiesOperationDispatcher dispatcher) {
+    this.secretPropertiesOperationDispatcher = dispatcher;
+  }
+
+  @GET
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "get-secret-properties." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "get-secret-properties", absolute = true)
+  @AuthorizationExpression(expression = AuthorizationExpressionConstants.CAN_ACCESS_METADATA)
+  public Response getSecretProperties(
+      @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
+          String metalake,
+      @PathParam("type") @AuthorizationObjectType String type,
+      @PathParam("fullName") @AuthorizationFullName String fullName) {
+    LOG.info(
+        "Received get secret-properties request for object type: {}, full name: {} under metalake: {}",
+        type,
+        fullName,
+        metalake);
+
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            MetadataObject object =
+                MetadataObjects.parse(
+                    fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
+            if (!SUPPORTS_SECRET_PROPERTIES_TYPES.contains(object.type())) {
+              throw new NotSupportedException(
+                  "Doesn't support secret-properties operations for metadata object type");
+            }
+
+            NameIdentifier identifier = MetadataObjectUtil.toEntityIdent(metalake, object);
+            Entity.EntityType entityType = MetadataObjectUtil.toEntityType(object);
+            Map<String, String> secretProperties =
+                secretPropertiesOperationDispatcher.getSecretProperties(identifier, entityType);
+            return Utils.ok(new SecretPropertiesResponse(secretProperties));
+          });
+    } catch (Exception e) {
+      return ExceptionHandlers.handleSecretPropertiesException(OperationType.GET, fullName, e);
+    }
+  }
+}

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetadataObjectSecretPropertiesOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetadataObjectSecretPropertiesOperations.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.web.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.MetadataObjects;
+import org.apache.gravitino.dto.responses.SecretPropertiesResponse;
+import org.apache.gravitino.rest.RESTUtils;
+import org.apache.gravitino.secret.SecretPropertiesOperationDispatcher;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestMetadataObjectSecretPropertiesOperations extends JerseyTest {
+
+  private static class MockServletRequestFactory extends ServletRequestFactoryBase {
+
+    @Override
+    public HttpServletRequest get() {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getRemoteUser()).thenReturn(null);
+      return request;
+    }
+  }
+
+  private final SecretPropertiesOperationDispatcher secretPropertiesOperationDispatcher =
+      mock(SecretPropertiesOperationDispatcher.class);
+
+  private final String metalake = "test_metalake";
+
+  @Override
+  protected Application configure() {
+    try {
+      forceSet(
+          TestProperties.CONTAINER_PORT, String.valueOf(RESTUtils.findAvailablePort(2000, 3000)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    ResourceConfig resourceConfig = new ResourceConfig();
+    resourceConfig.register(MetadataObjectSecretPropertiesOperations.class);
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            bind(secretPropertiesOperationDispatcher)
+                .to(SecretPropertiesOperationDispatcher.class)
+                .ranked(2);
+            bindFactory(MockServletRequestFactory.class).to(HttpServletRequest.class);
+          }
+        });
+
+    return resourceConfig;
+  }
+
+  @Test
+  public void testGetSecretPropertiesForCatalog() {
+    testGetSecretPropertiesForObject(MetadataObjects.parse("catalog", MetadataObject.Type.CATALOG));
+  }
+
+  @Test
+  public void testGetSecretPropertiesForSchema() {
+    testGetSecretPropertiesForObject(
+        MetadataObjects.parse("catalog.schema", MetadataObject.Type.SCHEMA));
+  }
+
+  @Test
+  public void testGetSecretPropertiesForFileset() {
+    testGetSecretPropertiesForObject(
+        MetadataObjects.parse("catalog.schema.fileset", MetadataObject.Type.FILESET));
+  }
+
+  private void testGetSecretPropertiesForObject(MetadataObject metadataObject) {
+    Map<String, String> expected = Map.of("jdbc-password", "secret-value");
+    when(secretPropertiesOperationDispatcher.getSecretProperties(any(), any()))
+        .thenReturn(expected);
+
+    Response response =
+        target(basePath(metalake))
+            .path(metadataObject.type().toString())
+            .path(metadataObject.fullName())
+            .path("/secret-properties")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    SecretPropertiesResponse body = response.readEntity(SecretPropertiesResponse.class);
+    Assertions.assertEquals(0, body.getCode());
+    Assertions.assertEquals(expected, body.getSecretProperties());
+
+    when(secretPropertiesOperationDispatcher.getSecretProperties(
+            any(), eq(Entity.EntityType.valueOf(metadataObject.type().name()))))
+        .thenReturn(Map.of());
+    response =
+        target(basePath(metalake))
+            .path(metadataObject.type().toString())
+            .path(metadataObject.fullName())
+            .path("/secret-properties")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    body = response.readEntity(SecretPropertiesResponse.class);
+    Assertions.assertEquals(0, body.getCode());
+    Assertions.assertTrue(body.getSecretProperties().isEmpty());
+  }
+
+  private String basePath(String metalake) {
+    return "/metalakes/" + metalake + "/objects";
+  }
+}

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/jdbc/GravitinoJdbcCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/jdbc/GravitinoJdbcCatalog.java
@@ -26,6 +26,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.credential.Credential;
 import org.apache.gravitino.credential.JdbcCredential;
+import org.apache.gravitino.secret.CatalogSecretProperties;
 import org.apache.gravitino.spark.connector.PropertiesConverter;
 import org.apache.gravitino.spark.connector.SparkTransformConverter;
 import org.apache.gravitino.spark.connector.SparkTypeConverter;
@@ -53,6 +54,7 @@ public class GravitinoJdbcCatalog extends BaseCatalog {
     Map<String, String> all =
         getPropertiesConverter().toSparkCatalogProperties(options, properties);
     applyJdbcCredential(gravitinoCatalogClient, all);
+    CatalogSecretProperties.applySecretProperties(gravitinoCatalogClient, all);
     jdbcTableCatalog.initialize(name, new CaseInsensitiveStringMap(all));
     return jdbcTableCatalog;
   }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorContext.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorContext.java
@@ -22,11 +22,13 @@ import com.google.common.base.Preconditions;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.session.PropertyMetadata;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.client.GravitinoMetalake;
 import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.secret.CatalogSecretProperties;
 import org.apache.gravitino.trino.connector.GravitinoConfig;
 import org.apache.gravitino.trino.connector.GravitinoConnector;
 import org.apache.gravitino.trino.connector.GravitinoConnectorPluginManager;
@@ -265,7 +267,8 @@ public class CatalogConnectorContext {
         credentials = new Credential[0];
       }
       Map<String, String> connectorConfig =
-          connectorAdapter.buildInternalConnectorConfig(catalog, credentials);
+          new HashMap<>(connectorAdapter.buildInternalConnectorConfig(catalog, credentials));
+      CatalogSecretProperties.applySecretProperties(liveCatalog, connectorConfig);
       String internalConnectorName = connectorAdapter.internalConnectorName();
 
       Connector connector =


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a dedicated delivery path for Vault-backed entity properties so remote Spark/Flink/Trino connectors can obtain secret plaintext without exposing secrets on Load Catalog or overloading credential vending.

- API: `SupportsSecretProperties.getSecretProperties()`
- REST: `GET /metalakes/{metalake}/objects/{type}/{fullName}/secret-properties` (catalog, schema, fileset)
- Core: `SecretPropertiesOperationDispatcher` loads entity props, keeps secret URN keys only, resolves via `SecretManager.toPlaintextProperties`
- Java client, OpenAPI (`secret-properties.yaml`), and `CatalogSecretProperties` helper
- Spark/Flink JDBC and Trino catalog connector merge secret properties into engine config after credentials

### Why are the changes needed?

Load Catalog and UI must omit secret keys/URNs. `getCredentials` only covers credential types. Remote connectors therefore need a separate, trusted API to fetch arbitrary Vault-backed sensitive configuration.

Fix: #12506

### Does this PR introduce _any_ user-facing change?

1. New REST endpoint: `GET .../objects/{type}/{fullName}/secret-properties`
2. New API interface: `SupportsSecretProperties` on `Catalog` and `Fileset`
3. Java client: `catalog.supportsSecretProperties().getSecretProperties()`
4. No change to Load Catalog / schema / fileset responses (secrets still omitted)

### How was this patch tested?

- [x] `./gradlew :common:test --tests org.apache.gravitino.secret.TestCatalogSecretProperties`
- [x] `./gradlew :core:test --tests org.apache.gravitino.secret.TestSecretPropertiesOperationDispatcher`
- [x] `./gradlew :server:test --tests org.apache.gravitino.server.web.rest.TestMetadataObjectSecretPropertiesOperations`
- [x] `./gradlew :docs:build` (OpenAPI validation)
- [x] `./gradlew :spark-connector:spark-common:compileJava :flink-connector:flink-common:compileJava :trino-connector:trino-connector:compileJava`


Made with [Cursor](https://cursor.com)