### PR TITLE
[#12515] fix(auth): allow unauthenticated access to /api/version endpoint

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/JwksTokenValidatorIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/JwksTokenValidatorIT.java
@@ -125,7 +125,7 @@ public class JwksTokenValidatorIT extends BaseIT {
             rsaKey, SUBJECT, SERVICE_AUDIENCE, Instant.now().minusSeconds(3600));
     withToken(
         expiredToken,
-        badClient -> Assertions.assertThrows(RuntimeException.class, badClient::serverVersion));
+        badClient -> Assertions.assertThrows(RuntimeException.class, badClient::listMetalakes));
   }
 
   @Test
@@ -135,7 +135,7 @@ public class JwksTokenValidatorIT extends BaseIT {
             rsaKey, SUBJECT, "wrong-audience", Instant.now().plusSeconds(1_000_000));
     withToken(
         wrongAudToken,
-        badClient -> Assertions.assertThrows(RuntimeException.class, badClient::serverVersion));
+        badClient -> Assertions.assertThrows(RuntimeException.class, badClient::listMetalakes));
   }
 
   @Test
@@ -146,7 +146,7 @@ public class JwksTokenValidatorIT extends BaseIT {
             differentKey, SUBJECT, SERVICE_AUDIENCE, Instant.now().plusSeconds(1_000_000));
     withToken(
         wrongKeyToken,
-        badClient -> Assertions.assertThrows(RuntimeException.class, badClient::serverVersion));
+        badClient -> Assertions.assertThrows(RuntimeException.class, badClient::listMetalakes));
   }
 
   @Test

