### PR TITLE
[#12466] fix(web-v2): detect basic auth when /configs returns 401

### DIFF
--- a/web-v2/web/src/lib/utils/axios/index.js
+++ b/web-v2/web/src/lib/utils/axios/index.js
@@ -286,6 +286,20 @@ const transform = {
     checkStatus(error?.response?.status, msg, errorMessageMode)
 
     if (response?.status === 401 && !originConfig?._retry && response?.config?.url !== githubApis.GET) {
+      // If the 401 comes from the /configs endpoint, the server requires basic auth
+      // and we haven't set authType yet. Persist authType='basic' so the login page
+      // renders the BasicLogin component instead of an indefinite spinner.
+      if (originConfig?.url?.includes('/configs')) {
+        localStorage.setItem('authType', 'basic')
+
+        // If we are already on the login page, don't redirect again to avoid an
+        // infinite redirect loop. The Redux store will pick up authType from
+        // localStorage and the login page will render the BasicLogin component.
+        if (window.location.pathname.includes('/login')) {
+          return Promise.reject(error)
+        }
+      }
+
       // Clear OAuth + BasicAuth tokens
       localStorage.removeItem('accessToken')
       localStorage.removeItem('authParams')


### PR DESCRIPTION
### What changes were proposed in this pull request?

When the Gravitino server is configured with basic authentication, the `/configs` endpoint also requires authentication. During the initial bootstrap, the frontend calls `/configs` to determine the auth type, but since `authType` is not yet known, the request goes out without credentials and receives a 401. The axios response interceptor then redirects to `/login` before `authType` is ever persisted, causing the login page to show an indefinite spinner instead of the `BasicLogin` component.

This PR fixes the chicken-and-egg problem by:
1. When `/configs` returns 401, set `authType='basic'` in localStorage before redirecting to `/login`
2. Skip the redirect when already on the `/login` page to avoid an infinite redirect loop — the Redux store will pick up `authType` from localStorage and render `BasicLogin` correctly

### Why are the changes needed?

Fix: #12466

Without this fix, users cannot log in via the Web V2 UI when basic authentication is enabled on the server. The login page shows a loading spinner indefinitely.

### Does this PR introduce _any_ user-facing change?

Yes — the Web V2 login page now correctly renders the username/password form when basic authentication is configured.

### How was this patch tested?

Manual verification of the logic flow. The fix is purely in the frontend axios interceptor and does not affect any backend behavior.