### PR TITLE
[#12480] fix(flink): Distinguish authorization failures from speculative schema probes

### DIFF
--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java
@@ -272,9 +272,14 @@ public abstract class BaseCatalog extends AbstractCatalog {
       // Fall through to check views.
     } catch (ForbiddenException e) {
       // Flink/Calcite speculatively probes tables during multi-part identifier resolution.
-      // Treat authorization failure as table-not-exist to allow Calcite to fall back to
+      // When the table name is actually a schema name (speculative probe), treat the
+      // authorization failure as table-not-exist to allow Calcite to fall back to
       // alternative resolution paths (e.g., treating the name as a schema).
-      throw new TableNotExistException(catalogName(), tablePath, e);
+      // Otherwise, propagate the authorization failure as a CatalogException.
+      if (isSpeculativeSchemaProbe(tablePath)) {
+        throw new TableNotExistException(catalogName(), tablePath, e);
+      }
+      throw new CatalogException(e);
     } catch (CatalogException e) {
       throw e;
     } catch (Exception e) {
@@ -1018,6 +1023,30 @@ public abstract class BaseCatalog extends AbstractCatalog {
       throw new TableNotExistException(catalogName(), tablePath, e);
     } catch (Exception e) {
       throw new CatalogException(e);
+    }
+  }
+
+  /**
+   * Checks whether a {@link ForbiddenException} during {@code getTable} is likely a speculative
+   * schema probe by Calcite during multi-part identifier resolution. If the table name is actually
+   * an existing database/schema, then Calcite is probing whether a schema name might be a table,
+   * and we should preserve the {@link TableNotExistException} fallback. Otherwise, the authorization
+   * failure is a genuine permission issue on an existing table.
+   *
+   * @param tablePath the table path being probed
+   * @return {@code true} if the object name is a known schema (speculative probe), {@code false}
+   *     otherwise (real auth failure)
+   */
+  private boolean isSpeculativeSchemaProbe(ObjectPath tablePath) {
+    try {
+      return databaseExists(tablePath.getObjectName());
+    } catch (Exception e) {
+      LOG.debug(
+          "Failed to check if {} is a schema; assuming speculative probe for table {}",
+          tablePath.getObjectName(),
+          tablePath,
+          e);
+      return true;
     }
   }
 

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/hive/GravitinoHiveCatalog.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/hive/GravitinoHiveCatalog.java
@@ -207,7 +207,10 @@ public class GravitinoHiveCatalog extends BaseCatalog {
     } catch (NoSuchTableException e) {
       // Fall through to check views.
     } catch (ForbiddenException e) {
-      throw new TableNotExistException(catalogName(), tablePath, e);
+      if (isSpeculativeSchemaProbe(tablePath)) {
+        throw new TableNotExistException(catalogName(), tablePath, e);
+      }
+      throw new CatalogException(e);
     } catch (Exception e) {
       LOG.warn("Failed to load table {} from catalog {}", tablePath, catalogName(), e);
       throw new CatalogException(e);

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -33,14 +33,18 @@ import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedCatalogView;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.catalog.lakehouse.paimon.PaimonConstants;
+import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.flink.connector.PartitionConverter;
 import org.apache.gravitino.flink.connector.SchemaAndTablePropertiesConverter;
 import org.apache.gravitino.flink.connector.utils.DefaultCatalogCompat;
@@ -401,5 +405,59 @@ public class TestBaseCatalog {
     protected Catalog catalog() {
       return gravitinoCatalog;
     }
+  }
+
+  @Test
+  public void testGetTableThrowsCatalogExceptionWhenForbidden() throws Exception {
+    Catalog gravitinoCatalog = Mockito.mock(Catalog.class);
+    org.apache.gravitino.TableCatalog tableCatalog =
+        Mockito.mock(org.apache.gravitino.TableCatalog.class);
+    org.apache.gravitino.SchemaCatalog schemaCatalog =
+        Mockito.mock(org.apache.gravitino.SchemaCatalog.class);
+
+    ObjectPath tablePath = new ObjectPath("db", "tbl");
+    NameIdentifier ident = NameIdentifier.of("db", "tbl");
+
+    Mockito.when(gravitinoCatalog.asTableCatalog()).thenReturn(tableCatalog);
+    Mockito.when(gravitinoCatalog.asSchemas()).thenReturn(schemaCatalog);
+    Mockito.when(tableCatalog.loadTable(ident))
+        .thenThrow(new ForbiddenException("Access denied"));
+    // table name is NOT a schema -> real auth failure
+    Mockito.when(schemaCatalog.schemaExists("tbl")).thenReturn(false);
+
+    TestableBaseCatalog catalog =
+        new TestableBaseCatalog(Mockito.mock(AbstractCatalog.class), gravitinoCatalog);
+
+    Assertions.assertThrows(
+        CatalogException.class,
+        () -> catalog.getTable(tablePath),
+        "Should throw CatalogException for real auth failure");
+  }
+
+  @Test
+  public void testGetTableThrowsTableNotExistWhenSpeculativeSchemaProbe() throws Exception {
+    Catalog gravitinoCatalog = Mockito.mock(Catalog.class);
+    org.apache.gravitino.TableCatalog tableCatalog =
+        Mockito.mock(org.apache.gravitino.TableCatalog.class);
+    org.apache.gravitino.SchemaCatalog schemaCatalog =
+        Mockito.mock(org.apache.gravitino.SchemaCatalog.class);
+
+    ObjectPath tablePath = new ObjectPath("default", "db");
+    NameIdentifier ident = NameIdentifier.of("default", "db");
+
+    Mockito.when(gravitinoCatalog.asTableCatalog()).thenReturn(tableCatalog);
+    Mockito.when(gravitinoCatalog.asSchemas()).thenReturn(schemaCatalog);
+    Mockito.when(tableCatalog.loadTable(ident))
+        .thenThrow(new ForbiddenException("Access denied"));
+    // table name IS a schema -> speculative probe
+    Mockito.when(schemaCatalog.schemaExists("db")).thenReturn(true);
+
+    TestableBaseCatalog catalog =
+        new TestableBaseCatalog(Mockito.mock(AbstractCatalog.class), gravitinoCatalog);
+
+    Assertions.assertThrows(
+        TableNotExistException.class,
+        () -> catalog.getTable(tablePath),
+        "Should throw TableNotExistException for speculative schema probe");
   }
 }

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/hive/TestGravitinoHiveCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/hive/TestGravitinoHiveCatalog.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.flink.connector.hive;
+
+import java.util.Collections;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.exceptions.ForbiddenException;
+import org.apache.gravitino.flink.connector.PartitionConverter;
+import org.apache.gravitino.flink.connector.SchemaAndTablePropertiesConverter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestGravitinoHiveCatalog {
+
+  @Test
+  public void testGetTableThrowsCatalogExceptionWhenForbidden() throws Exception {
+    GravitinoHiveCatalog catalog =
+        createMockCatalog(
+            "db", "tbl", new ForbiddenException("Access denied"), false /* schemaExists */);
+
+    ObjectPath tablePath = new ObjectPath("db", "tbl");
+    Assertions.assertThrows(
+        CatalogException.class,
+        () -> catalog.getTable(tablePath),
+        "Should throw CatalogException for real auth failure");
+  }
+
+  @Test
+  public void testGetTableThrowsTableNotExistWhenSpeculativeSchemaProbe() throws Exception {
+    GravitinoHiveCatalog catalog =
+        createMockCatalog(
+            "default", "db", new ForbiddenException("Access denied"), true /* schemaExists */);
+
+    ObjectPath tablePath = new ObjectPath("default", "db");
+    Assertions.assertThrows(
+        TableNotExistException.class,
+        () -> catalog.getTable(tablePath),
+        "Should throw TableNotExistException for speculative schema probe");
+  }
+
+  /**
+   * Creates a mock {@link GravitinoHiveCatalog} whose {@code catalog()} returns a Gravitino catalog
+   * that throws the given exception on {@code loadTable}.
+   */
+  private static GravitinoHiveCatalog createMockCatalog(
+      String schemaName, String tableName, Exception loadTableException, boolean schemaExists)
+      throws Exception {
+    org.apache.gravitino.Catalog gravitinoCatalog =
+        Mockito.mock(org.apache.gravitino.Catalog.class);
+    org.apache.gravitino.TableCatalog tableCatalog =
+        Mockito.mock(org.apache.gravitino.TableCatalog.class);
+    org.apache.gravitino.SchemaCatalog schemaCatalog =
+        Mockito.mock(org.apache.gravitino.SchemaCatalog.class);
+
+    NameIdentifier ident = NameIdentifier.of(schemaName, tableName);
+
+    Mockito.when(gravitinoCatalog.asTableCatalog()).thenReturn(tableCatalog);
+    Mockito.when(gravitinoCatalog.asSchemas()).thenReturn(schemaCatalog);
+    Mockito.when(tableCatalog.loadTable(ident)).thenThrow(loadTableException);
+    Mockito.when(schemaCatalog.schemaExists(tableName)).thenReturn(schemaExists);
+
+    return new MockGravitinoHiveCatalog(gravitinoCatalog);
+  }
+
+  /** A testable subclass that allows injecting a mock Gravitino catalog. */
+  private static class MockGravitinoHiveCatalog extends GravitinoHiveCatalog {
+
+    private final org.apache.gravitino.Catalog catalog;
+
+    MockGravitinoHiveCatalog(org.apache.gravitino.Catalog catalog) {
+      super(
+          "test",
+          "default",
+          Collections.emptyMap(),
+          Mockito.mock(SchemaAndTablePropertiesConverter.class),
+          Mockito.mock(PartitionConverter.class),
+          null,
+          null);
+      this.catalog = catalog;
+    }
+
+    @Override
+    protected org.apache.gravitino.Catalog catalog() {
+      return catalog;
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes #12480. When Gravitino authorization rejects a Flink table access, the Flink connector now correctly reports the authorization failure instead of misreporting it as "table not found".

### Why are the changes needed?

Calcite performs speculative schema probes that can trigger ForbiddenException. The fix distinguishes between speculative probes (where the schema name is being tested as a table name) and real authorization failures by checking databaseExists().

### Changes
- BaseCatalog.java: Added isSpeculativeSchemaProbe() logic
- GravitinoHiveCatalog.java: Applied same fix
- Added unit tests for both catalogs