--- a/server-common/src/main/java/org/apache/gravitino/server/web/HealthCheckPathMatcher.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/HealthCheckPathMatcher.java
@@ -19,12 +19,14 @@
 package org.apache.gravitino.server.web;
 
 /**
- * Determines whether a URI path targets a health check endpoint.
+ * Determines whether a URI path targets a health check or other public endpoint that should bypass
+ * authentication.
  *
  * <p>The base implementation covers the canonical Gravitino health paths ({@code /health}, {@code
- * /health/*}, {@code /health.html}, {@code /api/health}, {@code /api/health/*}). Server-specific
- * subclasses (e.g. {@code IcebergHealthCheckPathMatcher}) extend this class to add additional
- * health endpoints served by their respective REST servers.
+ * /health/*}, {@code /health.html}, {@code /api/health}, {@code /api/health/*}) and the read-only
+ * version endpoint ({@code /api/version}). Server-specific subclasses (e.g. {@code
+ * IcebergHealthCheckPathMatcher}) extend this class to add additional endpoints served by their
+ * respective REST servers.
  *
  * <p>Both {@link org.apache.gravitino.server.authentication.AuthenticationFilter} (to bypass
  * authentication for probe traffic) and {@link HttpAuditFilter} (to skip audit logging for probe
@@ -34,19 +36,26 @@ package org.apache.gravitino.server.web;
 public class HealthCheckPathMatcher {
 
   /**
-   * Returns {@code true} if {@code path} targets a Gravitino health check endpoint.
+   * Returns {@code true} if {@code path} targets a Gravitino public endpoint that should bypass
+   * authentication.
    *
-   * <p>Covers the canonical API path ({@code /api/health} and {@code /api/health/*}) and the
-   * root-level aliases ({@code /health}, {@code /health/*}, {@code /health.html}) that forward to
-   * the canonical paths. During a {@link javax.servlet.RequestDispatcher} forward, {@code
-   * getRequestURI()} returns the original URI rather than the target, so these aliases must be
-   * included here.
+   * <p>Covers:
+   *
+   * <ul>
+   *   <li>Health check paths: {@code /api/health}, {@code /api/health/*}, and the root-level
+   *       aliases {@code /health}, {@code /health/*}, {@code /health.html} that forward to the
+   *       canonical paths. During a {@link javax.servlet.RequestDispatcher} forward, {@code
+   *       getRequestURI()} returns the original URI rather than the target, so these aliases must
+   *       be included here.
+   *   <li>Version endpoint: {@code /api/version} — a read-only, non-sensitive endpoint used by
+   *       operators and tooling to check server version without requiring credentials.
+   * </ul>
    *
    * <p>Subclasses should override this method and call {@code super.isHealthCheckPath(path)} first
    * to preserve the base paths.
    *
    * @param path the URI path to test; may be {@code null}
-   * @return {@code true} if {@code path} is a health check endpoint
+   * @return {@code true} if {@code path} is a public endpoint that bypasses authentication
    */
   public boolean isHealthCheckPath(String path) {
     if (path == null) {
@@ -56,6 +65,7 @@ public class HealthCheckPathMatcher {
         || path.startsWith("/health/")
         || path.equals("/health.html")
         || path.equals("/api/health")
-        || path.startsWith("/api/health/");
+        || path.startsWith("/api/health/")
+        || path.equals("/api/version");
   }
 }

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestAuthenticationFilter.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestAuthenticationFilter.java
@@ -240,7 +240,8 @@ public class TestAuthenticationFilter {
       throws ServletException, IOException {
     // /health, /health/live, /health/ready are root-level aliases; during a Jetty forward
     // getRequestURI() returns the original URI so the bypass must also match /health/* directly.
-    String[] healthPaths = {
+    // /api/version is also public — read-only, non-sensitive, no credentials needed.
+    String[] publicPaths = {
       "/health",
       "/health/live",
       "/health/ready",
@@ -248,9 +249,10 @@ public class TestAuthenticationFilter {
       "/api/health",
       "/api/health/",
       "/api/health/live",
-      "/api/health/ready"
+      "/api/health/ready",
+      "/api/version"
     };
-    for (String path : healthPaths) {
+    for (String path : publicPaths) {
       Authenticator authenticator = mock(Authenticator.class);
       AuthenticationFilter filter = new AuthenticationFilter(Lists.newArrayList(authenticator));
       FilterChain mockChain = mock(FilterChain.class);
@@ -273,7 +275,7 @@ public class TestAuthenticationFilter {
     // Regression guard against an overly broad exemption. Paths that merely contain
     // "health" or share a prefix with "/api/health" must still be authenticated.
     String[] nonHealthPaths = {
-      "/api/metalakes/health_metalake", "/api/healthcheck", "/api/version", "/api/metalakes"
+      "/api/metalakes/health_metalake", "/api/healthcheck", "/api/metalakes"
     };
     for (String path : nonHealthPaths) {
       Authenticator authenticator = mock(Authenticator.class);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `/api/version` to the public bypass list in `HealthCheckPathMatcher` so that `AuthenticationFilter` skips authentication for `GET /api/version` requests.

- Extend `HealthCheckPathMatcher.isHealthCheckPath()` to also match `/api/version`
- Update Javadoc to reflect the broader scope (public endpoints, not just health checks)
- Move `/api/version` from the non-exempt path list to the public bypass list in `TestAuthenticationFilter` and add it to the bypass assertion loop

### Why are the changes needed?

The `/api/version` endpoint is read-only and exposes no sensitive data. Requiring authentication creates unnecessary friction for:

- Operators checking server version during deployment or upgrades (e.g. Helm pre-upgrade hooks)
- Health monitoring tools and scripts that do not need full credentials
- Client compatibility checks before establishing an authenticated session
- Deployment automation that needs to detect the running version without knowing the auth mode (basic, OAuth, etc.)

The `/api/health` endpoint already bypasses authentication via `HealthCheckPathMatcher`. This change applies the same established pattern consistently to `/api/version`.

Fix: #12515

### Does this PR introduce _any_ user-facing change?

Yes. `GET /api/version` no longer requires an `Authorization` header. Unauthenticated clients will receive the version response instead of a `401 UnauthorizedException`.

### How was this patch tested?

- Updated `TestAuthenticationFilter.testDoFilterBypassesAuthenticationForHealthEndpoints` to include `/api/version` in the public bypass assertion loop.
- Updated `TestAuthenticationFilter.testDoFilterDoesNotBypassAuthenticationForNonHealthPaths` to remove `/api/version` from the non-exempt list (it is now public).
- Run: `./gradlew :server-common:test -PskipITs`