### PR TITLE
[#12580] fix(core): return masked placeholder for hidden credential properties

### DIFF
--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/FilesetCatalogIT.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/FilesetCatalogIT.java
@@ -40,11 +40,13 @@ import org.apache.gravitino.CatalogChange;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.audit.CallerContext;
 import org.apache.gravitino.audit.FilesetAuditConstants;
 import org.apache.gravitino.audit.FilesetDataOperation;
 import org.apache.gravitino.audit.InternalClientType;
 import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalNameIdentifierException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
@@ -338,7 +340,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals(MANAGED, fileset.type());
     Assertions.assertEquals(storageLocation, fileset.storageLocation());
     Assertions.assertEquals(storageLocation, fileset.storageLocations().get(LOCATION_NAME_UNKNOWN));
-    Assertions.assertEquals(2, fileset.properties().size());
+    assertFilesetPropertiesSize(fileset.properties(), 2);
     Assertions.assertEquals("v1", fileset.properties().get("k1"));
     Assertions.assertEquals(
         LOCATION_NAME_UNKNOWN, fileset.properties().get(PROPERTY_DEFAULT_LOCATION_NAME));
@@ -385,7 +387,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals(expectedStorageLocation4, fileset4.storageLocation());
     Assertions.assertEquals(
         expectedStorageLocation4, fileset4.storageLocations().get(LOCATION_NAME_UNKNOWN));
-    Assertions.assertEquals(1, fileset4.properties().size(), "properties should be empty");
+    assertFilesetPropertiesSize(fileset4.properties(), 1);
     Assertions.assertEquals(
         LOCATION_NAME_UNKNOWN, fileset4.properties().get(PROPERTY_DEFAULT_LOCATION_NAME));
 
@@ -414,7 +416,7 @@ public class FilesetCatalogIT extends BaseIT {
           }
         };
     Assertions.assertEquals(expectedStorageLocations, fileset.storageLocations());
-    Assertions.assertEquals(1, fileset.properties().size());
+    assertFilesetPropertiesSize(fileset.properties(), 1);
     Assertions.assertEquals("location1", fileset.properties().get(PROPERTY_DEFAULT_LOCATION_NAME));
 
     assertFilesetExists(filesetName5);
@@ -423,7 +425,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals("comment", fileset.comment());
     Assertions.assertEquals(MANAGED, fileset.type());
     Assertions.assertEquals(expectedStorageLocations, fileset.storageLocations());
-    Assertions.assertEquals(1, fileset.properties().size());
+    assertFilesetPropertiesSize(fileset.properties(), 1);
     Assertions.assertEquals("location1", fileset.properties().get(PROPERTY_DEFAULT_LOCATION_NAME));
 
     // create fileset with null multiple locations
@@ -517,7 +519,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals("这是中文comment", fileset.comment());
     Assertions.assertEquals(MANAGED, fileset.type());
     Assertions.assertEquals(storageLocation, fileset.storageLocation());
-    Assertions.assertEquals(4, fileset.properties().size());
+    assertFilesetPropertiesSize(fileset.properties(), 4);
     Assertions.assertEquals("v1", fileset.properties().get("k1"));
     Assertions.assertEquals("中文测试test", fileset.properties().get("test"));
     Assertions.assertEquals("test1", fileset.properties().get("中文key"));
@@ -544,7 +546,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals("comment", fileset.comment());
     Assertions.assertEquals(Fileset.Type.EXTERNAL, fileset.type());
     Assertions.assertEquals(storageLocation, fileset.storageLocation());
-    Assertions.assertEquals(2, fileset.properties().size());
+    assertFilesetPropertiesSize(fileset.properties(), 2);
     Assertions.assertEquals("v1", fileset.properties().get("k1"));
     Assertions.assertTrue(
         fileSystem.exists(new Path(storageLocation)), "storage location should be created");
@@ -930,7 +932,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be change");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be change");
-    Assertions.assertEquals(2, newFileset.properties().size(), "properties should not be change");
+    assertFilesetPropertiesSize(newFileset.properties(), 2);
     Assertions.assertEquals(
         "v1", newFileset.properties().get("k1"), "properties should not be change");
     Assertions.assertEquals(
@@ -962,7 +964,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be change");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be change");
-    Assertions.assertEquals(2, newFileset.properties().size(), "properties should not be change");
+    assertFilesetPropertiesSize(newFileset.properties(), 2);
     Assertions.assertEquals(
         "v1", newFileset.properties().get("k1"), "properties should not be change");
     Assertions.assertEquals(
@@ -992,7 +994,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be change");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be change");
-    Assertions.assertEquals(2, newFileset.properties().size(), "properties should not be change");
+    assertFilesetPropertiesSize(newFileset.properties(), 2);
     Assertions.assertEquals(
         "v2", newFileset.properties().get("k1"), "properties should be updated");
     Assertions.assertEquals(
@@ -1022,7 +1024,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be change");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be change");
-    Assertions.assertEquals(1, newFileset.properties().size(), "properties should be removed");
+    assertFilesetPropertiesSize(newFileset.properties(), 1);
     Assertions.assertEquals(
         LOCATION_NAME_UNKNOWN, newFileset.properties().get(PROPERTY_DEFAULT_LOCATION_NAME));
   }
@@ -1050,7 +1052,7 @@ public class FilesetCatalogIT extends BaseIT {
     Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be changed");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be changed");
-    Assertions.assertEquals(2, newFileset.properties().size(), "properties should not be changed");
+    assertFilesetPropertiesSize(newFileset.properties(), 2);
     Assertions.assertEquals(
         "v1", newFileset.properties().get("k1"), "properties should not be changed");
     Assertions.assertEquals(
@@ -1363,5 +1365,17 @@ public class FilesetCatalogIT extends BaseIT {
 
   private String storageLocation(String filesetName) {
     return defaultBaseLocation() + "/" + filesetName;
+  }
+
+  /**
+   * Historical size asserts excluded gravitino.identifier (previously omitted). It is now returned
+   * as a masked placeholder, so expected size is historical + 1.
+   */
+  private static void assertFilesetPropertiesSize(
+      Map<String, String> properties, int expectedSizeWithoutIdentifier) {
+    Assertions.assertEquals(
+        expectedSizeWithoutIdentifier + 1, properties.size(), () -> "properties=" + properties);
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, properties.get(StringIdentifier.ID_KEY));
   }
 }

--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/FilesetCatalogIT.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/FilesetCatalogIT.java
@@ -368,9 +368,9 @@ public class FilesetCatalogIT extends BaseIT {
         storageLocation(filesetName2),
         fileset2.storageLocations().get(LOCATION_NAME_UNKNOWN),
         "storage location should be created");
+    assertFilesetPropertiesSize(fileset2.properties(), 1);
     Assertions.assertEquals(
-        ImmutableMap.of(PROPERTY_DEFAULT_LOCATION_NAME, LOCATION_NAME_UNKNOWN),
-        fileset2.properties());
+        LOCATION_NAME_UNKNOWN, fileset2.properties().get(PROPERTY_DEFAULT_LOCATION_NAME));
 
     // create fileset with placeholder in storage location
     String filesetName4 = "test_create_fileset_with_placeholder";

--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/FilesetSecretsIT.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/FilesetSecretsIT.java
@@ -103,10 +103,11 @@ public class FilesetSecretsIT extends BaseIT {
                 ImmutableMap.of());
 
     Assertions.assertEquals("visible-value", fileset.properties().get("visible-key"));
-    // Default load properties omit secret-manager values; plaintext comes from getSecrets().
-    Assertions.assertFalse(
-        fileset.properties().containsKey("custom-secret"),
-        "secret bindings must not appear in default load properties");
+    // Secret bindings are returned as a masked placeholder in default load properties.
+    Assertions.assertEquals(
+        org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
+        fileset.properties().get("custom-secret"),
+        "secret bindings must appear as masked placeholders in default load properties");
 
     Map<String, String> secrets = fileset.supportsSecrets().getSecrets();
     Assertions.assertEquals("mem-plaintext", secrets.get("custom-secret"));

--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/HadoopUserImpersonationIT.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/HadoopUserImpersonationIT.java
@@ -370,7 +370,8 @@ public class HadoopUserImpersonationIT extends BaseIT {
     Assertions.assertEquals(Fileset.Type.MANAGED, fileset.type());
     Assertions.assertEquals(storageLocation, fileset.storageLocation());
     // historical size 2 (k1 + default-location-name) + masked gravitino.identifier
-    Assertions.assertEquals(3, fileset.properties().size(), () -> "properties=" + fileset.properties());
+    Assertions.assertEquals(
+        3, fileset.properties().size(), () -> "properties=" + fileset.properties());
     Assertions.assertEquals(
         HiddenPropertyMaskUtils.MASKED_VALUE, fileset.properties().get(StringIdentifier.ID_KEY));
     Assertions.assertTrue(

--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/HadoopUserImpersonationIT.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/HadoopUserImpersonationIT.java
@@ -41,7 +41,9 @@ import org.apache.commons.lang3.SystemUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalNameIdentifierException;
 import org.apache.gravitino.file.Fileset;
@@ -367,7 +369,10 @@ public class HadoopUserImpersonationIT extends BaseIT {
     Assertions.assertEquals("comment", fileset.comment());
     Assertions.assertEquals(Fileset.Type.MANAGED, fileset.type());
     Assertions.assertEquals(storageLocation, fileset.storageLocation());
-    Assertions.assertEquals(2, fileset.properties().size());
+    // historical size 2 (k1 + default-location-name) + masked gravitino.identifier
+    Assertions.assertEquals(3, fileset.properties().size(), () -> "properties=" + fileset.properties());
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, fileset.properties().get(StringIdentifier.ID_KEY));
     Assertions.assertTrue(
         fileset.properties().containsKey(Fileset.PROPERTY_DEFAULT_LOCATION_NAME),
         "properties should contain default location name");

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcCatalogCredential.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcCatalogCredential.java
@@ -31,6 +31,7 @@ import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConvert
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.credential.CredentialConstants;
 import org.apache.gravitino.credential.JdbcCredential;
 import org.apache.gravitino.meta.AuditInfo;
@@ -203,7 +204,7 @@ public class TestJdbcCatalogCredential {
   }
 
   @Test
-  void testJdbcCatalogPropertiesHidesCredentials() {
+  void testJdbcCatalogPropertiesMasksCredentials() {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
 
@@ -229,8 +230,10 @@ public class TestJdbcCatalogCredential {
 
     // GravitinoEnv is not initialized in unit tests, so backfill is disabled by default.
     Map<String, String> publicProps = jdbcCatalog.properties();
-    Assertions.assertFalse(publicProps.containsKey(JdbcConfig.USERNAME.getKey()));
-    Assertions.assertFalse(publicProps.containsKey(JdbcConfig.PASSWORD.getKey()));
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, publicProps.get(JdbcConfig.USERNAME.getKey()));
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, publicProps.get(JdbcConfig.PASSWORD.getKey()));
 
     // propertiesWithCredentialProviders must still see the raw credentials
     Map<String, String> credProps = jdbcCatalog.propertiesWithCredentialProviders();

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlCredentialIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlCredentialIT.java
@@ -166,11 +166,13 @@ public class CatalogMysqlCredentialIT extends BaseIT {
     Catalog catalog = metalake.loadCatalog(catalogName);
     Map<String, String> props = catalog.properties();
 
-    Assertions.assertFalse(
-        props.containsKey(JdbcConfig.USERNAME.getKey()),
-        "jdbc-user must be hidden in catalog properties");
-    Assertions.assertFalse(
-        props.containsKey(JdbcConfig.PASSWORD.getKey()),
-        "jdbc-password must be hidden in catalog properties");
+    Assertions.assertEquals(
+        org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
+        props.get(JdbcConfig.USERNAME.getKey()),
+        "jdbc-user must be masked in catalog properties");
+    Assertions.assertEquals(
+        org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
+        props.get(JdbcConfig.PASSWORD.getKey()),
+        "jdbc-password must be masked in catalog properties");
   }
 }

--- a/catalogs/catalog-lakehouse-hudi/src/test/java/org/apache/gravitino/catalog/lakehouse/hudi/integration/test/HudiCatalogHMSIT.java
+++ b/catalogs/catalog-lakehouse-hudi/src/test/java/org/apache/gravitino/catalog/lakehouse/hudi/integration/test/HudiCatalogHMSIT.java
@@ -34,8 +34,10 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.SchemaChange;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.SupportsSchemas;
 import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.dto.rel.ColumnDTO;
 import org.apache.gravitino.integration.test.container.ContainerSuite;
 import org.apache.gravitino.integration.test.container.HiveContainer;
@@ -171,6 +173,7 @@ public class HudiCatalogHMSIT extends BaseIT {
     Assertions.assertEquals(comment, catalog.comment());
     Map<String, String> expectedProperties = new HashMap<>(properties);
     expectedProperties.put(PROPERTY_IN_USE, "true");
+    expectedProperties.put(StringIdentifier.ID_KEY, HiddenPropertyMaskUtils.MASKED_VALUE);
     Assertions.assertEquals(expectedProperties, catalog.properties());
     Assertions.assertDoesNotThrow(() -> metalake.testConnection(catalogName));
 

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -54,6 +54,7 @@ import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergTable;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata;
 import org.apache.gravitino.catalog.lakehouse.iceberg.ops.IcebergCatalogWrapperHelper;
 import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchViewException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
@@ -1540,8 +1541,10 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
     Schema loadSchema = catalog.asSchemas().loadSchema(ident.name());
     Assertions.assertEquals(AuthConstants.ANONYMOUS_USER, loadSchema.auditInfo().creator());
     Assertions.assertNull(loadSchema.auditInfo().lastModifier());
-    Assertions.assertFalse(
-        loadSchema.properties().containsKey(IcebergSchemaPropertiesMetadata.COMMENT));
+    // comment is reserved+hidden: key remains, value is masked
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE,
+        loadSchema.properties().get(IcebergSchemaPropertiesMetadata.COMMENT));
     prop.forEach((key, value) -> Assertions.assertEquals(loadSchema.properties().get(key), value));
 
     // alter

--- a/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
+++ b/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
@@ -30,7 +30,9 @@ import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.ModelAlreadyExistsException;
 import org.apache.gravitino.exceptions.ModelVersionAliasesAlreadyExistException;
 import org.apache.gravitino.exceptions.NoSuchModelException;
@@ -97,12 +99,12 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Model model = gravitinoCatalog.asModelCatalog().registerModel(modelIdent, comment, properties);
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals(comment, model.comment());
-    Assertions.assertEquals(properties, model.properties());
+    assertPropertiesEqual(properties, model.properties());
 
     Model loadModel = gravitinoCatalog.asModelCatalog().getModel(modelIdent);
     Assertions.assertEquals(modelName, loadModel.name());
     Assertions.assertEquals(comment, loadModel.comment());
-    Assertions.assertEquals(properties, loadModel.properties());
+    assertPropertiesEqual(properties, loadModel.properties());
 
     Assertions.assertTrue(gravitinoCatalog.asModelCatalog().modelExists(modelIdent));
 
@@ -208,7 +210,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(new String[] {"alias1"}, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
     Assertions.assertTrue(
         gravitinoCatalog.asModelCatalog().modelVersionExists(modelIdent, "alias1"));
 
@@ -353,7 +355,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri1", modelVersions[0].uri());
     Assertions.assertArrayEquals(new String[] {"alias1"}, modelVersions[0].aliases());
     Assertions.assertEquals("comment1", modelVersions[0].comment());
-    Assertions.assertEquals(Collections.emptyMap(), modelVersions[0].properties());
+    assertPropertiesEqual(Collections.emptyMap(), modelVersions[0].properties());
     Assertions.assertTrue(
         gravitinoCatalog.asModelCatalog().modelVersionExists(modelIdent, "alias1"));
 
@@ -396,7 +398,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(uris, modelVersion.uris());
     Assertions.assertArrayEquals(new String[] {"alias1"}, modelVersion.aliases());
     Assertions.assertEquals("comment1", modelVersion.comment());
-    Assertions.assertEquals(Collections.emptyMap(), modelVersion.properties());
+    assertPropertiesEqual(Collections.emptyMap(), modelVersion.properties());
 
     // Test list model versions
     int[] modelVersions = gravitinoCatalog.asModelCatalog().listModelVersions(modelIdent);
@@ -412,7 +414,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(uris, modelVersionInfos[0].uris());
     Assertions.assertArrayEquals(new String[] {"alias1"}, modelVersionInfos[0].aliases());
     Assertions.assertEquals("comment1", modelVersionInfos[0].comment());
-    Assertions.assertEquals(Collections.emptyMap(), modelVersionInfos[0].properties());
+    assertPropertiesEqual(Collections.emptyMap(), modelVersionInfos[0].properties());
 
     // Test delete and list model versions info
     Assertions.assertTrue(gravitinoCatalog.asModelCatalog().deleteModelVersion(modelIdent, 0));
@@ -440,7 +442,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(new String[] {"alias1"}, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange updateComment = ModelVersionChange.updateComment(versionNewComment);
     ModelVersion updatedModelVersion =
@@ -472,7 +474,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(new String[] {"alias1"}, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange updateComment = ModelVersionChange.updateComment(aliasNewComment);
     ModelVersion updatedModelVersion =
@@ -542,14 +544,14 @@ public class ModelCatalogOperationsIT extends BaseIT {
 
     Assertions.assertEquals(modelName, alteredModel.name());
     Assertions.assertNotEquals(createdModel.properties(), alteredModel.properties());
-    Assertions.assertEquals(newProperties, alteredModel.properties());
+    assertPropertiesEqual(newProperties, alteredModel.properties());
     Assertions.assertEquals(createdModel.comment(), alteredModel.comment());
 
     // reload model and check properties
     Model reloadedModel = gravitinoCatalog.asModelCatalog().getModel(modelIdent);
     Assertions.assertEquals(modelName, reloadedModel.name());
     Assertions.assertNotEquals(createdModel.properties(), reloadedModel.properties());
-    Assertions.assertEquals(newProperties, reloadedModel.properties());
+    assertPropertiesEqual(newProperties, reloadedModel.properties());
     Assertions.assertEquals(createdModel.comment(), reloadedModel.comment());
   }
 
@@ -567,13 +569,13 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Model alteredModel = gravitinoCatalog.asModelCatalog().alterModel(modelIdent, addProperty);
 
     Assertions.assertEquals(modelName, alteredModel.name());
-    Assertions.assertEquals(newProperties, alteredModel.properties());
+    assertPropertiesEqual(newProperties, alteredModel.properties());
     Assertions.assertEquals(createdModel.comment(), alteredModel.comment());
 
     // reload model and check properties
     Model reloadedModel = gravitinoCatalog.asModelCatalog().getModel(modelIdent);
     Assertions.assertEquals(modelName, reloadedModel.name());
-    Assertions.assertEquals(newProperties, reloadedModel.properties());
+    assertPropertiesEqual(newProperties, reloadedModel.properties());
     Assertions.assertEquals(createdModel.comment(), reloadedModel.comment());
   }
 
@@ -591,13 +593,13 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Model alteredModel = gravitinoCatalog.asModelCatalog().alterModel(modelIdent, addProperty);
 
     Assertions.assertEquals(modelName, alteredModel.name());
-    Assertions.assertEquals(newProperties, alteredModel.properties());
+    assertPropertiesEqual(newProperties, alteredModel.properties());
     Assertions.assertEquals(createdModel.comment(), alteredModel.comment());
 
     // reload model and check properties
     Model reloadedModel = gravitinoCatalog.asModelCatalog().getModel(modelIdent);
     Assertions.assertEquals(modelName, reloadedModel.name());
-    Assertions.assertEquals(newProperties, reloadedModel.properties());
+    assertPropertiesEqual(newProperties, reloadedModel.properties());
     Assertions.assertEquals(createdModel.comment(), reloadedModel.comment());
   }
 
@@ -646,7 +648,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange[] changes = {
       ModelVersionChange.setProperty("key1", "new value"),
@@ -659,7 +661,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(modelVersion.uri(), updatedModelVersion.uri());
     Assertions.assertArrayEquals(modelVersion.aliases(), updatedModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), updatedModelVersion.comment());
-    Assertions.assertEquals(newProperties, updatedModelVersion.properties());
+    assertPropertiesEqual(newProperties, updatedModelVersion.properties());
 
     // reload model version and check properties
     ModelVersion reloadedModelVersion =
@@ -669,7 +671,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(modelVersion.uri(), reloadedModelVersion.uri());
     Assertions.assertArrayEquals(modelVersion.aliases(), reloadedModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), reloadedModelVersion.comment());
-    Assertions.assertEquals(newProperties, reloadedModelVersion.properties());
+    assertPropertiesEqual(newProperties, reloadedModelVersion.properties());
   }
 
   @Test
@@ -694,7 +696,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange[] changes = {
       ModelVersionChange.setProperty("key1", "new value"),
@@ -707,7 +709,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(modelVersion.uri(), updatedModelVersion.uri());
     Assertions.assertArrayEquals(modelVersion.aliases(), updatedModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), updatedModelVersion.comment());
-    Assertions.assertEquals(newProperties, updatedModelVersion.properties());
+    assertPropertiesEqual(newProperties, updatedModelVersion.properties());
 
     // reload model version and check properties
     ModelVersion reloadedModelVersion =
@@ -717,7 +719,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(modelVersion.uri(), reloadedModelVersion.uri());
     Assertions.assertArrayEquals(modelVersion.aliases(), reloadedModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), reloadedModelVersion.comment());
-    Assertions.assertEquals(newProperties, reloadedModelVersion.properties());
+    assertPropertiesEqual(newProperties, reloadedModelVersion.properties());
   }
 
   @Test
@@ -743,7 +745,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(uri, modelVersion.uri());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals(versionComment, modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange updateUriChange = ModelVersionChange.updateUri(newUri);
     ModelVersion updatedModelVersion =
@@ -786,7 +788,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(uris, modelVersion.uris());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals(versionComment, modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     // Test update uri
     Map<String, String> updatedUris = ImmutableMap.of("n1", "u1-1");
@@ -868,7 +870,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(uri, modelVersion.uri());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals(versionComment, modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange updateUriChange = ModelVersionChange.updateUri(newUri);
     ModelVersion updatedModelVersion =
@@ -913,7 +915,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange change = ModelVersionChange.removeProperty("key1");
     ModelVersion updatedModelVersion =
@@ -923,7 +925,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(modelVersion.uri(), updatedModelVersion.uri());
     Assertions.assertArrayEquals(modelVersion.aliases(), updatedModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), updatedModelVersion.comment());
-    Assertions.assertEquals(newProperties, updatedModelVersion.properties());
+    assertPropertiesEqual(newProperties, updatedModelVersion.properties());
 
     // reload model version and check properties
     ModelVersion reloadedModelVersion =
@@ -933,7 +935,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(modelVersion.uri(), reloadedModelVersion.uri());
     Assertions.assertArrayEquals(modelVersion.aliases(), reloadedModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), reloadedModelVersion.comment());
-    Assertions.assertEquals(newProperties, reloadedModelVersion.properties());
+    assertPropertiesEqual(newProperties, reloadedModelVersion.properties());
   }
 
   @Test
@@ -957,7 +959,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange change = ModelVersionChange.removeProperty("key1");
     ModelVersion updatedModelVersion =
@@ -967,7 +969,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(modelVersion.uri(), updatedModelVersion.uri());
     Assertions.assertArrayEquals(modelVersion.aliases(), updatedModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), updatedModelVersion.comment());
-    Assertions.assertEquals(newProperties, updatedModelVersion.properties());
+    assertPropertiesEqual(newProperties, updatedModelVersion.properties());
 
     // reload model version and check properties
     ModelVersion reloadedModelVersion =
@@ -977,7 +979,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals(modelVersion.uri(), reloadedModelVersion.uri());
     Assertions.assertArrayEquals(modelVersion.aliases(), reloadedModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), reloadedModelVersion.comment());
-    Assertions.assertEquals(newProperties, reloadedModelVersion.properties());
+    assertPropertiesEqual(newProperties, reloadedModelVersion.properties());
   }
 
   @Test
@@ -999,7 +1001,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange change =
         ModelVersionChange.updateAliases(
@@ -1045,7 +1047,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
     Assertions.assertEquals("uri", modelVersion.uri());
     Assertions.assertArrayEquals(aliases, modelVersion.aliases());
     Assertions.assertEquals("comment", modelVersion.comment());
-    Assertions.assertEquals(properties, modelVersion.properties());
+    assertPropertiesEqual(properties, modelVersion.properties());
 
     ModelVersionChange change =
         ModelVersionChange.updateAliases(
@@ -1256,6 +1258,15 @@ public class ModelCatalogOperationsIT extends BaseIT {
         () -> gravitinoCatalog.asModelCatalog().getModelVersionUri(modelIdent1, "alias3", "n3"));
     Assertions.assertEquals(
         "u2", gravitinoCatalog.asModelCatalog().getModelVersionUri(modelIdent1, "alias3", null));
+  }
+
+  private static void assertPropertiesEqual(
+      Map<String, String> expectedUserProps, Map<String, String> actual) {
+    Map<String, String> expected = Maps.newHashMap(expectedUserProps);
+    if (actual.containsKey(StringIdentifier.ID_KEY)) {
+      expected.put(StringIdentifier.ID_KEY, HiddenPropertyMaskUtils.MASKED_VALUE);
+    }
+    Assertions.assertEquals(expected, actual);
   }
 
   private void createMetalake() {

--- a/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
+++ b/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
@@ -1262,9 +1262,12 @@ public class ModelCatalogOperationsIT extends BaseIT {
 
   private static void assertPropertiesEqual(
       Map<String, String> expectedUserProps, Map<String, String> actual) {
-    Map<String, String> expected = Maps.newHashMap(expectedUserProps);
-    expected.put(StringIdentifier.ID_KEY, HiddenPropertyMaskUtils.MASKED_VALUE);
-    Assertions.assertEquals(expected, actual);
+    Assertions.assertTrue(
+        !actual.containsKey(StringIdentifier.ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(actual.get(StringIdentifier.ID_KEY)));
+    Map<String, String> actualWithoutId = Maps.newHashMap(actual);
+    actualWithoutId.remove(StringIdentifier.ID_KEY);
+    Assertions.assertEquals(expectedUserProps, actualWithoutId);
   }
 
   private void createMetalake() {

--- a/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
+++ b/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
@@ -1263,9 +1263,7 @@ public class ModelCatalogOperationsIT extends BaseIT {
   private static void assertPropertiesEqual(
       Map<String, String> expectedUserProps, Map<String, String> actual) {
     Map<String, String> expected = Maps.newHashMap(expectedUserProps);
-    if (actual.containsKey(StringIdentifier.ID_KEY)) {
-      expected.put(StringIdentifier.ID_KEY, HiddenPropertyMaskUtils.MASKED_VALUE);
-    }
+    expected.put(StringIdentifier.ID_KEY, HiddenPropertyMaskUtils.MASKED_VALUE);
     Assertions.assertEquals(expected, actual);
   }
 

--- a/clients/client-python/tests/integration/integration_test_env.py
+++ b/clients/client-python/tests/integration/integration_test_env.py
@@ -67,15 +67,20 @@ class IntegrationTestEnv(unittest.TestCase):
     gravitino_startup_script = None
     gravitino_admin_client: GravitinoAdminClient = None
 
-    # Hidden reserved properties are returned as this placeholder in API responses.
+    # Hidden/secret property values are returned as this placeholder in API responses.
     MASKED_PROPERTY_VALUE = "******"
     GRAVITINO_IDENTIFIER_KEY = "gravitino.identifier"
 
     def assert_properties_equal(self, expected, actual, msg=None):
-        """Assert entity properties, expecting masked gravitino.identifier when present."""
+        """Assert entity properties.
+
+        Hidden/reserved-hidden keys (e.g. gravitino.identifier, comment) are returned as
+        MASKED_PROPERTY_VALUE; add any such keys present in actual into the expected map.
+        """
         expected_full = dict(expected)
-        if self.GRAVITINO_IDENTIFIER_KEY in actual:
-            expected_full[self.GRAVITINO_IDENTIFIER_KEY] = self.MASKED_PROPERTY_VALUE
+        for key, value in actual.items():
+            if value == self.MASKED_PROPERTY_VALUE and key not in expected_full:
+                expected_full[key] = self.MASKED_PROPERTY_VALUE
         self.assertEqual(expected_full, actual, msg)
 
     @staticmethod

--- a/clients/client-python/tests/integration/integration_test_env.py
+++ b/clients/client-python/tests/integration/integration_test_env.py
@@ -67,6 +67,17 @@ class IntegrationTestEnv(unittest.TestCase):
     gravitino_startup_script = None
     gravitino_admin_client: GravitinoAdminClient = None
 
+    # Hidden reserved properties are returned as this placeholder in API responses.
+    MASKED_PROPERTY_VALUE = "******"
+    GRAVITINO_IDENTIFIER_KEY = "gravitino.identifier"
+
+    def assert_properties_equal(self, expected, actual, msg=None):
+        """Assert entity properties, expecting masked gravitino.identifier when present."""
+        expected_full = dict(expected)
+        if self.GRAVITINO_IDENTIFIER_KEY in actual:
+            expected_full[self.GRAVITINO_IDENTIFIER_KEY] = self.MASKED_PROPERTY_VALUE
+        self.assertEqual(expected_full, actual, msg)
+
     @staticmethod
     def use_external_gravitino() -> bool:
         return os.environ.get("START_EXTERNAL_GRAVITINO", "").lower() == "true"

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -87,12 +87,12 @@ class TestCatalog(MetalakeTestMixin, IntegrationTestEnv):
     def test_create_catalog(self):
         catalog = self.create_catalog(self.catalog_name)
         self.assertEqual(catalog.name(), self.catalog_name)
-        self.assertEqual(
-            catalog.properties(),
+        self.assert_properties_equal(
             {
                 self.catalog_location_prop: "/tmp/test_schema",
                 self.catalog_in_use_prop: "true",
             },
+            catalog.properties(),
         )
 
     def test_failed_create_catalog(self):
@@ -169,12 +169,12 @@ class TestCatalog(MetalakeTestMixin, IntegrationTestEnv):
         self.assertIsNotNone(catalog)
         self.assertEqual(catalog.name(), self.catalog_name)
         self.assertEqual(catalog.comment(), self.catalog_comment)
-        self.assertEqual(
-            catalog.properties(),
+        self.assert_properties_equal(
             {
                 self.catalog_location_prop: "/tmp/test_schema",
                 self.catalog_in_use_prop: "true",
             },
+            catalog.properties(),
         )
         self.assertEqual(catalog.audit_info().creator(), "anonymous")
 

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -227,12 +227,12 @@ class TestFilesetCatalog(IntegrationTestEnv):
         self.assertIsNotNone(fileset)
         self.assertEqual(fileset.type(), Fileset.Type.MANAGED)
         self.assertEqual(fileset.comment(), self.fileset_comment)
-        self.assertEqual(
-            fileset.properties(),
+        self.assert_properties_equal(
             {
                 Fileset.PROPERTY_DEFAULT_LOCATION_NAME: Fileset.LOCATION_NAME_UNKNOWN,
                 **self.fileset_properties,
             },
+            fileset.properties(),
         )
         self.assertEqual(fileset.storage_location(), f"file:{self.fileset_location}")
 
@@ -241,8 +241,8 @@ class TestFilesetCatalog(IntegrationTestEnv):
         self.assertIsNotNone(fileset)
         self.assertEqual(fileset.type(), Fileset.Type.MANAGED)
         self.assertEqual(fileset.comment(), self.fileset_comment)
-        self.assertEqual(
-            fileset.properties(), self.multiple_locations_fileset_properties
+        self.assert_properties_equal(
+            self.multiple_locations_fileset_properties, fileset.properties()
         )
         self.assertEqual(
             fileset.storage_location(),
@@ -283,12 +283,12 @@ class TestFilesetCatalog(IntegrationTestEnv):
         self.assertIsNotNone(fileset)
         self.assertEqual(fileset.name(), self.fileset_name)
         self.assertEqual(fileset.comment(), self.fileset_comment)
-        self.assertEqual(
-            fileset.properties(),
+        self.assert_properties_equal(
             {
                 Fileset.PROPERTY_DEFAULT_LOCATION_NAME: Fileset.LOCATION_NAME_UNKNOWN,
                 **self.fileset_properties,
             },
+            fileset.properties(),
         )
         self.assertEqual(fileset.audit_info().creator(), "anonymous")
 

--- a/clients/client-python/tests/integration/test_metalake.py
+++ b/clients/client-python/tests/integration/test_metalake.py
@@ -75,7 +75,7 @@ class TestMetalake(IntegrationTestEnv):
         metalake = self.create_metalake(self.metalake_name)
         self.assertEqual(metalake.name(), self.metalake_name)
         self.assertEqual(metalake.comment(), self.metalake_comment)
-        self.assertEqual(metalake.properties(), self.metalake_properties)
+        self.assert_properties_equal(self.metalake_properties, metalake.properties())
         self.assertEqual(metalake.audit_info().creator(), "anonymous")
 
     def create_metalake(self, metalake_name) -> GravitinoMetalake:
@@ -160,8 +160,8 @@ class TestMetalake(IntegrationTestEnv):
         self.assertIsNotNone(metalake)
         self.assertEqual(metalake.name(), self.metalake_name)
         self.assertEqual(metalake.comment(), self.metalake_comment)
-        self.assertEqual(
-            metalake.properties(), {**self.metalake_properties, "in-use": "true"}
+        self.assert_properties_equal(
+            {**self.metalake_properties, "in-use": "true"}, metalake.properties()
         )
         self.assertEqual(metalake.audit_info().creator(), "anonymous")
 

--- a/clients/client-python/tests/integration/test_model_catalog.py
+++ b/clients/client-python/tests/integration/test_model_catalog.py
@@ -85,7 +85,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(model_name, model.name())
         self.assertEqual(comment, model.comment())
         self.assertEqual(0, model.latest_version())
-        self.assertEqual(properties, model.properties())
+        self.assert_properties_equal(properties, model.properties())
 
         # Test register model without comment and properties
         model = self._catalog.as_model_catalog().register_model(
@@ -98,7 +98,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(model_name + "_no_comment_no_properties", model.name())
         self.assertIsNone(model.comment())
         self.assertEqual(0, model.latest_version())
-        self.assertEqual({}, model.properties())
+        self.assert_properties_equal({}, model.properties())
 
         ## Test register same name model again
         with self.assertRaises(ModelAlreadyExistsException):
@@ -119,7 +119,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(model_name, model.name())
         self.assertEqual(comment, model.comment())
         self.assertEqual(0, model.latest_version())
-        self.assertEqual(properties, model.properties())
+        self.assert_properties_equal(properties, model.properties())
 
         # Test get non-existent model
         with self.assertRaises(NoSuchModelException):
@@ -218,7 +218,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(model_name, renamed_model.name())
         self.assertEqual(comment, renamed_model.comment())
         self.assertEqual(0, renamed_model.latest_version())
-        self.assertEqual(properties, renamed_model.properties())
+        self.assert_properties_equal(properties, renamed_model.properties())
 
         changes = [ModelChange.rename(model_new_name)]
 
@@ -227,7 +227,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(model_new_name, renamed_model.name())
         self.assertEqual(comment, renamed_model.comment())
         self.assertEqual(0, renamed_model.latest_version())
-        self.assertEqual(properties, renamed_model.properties())
+        self.assert_properties_equal(properties, renamed_model.properties())
 
     def test_register_set_model_property(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -242,7 +242,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(origin_model.name(), model_name)
         self.assertEqual(origin_model.comment(), comment)
         self.assertEqual(origin_model.latest_version(), 0)
-        self.assertEqual(origin_model.properties(), properties)
+        self.assert_properties_equal(properties, origin_model.properties())
 
         changes = [
             ModelChange.set_property("k1", "v11"),
@@ -255,9 +255,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(update_property_model.name(), model_name)
         self.assertEqual(update_property_model.comment(), comment)
         self.assertEqual(update_property_model.latest_version(), 0)
-        self.assertEqual(
-            update_property_model.properties(), {"k1": "v11", "k2": "v2", "k3": "v3"}
-        )
+        self.assert_properties_equal({"k1": "v11", "k2": "v2", "k3": "v3"}, update_property_model.properties())
 
     def test_register_remove_model_property(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -272,7 +270,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(origin_model.name(), model_name)
         self.assertEqual(origin_model.comment(), comment)
         self.assertEqual(origin_model.latest_version(), 0)
-        self.assertEqual(origin_model.properties(), properties)
+        self.assert_properties_equal(properties, origin_model.properties())
 
         changes = [ModelChange.remove_property("k1")]
         self._catalog.as_model_catalog().alter_model(model_ident, *changes)
@@ -280,7 +278,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(update_property_model.name(), model_name)
         self.assertEqual(update_property_model.comment(), comment)
         self.assertEqual(update_property_model.latest_version(), 0)
-        self.assertEqual(update_property_model.properties(), {"k2": "v2"})
+        self.assert_properties_equal({"k2": "v2"}, update_property_model.properties())
 
     def test_register_update_model_comment(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -297,7 +295,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(origin_model.name(), model_name)
         self.assertEqual(origin_model.comment(), comment)
         self.assertEqual(origin_model.latest_version(), 0)
-        self.assertEqual(origin_model.properties(), properties)
+        self.assert_properties_equal(properties, origin_model.properties())
 
         # Alter model and validate the updated model
         changes = [ModelChange.update_comment(new_comment)]
@@ -306,7 +304,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(update_comment_model.name(), model_name)
         self.assertEqual(update_comment_model.comment(), new_comment)
         self.assertEqual(update_comment_model.latest_version(), 0)
-        self.assertEqual(update_comment_model.properties(), properties)
+        self.assert_properties_equal(properties, update_comment_model.properties())
 
     def test_link_update_model_version_comment(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -329,7 +327,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", model_version.uri())
         self.assertEqual(["alias1", "alias2"], model_version.aliases())
         self.assertEqual("comment", model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_version.properties())
 
         model_version = self._catalog.as_model_catalog().get_model_version_by_alias(
             model_ident, "alias1"
@@ -352,7 +350,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(0, updated_model_version.version())
         self.assertEqual("new comment", updated_model_version.comment())
         self.assertEqual(["alias1", "alias2"], updated_model_version.aliases())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
         self.assertEqual("uri", updated_model_version.uri())
 
     def test_link_update_model_version_property(self):
@@ -381,7 +379,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", original_model_version.uri())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
 
         changes = [
             ModelVersionChange.set_property("k1", "v11"),
@@ -400,7 +398,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(update_property_model.uri(), "uri")
         self.assertEqual(update_property_model.comment(), comment)
         self.assertEqual(update_property_model.aliases(), aliases)
-        self.assertEqual(update_property_model.properties(), {"k1": "v11", "k3": "v3"})
+        self.assert_properties_equal({"k1": "v11", "k3": "v3"}, update_property_model.properties())
 
     def test_link_update_model_version_uri(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -427,7 +425,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", original_model_version.uri())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
 
         changes = [ModelVersionChange.update_uri("new_uri")]
         self._catalog.as_model_catalog().alter_model_version(model_ident, 0, *changes)
@@ -439,7 +437,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("new_uri", updated_model_version.uri())
         self.assertEqual(["alias1", "alias2"], updated_model_version.aliases())
         self.assertEqual("comment", updated_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
 
     def test_link_add_model_version_uri(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -466,7 +464,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1"}, original_model_version.uris())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
 
         changes = [ModelVersionChange.add_uri("n2", "u2")]
         self._catalog.as_model_catalog().alter_model_version(model_ident, 0, *changes)
@@ -478,7 +476,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, updated_model_version.uris())
         self.assertEqual(["alias1", "alias2"], updated_model_version.aliases())
         self.assertEqual("comment", updated_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
 
     def test_link_remove_model_version_uri(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -505,7 +503,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, original_model_version.uris())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
 
         changes = [ModelVersionChange.remove_uri("n1")]
         self._catalog.as_model_catalog().alter_model_version(model_ident, 0, *changes)
@@ -517,7 +515,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n2": "u2"}, updated_model_version.uris())
         self.assertEqual(["alias1", "alias2"], updated_model_version.aliases())
         self.assertEqual("comment", updated_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
 
     def test_link_update_model_version_aliases(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -544,7 +542,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", original_model_version.uri())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
 
         # todo
         changes = [
@@ -562,7 +560,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", updated_model_version.uri())
         self.assertEqual(["alias2", "alias3"], updated_model_version.aliases())
         self.assertEqual("comment", updated_model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
 
     def test_link_update_model_version_aliases_from_empty(self):
         # Regression test for https://github.com/apache/gravitino/issues/9727:
@@ -649,7 +647,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", model_version.uri())
         self.assertEqual(["alias1", "alias2"], model_version.aliases())
         self.assertEqual("comment", model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_version.properties())
 
         model_version = self._catalog.as_model_catalog().get_model_version_by_alias(
             model_ident, "alias1"
@@ -694,7 +692,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", model_version.uri())
         self.assertEqual([], model_version.aliases())
         self.assertIsNone(model_version.comment())
-        self.assertEqual({}, model_version.properties())
+        self.assert_properties_equal({}, model_version.properties())
 
     def test_link_list_model_versions(self):
         model_name = "model_it_model" + str(randint(0, 1000))
@@ -770,7 +768,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(model_versions[0].uri(), "uri1")
         self.assertEqual(model_versions[0].comment(), "comment")
         self.assertEqual(model_versions[0].aliases(), ["alias1", "alias2"])
-        self.assertEqual(model_versions[0].properties(), {"k1": "v1", "k2": "v2"})
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_versions[0].properties())
 
         self.assertTrue(
             self._catalog.as_model_catalog().delete_model_version(model_ident, 0)
@@ -807,7 +805,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, model_version.uris())
         self.assertEqual(["alias1", "alias2"], model_version.aliases())
         self.assertEqual("comment", model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_version.properties())
 
         # Test get model version by alias
         model_version = self._catalog.as_model_catalog().get_model_version_by_alias(
@@ -843,7 +841,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, model_versions[0].uris())
         self.assertEqual("comment", model_versions[0].comment())
         self.assertEqual(["alias1", "alias2"], model_versions[0].aliases())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, model_versions[0].properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_versions[0].properties())
 
     def test_get_model_version_uri(self):
         model_name = "model_it_model" + str(randint(0, 1000))
@@ -867,7 +865,7 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, model_version.uris())
         self.assertEqual(["alias1", "alias2"], model_version.aliases())
         self.assertEqual("comment", model_version.comment())
-        self.assertEqual({"k1": "v1", "k2": "v2"}, model_version.properties())
+        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_version.properties())
 
         # Test get model version uri
         model_version_uri = self._catalog.as_model_catalog().get_model_version_uri(

--- a/clients/client-python/tests/integration/test_relational_catalog.py
+++ b/clients/client-python/tests/integration/test_relational_catalog.py
@@ -178,7 +178,7 @@ class TestRelationalCatalog(IntegrationTestEnv):
         self.assertIsNotNone(table)
         self.assertEqual(table.name(), TestRelationalCatalog.TABLE_NAME)
         self.assertEqual(table.comment(), TestRelationalCatalog.TABLE_COMMENT)
-        self.assertEqual(table.properties(), TestRelationalCatalog.TABLE_PROPERTIES)
+        self.assert_properties_equal(TestRelationalCatalog.TABLE_PROPERTIES, table.properties())
         self.assertEqual(len(table.columns()), 3)
 
         columns = table.columns()

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -125,7 +125,7 @@ class TestSchema(MetalakeTestMixin, IntegrationTestEnv):
         schema = self.create_schema()
         self.assertEqual(schema.name(), self.schema_name)
         self.assertEqual(schema.comment(), self.schema_comment)
-        self.assertEqual(schema.properties(), self.schema_properties)
+        self.assert_properties_equal(self.schema_properties, schema.properties())
         self.assertEqual(schema.audit_info().creator(), "anonymous")
 
     def test_failed_create_schema(self):
@@ -155,7 +155,7 @@ class TestSchema(MetalakeTestMixin, IntegrationTestEnv):
         self.assertIsNotNone(schema)
         self.assertEqual(schema.name(), self.schema_name)
         self.assertEqual(schema.comment(), self.schema_comment)
-        self.assertEqual(schema.properties(), self.schema_properties)
+        self.assert_properties_equal(self.schema_properties, schema.properties())
         self.assertEqual(schema.audit_info().creator(), "anonymous")
 
     def test_failed_load_schema(self):

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1359,8 +1359,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   }
 
   /**
-   * Get the resolved properties (filter out the hidden properties and add some required default
-   * properties) of the catalog entity.
+   * Get the resolved properties (mask hidden properties and add some required default properties)
+   * of the catalog entity.
    *
    * @param entity The catalog entity.
    * @return The resolved properties.

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedFileset.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedFileset.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.FilesetEntity;
@@ -36,9 +35,6 @@ public final class EntityCombinedFileset implements Fileset {
 
   // Sets of properties that should be hidden from the user.
   private Set<String> hiddenProperties = Collections.emptySet();
-
-  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
-  private Set<String> omittedProperties = Collections.emptySet();
 
   private EntityCombinedFileset(Fileset fileset, FilesetEntity filesetEntity) {
     this.fileset = fileset;
@@ -63,19 +59,6 @@ public final class EntityCombinedFileset implements Fileset {
 
   public EntityCombinedFileset withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties != null ? hiddenProperties : Collections.emptySet();
-    this.omittedProperties = Collections.emptySet();
-    return this;
-  }
-
-  /** Applies mask/omit policy for API property responses. */
-  public EntityCombinedFileset withHiddenProperties(PropertyResponsePolicy policy) {
-    if (policy == null) {
-      this.hiddenProperties = Collections.emptySet();
-      this.omittedProperties = Collections.emptySet();
-    } else {
-      this.hiddenProperties = policy.keysToMask();
-      this.omittedProperties = policy.keysToOmit();
-    }
     return this;
   }
 
@@ -101,8 +84,7 @@ public final class EntityCombinedFileset implements Fileset {
 
   @Override
   public Map<String, String> properties() {
-    return HiddenPropertyMaskUtils.maskHiddenProperties(
-        fileset.properties(), hiddenProperties, omittedProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(fileset.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedFileset.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedFileset.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.catalog;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.gravitino.Audit;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.FilesetEntity;
@@ -84,10 +84,7 @@ public final class EntityCombinedFileset implements Fileset {
 
   @Override
   public Map<String, String> properties() {
-    return fileset.properties().entrySet().stream()
-        .filter(p -> !hiddenProperties.contains(p.getKey()))
-        .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return HiddenPropertyMaskUtils.maskHiddenProperties(fileset.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedFileset.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedFileset.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.FilesetEntity;
@@ -35,6 +36,9 @@ public final class EntityCombinedFileset implements Fileset {
 
   // Sets of properties that should be hidden from the user.
   private Set<String> hiddenProperties = Collections.emptySet();
+
+  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
+  private Set<String> omittedProperties = Collections.emptySet();
 
   private EntityCombinedFileset(Fileset fileset, FilesetEntity filesetEntity) {
     this.fileset = fileset;
@@ -59,6 +63,19 @@ public final class EntityCombinedFileset implements Fileset {
 
   public EntityCombinedFileset withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties != null ? hiddenProperties : Collections.emptySet();
+    this.omittedProperties = Collections.emptySet();
+    return this;
+  }
+
+  /** Applies mask/omit policy for API property responses. */
+  public EntityCombinedFileset withHiddenProperties(PropertyResponsePolicy policy) {
+    if (policy == null) {
+      this.hiddenProperties = Collections.emptySet();
+      this.omittedProperties = Collections.emptySet();
+    } else {
+      this.hiddenProperties = policy.keysToMask();
+      this.omittedProperties = policy.keysToOmit();
+    }
     return this;
   }
 
@@ -84,7 +101,8 @@ public final class EntityCombinedFileset implements Fileset {
 
   @Override
   public Map<String, String> properties() {
-    return HiddenPropertyMaskUtils.maskHiddenProperties(fileset.properties(), hiddenProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(
+        fileset.properties(), hiddenProperties, omittedProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModel.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModel.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.model.Model;
@@ -34,6 +35,9 @@ public final class EntityCombinedModel implements Model {
   private final ModelEntity modelEntity;
 
   private Set<String> hiddenProperties = Collections.emptySet();
+
+  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
+  private Set<String> omittedProperties = Collections.emptySet();
 
   private EntityCombinedModel(Model model, ModelEntity modelEntity) {
     this.model = model;
@@ -57,7 +61,20 @@ public final class EntityCombinedModel implements Model {
   }
 
   public EntityCombinedModel withHiddenProperties(Set<String> hiddenProperties) {
-    this.hiddenProperties = hiddenProperties;
+    this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
+    this.omittedProperties = Collections.emptySet();
+    return this;
+  }
+
+  /** Applies mask/omit policy for API property responses. */
+  public EntityCombinedModel withHiddenProperties(PropertyResponsePolicy policy) {
+    if (policy == null) {
+      this.hiddenProperties = Collections.emptySet();
+      this.omittedProperties = Collections.emptySet();
+    } else {
+      this.hiddenProperties = policy.keysToMask();
+      this.omittedProperties = policy.keysToOmit();
+    }
     return this;
   }
 
@@ -75,7 +92,8 @@ public final class EntityCombinedModel implements Model {
   public Map<String, String> properties() {
     return model.properties() == null
         ? null
-        : HiddenPropertyMaskUtils.maskHiddenProperties(model.properties(), hiddenProperties);
+        : HiddenPropertyMaskUtils.maskHiddenProperties(
+            model.properties(), hiddenProperties, omittedProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModel.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModel.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.model.Model;
@@ -35,9 +34,6 @@ public final class EntityCombinedModel implements Model {
   private final ModelEntity modelEntity;
 
   private Set<String> hiddenProperties = Collections.emptySet();
-
-  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
-  private Set<String> omittedProperties = Collections.emptySet();
 
   private EntityCombinedModel(Model model, ModelEntity modelEntity) {
     this.model = model;
@@ -61,20 +57,7 @@ public final class EntityCombinedModel implements Model {
   }
 
   public EntityCombinedModel withHiddenProperties(Set<String> hiddenProperties) {
-    this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
-    this.omittedProperties = Collections.emptySet();
-    return this;
-  }
-
-  /** Applies mask/omit policy for API property responses. */
-  public EntityCombinedModel withHiddenProperties(PropertyResponsePolicy policy) {
-    if (policy == null) {
-      this.hiddenProperties = Collections.emptySet();
-      this.omittedProperties = Collections.emptySet();
-    } else {
-      this.hiddenProperties = policy.keysToMask();
-      this.omittedProperties = policy.keysToOmit();
-    }
+    this.hiddenProperties = hiddenProperties;
     return this;
   }
 
@@ -92,8 +75,7 @@ public final class EntityCombinedModel implements Model {
   public Map<String, String> properties() {
     return model.properties() == null
         ? null
-        : HiddenPropertyMaskUtils.maskHiddenProperties(
-            model.properties(), hiddenProperties, omittedProperties);
+        : HiddenPropertyMaskUtils.maskHiddenProperties(model.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModel.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModel.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.catalog;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.gravitino.Audit;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.model.Model;
@@ -75,10 +75,7 @@ public final class EntityCombinedModel implements Model {
   public Map<String, String> properties() {
     return model.properties() == null
         ? null
-        : model.properties().entrySet().stream()
-            .filter(e -> !hiddenProperties.contains(e.getKey()))
-            .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        : HiddenPropertyMaskUtils.maskHiddenProperties(model.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModelVersion.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModelVersion.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.catalog;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.gravitino.Audit;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.model.ModelVersion;
@@ -69,10 +69,7 @@ public final class EntityCombinedModelVersion implements ModelVersion {
   public Map<String, String> properties() {
     return modelVersion.properties() == null
         ? null
-        : modelVersion.properties().entrySet().stream()
-            .filter(e -> !hiddenProperties.contains(e.getKey()))
-            .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        : HiddenPropertyMaskUtils.maskHiddenProperties(modelVersion.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModelVersion.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModelVersion.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.model.ModelVersion;
@@ -34,6 +35,9 @@ public final class EntityCombinedModelVersion implements ModelVersion {
   private final ModelVersionEntity modelVersionEntity;
 
   private Set<String> hiddenProperties = Collections.emptySet();
+
+  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
+  private Set<String> omittedProperties = Collections.emptySet();
 
   private EntityCombinedModelVersion(
       ModelVersion modelVersion, ModelVersionEntity modelVersionEntity) {
@@ -51,7 +55,20 @@ public final class EntityCombinedModelVersion implements ModelVersion {
   }
 
   public EntityCombinedModelVersion withHiddenProperties(Set<String> hiddenProperties) {
-    this.hiddenProperties = hiddenProperties;
+    this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
+    this.omittedProperties = Collections.emptySet();
+    return this;
+  }
+
+  /** Applies mask/omit policy for API property responses. */
+  public EntityCombinedModelVersion withHiddenProperties(PropertyResponsePolicy policy) {
+    if (policy == null) {
+      this.hiddenProperties = Collections.emptySet();
+      this.omittedProperties = Collections.emptySet();
+    } else {
+      this.hiddenProperties = policy.keysToMask();
+      this.omittedProperties = policy.keysToOmit();
+    }
     return this;
   }
 
@@ -69,7 +86,8 @@ public final class EntityCombinedModelVersion implements ModelVersion {
   public Map<String, String> properties() {
     return modelVersion.properties() == null
         ? null
-        : HiddenPropertyMaskUtils.maskHiddenProperties(modelVersion.properties(), hiddenProperties);
+        : HiddenPropertyMaskUtils.maskHiddenProperties(
+            modelVersion.properties(), hiddenProperties, omittedProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModelVersion.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedModelVersion.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.model.ModelVersion;
@@ -35,9 +34,6 @@ public final class EntityCombinedModelVersion implements ModelVersion {
   private final ModelVersionEntity modelVersionEntity;
 
   private Set<String> hiddenProperties = Collections.emptySet();
-
-  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
-  private Set<String> omittedProperties = Collections.emptySet();
 
   private EntityCombinedModelVersion(
       ModelVersion modelVersion, ModelVersionEntity modelVersionEntity) {
@@ -55,20 +51,7 @@ public final class EntityCombinedModelVersion implements ModelVersion {
   }
 
   public EntityCombinedModelVersion withHiddenProperties(Set<String> hiddenProperties) {
-    this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
-    this.omittedProperties = Collections.emptySet();
-    return this;
-  }
-
-  /** Applies mask/omit policy for API property responses. */
-  public EntityCombinedModelVersion withHiddenProperties(PropertyResponsePolicy policy) {
-    if (policy == null) {
-      this.hiddenProperties = Collections.emptySet();
-      this.omittedProperties = Collections.emptySet();
-    } else {
-      this.hiddenProperties = policy.keysToMask();
-      this.omittedProperties = policy.keysToOmit();
-    }
+    this.hiddenProperties = hiddenProperties;
     return this;
   }
 
@@ -86,8 +69,7 @@ public final class EntityCombinedModelVersion implements ModelVersion {
   public Map<String, String> properties() {
     return modelVersion.properties() == null
         ? null
-        : HiddenPropertyMaskUtils.maskHiddenProperties(
-            modelVersion.properties(), hiddenProperties, omittedProperties);
+        : HiddenPropertyMaskUtils.maskHiddenProperties(modelVersion.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedSchema.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedSchema.java
@@ -25,6 +25,7 @@ import org.apache.gravitino.Audit;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.SchemaEntity;
 
@@ -40,6 +41,9 @@ public final class EntityCombinedSchema implements Schema {
 
   // Property keys whose values are masked in API responses.
   private Set<String> hiddenProperties = Collections.emptySet();
+
+  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
+  private Set<String> omittedProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -72,6 +76,19 @@ public final class EntityCombinedSchema implements Schema {
 
   public EntityCombinedSchema withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
+    this.omittedProperties = Collections.emptySet();
+    return this;
+  }
+
+  /** Applies mask/omit policy for API property responses. */
+  public EntityCombinedSchema withHiddenProperties(PropertyResponsePolicy policy) {
+    if (policy == null) {
+      this.hiddenProperties = Collections.emptySet();
+      this.omittedProperties = Collections.emptySet();
+    } else {
+      this.hiddenProperties = policy.keysToMask();
+      this.omittedProperties = policy.keysToOmit();
+    }
     return this;
   }
 
@@ -92,7 +109,8 @@ public final class EntityCombinedSchema implements Schema {
 
   @Override
   public Map<String, String> properties() {
-    return HiddenPropertyMaskUtils.maskHiddenProperties(schema.properties(), hiddenProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(
+        schema.properties(), hiddenProperties, omittedProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedSchema.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedSchema.java
@@ -18,12 +18,13 @@
  */
 package org.apache.gravitino.catalog;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.SchemaEntity;
 
@@ -37,8 +38,8 @@ public final class EntityCombinedSchema implements Schema {
 
   private final SchemaEntity schemaEntity;
 
-  // Sets of properties that should be hidden from the user.
-  private Set<String> hiddenProperties;
+  // Property keys whose values are masked in API responses.
+  private Set<String> hiddenProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -70,7 +71,7 @@ public final class EntityCombinedSchema implements Schema {
   }
 
   public EntityCombinedSchema withHiddenProperties(Set<String> hiddenProperties) {
-    this.hiddenProperties = hiddenProperties;
+    this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
     return this;
   }
 
@@ -91,10 +92,7 @@ public final class EntityCombinedSchema implements Schema {
 
   @Override
   public Map<String, String> properties() {
-    return schema.properties().entrySet().stream()
-        .filter(e -> !hiddenProperties.contains(e.getKey()))
-        .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return HiddenPropertyMaskUtils.maskHiddenProperties(schema.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedSchema.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedSchema.java
@@ -25,7 +25,6 @@ import org.apache.gravitino.Audit;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.SchemaEntity;
 
@@ -41,9 +40,6 @@ public final class EntityCombinedSchema implements Schema {
 
   // Property keys whose values are masked in API responses.
   private Set<String> hiddenProperties = Collections.emptySet();
-
-  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
-  private Set<String> omittedProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -76,19 +72,6 @@ public final class EntityCombinedSchema implements Schema {
 
   public EntityCombinedSchema withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
-    this.omittedProperties = Collections.emptySet();
-    return this;
-  }
-
-  /** Applies mask/omit policy for API property responses. */
-  public EntityCombinedSchema withHiddenProperties(PropertyResponsePolicy policy) {
-    if (policy == null) {
-      this.hiddenProperties = Collections.emptySet();
-      this.omittedProperties = Collections.emptySet();
-    } else {
-      this.hiddenProperties = policy.keysToMask();
-      this.omittedProperties = policy.keysToOmit();
-    }
     return this;
   }
 
@@ -109,8 +92,7 @@ public final class EntityCombinedSchema implements Schema {
 
   @Override
   public Map<String, String> properties() {
-    return HiddenPropertyMaskUtils.maskHiddenProperties(
-        schema.properties(), hiddenProperties, omittedProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(schema.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.rel.Column;
@@ -47,9 +46,6 @@ public final class EntityCombinedTable implements Table {
 
   // Property keys whose values are masked in API responses.
   private Set<String> hiddenProperties = Collections.emptySet();
-
-  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
-  private Set<String> omittedProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -74,19 +70,6 @@ public final class EntityCombinedTable implements Table {
 
   public EntityCombinedTable withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
-    this.omittedProperties = Collections.emptySet();
-    return this;
-  }
-
-  /** Applies mask/omit policy for API property responses. */
-  public EntityCombinedTable withHiddenProperties(PropertyResponsePolicy policy) {
-    if (policy == null) {
-      this.hiddenProperties = Collections.emptySet();
-      this.omittedProperties = Collections.emptySet();
-    } else {
-      this.hiddenProperties = policy.keysToMask();
-      this.omittedProperties = policy.keysToOmit();
-    }
     return this;
   }
 
@@ -112,8 +95,7 @@ public final class EntityCombinedTable implements Table {
 
   @Override
   public Map<String, String> properties() {
-    return HiddenPropertyMaskUtils.maskHiddenProperties(
-        table.properties(), hiddenProperties, omittedProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(table.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
@@ -18,11 +18,12 @@
  */
 package org.apache.gravitino.catalog;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.rel.Column;
@@ -43,8 +44,8 @@ public final class EntityCombinedTable implements Table {
 
   private final TableEntity tableEntity;
 
-  // Sets of properties that should be hidden from the user.
-  private Set<String> hiddenProperties;
+  // Property keys whose values are masked in API responses.
+  private Set<String> hiddenProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -68,7 +69,7 @@ public final class EntityCombinedTable implements Table {
   }
 
   public EntityCombinedTable withHiddenProperties(Set<String> hiddenProperties) {
-    this.hiddenProperties = hiddenProperties;
+    this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
     return this;
   }
 
@@ -94,10 +95,7 @@ public final class EntityCombinedTable implements Table {
 
   @Override
   public Map<String, String> properties() {
-    return table.properties().entrySet().stream()
-        .filter(p -> !hiddenProperties.contains(p.getKey()))
-        .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return HiddenPropertyMaskUtils.maskHiddenProperties(table.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.rel.Column;
@@ -46,6 +47,9 @@ public final class EntityCombinedTable implements Table {
 
   // Property keys whose values are masked in API responses.
   private Set<String> hiddenProperties = Collections.emptySet();
+
+  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
+  private Set<String> omittedProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -70,6 +74,19 @@ public final class EntityCombinedTable implements Table {
 
   public EntityCombinedTable withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
+    this.omittedProperties = Collections.emptySet();
+    return this;
+  }
+
+  /** Applies mask/omit policy for API property responses. */
+  public EntityCombinedTable withHiddenProperties(PropertyResponsePolicy policy) {
+    if (policy == null) {
+      this.hiddenProperties = Collections.emptySet();
+      this.omittedProperties = Collections.emptySet();
+    } else {
+      this.hiddenProperties = policy.keysToMask();
+      this.omittedProperties = policy.keysToOmit();
+    }
     return this;
   }
 
@@ -95,7 +112,8 @@ public final class EntityCombinedTable implements Table {
 
   @Override
   public Map<String, String> properties() {
-    return HiddenPropertyMaskUtils.maskHiddenProperties(table.properties(), hiddenProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(
+        table.properties(), hiddenProperties, omittedProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTopic.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTopic.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.messaging.Topic;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TopicEntity;
@@ -39,6 +40,9 @@ public class EntityCombinedTopic implements Topic {
 
   // Property keys whose values are masked in API responses.
   private Set<String> hiddenProperties = Collections.emptySet();
+
+  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
+  private Set<String> omittedProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -71,6 +75,19 @@ public class EntityCombinedTopic implements Topic {
 
   public EntityCombinedTopic withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
+    this.omittedProperties = Collections.emptySet();
+    return this;
+  }
+
+  /** Applies mask/omit policy for API property responses. */
+  public EntityCombinedTopic withHiddenProperties(PropertyResponsePolicy policy) {
+    if (policy == null) {
+      this.hiddenProperties = Collections.emptySet();
+      this.omittedProperties = Collections.emptySet();
+    } else {
+      this.hiddenProperties = policy.keysToMask();
+      this.omittedProperties = policy.keysToOmit();
+    }
     return this;
   }
 
@@ -91,7 +108,8 @@ public class EntityCombinedTopic implements Topic {
 
   @Override
   public Map<String, String> properties() {
-    return HiddenPropertyMaskUtils.maskHiddenProperties(topic.properties(), hiddenProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(
+        topic.properties(), hiddenProperties, omittedProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTopic.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTopic.java
@@ -18,11 +18,12 @@
  */
 package org.apache.gravitino.catalog;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.messaging.Topic;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TopicEntity;
@@ -36,8 +37,8 @@ public class EntityCombinedTopic implements Topic {
   private final Topic topic;
   private final TopicEntity topicEntity;
 
-  // Sets of properties that should be hidden from the user.
-  private Set<String> hiddenProperties;
+  // Property keys whose values are masked in API responses.
+  private Set<String> hiddenProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -69,7 +70,7 @@ public class EntityCombinedTopic implements Topic {
   }
 
   public EntityCombinedTopic withHiddenProperties(Set<String> hiddenProperties) {
-    this.hiddenProperties = hiddenProperties;
+    this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
     return this;
   }
 
@@ -90,10 +91,7 @@ public class EntityCombinedTopic implements Topic {
 
   @Override
   public Map<String, String> properties() {
-    return topic.properties().entrySet().stream()
-        .filter(p -> !hiddenProperties.contains(p.getKey()))
-        .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return HiddenPropertyMaskUtils.maskHiddenProperties(topic.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTopic.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTopic.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.messaging.Topic;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TopicEntity;
@@ -40,9 +39,6 @@ public class EntityCombinedTopic implements Topic {
 
   // Property keys whose values are masked in API responses.
   private Set<String> hiddenProperties = Collections.emptySet();
-
-  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
-  private Set<String> omittedProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -75,19 +71,6 @@ public class EntityCombinedTopic implements Topic {
 
   public EntityCombinedTopic withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
-    this.omittedProperties = Collections.emptySet();
-    return this;
-  }
-
-  /** Applies mask/omit policy for API property responses. */
-  public EntityCombinedTopic withHiddenProperties(PropertyResponsePolicy policy) {
-    if (policy == null) {
-      this.hiddenProperties = Collections.emptySet();
-      this.omittedProperties = Collections.emptySet();
-    } else {
-      this.hiddenProperties = policy.keysToMask();
-      this.omittedProperties = policy.keysToOmit();
-    }
     return this;
   }
 
@@ -108,8 +91,7 @@ public class EntityCombinedTopic implements Topic {
 
   @Override
   public Map<String, String> properties() {
-    return HiddenPropertyMaskUtils.maskHiddenProperties(
-        topic.properties(), hiddenProperties, omittedProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(topic.properties(), hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedView.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedView.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ViewEntity;
 import org.apache.gravitino.rel.Column;
@@ -42,6 +43,9 @@ public final class EntityCombinedView implements View {
 
   // Sets of properties that should be hidden from the user.
   private Set<String> hiddenProperties = Collections.emptySet();
+
+  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
+  private Set<String> omittedProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -69,6 +73,19 @@ public final class EntityCombinedView implements View {
 
   public EntityCombinedView withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
+    this.omittedProperties = Collections.emptySet();
+    return this;
+  }
+
+  /** Applies mask/omit policy for API property responses. */
+  public EntityCombinedView withHiddenProperties(PropertyResponsePolicy policy) {
+    if (policy == null) {
+      this.hiddenProperties = Collections.emptySet();
+      this.omittedProperties = Collections.emptySet();
+    } else {
+      this.hiddenProperties = policy.keysToMask();
+      this.omittedProperties = policy.keysToOmit();
+    }
     return this;
   }
 
@@ -108,7 +125,7 @@ public final class EntityCombinedView implements View {
     if (props == null) {
       return Collections.emptyMap();
     }
-    return HiddenPropertyMaskUtils.maskHiddenProperties(props, hiddenProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(props, hiddenProperties, omittedProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedView.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedView.java
@@ -21,9 +21,9 @@ package org.apache.gravitino.catalog;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.gravitino.Audit;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ViewEntity;
 import org.apache.gravitino.rel.Column;
@@ -108,10 +108,7 @@ public final class EntityCombinedView implements View {
     if (props == null) {
       return Collections.emptyMap();
     }
-    return props.entrySet().stream()
-        .filter(p -> !hiddenProperties.contains(p.getKey()))
-        .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return HiddenPropertyMaskUtils.maskHiddenProperties(props, hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedView.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedView.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.ViewEntity;
 import org.apache.gravitino.rel.Column;
@@ -43,9 +42,6 @@ public final class EntityCombinedView implements View {
 
   // Sets of properties that should be hidden from the user.
   private Set<String> hiddenProperties = Collections.emptySet();
-
-  // Reserved+hidden system keys omitted from API responses (e.g. gravitino.identifier).
-  private Set<String> omittedProperties = Collections.emptySet();
 
   // Field "imported" is used to indicate whether the entity has been imported to Gravitino
   // managed storage backend. If "imported" is true, it means that storage backend have stored
@@ -73,19 +69,6 @@ public final class EntityCombinedView implements View {
 
   public EntityCombinedView withHiddenProperties(Set<String> hiddenProperties) {
     this.hiddenProperties = hiddenProperties == null ? Collections.emptySet() : hiddenProperties;
-    this.omittedProperties = Collections.emptySet();
-    return this;
-  }
-
-  /** Applies mask/omit policy for API property responses. */
-  public EntityCombinedView withHiddenProperties(PropertyResponsePolicy policy) {
-    if (policy == null) {
-      this.hiddenProperties = Collections.emptySet();
-      this.omittedProperties = Collections.emptySet();
-    } else {
-      this.hiddenProperties = policy.keysToMask();
-      this.omittedProperties = policy.keysToOmit();
-    }
     return this;
   }
 
@@ -125,7 +108,7 @@ public final class EntityCombinedView implements View {
     if (props == null) {
       return Collections.emptyMap();
     }
-    return HiddenPropertyMaskUtils.maskHiddenProperties(props, hiddenProperties, omittedProperties);
+    return HiddenPropertyMaskUtils.maskHiddenProperties(props, hiddenProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -23,6 +23,8 @@ import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier
 
 import com.google.common.collect.Maps;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.HasIdentifier;
@@ -30,8 +32,6 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HasPropertyMetadata;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -41,6 +41,7 @@ import org.apache.gravitino.rel.SupportsPartitions;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.ViewChange;
 import org.apache.gravitino.secret.SecretManager;
+import org.apache.gravitino.secret.SecretPropertyUtils;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.ThrowableFunction;
 import org.slf4j.Logger;
@@ -138,11 +139,7 @@ public abstract class OperationDispatcher {
     }
   }
 
-  /**
-   * Resolves which property keys should be masked vs omitted in API responses for the given entity
-   * properties.
-   */
-  protected PropertyResponsePolicy getHiddenPropertyNames(
+  protected Set<String> getHiddenPropertyNames(
       NameIdentifier catalogIdent,
       ThrowableFunction<HasPropertyMetadata, PropertiesMetadata> provider,
       Map<String, String> properties) {
@@ -150,9 +147,16 @@ public abstract class OperationDispatcher {
         catalogIdent,
         c ->
             c.doWithPropertiesMeta(
-                p ->
-                    HiddenPropertyMaskUtils.buildPropertyResponsePolicy(
-                        properties, provider.apply(p))),
+                p -> {
+                  PropertiesMetadata propertiesMetadata = provider.apply(p);
+                  return properties.entrySet().stream()
+                      .filter(
+                          e ->
+                              propertiesMetadata.isHiddenProperty(e.getKey())
+                                  || SecretPropertyUtils.isSecretProperty(e.getKey(), e.getValue()))
+                      .map(Map.Entry::getKey)
+                      .collect(Collectors.toSet());
+                }),
         IllegalArgumentException.class);
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -23,8 +23,6 @@ import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier
 
 import com.google.common.collect.Maps;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.HasIdentifier;
@@ -32,6 +30,8 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HasPropertyMetadata;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils.PropertyResponsePolicy;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -41,7 +41,6 @@ import org.apache.gravitino.rel.SupportsPartitions;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.ViewChange;
 import org.apache.gravitino.secret.SecretManager;
-import org.apache.gravitino.secret.SecretPropertyUtils;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.ThrowableFunction;
 import org.slf4j.Logger;
@@ -139,7 +138,11 @@ public abstract class OperationDispatcher {
     }
   }
 
-  protected Set<String> getHiddenPropertyNames(
+  /**
+   * Resolves which property keys should be masked vs omitted in API responses for the given entity
+   * properties.
+   */
+  protected PropertyResponsePolicy getHiddenPropertyNames(
       NameIdentifier catalogIdent,
       ThrowableFunction<HasPropertyMetadata, PropertiesMetadata> provider,
       Map<String, String> properties) {
@@ -147,16 +150,9 @@ public abstract class OperationDispatcher {
         catalogIdent,
         c ->
             c.doWithPropertiesMeta(
-                p -> {
-                  PropertiesMetadata propertiesMetadata = provider.apply(p);
-                  return properties.entrySet().stream()
-                      .filter(
-                          e ->
-                              propertiesMetadata.isHiddenProperty(e.getKey())
-                                  || SecretPropertyUtils.isSecretProperty(e.getKey(), e.getValue()))
-                      .map(Map.Entry::getKey)
-                      .collect(Collectors.toSet());
-                }),
+                p ->
+                    HiddenPropertyMaskUtils.buildPropertyResponsePolicy(
+                        properties, provider.apply(p))),
         IllegalArgumentException.class);
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -37,6 +37,8 @@ import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.messaging.TopicChange;
+import org.apache.gravitino.model.ModelChange;
+import org.apache.gravitino.model.ModelVersionChange;
 import org.apache.gravitino.rel.SupportsPartitions;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.ViewChange;
@@ -277,13 +279,11 @@ public abstract class OperationDispatcher {
       } else if (item instanceof ViewChange.SetProperty) {
         ViewChange.SetProperty setProperty = (ViewChange.SetProperty) item;
         properties.put(setProperty.getProperty(), setProperty.getValue());
-      } else if (item instanceof org.apache.gravitino.model.ModelChange.SetProperty) {
-        org.apache.gravitino.model.ModelChange.SetProperty setProperty =
-            (org.apache.gravitino.model.ModelChange.SetProperty) item;
+      } else if (item instanceof ModelChange.SetProperty) {
+        ModelChange.SetProperty setProperty = (ModelChange.SetProperty) item;
         properties.put(setProperty.property(), setProperty.value());
-      } else if (item instanceof org.apache.gravitino.model.ModelVersionChange.SetProperty) {
-        org.apache.gravitino.model.ModelVersionChange.SetProperty setProperty =
-            (org.apache.gravitino.model.ModelVersionChange.SetProperty) item;
+      } else if (item instanceof ModelVersionChange.SetProperty) {
+        ModelVersionChange.SetProperty setProperty = (ModelVersionChange.SetProperty) item;
         properties.put(setProperty.property(), setProperty.value());
       }
     }

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -277,6 +277,14 @@ public abstract class OperationDispatcher {
       } else if (item instanceof ViewChange.SetProperty) {
         ViewChange.SetProperty setProperty = (ViewChange.SetProperty) item;
         properties.put(setProperty.getProperty(), setProperty.getValue());
+      } else if (item instanceof org.apache.gravitino.model.ModelChange.SetProperty) {
+        org.apache.gravitino.model.ModelChange.SetProperty setProperty =
+            (org.apache.gravitino.model.ModelChange.SetProperty) item;
+        properties.put(setProperty.property(), setProperty.value());
+      } else if (item instanceof org.apache.gravitino.model.ModelVersionChange.SetProperty) {
+        org.apache.gravitino.model.ModelVersionChange.SetProperty setProperty =
+            (org.apache.gravitino.model.ModelVersionChange.SetProperty) item;
+        properties.put(setProperty.property(), setProperty.value());
       }
     }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/PropertiesMetadataHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PropertiesMetadataHelpers.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.PropertyEntry;
 
@@ -47,6 +48,8 @@ public class PropertiesMetadataHelpers {
     if (properties == null) {
       return;
     }
+
+    HiddenPropertyMaskUtils.validateNoMaskedPlaceholders(properties);
 
     List<String> reservedProperties =
         properties.keySet().stream()
@@ -87,6 +90,8 @@ public class PropertiesMetadataHelpers {
       PropertiesMetadata propertiesMetadata,
       Map<String, String> upserts,
       Map<String, String> deletes) {
+    HiddenPropertyMaskUtils.validateNoMaskedPlaceholders(upserts);
+
     for (Map.Entry<String, String> entry : upserts.entrySet()) {
       if (!propertiesMetadata.containsProperty(entry.getKey())) {
         continue;

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -478,10 +478,11 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     if (!shouldBackfillCredential()) {
       return properties;
     }
-    // Backfill may reintroduce raw credential values; mask them again for the API response.
+    // Escape hatch for legacy connectors: intentionally return plaintext credentials when
+    // gravitino.catalog.credential.backfillToProperties=true. Do not remask here.
     Map<String, String> result = Maps.newHashMap(properties);
     result.putAll(propertiesWithCredentialProviders());
-    return HiddenPropertyMaskUtils.maskHiddenProperties(result, catalogPropertiesMetadata());
+    return result;
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -48,7 +48,6 @@ import org.apache.gravitino.credential.S3SecretKeyCredential;
 import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.meta.CatalogEntity;
-import org.apache.gravitino.secret.SecretPropertyUtils;
 import org.apache.gravitino.storage.AzureProperties;
 import org.apache.gravitino.storage.GCSProperties;
 import org.apache.gravitino.storage.OSSProperties;
@@ -465,15 +464,9 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     if (properties == null) {
       synchronized (this) {
         if (properties == null) {
-          Preconditions.checkArgument(entity != null, ENTITY_IS_NOT_SET);
-          Map<String, String> tempProperties = Maps.newHashMap(entity.getProperties());
-          tempProperties
-              .entrySet()
-              .removeIf(
-                  entry ->
-                      catalogPropertiesMetadata().isHiddenProperty(entry.getKey())
-                          || SecretPropertyUtils.isSecretProperty(
-                              entry.getKey(), entry.getValue()));
+          Map<String, String> tempProperties =
+              HiddenPropertyMaskUtils.maskHiddenProperties(
+                  entity.getProperties(), catalogPropertiesMetadata());
           tempProperties.putIfAbsent(
               PROPERTY_IN_USE,
               catalogPropertiesMetadata().getDefaultValue(PROPERTY_IN_USE).toString());

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -478,9 +478,10 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     if (!shouldBackfillCredential()) {
       return properties;
     }
+    // Backfill may reintroduce raw credential values; mask them again for the API response.
     Map<String, String> result = Maps.newHashMap(properties);
     result.putAll(propertiesWithCredentialProviders());
-    return result;
+    return HiddenPropertyMaskUtils.maskHiddenProperties(result, catalogPropertiesMetadata());
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/connector/HiddenPropertyMaskUtils.java
+++ b/core/src/main/java/org/apache/gravitino/connector/HiddenPropertyMaskUtils.java
@@ -20,9 +20,7 @@ package org.apache.gravitino.connector;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.gravitino.secret.SecretPropertyUtils;
@@ -30,16 +28,12 @@ import org.apache.gravitino.secret.SecretPropertyUtils;
 /**
  * Read/write helpers for sensitive entity properties.
  *
- * <p><b>Read (API response)</b>:
- *
- * <ul>
- *   <li>Non-reserved hidden keys (credentials such as {@code jdbc-password} / S3 secrets) and
- *       secret-manager URNs are kept with value {@link #MASKED_VALUE}.
- *   <li>Reserved+hidden system keys (for example {@code gravitino.identifier}, Hive {@code
- *       external}) are omitted, matching the historical response shape.
- *   <li>Other properties, including reserved-but-visible ones (for example {@code numFiles}), are
- *       returned as-is. Reserved only controls write rejection for non-hidden keys.
- * </ul>
+ * <p><b>Read (API response)</b>: keep every property key. Replace values with {@link #MASKED_VALUE}
+ * when the key is metadata-{@code hidden} (including credential keys such as {@code jdbc-password}
+ * / S3 secrets) or the value is a secret-manager URN. Other properties, including
+ * reserved-but-visible ones (for example {@code numFiles}, {@code creator}), are returned as-is.
+ * Reserved only controls whether users may write the property; it does not remove keys from the
+ * response.
  *
  * <p><b>Write (create / alter)</b>: reject any value equal to {@link #MASKED_VALUE} so the
  * placeholder is never persisted. Reserved / immutable rejection remains in {@code
@@ -47,43 +41,10 @@ import org.apache.gravitino.secret.SecretPropertyUtils;
  */
 public final class HiddenPropertyMaskUtils {
 
-  /** Placeholder returned instead of hidden credential / secret property values. */
+  /** Placeholder returned instead of hidden / credential / secret property values. */
   public static final String MASKED_VALUE = "******";
 
   private HiddenPropertyMaskUtils() {}
-
-  /** Property keys to mask vs omit when building API responses. */
-  public static final class PropertyResponsePolicy {
-    private final Set<String> keysToMask;
-    private final Set<String> keysToOmit;
-
-    /**
-     * Creates a response policy.
-     *
-     * @param keysToMask keys whose values become {@link #MASKED_VALUE}
-     * @param keysToOmit keys removed from the response
-     */
-    public PropertyResponsePolicy(Set<String> keysToMask, Set<String> keysToOmit) {
-      this.keysToMask =
-          keysToMask == null ? Collections.emptySet() : Collections.unmodifiableSet(keysToMask);
-      this.keysToOmit =
-          keysToOmit == null ? Collections.emptySet() : Collections.unmodifiableSet(keysToOmit);
-    }
-
-    /**
-     * @return keys to return with {@link #MASKED_VALUE}
-     */
-    public Set<String> keysToMask() {
-      return keysToMask;
-    }
-
-    /**
-     * @return keys to drop from the response
-     */
-    public Set<String> keysToOmit() {
-      return keysToOmit;
-    }
-  }
 
   /** Returns true when {@code value} is the read-path masked placeholder. */
   public static boolean isMaskedPlaceholder(@Nullable String value) {
@@ -110,50 +71,22 @@ public final class HiddenPropertyMaskUtils {
   }
 
   /**
-   * Builds a {@link PropertyResponsePolicy} from property metadata.
+   * Returns a mutable copy of {@code properties} with values for {@code keysToMask} replaced by
+   * {@link #MASKED_VALUE}. Entries with null keys or values are dropped.
    *
-   * <p>Non-reserved hidden keys and secret URNs are masked; reserved+hidden keys are omitted.
-   */
-  public static PropertyResponsePolicy buildPropertyResponsePolicy(
-      Map<String, String> properties, PropertiesMetadata metadata) {
-    if (properties == null || properties.isEmpty()) {
-      return new PropertyResponsePolicy(Collections.emptySet(), Collections.emptySet());
-    }
-    Set<String> toMask = new HashSet<>();
-    Set<String> toOmit = new HashSet<>();
-    for (Map.Entry<String, String> entry : properties.entrySet()) {
-      String key = entry.getKey();
-      if (key == null) {
-        continue;
-      }
-      boolean hidden = metadata.isHiddenProperty(key);
-      boolean reserved = metadata.isReservedProperty(key);
-      boolean secret = SecretPropertyUtils.isSecretProperty(key, entry.getValue());
-      if (secret || (hidden && !reserved)) {
-        toMask.add(key);
-      } else if (hidden) {
-        toOmit.add(key);
-      }
-    }
-    return new PropertyResponsePolicy(toMask, toOmit);
-  }
-
-  /**
-   * Returns a mutable copy of {@code properties} with {@code keysToMask} replaced by {@link
-   * #MASKED_VALUE} and {@code keysToOmit} removed. Entries with null keys or values are dropped.
+   * <p>The returned map is always mutable so callers can add defaults such as {@code in-use}.
    */
   public static Map<String, String> maskHiddenProperties(
-      Map<String, String> properties, Set<String> keysToMask, Set<String> keysToOmit) {
+      Map<String, String> properties, Set<String> keysToMask) {
     if (properties == null || properties.isEmpty()) {
       return new HashMap<>();
     }
     Set<String> mask = keysToMask == null ? Collections.emptySet() : keysToMask;
-    Set<String> omit = keysToOmit == null ? Collections.emptySet() : keysToOmit;
     Map<String, String> result = new HashMap<>(properties.size());
     for (Map.Entry<String, String> entry : properties.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
-      if (key == null || value == null || omit.contains(key)) {
+      if (key == null || value == null) {
         continue;
       }
       result.put(key, mask.contains(key) ? MASKED_VALUE : value);
@@ -162,38 +95,29 @@ public final class HiddenPropertyMaskUtils {
   }
 
   /**
-   * Returns a mutable copy of {@code properties} with values for {@code keysToMask} replaced by
-   * {@link #MASKED_VALUE}. Entries with null keys or values are dropped.
-   *
-   * <p>The returned map is always mutable so callers can add defaults such as {@code in-use}.
-   */
-  public static Map<String, String> maskHiddenProperties(
-      Map<String, String> properties, Set<String> keysToMask) {
-    return maskHiddenProperties(properties, keysToMask, Collections.emptySet());
-  }
-
-  /**
-   * Applies a {@link PropertyResponsePolicy} to {@code properties}.
-   *
-   * @see #maskHiddenProperties(Map, Set, Set)
-   */
-  public static Map<String, String> maskHiddenProperties(
-      Map<String, String> properties, PropertyResponsePolicy policy) {
-    if (policy == null) {
-      return maskHiddenProperties(properties, Collections.emptySet(), Collections.emptySet());
-    }
-    return maskHiddenProperties(properties, policy.keysToMask(), policy.keysToOmit());
-  }
-
-  /**
    * Returns a mutable API-response copy of {@code properties}.
    *
-   * <p>Non-reserved hidden keys and secret URNs become {@link #MASKED_VALUE}; reserved+hidden keys
-   * are omitted.
+   * <p>Values are replaced with {@link #MASKED_VALUE} when {@link
+   * PropertiesMetadata#isHiddenProperty(String)} is true (credential and other sensitive keys) or
+   * {@link SecretPropertyUtils#isSecretProperty(String, String)} is true. Reserved keys are not
+   * removed.
    */
   public static Map<String, String> maskHiddenProperties(
       Map<String, String> properties, PropertiesMetadata metadata) {
-    Objects.requireNonNull(metadata, "metadata");
-    return maskHiddenProperties(properties, buildPropertyResponsePolicy(properties, metadata));
+    if (properties == null || properties.isEmpty()) {
+      return new HashMap<>();
+    }
+    Map<String, String> result = new HashMap<>(properties.size());
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (key == null || value == null) {
+        continue;
+      }
+      boolean shouldMask =
+          metadata.isHiddenProperty(key) || SecretPropertyUtils.isSecretProperty(key, value);
+      result.put(key, shouldMask ? MASKED_VALUE : value);
+    }
+    return result;
   }
 }

--- a/core/src/main/java/org/apache/gravitino/connector/HiddenPropertyMaskUtils.java
+++ b/core/src/main/java/org/apache/gravitino/connector/HiddenPropertyMaskUtils.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.connector;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.gravitino.secret.SecretPropertyUtils;
+
+/** Masks hidden entity properties for API responses and rejects masked values on write. */
+public final class HiddenPropertyMaskUtils {
+
+  /** Placeholder returned instead of hidden credential and other sensitive property values. */
+  public static final String MASKED_VALUE = "******";
+
+  private HiddenPropertyMaskUtils() {}
+
+  /** Returns true when {@code value} is the read-path masked placeholder. */
+  public static boolean isMaskedPlaceholder(@Nullable String value) {
+    return MASKED_VALUE.equals(value);
+  }
+
+  /**
+   * Rejects property maps that use the read-path masked placeholder as a write value.
+   *
+   * @throws IllegalArgumentException if any property value is {@link #MASKED_VALUE}
+   */
+  public static void validateNoMaskedPlaceholders(Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return;
+    }
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      if (isMaskedPlaceholder(entry.getValue())) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Property '%s' cannot be set to the masked placeholder value '%s'",
+                entry.getKey(), MASKED_VALUE));
+      }
+    }
+  }
+
+  /**
+   * Returns a copy of {@code properties} with values for {@code hiddenPropertyNames} replaced by
+   * {@link #MASKED_VALUE}. Entries with null keys or values are omitted.
+   */
+  public static Map<String, String> maskHiddenProperties(
+      Map<String, String> properties, Set<String> hiddenPropertyNames) {
+    if (properties == null || properties.isEmpty()) {
+      return properties == null ? Map.of() : Map.copyOf(properties);
+    }
+    Set<String> hidden = hiddenPropertyNames == null ? Collections.emptySet() : hiddenPropertyNames;
+    Map<String, String> masked = new HashMap<>(properties.size());
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (key == null || value == null) {
+        continue;
+      }
+      masked.put(key, hidden.contains(key) ? MASKED_VALUE : value);
+    }
+    return masked;
+  }
+
+  /**
+   * Returns a copy of {@code properties} with values for metadata-hidden keys replaced by {@link
+   * #MASKED_VALUE}. Entries with null keys or values are omitted.
+   */
+  public static Map<String, String> maskHiddenProperties(
+      Map<String, String> properties, PropertiesMetadata metadata) {
+    if (properties == null || properties.isEmpty()) {
+      return properties == null ? Map.of() : Map.copyOf(properties);
+    }
+    Map<String, String> masked = new HashMap<>(properties.size());
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (key == null || value == null) {
+        continue;
+      }
+      masked.put(
+          key,
+          metadata.isHiddenProperty(key) || SecretPropertyUtils.isSecretProperty(key, value)
+              ? MASKED_VALUE
+              : value);
+    }
+    return masked;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/connector/HiddenPropertyMaskUtils.java
+++ b/core/src/main/java/org/apache/gravitino/connector/HiddenPropertyMaskUtils.java
@@ -20,7 +20,9 @@ package org.apache.gravitino.connector;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.gravitino.secret.SecretPropertyUtils;
@@ -28,12 +30,16 @@ import org.apache.gravitino.secret.SecretPropertyUtils;
 /**
  * Read/write helpers for sensitive entity properties.
  *
- * <p><b>Read (API response)</b>: keep every property key. Replace values with {@link #MASKED_VALUE}
- * when the key is metadata-{@code hidden} (including credential keys such as {@code jdbc-password}
- * / S3 secrets) or the value is a secret-manager URN. Other properties, including
- * reserved-but-visible ones (for example {@code numFiles}, {@code creator}), are returned as-is.
- * Reserved only controls whether users may write the property; it does not remove keys from the
- * response.
+ * <p><b>Read (API response)</b>:
+ *
+ * <ul>
+ *   <li>Non-reserved hidden keys (credentials such as {@code jdbc-password} / S3 secrets) and
+ *       secret-manager URNs are kept with value {@link #MASKED_VALUE}.
+ *   <li>Reserved+hidden system keys (for example {@code gravitino.identifier}, Hive {@code
+ *       external}) are omitted, matching the historical response shape.
+ *   <li>Other properties, including reserved-but-visible ones (for example {@code numFiles}), are
+ *       returned as-is. Reserved only controls write rejection for non-hidden keys.
+ * </ul>
  *
  * <p><b>Write (create / alter)</b>: reject any value equal to {@link #MASKED_VALUE} so the
  * placeholder is never persisted. Reserved / immutable rejection remains in {@code
@@ -41,10 +47,43 @@ import org.apache.gravitino.secret.SecretPropertyUtils;
  */
 public final class HiddenPropertyMaskUtils {
 
-  /** Placeholder returned instead of hidden / credential / secret property values. */
+  /** Placeholder returned instead of hidden credential / secret property values. */
   public static final String MASKED_VALUE = "******";
 
   private HiddenPropertyMaskUtils() {}
+
+  /** Property keys to mask vs omit when building API responses. */
+  public static final class PropertyResponsePolicy {
+    private final Set<String> keysToMask;
+    private final Set<String> keysToOmit;
+
+    /**
+     * Creates a response policy.
+     *
+     * @param keysToMask keys whose values become {@link #MASKED_VALUE}
+     * @param keysToOmit keys removed from the response
+     */
+    public PropertyResponsePolicy(Set<String> keysToMask, Set<String> keysToOmit) {
+      this.keysToMask =
+          keysToMask == null ? Collections.emptySet() : Collections.unmodifiableSet(keysToMask);
+      this.keysToOmit =
+          keysToOmit == null ? Collections.emptySet() : Collections.unmodifiableSet(keysToOmit);
+    }
+
+    /**
+     * @return keys to return with {@link #MASKED_VALUE}
+     */
+    public Set<String> keysToMask() {
+      return keysToMask;
+    }
+
+    /**
+     * @return keys to drop from the response
+     */
+    public Set<String> keysToOmit() {
+      return keysToOmit;
+    }
+  }
 
   /** Returns true when {@code value} is the read-path masked placeholder. */
   public static boolean isMaskedPlaceholder(@Nullable String value) {
@@ -71,22 +110,50 @@ public final class HiddenPropertyMaskUtils {
   }
 
   /**
-   * Returns a mutable copy of {@code properties} with values for {@code keysToMask} replaced by
-   * {@link #MASKED_VALUE}. Entries with null keys or values are dropped.
+   * Builds a {@link PropertyResponsePolicy} from property metadata.
    *
-   * <p>The returned map is always mutable so callers can add defaults such as {@code in-use}.
+   * <p>Non-reserved hidden keys and secret URNs are masked; reserved+hidden keys are omitted.
+   */
+  public static PropertyResponsePolicy buildPropertyResponsePolicy(
+      Map<String, String> properties, PropertiesMetadata metadata) {
+    if (properties == null || properties.isEmpty()) {
+      return new PropertyResponsePolicy(Collections.emptySet(), Collections.emptySet());
+    }
+    Set<String> toMask = new HashSet<>();
+    Set<String> toOmit = new HashSet<>();
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      String key = entry.getKey();
+      if (key == null) {
+        continue;
+      }
+      boolean hidden = metadata.isHiddenProperty(key);
+      boolean reserved = metadata.isReservedProperty(key);
+      boolean secret = SecretPropertyUtils.isSecretProperty(key, entry.getValue());
+      if (secret || (hidden && !reserved)) {
+        toMask.add(key);
+      } else if (hidden) {
+        toOmit.add(key);
+      }
+    }
+    return new PropertyResponsePolicy(toMask, toOmit);
+  }
+
+  /**
+   * Returns a mutable copy of {@code properties} with {@code keysToMask} replaced by {@link
+   * #MASKED_VALUE} and {@code keysToOmit} removed. Entries with null keys or values are dropped.
    */
   public static Map<String, String> maskHiddenProperties(
-      Map<String, String> properties, Set<String> keysToMask) {
+      Map<String, String> properties, Set<String> keysToMask, Set<String> keysToOmit) {
     if (properties == null || properties.isEmpty()) {
       return new HashMap<>();
     }
     Set<String> mask = keysToMask == null ? Collections.emptySet() : keysToMask;
+    Set<String> omit = keysToOmit == null ? Collections.emptySet() : keysToOmit;
     Map<String, String> result = new HashMap<>(properties.size());
     for (Map.Entry<String, String> entry : properties.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
-      if (key == null || value == null) {
+      if (key == null || value == null || omit.contains(key)) {
         continue;
       }
       result.put(key, mask.contains(key) ? MASKED_VALUE : value);
@@ -95,29 +162,38 @@ public final class HiddenPropertyMaskUtils {
   }
 
   /**
+   * Returns a mutable copy of {@code properties} with values for {@code keysToMask} replaced by
+   * {@link #MASKED_VALUE}. Entries with null keys or values are dropped.
+   *
+   * <p>The returned map is always mutable so callers can add defaults such as {@code in-use}.
+   */
+  public static Map<String, String> maskHiddenProperties(
+      Map<String, String> properties, Set<String> keysToMask) {
+    return maskHiddenProperties(properties, keysToMask, Collections.emptySet());
+  }
+
+  /**
+   * Applies a {@link PropertyResponsePolicy} to {@code properties}.
+   *
+   * @see #maskHiddenProperties(Map, Set, Set)
+   */
+  public static Map<String, String> maskHiddenProperties(
+      Map<String, String> properties, PropertyResponsePolicy policy) {
+    if (policy == null) {
+      return maskHiddenProperties(properties, Collections.emptySet(), Collections.emptySet());
+    }
+    return maskHiddenProperties(properties, policy.keysToMask(), policy.keysToOmit());
+  }
+
+  /**
    * Returns a mutable API-response copy of {@code properties}.
    *
-   * <p>Values are replaced with {@link #MASKED_VALUE} when {@link
-   * PropertiesMetadata#isHiddenProperty(String)} is true (credential and other sensitive keys) or
-   * {@link SecretPropertyUtils#isSecretProperty(String, String)} is true. Reserved keys are not
-   * removed.
+   * <p>Non-reserved hidden keys and secret URNs become {@link #MASKED_VALUE}; reserved+hidden keys
+   * are omitted.
    */
   public static Map<String, String> maskHiddenProperties(
       Map<String, String> properties, PropertiesMetadata metadata) {
-    if (properties == null || properties.isEmpty()) {
-      return new HashMap<>();
-    }
-    Map<String, String> result = new HashMap<>(properties.size());
-    for (Map.Entry<String, String> entry : properties.entrySet()) {
-      String key = entry.getKey();
-      String value = entry.getValue();
-      if (key == null || value == null) {
-        continue;
-      }
-      boolean shouldMask =
-          metadata.isHiddenProperty(key) || SecretPropertyUtils.isSecretProperty(key, value);
-      result.put(key, shouldMask ? MASKED_VALUE : value);
-    }
-    return result;
+    Objects.requireNonNull(metadata, "metadata");
+    return maskHiddenProperties(properties, buildPropertyResponsePolicy(properties, metadata));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/connector/HiddenPropertyMaskUtils.java
+++ b/core/src/main/java/org/apache/gravitino/connector/HiddenPropertyMaskUtils.java
@@ -25,10 +25,23 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.gravitino.secret.SecretPropertyUtils;
 
-/** Masks hidden entity properties for API responses and rejects masked values on write. */
+/**
+ * Read/write helpers for sensitive entity properties.
+ *
+ * <p><b>Read (API response)</b>: keep every property key. Replace values with {@link #MASKED_VALUE}
+ * when the key is metadata-{@code hidden} (including credential keys such as {@code jdbc-password}
+ * / S3 secrets) or the value is a secret-manager URN. Other properties, including
+ * reserved-but-visible ones (for example {@code numFiles}, {@code creator}), are returned as-is.
+ * Reserved only controls whether users may write the property; it does not remove keys from the
+ * response.
+ *
+ * <p><b>Write (create / alter)</b>: reject any value equal to {@link #MASKED_VALUE} so the
+ * placeholder is never persisted. Reserved / immutable rejection remains in {@code
+ * PropertiesMetadataHelpers}.
+ */
 public final class HiddenPropertyMaskUtils {
 
-  /** Placeholder returned instead of hidden credential and other sensitive property values. */
+  /** Placeholder returned instead of hidden / credential / secret property values. */
   public static final String MASKED_VALUE = "******";
 
   private HiddenPropertyMaskUtils() {}
@@ -58,49 +71,53 @@ public final class HiddenPropertyMaskUtils {
   }
 
   /**
-   * Returns a copy of {@code properties} with values for {@code hiddenPropertyNames} replaced by
-   * {@link #MASKED_VALUE}. Entries with null keys or values are omitted.
+   * Returns a mutable copy of {@code properties} with values for {@code keysToMask} replaced by
+   * {@link #MASKED_VALUE}. Entries with null keys or values are dropped.
+   *
+   * <p>The returned map is always mutable so callers can add defaults such as {@code in-use}.
    */
   public static Map<String, String> maskHiddenProperties(
-      Map<String, String> properties, Set<String> hiddenPropertyNames) {
+      Map<String, String> properties, Set<String> keysToMask) {
     if (properties == null || properties.isEmpty()) {
-      return properties == null ? Map.of() : Map.copyOf(properties);
+      return new HashMap<>();
     }
-    Set<String> hidden = hiddenPropertyNames == null ? Collections.emptySet() : hiddenPropertyNames;
-    Map<String, String> masked = new HashMap<>(properties.size());
+    Set<String> mask = keysToMask == null ? Collections.emptySet() : keysToMask;
+    Map<String, String> result = new HashMap<>(properties.size());
     for (Map.Entry<String, String> entry : properties.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
       if (key == null || value == null) {
         continue;
       }
-      masked.put(key, hidden.contains(key) ? MASKED_VALUE : value);
+      result.put(key, mask.contains(key) ? MASKED_VALUE : value);
     }
-    return masked;
+    return result;
   }
 
   /**
-   * Returns a copy of {@code properties} with values for metadata-hidden keys replaced by {@link
-   * #MASKED_VALUE}. Entries with null keys or values are omitted.
+   * Returns a mutable API-response copy of {@code properties}.
+   *
+   * <p>Values are replaced with {@link #MASKED_VALUE} when {@link
+   * PropertiesMetadata#isHiddenProperty(String)} is true (credential and other sensitive keys) or
+   * {@link SecretPropertyUtils#isSecretProperty(String, String)} is true. Reserved keys are not
+   * removed.
    */
   public static Map<String, String> maskHiddenProperties(
       Map<String, String> properties, PropertiesMetadata metadata) {
     if (properties == null || properties.isEmpty()) {
-      return properties == null ? Map.of() : Map.copyOf(properties);
+      return new HashMap<>();
     }
-    Map<String, String> masked = new HashMap<>(properties.size());
+    Map<String, String> result = new HashMap<>(properties.size());
     for (Map.Entry<String, String> entry : properties.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
       if (key == null || value == null) {
         continue;
       }
-      masked.put(
-          key,
-          metadata.isHiddenProperty(key) || SecretPropertyUtils.isSecretProperty(key, value)
-              ? MASKED_VALUE
-              : value);
+      boolean shouldMask =
+          metadata.isHiddenProperty(key) || SecretPropertyUtils.isSecretProperty(key, value);
+      result.put(key, shouldMask ? MASKED_VALUE : value);
     }
-    return masked;
+    return result;
   }
 }

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
@@ -38,6 +38,7 @@ import org.apache.gravitino.MetalakeChange;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.CatalogManager;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
 import org.apache.gravitino.exceptions.MetalakeInUseException;
@@ -234,10 +235,8 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
     Map<String, String> newProps =
         metalakeEntity.properties() == null
             ? new HashMap<>()
-            : new HashMap<>(metalakeEntity.properties());
-    newProps
-        .entrySet()
-        .removeIf(e -> metalakeEntity.propertiesMetadata().isHiddenProperty(e.getKey()));
+            : HiddenPropertyMaskUtils.maskHiddenProperties(
+                metalakeEntity.properties(), metalakeEntity.propertiesMetadata());
     newProps.putIfAbsent(
         PROPERTY_IN_USE,
         metalakeEntity.propertiesMetadata().getDefaultValue(PROPERTY_IN_USE).toString());

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
@@ -768,11 +768,7 @@ public class TestAccessControlManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
-      Assertions.assertEquals(
-          org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
-          testProps.get(StringIdentifier.ID_KEY));
-    }
+    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
@@ -769,8 +769,9 @@ public class TestAccessControlManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
+    Assertions.assertTrue(
+        !testProps.containsKey(StringIdentifier.ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(testProps.get(StringIdentifier.ID_KEY)));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
@@ -68,6 +68,7 @@ import org.apache.gravitino.bulk.BulkItemResult;
 import org.apache.gravitino.bulk.UserAdd;
 import org.apache.gravitino.catalog.CatalogManager;
 import org.apache.gravitino.connector.BaseCatalog;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.authorization.AuthorizationPlugin;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchGroupException;
@@ -768,11 +769,8 @@ public class TestAccessControlManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
-      Assertions.assertEquals(
-          org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
-          testProps.get(StringIdentifier.ID_KEY));
-    }
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
@@ -768,7 +768,11 @@ public class TestAccessControlManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
+    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
+      Assertions.assertEquals(
+          org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
+          testProps.get(StringIdentifier.ID_KEY));
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.StringIdentifier.ID_KEY;
+import static org.apache.gravitino.TestCatalog.PROPERTY_HIDDEN_KEY;
 import static org.apache.gravitino.TestCatalog.PROPERTY_KEY1;
 import static org.apache.gravitino.TestCatalog.PROPERTY_KEY2;
 import static org.apache.gravitino.TestCatalog.PROPERTY_KEY3;
@@ -61,6 +62,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.connector.BaseCatalog;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.TestCatalogOperations;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
@@ -235,6 +237,62 @@ public class TestCatalogManager {
             IllegalArgumentException.class, () -> catalogManager.alterCatalog(ident2, change5));
     Assertions.assertTrue(
         e3.getMessage().contains("Property key6-1 is immutable"), e3.getMessage());
+    reset();
+  }
+
+  @Test
+  void testAlterCatalogRejectsMaskedHiddenProperty() throws IOException {
+    NameIdentifier ident = NameIdentifier.of("metalake", "masked_hidden");
+    Map<String, String> props =
+        ImmutableMap.<String, String>builder()
+            .put(PROPERTY_KEY1, "value1")
+            .put(PROPERTY_KEY2, "value2")
+            .put(PROPERTY_KEY3, "3")
+            .put(PROPERTY_KEY4, "value4")
+            .put(PROPERTY_KEY5_PREFIX + "1", "value1")
+            .put(PROPERTY_KEY6_PREFIX + "1", "value1")
+            .put(PROPERTY_HIDDEN_KEY, "secret")
+            .put("mock", "mock")
+            .build();
+    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, "comment", props);
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalogManager.alterCatalog(
+                    ident,
+                    CatalogChange.setProperty(
+                        PROPERTY_HIDDEN_KEY, HiddenPropertyMaskUtils.MASKED_VALUE)));
+
+    Assertions.assertTrue(exception.getMessage().contains(PROPERTY_HIDDEN_KEY));
+    CatalogEntity entity = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
+    Assertions.assertEquals("secret", entity.getProperties().get(PROPERTY_HIDDEN_KEY));
+    reset();
+  }
+
+  @Test
+  void testCreateCatalogRejectsMaskedHiddenProperty() throws IOException {
+    NameIdentifier ident = NameIdentifier.of("metalake", "masked_create");
+    Map<String, String> props =
+        ImmutableMap.<String, String>builder()
+            .put(PROPERTY_KEY1, "value1")
+            .put(PROPERTY_KEY2, "value2")
+            .put(PROPERTY_KEY3, "3")
+            .put(PROPERTY_KEY4, "value4")
+            .put(PROPERTY_KEY5_PREFIX + "1", "value1")
+            .put(PROPERTY_KEY6_PREFIX + "1", "value1")
+            .put(PROPERTY_HIDDEN_KEY, HiddenPropertyMaskUtils.MASKED_VALUE)
+            .put("mock", "mock")
+            .build();
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalogManager.createCatalog(
+                    ident, Catalog.Type.RELATIONAL, provider, "comment", props));
+    Assertions.assertTrue(exception.getMessage().contains(PROPERTY_HIDDEN_KEY));
     reset();
   }
 

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -1540,7 +1540,10 @@ public class TestCatalogManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertFalse(testProps.containsKey(ID_KEY), "`gravitino.identifier` is missing");
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE,
+        testProps.get(ID_KEY),
+        "`gravitino.identifier` should be returned as a masked placeholder");
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -1561,7 +1561,8 @@ public class TestCatalogManager {
               catalogProps(),
               Map.of(PROPERTY_KEY4, new SecretBinding("memory", "s3cr3t")),
               Map.of());
-      Assertions.assertFalse(catalog.properties().containsKey(PROPERTY_KEY4));
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, catalog.properties().get(PROPERTY_KEY4));
       String urn =
           entityStore
               .get(ident, EntityType.CATALOG, CatalogEntity.class)

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -1540,10 +1540,8 @@ public class TestCatalogManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE,
-        testProps.get(ID_KEY),
-        "`gravitino.identifier` should be returned as a masked placeholder");
+    Assertions.assertFalse(
+        testProps.containsKey(ID_KEY), "`gravitino.identifier` should be omitted from responses");
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -1540,8 +1540,10 @@ public class TestCatalogManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertFalse(
-        testProps.containsKey(ID_KEY), "`gravitino.identifier` should be omitted from responses");
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE,
+        testProps.get(ID_KEY),
+        "`gravitino.identifier` should be returned as a masked placeholder");
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestEntityCombinedFileset.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestEntityCombinedFileset.java
@@ -23,6 +23,7 @@ import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.FilesetEntity;
@@ -70,7 +71,7 @@ public class TestEntityCombinedFileset {
     Assertions.assertEquals(properties, entityCombinedFileset.properties());
   }
 
-  /** Test that properties() method correctly filters hidden properties. */
+  /** Test that properties() method masks hidden properties. */
   @Test
   void testPropertiesWithHiddenProperties() {
     Fileset fileset = Mockito.mock(Fileset.class);
@@ -83,11 +84,10 @@ public class TestEntityCombinedFileset {
 
     Map<String, String> result = entityCombinedFileset.properties();
 
-    // Should only contain non-hidden properties
-    Assertions.assertEquals(2, result.size());
+    Assertions.assertEquals(3, result.size());
     Assertions.assertEquals("valueA", result.get("propA"));
     Assertions.assertEquals("valueB", result.get("propB"));
-    Assertions.assertNull(result.get("hiddenProp"));
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, result.get("hiddenProp"));
   }
 
   /** Test that withHiddenProperties() method handles null input correctly. */

--- a/core/src/test/java/org/apache/gravitino/catalog/TestEntityCombinedFileset.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestEntityCombinedFileset.java
@@ -23,7 +23,6 @@ import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
-import java.util.Set;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.meta.AuditInfo;
@@ -99,7 +98,7 @@ public class TestEntityCombinedFileset {
     Mockito.when(fileset.properties()).thenReturn(properties);
 
     EntityCombinedFileset entityCombinedFileset =
-        EntityCombinedFileset.of(fileset).withHiddenProperties((Set<String>) null);
+        EntityCombinedFileset.of(fileset).withHiddenProperties(null);
 
     // Should not throw NPE and should return all properties
     Assertions.assertEquals(properties, entityCombinedFileset.properties());

--- a/core/src/test/java/org/apache/gravitino/catalog/TestEntityCombinedFileset.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestEntityCombinedFileset.java
@@ -23,6 +23,7 @@ import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
+import java.util.Set;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.meta.AuditInfo;
@@ -98,7 +99,7 @@ public class TestEntityCombinedFileset {
     Mockito.when(fileset.properties()).thenReturn(properties);
 
     EntityCombinedFileset entityCombinedFileset =
-        EntityCombinedFileset.of(fileset).withHiddenProperties(null);
+        EntityCombinedFileset.of(fileset).withHiddenProperties((Set<String>) null);
 
     // Should not throw NPE and should return all properties
     Assertions.assertEquals(properties, entityCombinedFileset.properties());

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.audit.CallerContext;
 import org.apache.gravitino.audit.FilesetAuditConstants;
 import org.apache.gravitino.audit.FilesetDataOperation;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.file.Fileset;
@@ -372,6 +373,32 @@ public class TestFilesetOperationDispatcher extends TestOperationDispatcher {
       Assertions.assertTrue(filesets.dropFileset(ident));
       Assertions.assertThrows(IllegalArgumentException.class, () -> secrets.readSecret(urn));
     }
+  }
+
+  @Test
+  public void testCreateAndAlterFilesetRejectMaskedPlaceholder() {
+    Namespace filesetNs = Namespace.of(metalake, catalog, "schema_masked_fileset");
+    schemaOperationDispatcher.createSchema(
+        NameIdentifier.of(filesetNs.levels()), "comment", ImmutableMap.of("k1", "v1", "k2", "v2"));
+
+    NameIdentifier filesetIdent = NameIdentifier.of(filesetNs, "fileset_masked");
+    Map<String, String> createProps =
+        ImmutableMap.of("k1", "v1", "k2", HiddenPropertyMaskUtils.MASKED_VALUE);
+    testMaskedPlaceholderRejected(
+        () ->
+            filesetOperationDispatcher.createFileset(
+                filesetIdent, "comment", Fileset.Type.MANAGED, "loc", createProps),
+        "k2");
+
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    filesetOperationDispatcher.createFileset(
+        filesetIdent, "comment", Fileset.Type.MANAGED, "loc", props);
+    testMaskedPlaceholderRejected(
+        () ->
+            filesetOperationDispatcher.alterFileset(
+                filesetIdent,
+                FilesetChange.setProperty("k3", HiddenPropertyMaskUtils.MASKED_VALUE)),
+        "k3");
   }
 
   private static SecretManager memorySecretManager() {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
@@ -348,7 +348,7 @@ public class TestFilesetOperationDispatcher extends TestOperationDispatcher {
       Fileset fileset =
           filesets.createMultipleLocationFileset(
               ident, "comment", Fileset.Type.MANAGED, locations, props, bindings, Map.of());
-      Assertions.assertFalse(fileset.properties().containsKey("k2"));
+      Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, fileset.properties().get("k2"));
 
       Fileset stored =
           catalogManager

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.NoSuchModelException;
 import org.apache.gravitino.exceptions.NoSuchModelVersionException;
 import org.apache.gravitino.exceptions.NoSuchModelVersionURINameException;
@@ -84,14 +85,17 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Model model = modelOperationDispatcher.registerModel(modelIdent, "comment", props);
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals("comment", model.comment());
-    Assertions.assertEquals(props, model.properties());
-    Assertions.assertFalse(model.properties().containsKey(ID_KEY));
+    props.forEach((k, v) -> Assertions.assertEquals(v, model.properties().get(k)));
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, model.properties().get(ID_KEY));
 
     Model registeredModel = modelOperationDispatcher.getModel(modelIdent);
     Assertions.assertEquals(modelName, registeredModel.name());
     Assertions.assertEquals("comment", registeredModel.comment());
-    Assertions.assertEquals(props, registeredModel.properties());
-    Assertions.assertFalse(registeredModel.properties().containsKey(ID_KEY));
+    props.forEach((k, v) -> Assertions.assertEquals(v, registeredModel.properties().get(k)));
+    if (registeredModel.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, registeredModel.properties().get(ID_KEY));
+    }
 
     // Test register model with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -170,8 +174,11 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
-    Assertions.assertEquals(props, linkedModelVersion.properties());
-    Assertions.assertFalse(linkedModelVersion.properties().containsKey(ID_KEY));
+    props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
+    if (linkedModelVersion.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
+    }
 
     // Test get model version with alias
     ModelVersion linkedModelVersionWithAlias =
@@ -179,14 +186,20 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(0, linkedModelVersionWithAlias.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias.aliases());
-    Assertions.assertFalse(linkedModelVersionWithAlias.properties().containsKey(ID_KEY));
+    if (linkedModelVersionWithAlias.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE,
+          linkedModelVersionWithAlias.properties().get(ID_KEY));
+    }
 
     ModelVersion linkedModelVersionWithAlias2 =
         modelOperationDispatcher.getModelVersion(modelIdent, "alias2");
     Assertions.assertEquals(0, linkedModelVersionWithAlias2.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias2.aliases());
-    Assertions.assertFalse(linkedModelVersionWithAlias2.properties().containsKey(ID_KEY));
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE,
+        linkedModelVersionWithAlias2.properties().get(ID_KEY));
 
     // Test Link model version with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -250,7 +263,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(uris, versions[0].uris());
     Assertions.assertArrayEquals(aliases, versions[0].aliases());
     Assertions.assertEquals("comment", versions[0].comment());
-    Assertions.assertEquals(props, versions[0].properties());
+    assertPropertiesContain(props, versions[0].properties());
   }
 
   @Test
@@ -313,8 +326,11 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
-    Assertions.assertEquals(props, linkedModelVersion.properties());
-    Assertions.assertFalse(linkedModelVersion.properties().containsKey(ID_KEY));
+    props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
+    if (linkedModelVersion.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
+    }
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -387,8 +403,12 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(uris, version1.uris());
     Assertions.assertArrayEquals(aliases, version1.aliases());
     Assertions.assertEquals("comment", version1.comment());
-    Assertions.assertEquals(versionPropsWithoutDefaultUriName, version1.properties());
-    Assertions.assertFalse(version1.properties().containsKey(ID_KEY));
+    versionPropsWithoutDefaultUriName.forEach(
+        (k, v) -> Assertions.assertEquals(v, version1.properties().get(k)));
+    if (version1.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, version1.properties().get(ID_KEY));
+    }
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -420,8 +440,12 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(uris, version2.uris());
     Assertions.assertArrayEquals(new String[] {"alias3"}, version2.aliases());
     Assertions.assertEquals("comment", version2.comment());
-    Assertions.assertEquals(versionPropsWithDefaultUriName, version2.properties());
-    Assertions.assertFalse(version2.properties().containsKey(ID_KEY));
+    versionPropsWithDefaultUriName.forEach(
+        (k, v) -> Assertions.assertEquals(v, version2.properties().get(k)));
+    if (version2.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, version2.properties().get(ID_KEY));
+    }
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 1, "n1"));
@@ -477,7 +501,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     // validate registered model
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals(modelComment, model.comment());
-    Assertions.assertEquals(props, model.properties());
+    assertPropertiesContain(props, model.properties());
 
     ModelChange[] addProperty = new ModelChange[] {ModelChange.setProperty("k3", "v3")};
     Model alteredModel = modelOperationDispatcher.alterModel(modelIdent, addProperty);
@@ -485,7 +509,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     // validate updated model
     Assertions.assertEquals(modelName, alteredModel.name());
     Assertions.assertEquals(modelComment, alteredModel.comment());
-    Assertions.assertEquals(
+    assertPropertiesContain(
         ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"), alteredModel.properties());
   }
 
@@ -506,7 +530,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     // validate registered model
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals(modelComment, model.comment());
-    Assertions.assertEquals(props, model.properties());
+    assertPropertiesContain(props, model.properties());
 
     ModelChange[] updateProperty = new ModelChange[] {ModelChange.setProperty("k1", "v3")};
     Model alteredModel = modelOperationDispatcher.alterModel(modelIdent, updateProperty);
@@ -514,7 +538,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     // validate updated model
     Assertions.assertEquals(modelName, alteredModel.name());
     Assertions.assertEquals(modelComment, alteredModel.comment());
-    Assertions.assertEquals(ImmutableMap.of("k1", "v3", "k2", "v2"), alteredModel.properties());
+    assertPropertiesContain(ImmutableMap.of("k1", "v3", "k2", "v2"), alteredModel.properties());
   }
 
   @Test
@@ -534,7 +558,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     // validate registered model
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals(modelComment, model.comment());
-    Assertions.assertEquals(props, model.properties());
+    assertPropertiesContain(props, model.properties());
 
     ModelChange[] removeProperty = new ModelChange[] {ModelChange.removeProperty("k1")};
     Model alteredModel = modelOperationDispatcher.alterModel(modelIdent, removeProperty);
@@ -542,7 +566,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     // validate updated model
     Assertions.assertEquals(modelName, alteredModel.name());
     Assertions.assertEquals(modelComment, alteredModel.comment());
-    Assertions.assertEquals(ImmutableMap.of("k2", "v2"), alteredModel.properties());
+    assertPropertiesContain(ImmutableMap.of("k2", "v2"), alteredModel.properties());
   }
 
   @Test
@@ -565,7 +589,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     // validate registered model
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals(modelComment, model.comment());
-    Assertions.assertEquals(props, model.properties());
+    assertPropertiesContain(props, model.properties());
 
     ModelChange change = ModelChange.updateComment(newModelComment);
     Model alteredModel = modelOperationDispatcher.alterModel(modelIdent, change);
@@ -573,7 +597,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     // validate updated model
     Assertions.assertEquals(modelName, alteredModel.name());
     Assertions.assertEquals(newModelComment, alteredModel.comment());
-    Assertions.assertEquals(props, alteredModel.properties());
+    assertPropertiesContain(props, alteredModel.properties());
   }
 
   @Test
@@ -647,7 +671,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(modelVersion.version(), alteredModelVersion.version());
     Assertions.assertEquals(modelVersion.aliases(), alteredModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), alteredModelVersion.comment());
-    Assertions.assertEquals(newProps, alteredModelVersion.properties());
+    assertPropertiesContain(newProps, alteredModelVersion.properties());
   }
 
   @Test
@@ -688,7 +712,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(modelVersion.version(), alteredModelVersion.version());
     Assertions.assertEquals(modelVersion.aliases(), alteredModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), alteredModelVersion.comment());
-    Assertions.assertEquals(newProps, alteredModelVersion.properties());
+    assertPropertiesContain(newProps, alteredModelVersion.properties());
   }
 
   @Test
@@ -725,7 +749,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(modelVersion.version(), alteredModelVersion.version());
     Assertions.assertEquals(modelVersion.aliases(), alteredModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), alteredModelVersion.comment());
-    Assertions.assertEquals(newProps, alteredModelVersion.properties());
+    assertPropertiesContain(newProps, alteredModelVersion.properties());
   }
 
   @Test
@@ -763,7 +787,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(modelVersion.version(), alteredModelVersion.version());
     Assertions.assertEquals(modelVersion.aliases(), alteredModelVersion.aliases());
     Assertions.assertEquals(modelVersion.comment(), alteredModelVersion.comment());
-    Assertions.assertEquals(newProps, alteredModelVersion.properties());
+    assertPropertiesContain(newProps, alteredModelVersion.properties());
   }
 
   @Test
@@ -1286,5 +1310,13 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
 
   private String randomModelName() {
     return "model_" + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  private static void assertPropertiesContain(
+      Map<String, String> expectedUserProps, Map<String, String> actual) {
+    expectedUserProps.forEach((k, v) -> Assertions.assertEquals(v, actual.get(k)));
+    if (actual.containsKey(ID_KEY)) {
+      Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, actual.get(ID_KEY));
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.NoSuchModelException;
 import org.apache.gravitino.exceptions.NoSuchModelVersionException;
 import org.apache.gravitino.exceptions.NoSuchModelVersionURINameException;
@@ -85,13 +86,16 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals("comment", model.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, model.properties().get(k)));
-    Assertions.assertFalse(model.properties().containsKey(ID_KEY));
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, model.properties().get(ID_KEY));
 
     Model registeredModel = modelOperationDispatcher.getModel(modelIdent);
     Assertions.assertEquals(modelName, registeredModel.name());
     Assertions.assertEquals("comment", registeredModel.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, registeredModel.properties().get(k)));
-    Assertions.assertFalse(registeredModel.properties().containsKey(ID_KEY));
+    if (registeredModel.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, registeredModel.properties().get(ID_KEY));
+    }
 
     // Test register model with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -171,7 +175,10 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
-    Assertions.assertFalse(linkedModelVersion.properties().containsKey(ID_KEY));
+    if (linkedModelVersion.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
+    }
 
     // Test get model version with alias
     ModelVersion linkedModelVersionWithAlias =
@@ -179,14 +186,20 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(0, linkedModelVersionWithAlias.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias.aliases());
-    Assertions.assertFalse(linkedModelVersionWithAlias.properties().containsKey(ID_KEY));
+    if (linkedModelVersionWithAlias.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE,
+          linkedModelVersionWithAlias.properties().get(ID_KEY));
+    }
 
     ModelVersion linkedModelVersionWithAlias2 =
         modelOperationDispatcher.getModelVersion(modelIdent, "alias2");
     Assertions.assertEquals(0, linkedModelVersionWithAlias2.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias2.aliases());
-    Assertions.assertFalse(linkedModelVersionWithAlias2.properties().containsKey(ID_KEY));
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE,
+        linkedModelVersionWithAlias2.properties().get(ID_KEY));
 
     // Test Link model version with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -314,7 +327,10 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
-    Assertions.assertFalse(linkedModelVersion.properties().containsKey(ID_KEY));
+    if (linkedModelVersion.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
+    }
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -389,7 +405,10 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("comment", version1.comment());
     versionPropsWithoutDefaultUriName.forEach(
         (k, v) -> Assertions.assertEquals(v, version1.properties().get(k)));
-    Assertions.assertFalse(version1.properties().containsKey(ID_KEY));
+    if (version1.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, version1.properties().get(ID_KEY));
+    }
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -423,7 +442,10 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("comment", version2.comment());
     versionPropsWithDefaultUriName.forEach(
         (k, v) -> Assertions.assertEquals(v, version2.properties().get(k)));
-    Assertions.assertFalse(version2.properties().containsKey(ID_KEY));
+    if (version2.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, version2.properties().get(ID_KEY));
+    }
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 1, "n1"));
@@ -1293,6 +1315,8 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
   private static void assertPropertiesContain(
       Map<String, String> expectedUserProps, Map<String, String> actual) {
     expectedUserProps.forEach((k, v) -> Assertions.assertEquals(v, actual.get(k)));
-    Assertions.assertFalse(actual.containsKey(ID_KEY));
+    if (actual.containsKey(ID_KEY)) {
+      Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, actual.get(ID_KEY));
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -92,10 +92,8 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(modelName, registeredModel.name());
     Assertions.assertEquals("comment", registeredModel.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, registeredModel.properties().get(k)));
-    if (registeredModel.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, registeredModel.properties().get(ID_KEY));
-    }
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, registeredModel.properties().get(ID_KEY));
 
     // Test register model with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -175,10 +173,8 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
-    if (linkedModelVersion.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
-    }
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
 
     // Test get model version with alias
     ModelVersion linkedModelVersionWithAlias =
@@ -186,11 +182,8 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(0, linkedModelVersionWithAlias.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias.aliases());
-    if (linkedModelVersionWithAlias.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE,
-          linkedModelVersionWithAlias.properties().get(ID_KEY));
-    }
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersionWithAlias.properties().get(ID_KEY));
 
     ModelVersion linkedModelVersionWithAlias2 =
         modelOperationDispatcher.getModelVersion(modelIdent, "alias2");
@@ -327,10 +320,8 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
-    if (linkedModelVersion.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
-    }
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -405,10 +396,8 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("comment", version1.comment());
     versionPropsWithoutDefaultUriName.forEach(
         (k, v) -> Assertions.assertEquals(v, version1.properties().get(k)));
-    if (version1.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, version1.properties().get(ID_KEY));
-    }
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, version1.properties().get(ID_KEY));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -442,10 +431,8 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("comment", version2.comment());
     versionPropsWithDefaultUriName.forEach(
         (k, v) -> Assertions.assertEquals(v, version2.properties().get(k)));
-    if (version2.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, version2.properties().get(ID_KEY));
-    }
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, version2.properties().get(ID_KEY));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 1, "n1"));
@@ -1315,8 +1302,6 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
   private static void assertPropertiesContain(
       Map<String, String> expectedUserProps, Map<String, String> actual) {
     expectedUserProps.forEach((k, v) -> Assertions.assertEquals(v, actual.get(k)));
-    if (actual.containsKey(ID_KEY)) {
-      Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, actual.get(ID_KEY));
-    }
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, actual.get(ID_KEY));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -36,7 +36,6 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.NoSuchModelException;
 import org.apache.gravitino.exceptions.NoSuchModelVersionException;
 import org.apache.gravitino.exceptions.NoSuchModelVersionURINameException;
@@ -86,16 +85,13 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals("comment", model.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, model.properties().get(k)));
-    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, model.properties().get(ID_KEY));
+    Assertions.assertFalse(model.properties().containsKey(ID_KEY));
 
     Model registeredModel = modelOperationDispatcher.getModel(modelIdent);
     Assertions.assertEquals(modelName, registeredModel.name());
     Assertions.assertEquals("comment", registeredModel.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, registeredModel.properties().get(k)));
-    if (registeredModel.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, registeredModel.properties().get(ID_KEY));
-    }
+    Assertions.assertFalse(registeredModel.properties().containsKey(ID_KEY));
 
     // Test register model with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -175,10 +171,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
-    if (linkedModelVersion.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
-    }
+    Assertions.assertFalse(linkedModelVersion.properties().containsKey(ID_KEY));
 
     // Test get model version with alias
     ModelVersion linkedModelVersionWithAlias =
@@ -186,20 +179,14 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(0, linkedModelVersionWithAlias.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias.aliases());
-    if (linkedModelVersionWithAlias.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE,
-          linkedModelVersionWithAlias.properties().get(ID_KEY));
-    }
+    Assertions.assertFalse(linkedModelVersionWithAlias.properties().containsKey(ID_KEY));
 
     ModelVersion linkedModelVersionWithAlias2 =
         modelOperationDispatcher.getModelVersion(modelIdent, "alias2");
     Assertions.assertEquals(0, linkedModelVersionWithAlias2.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias2.aliases());
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE,
-        linkedModelVersionWithAlias2.properties().get(ID_KEY));
+    Assertions.assertFalse(linkedModelVersionWithAlias2.properties().containsKey(ID_KEY));
 
     // Test Link model version with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -327,10 +314,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
-    if (linkedModelVersion.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
-    }
+    Assertions.assertFalse(linkedModelVersion.properties().containsKey(ID_KEY));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -405,10 +389,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("comment", version1.comment());
     versionPropsWithoutDefaultUriName.forEach(
         (k, v) -> Assertions.assertEquals(v, version1.properties().get(k)));
-    if (version1.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, version1.properties().get(ID_KEY));
-    }
+    Assertions.assertFalse(version1.properties().containsKey(ID_KEY));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -442,10 +423,7 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("comment", version2.comment());
     versionPropsWithDefaultUriName.forEach(
         (k, v) -> Assertions.assertEquals(v, version2.properties().get(k)));
-    if (version2.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, version2.properties().get(ID_KEY));
-    }
+    Assertions.assertFalse(version2.properties().containsKey(ID_KEY));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 1, "n1"));
@@ -1315,8 +1293,6 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
   private static void assertPropertiesContain(
       Map<String, String> expectedUserProps, Map<String, String> actual) {
     expectedUserProps.forEach((k, v) -> Assertions.assertEquals(v, actual.get(k)));
-    if (actual.containsKey(ID_KEY)) {
-      Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, actual.get(ID_KEY));
-    }
+    Assertions.assertFalse(actual.containsKey(ID_KEY));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -86,14 +86,18 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(modelName, model.name());
     Assertions.assertEquals("comment", model.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, model.properties().get(k)));
-    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, model.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !model.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(model.properties().get(ID_KEY)));
 
     Model registeredModel = modelOperationDispatcher.getModel(modelIdent);
     Assertions.assertEquals(modelName, registeredModel.name());
     Assertions.assertEquals("comment", registeredModel.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, registeredModel.properties().get(k)));
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, registeredModel.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !registeredModel.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(
+                registeredModel.properties().get(ID_KEY)));
 
     // Test register model with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -173,8 +177,10 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !linkedModelVersion.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(
+                linkedModelVersion.properties().get(ID_KEY)));
 
     // Test get model version with alias
     ModelVersion linkedModelVersionWithAlias =
@@ -182,17 +188,20 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(0, linkedModelVersionWithAlias.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias.aliases());
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersionWithAlias.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !linkedModelVersionWithAlias.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(
+                linkedModelVersionWithAlias.properties().get(ID_KEY)));
 
     ModelVersion linkedModelVersionWithAlias2 =
         modelOperationDispatcher.getModelVersion(modelIdent, "alias2");
     Assertions.assertEquals(0, linkedModelVersionWithAlias2.version());
     Assertions.assertEquals(uris, linkedModelVersion.uris());
     Assertions.assertArrayEquals(aliases, linkedModelVersionWithAlias2.aliases());
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE,
-        linkedModelVersionWithAlias2.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !linkedModelVersionWithAlias2.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(
+                linkedModelVersionWithAlias2.properties().get(ID_KEY)));
 
     // Test Link model version with illegal property
     Map<String, String> illegalProps = ImmutableMap.of("k1", "v1", ID_KEY, "test");
@@ -320,8 +329,10 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertArrayEquals(aliases, linkedModelVersion.aliases());
     Assertions.assertEquals("comment", linkedModelVersion.comment());
     props.forEach((k, v) -> Assertions.assertEquals(v, linkedModelVersion.properties().get(k)));
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, linkedModelVersion.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !linkedModelVersion.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(
+                linkedModelVersion.properties().get(ID_KEY)));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -396,8 +407,9 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("comment", version1.comment());
     versionPropsWithoutDefaultUriName.forEach(
         (k, v) -> Assertions.assertEquals(v, version1.properties().get(k)));
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, version1.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !version1.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(version1.properties().get(ID_KEY)));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 0, "n1"));
@@ -431,8 +443,9 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals("comment", version2.comment());
     versionPropsWithDefaultUriName.forEach(
         (k, v) -> Assertions.assertEquals(v, version2.properties().get(k)));
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, version2.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !version2.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(version2.properties().get(ID_KEY)));
 
     // get uri with uri name
     Assertions.assertEquals("u1", modelOperationDispatcher.getModelVersionUri(modelIdent, 1, "n1"));
@@ -1302,6 +1315,8 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
   private static void assertPropertiesContain(
       Map<String, String> expectedUserProps, Map<String, String> actual) {
     expectedUserProps.forEach((k, v) -> Assertions.assertEquals(v, actual.get(k)));
-    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, actual.get(ID_KEY));
+    Assertions.assertTrue(
+        !actual.containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(actual.get(ID_KEY)));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
@@ -48,6 +48,7 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.authorization.AuthorizationUtils;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.IllegalNamespaceException;
 import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
@@ -167,6 +168,14 @@ public abstract class TestOperationDispatcher {
     for (String msg : errorMessage) {
       Assertions.assertTrue(exception.getMessage().contains(msg));
     }
+  }
+
+  void testMaskedPlaceholderRejected(Executable operation, String propertyKey) {
+    testPropertyException(
+        operation,
+        propertyKey,
+        HiddenPropertyMaskUtils.MASKED_VALUE,
+        "cannot be set to the masked placeholder value");
   }
 
   public static void withMockedAuthorizationUtils(Runnable testCode) {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
@@ -159,15 +159,12 @@ public abstract class TestOperationDispatcher {
         (k, v) -> {
           Assertions.assertEquals(v, testProps.get(k));
         });
-    // If a hidden key is present, it must be masked (never plaintext).
-    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
-    }
-    if (testProps.containsKey(TEST_FILESET_HIDDEN_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(TEST_FILESET_HIDDEN_KEY));
-    }
+    // Hidden reserved keys must be returned as a masked placeholder.
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE,
+        testProps.getOrDefault(TEST_FILESET_HIDDEN_KEY, HiddenPropertyMaskUtils.MASKED_VALUE));
   }
 
   void testPropertyException(Executable operation, String... errorMessage) {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
@@ -159,8 +159,15 @@ public abstract class TestOperationDispatcher {
         (k, v) -> {
           Assertions.assertEquals(v, testProps.get(k));
         });
-    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
-    Assertions.assertFalse(testProps.containsKey(TEST_FILESET_HIDDEN_KEY));
+    // If a hidden key is present, it must be masked (never plaintext).
+    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
+    }
+    if (testProps.containsKey(TEST_FILESET_HIDDEN_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(TEST_FILESET_HIDDEN_KEY));
+    }
   }
 
   void testPropertyException(Executable operation, String... errorMessage) {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
@@ -160,7 +160,10 @@ public abstract class TestOperationDispatcher {
           Assertions.assertEquals(v, testProps.get(k));
         });
     // If a hidden key is present, it must be masked (never plaintext).
-    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
+    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
+    }
     if (testProps.containsKey(TEST_FILESET_HIDDEN_KEY)) {
       Assertions.assertEquals(
           HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(TEST_FILESET_HIDDEN_KEY));

--- a/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
@@ -160,10 +160,7 @@ public abstract class TestOperationDispatcher {
           Assertions.assertEquals(v, testProps.get(k));
         });
     // If a hidden key is present, it must be masked (never plaintext).
-    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
-    }
+    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
     if (testProps.containsKey(TEST_FILESET_HIDDEN_KEY)) {
       Assertions.assertEquals(
           HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(TEST_FILESET_HIDDEN_KEY));

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPropertiesMetadataHelpers.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPropertiesMetadataHelpers.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.apache.gravitino.TestBasePropertiesMetadata.TEST_REQUIRED_KEY;
+import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForAlter;
+import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.TestBasePropertiesMetadata;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.junit.jupiter.api.Test;
+
+public class TestPropertiesMetadataHelpers {
+
+  private static final TestBasePropertiesMetadata METADATA = new TestBasePropertiesMetadata();
+
+  @Test
+  void testCreateRejectsMaskedPlaceholder() {
+    Map<String, String> props =
+        ImmutableMap.of(TEST_REQUIRED_KEY, "value", "custom", HiddenPropertyMaskUtils.MASKED_VALUE);
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> validatePropertyForCreate(METADATA, props));
+    assertTrue(exception.getMessage().contains("custom"));
+    assertTrue(exception.getMessage().contains(HiddenPropertyMaskUtils.MASKED_VALUE));
+  }
+
+  @Test
+  void testCreateAllowsNormalValues() {
+    Map<String, String> props = ImmutableMap.of(TEST_REQUIRED_KEY, "value", "custom", "secret");
+    assertDoesNotThrow(() -> validatePropertyForCreate(METADATA, props));
+  }
+
+  @Test
+  void testAlterRejectsMaskedPlaceholder() {
+    Map<String, String> upserts = ImmutableMap.of("custom", HiddenPropertyMaskUtils.MASKED_VALUE);
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validatePropertyForAlter(METADATA, upserts, Collections.emptyMap()));
+    assertTrue(exception.getMessage().contains("custom"));
+  }
+
+  @Test
+  void testAlterAllowsNormalUpserts() {
+    Map<String, String> upserts = ImmutableMap.of("custom", "new-value");
+    assertDoesNotThrow(() -> validatePropertyForAlter(METADATA, upserts, Collections.emptyMap()));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -49,6 +49,7 @@ import org.apache.gravitino.Schema;
 import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.TestCatalog;
 import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.TestCatalogOperations;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
@@ -472,6 +473,23 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
       Assertions.assertTrue(d.dropSchema(ident, false));
       Assertions.assertThrows(IllegalArgumentException.class, () -> secrets.readSecret(urn));
     }
+  }
+
+  @Test
+  public void testCreateAndAlterSchemaRejectMaskedPlaceholder() {
+    NameIdentifier schemaIdent = NameIdentifier.of(metalake, catalog, "schema_masked");
+    Map<String, String> createProps =
+        ImmutableMap.of("k1", HiddenPropertyMaskUtils.MASKED_VALUE, "k2", "v2");
+    testMaskedPlaceholderRejected(
+        () -> dispatcher.createSchema(schemaIdent, "comment", createProps), "k1");
+
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    dispatcher.createSchema(schemaIdent, "comment", props);
+    testMaskedPlaceholderRejected(
+        () ->
+            dispatcher.alterSchema(
+                schemaIdent, SchemaChange.setProperty("k3", HiddenPropertyMaskUtils.MASKED_VALUE)),
+        "k3");
   }
 
   private static SecretManager memorySecretManager() {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -450,7 +450,7 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
       Map<String, SecretBinding> bindings = Map.of("k2", new SecretBinding("memory", "s3cr3t"));
       Schema schema =
           d.createSchema(ident, "comment", ImmutableMap.of("k1", "v1"), bindings, Map.of());
-      Assertions.assertFalse(schema.properties().containsKey("k2"));
+      Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, schema.properties().get("k2"));
 
       Schema stored =
           catalogManager

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -56,6 +56,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestCatalog;
 import org.apache.gravitino.TestColumn;
 import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.TestCatalogOperations;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -1244,6 +1245,38 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
           Assertions.assertEquals(e.autoIncrement(), actualColumn.autoIncrement());
           Assertions.assertEquals(e.defaultValue(), actualColumn.defaultValue());
         });
+  }
+
+  @Test
+  public void testCreateAndAlterTableRejectMaskedPlaceholder() {
+    Namespace tableNs = Namespace.of(metalake, catalog, "schema_masked_table");
+    schemaOperationDispatcher.createSchema(
+        NameIdentifier.of(tableNs.levels()), "comment", ImmutableMap.of("k1", "v1", "k2", "v2"));
+
+    NameIdentifier tableIdent = NameIdentifier.of(tableNs, "table_masked");
+    Column[] columns =
+        new Column[] {
+          TestColumn.builder()
+              .withName("col1")
+              .withPosition(0)
+              .withType(Types.StringType.get())
+              .build()
+        };
+    Map<String, String> createProps =
+        ImmutableMap.of("k1", HiddenPropertyMaskUtils.MASKED_VALUE, "k2", "v2");
+    testMaskedPlaceholderRejected(
+        () ->
+            tableOperationDispatcher.createTable(
+                tableIdent, columns, "comment", createProps, new Transform[0]),
+        "k1");
+
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    tableOperationDispatcher.createTable(tableIdent, columns, "comment", props, new Transform[0]);
+    testMaskedPlaceholderRejected(
+        () ->
+            tableOperationDispatcher.alterTable(
+                tableIdent, TableChange.setProperty("k3", HiddenPropertyMaskUtils.MASKED_VALUE)),
+        "k3");
   }
 
   private void putSchemaEntity(NameIdentifier ident) throws IOException {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -160,10 +160,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertNotNull(tableEntity);
     Assertions.assertEquals("table1", tableEntity.name());
 
-    if (table1.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, table1.properties().get(ID_KEY));
-    }
+    Assertions.assertFalse(table1.properties().containsKey(ID_KEY));
 
     Optional<NameIdentifier> ident1 =
         Arrays.stream(tableOperationDispatcher.listTables(tableNs))

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -160,7 +160,9 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertNotNull(tableEntity);
     Assertions.assertEquals("table1", tableEntity.name());
 
-    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, table1.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !table1.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(table1.properties().get(ID_KEY)));
 
     Optional<NameIdentifier> ident1 =
         Arrays.stream(tableOperationDispatcher.listTables(tableNs))

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -160,10 +160,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertNotNull(tableEntity);
     Assertions.assertEquals("table1", tableEntity.name());
 
-    if (table1.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, table1.properties().get(ID_KEY));
-    }
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, table1.properties().get(ID_KEY));
 
     Optional<NameIdentifier> ident1 =
         Arrays.stream(tableOperationDispatcher.listTables(tableNs))

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -160,7 +160,10 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertNotNull(tableEntity);
     Assertions.assertEquals("table1", tableEntity.name());
 
-    Assertions.assertFalse(table1.properties().containsKey(ID_KEY));
+    if (table1.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, table1.properties().get(ID_KEY));
+    }
 
     Optional<NameIdentifier> ident1 =
         Arrays.stream(tableOperationDispatcher.listTables(tableNs))

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
@@ -47,6 +47,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestCatalog;
 import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.TestCatalogOperations;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.lock.LockManager;
@@ -272,6 +273,27 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
     topicOperationDispatcher.createTopic(topicIdent, "comment", null, props);
     Assertions.assertTrue(entityStore.exists(NameIdentifier.of(topicNs.levels()), SCHEMA));
     Assertions.assertTrue(entityStore.exists(topicIdent, Entity.EntityType.TOPIC));
+  }
+
+  @Test
+  public void testCreateAndAlterTopicRejectMaskedPlaceholder() throws IOException {
+    Namespace topicNs = Namespace.of(metalake, catalog, "schema_masked_topic");
+    NameIdentifier topicIdent = NameIdentifier.of(topicNs, "topic_masked");
+    schemaOperationDispatcher.createSchema(
+        NameIdentifier.of(topicNs.levels()), "comment", ImmutableMap.of("k1", "v1", "k2", "v2"));
+
+    Map<String, String> createProps =
+        ImmutableMap.of("k1", HiddenPropertyMaskUtils.MASKED_VALUE, "k2", "v2");
+    testMaskedPlaceholderRejected(
+        () -> topicOperationDispatcher.createTopic(topicIdent, "comment", null, createProps), "k1");
+
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    topicOperationDispatcher.createTopic(topicIdent, "comment", null, props);
+    testMaskedPlaceholderRejected(
+        () ->
+            topicOperationDispatcher.alterTopic(
+                topicIdent, TopicChange.setProperty("k3", HiddenPropertyMaskUtils.MASKED_VALUE)),
+        "k3");
   }
 
   public static SchemaOperationDispatcher getSchemaOperationDispatcher() {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -53,7 +53,6 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestCatalog;
-import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.TestCatalogOperations;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -491,10 +490,7 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
         "comment",
         "gravitino.identifier");
 
-    if (created.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, created.properties().get(ID_KEY));
-    }
+    Assertions.assertFalse(created.properties().containsKey(ID_KEY));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -491,10 +491,7 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
         "comment",
         "gravitino.identifier");
 
-    if (created.properties().containsKey(ID_KEY)) {
-      Assertions.assertEquals(
-          HiddenPropertyMaskUtils.MASKED_VALUE, created.properties().get(ID_KEY));
-    }
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, created.properties().get(ID_KEY));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -53,6 +53,7 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestCatalog;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.TestCatalogOperations;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -490,7 +491,10 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
         "comment",
         "gravitino.identifier");
 
-    Assertions.assertFalse(created.properties().containsKey(ID_KEY));
+    if (created.properties().containsKey(ID_KEY)) {
+      Assertions.assertEquals(
+          HiddenPropertyMaskUtils.MASKED_VALUE, created.properties().get(ID_KEY));
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -491,7 +491,9 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
         "comment",
         "gravitino.identifier");
 
-    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, created.properties().get(ID_KEY));
+    Assertions.assertTrue(
+        !created.properties().containsKey(ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(created.properties().get(ID_KEY)));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/connector/TestHiddenPropertyMaskUtils.java
+++ b/core/src/test/java/org/apache/gravitino/connector/TestHiddenPropertyMaskUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.connector;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestHiddenPropertyMaskUtils {
+
+  @Test
+  void testMaskHiddenPropertiesByName() {
+    Map<String, String> properties =
+        ImmutableMap.of("visible", "v", "jdbc-password", "secret", "jdbc-user", "admin");
+    Map<String, String> masked =
+        HiddenPropertyMaskUtils.maskHiddenProperties(
+            properties, ImmutableSet.of("jdbc-password", "jdbc-user"));
+
+    Assertions.assertEquals("v", masked.get("visible"));
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("jdbc-password"));
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("jdbc-user"));
+  }
+
+  @Test
+  void testMaskHiddenPropertiesSkipsNullEntries() {
+    Map<String, String> properties = new java.util.HashMap<>();
+    properties.put("visible", "v");
+    properties.put("hidden", "secret");
+    properties.put("nullValue", null);
+
+    Map<String, String> masked =
+        HiddenPropertyMaskUtils.maskHiddenProperties(properties, ImmutableSet.of("hidden"));
+
+    Assertions.assertEquals(2, masked.size());
+    Assertions.assertEquals("v", masked.get("visible"));
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("hidden"));
+    Assertions.assertFalse(masked.containsKey("nullValue"));
+  }
+
+  @Test
+  void testValidateNoMaskedPlaceholdersRejectsMaskedValue() {
+    Map<String, String> properties =
+        ImmutableMap.of("jdbc-password", HiddenPropertyMaskUtils.MASKED_VALUE, "comment", "new");
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> HiddenPropertyMaskUtils.validateNoMaskedPlaceholders(properties));
+    Assertions.assertTrue(exception.getMessage().contains("jdbc-password"));
+    Assertions.assertTrue(exception.getMessage().contains(HiddenPropertyMaskUtils.MASKED_VALUE));
+  }
+
+  @Test
+  void testValidateNoMaskedPlaceholdersAllowsNormalValues() {
+    HiddenPropertyMaskUtils.validateNoMaskedPlaceholders(
+        ImmutableMap.of("jdbc-password", "secret", "comment", "new"));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/connector/TestHiddenPropertyMaskUtils.java
+++ b/core/src/test/java/org/apache/gravitino/connector/TestHiddenPropertyMaskUtils.java
@@ -82,7 +82,7 @@ public class TestHiddenPropertyMaskUtils {
   }
 
   @Test
-  void testMaskHiddenPropertiesKeepsReservedVisibleKeys() {
+  void testMaskHiddenPropertiesOmitsReservedHiddenKeys() {
     PropertiesMetadata metadata =
         new PropertiesMetadata() {
           @Override
@@ -113,11 +113,10 @@ public class TestHiddenPropertyMaskUtils {
 
     // reserved + not hidden → keep real value
     Assertions.assertEquals("10", masked.get("numFiles"));
-    // hidden credential → ******
+    // hidden credential (not reserved) → ******
     Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("jdbc-password"));
-    // reserved + hidden → still returned, but masked (no omit)
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("gravitino.identifier"));
+    // reserved + hidden → omitted from API response
+    Assertions.assertFalse(masked.containsKey("gravitino.identifier"));
     Assertions.assertEquals("v", masked.get("visible"));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/connector/TestHiddenPropertyMaskUtils.java
+++ b/core/src/test/java/org/apache/gravitino/connector/TestHiddenPropertyMaskUtils.java
@@ -82,7 +82,7 @@ public class TestHiddenPropertyMaskUtils {
   }
 
   @Test
-  void testMaskHiddenPropertiesOmitsReservedHiddenKeys() {
+  void testMaskHiddenPropertiesKeepsReservedVisibleKeys() {
     PropertiesMetadata metadata =
         new PropertiesMetadata() {
           @Override
@@ -113,10 +113,11 @@ public class TestHiddenPropertyMaskUtils {
 
     // reserved + not hidden → keep real value
     Assertions.assertEquals("10", masked.get("numFiles"));
-    // hidden credential (not reserved) → ******
+    // hidden credential → ******
     Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("jdbc-password"));
-    // reserved + hidden → omitted from API response
-    Assertions.assertFalse(masked.containsKey("gravitino.identifier"));
+    // reserved + hidden → still returned, but masked (no omit)
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("gravitino.identifier"));
     Assertions.assertEquals("v", masked.get("visible"));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/connector/TestHiddenPropertyMaskUtils.java
+++ b/core/src/test/java/org/apache/gravitino/connector/TestHiddenPropertyMaskUtils.java
@@ -72,4 +72,52 @@ public class TestHiddenPropertyMaskUtils {
     HiddenPropertyMaskUtils.validateNoMaskedPlaceholders(
         ImmutableMap.of("jdbc-password", "secret", "comment", "new"));
   }
+
+  @Test
+  void testMaskHiddenPropertiesReturnsMutableEmptyMap() {
+    Map<String, String> masked =
+        HiddenPropertyMaskUtils.maskHiddenProperties(Map.of(), ImmutableSet.of());
+    masked.put("in-use", "true");
+    Assertions.assertEquals("true", masked.get("in-use"));
+  }
+
+  @Test
+  void testMaskHiddenPropertiesKeepsReservedVisibleKeys() {
+    PropertiesMetadata metadata =
+        new PropertiesMetadata() {
+          @Override
+          public Map<String, PropertyEntry<?>> propertyEntries() {
+            return ImmutableMap.of(
+                "numFiles",
+                PropertyEntry.stringReservedPropertyEntry("numFiles", "number of files", false),
+                "jdbc-password",
+                PropertyEntry.stringOptionalPropertyEntry(
+                    "jdbc-password", "password", false, null, true),
+                "gravitino.identifier",
+                PropertyEntry.stringReservedPropertyEntry(
+                    "gravitino.identifier", "system id", true));
+          }
+        };
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            "numFiles",
+            "10",
+            "jdbc-password",
+            "secret",
+            "gravitino.identifier",
+            "uid-1",
+            "visible",
+            "v");
+    Map<String, String> masked = HiddenPropertyMaskUtils.maskHiddenProperties(properties, metadata);
+
+    // reserved + not hidden → keep real value
+    Assertions.assertEquals("10", masked.get("numFiles"));
+    // hidden credential → ******
+    Assertions.assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("jdbc-password"));
+    // reserved + hidden → still returned, but masked (no omit)
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, masked.get("gravitino.identifier"));
+    Assertions.assertEquals("v", masked.get("visible"));
+  }
 }

--- a/core/src/test/java/org/apache/gravitino/meta/TestEntityCombinedObject.java
+++ b/core/src/test/java/org/apache/gravitino/meta/TestEntityCombinedObject.java
@@ -33,6 +33,7 @@ import org.apache.gravitino.catalog.EntityCombinedModelVersion;
 import org.apache.gravitino.catalog.EntityCombinedSchema;
 import org.apache.gravitino.catalog.EntityCombinedTable;
 import org.apache.gravitino.catalog.EntityCombinedTopic;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.messaging.Topic;
 import org.apache.gravitino.model.Model;
@@ -76,10 +77,7 @@ public class TestEntityCombinedObject {
         EntityCombinedSchema.of(originSchema).withHiddenProperties(hiddenProperties);
     Assertions.assertEquals(originSchema.name(), entityCombinedSchema.name());
     Assertions.assertEquals(originSchema.comment(), entityCombinedSchema.comment());
-    Map<String, String> filterProp = new HashMap<>(originSchema.properties());
-    filterProp.remove("k3");
-    filterProp.remove(null);
-    filterProp.remove("k5");
+    Map<String, String> filterProp = expectedMaskedProperties(originSchema.properties());
     Assertions.assertEquals(filterProp, entityCombinedSchema.properties());
     Assertions.assertEquals(originSchema.auditInfo(), entityCombinedSchema.auditInfo());
   }
@@ -90,10 +88,7 @@ public class TestEntityCombinedObject {
         EntityCombinedTopic.of(originTopic).withHiddenProperties(hiddenProperties);
     Assertions.assertEquals(originTopic.name(), entityCombinedTopic.name());
     Assertions.assertEquals(originTopic.comment(), entityCombinedTopic.comment());
-    Map<String, String> filterProp = new HashMap<>(originTopic.properties());
-    filterProp.remove("k3");
-    filterProp.remove(null);
-    filterProp.remove("k5");
+    Map<String, String> filterProp = expectedMaskedProperties(originTopic.properties());
     Assertions.assertEquals(filterProp, entityCombinedTopic.properties());
     Assertions.assertEquals(originTopic.auditInfo(), entityCombinedTopic.auditInfo());
   }
@@ -104,10 +99,7 @@ public class TestEntityCombinedObject {
         EntityCombinedTable.of(originTable).withHiddenProperties(hiddenProperties);
     Assertions.assertEquals(originTable.name(), entityCombinedTable.name());
     Assertions.assertEquals(originTable.comment(), entityCombinedTable.comment());
-    Map<String, String> filterProp = new HashMap<>(originTopic.properties());
-    filterProp.remove("k3");
-    filterProp.remove(null);
-    filterProp.remove("k5");
+    Map<String, String> filterProp = expectedMaskedProperties(originTable.properties());
     Assertions.assertEquals(filterProp, entityCombinedTable.properties());
     Assertions.assertEquals(originTable.auditInfo(), entityCombinedTable.auditInfo());
   }
@@ -118,10 +110,7 @@ public class TestEntityCombinedObject {
         EntityCombinedFileset.of(originFileset).withHiddenProperties(hiddenProperties);
     Assertions.assertEquals(originFileset.name(), entityCombinedFileset.name());
     Assertions.assertEquals(originFileset.comment(), entityCombinedFileset.comment());
-    Map<String, String> filterProp = new HashMap<>(originFileset.properties());
-    filterProp.remove("k3");
-    filterProp.remove(null);
-    filterProp.remove("k5");
+    Map<String, String> filterProp = expectedMaskedProperties(originFileset.properties());
     Assertions.assertEquals(filterProp, entityCombinedFileset.properties());
     Assertions.assertEquals(originFileset.auditInfo(), entityCombinedFileset.auditInfo());
   }
@@ -132,10 +121,7 @@ public class TestEntityCombinedObject {
         EntityCombinedModel.of(originModel).withHiddenProperties(hiddenProperties);
     Assertions.assertEquals(originModel.name(), entityCombinedModel.name());
     Assertions.assertEquals(originModel.comment(), entityCombinedModel.comment());
-    Map<String, String> filterProp = new HashMap<>(originModel.properties());
-    filterProp.remove("k3");
-    filterProp.remove(null);
-    filterProp.remove("k5");
+    Map<String, String> filterProp = expectedMaskedProperties(originModel.properties());
     Assertions.assertEquals(filterProp, entityCombinedModel.properties());
     Assertions.assertEquals(originModel.auditInfo(), entityCombinedModel.auditInfo());
   }
@@ -145,14 +131,19 @@ public class TestEntityCombinedObject {
     EntityCombinedModelVersion entityCombinedModelVersion =
         EntityCombinedModelVersion.of(originModelVersion).withHiddenProperties(hiddenProperties);
     Assertions.assertEquals(originModelVersion.comment(), entityCombinedModelVersion.comment());
-    Map<String, String> filterProp = new HashMap<>(originModelVersion.properties());
-    filterProp.remove("k3");
-    filterProp.remove(null);
-    filterProp.remove("k5");
+    Map<String, String> filterProp = expectedMaskedProperties(originModelVersion.properties());
     Assertions.assertEquals(filterProp, entityCombinedModelVersion.properties());
     Assertions.assertEquals(originModelVersion.auditInfo(), entityCombinedModelVersion.auditInfo());
     Assertions.assertEquals(originModelVersion.version(), entityCombinedModelVersion.version());
     Assertions.assertEquals(originModelVersion.uris(), entityCombinedModelVersion.uris());
+  }
+
+  private static Map<String, String> expectedMaskedProperties(Map<String, String> source) {
+    Map<String, String> expected = new HashMap<>(source);
+    expected.put("k3", HiddenPropertyMaskUtils.MASKED_VALUE);
+    expected.remove(null);
+    expected.remove("k5");
+    return expected;
   }
 
   private Schema mockSchema() {

--- a/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
+++ b/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
@@ -309,10 +309,6 @@ public class TestMetalakeManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
-      Assertions.assertEquals(
-          org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
-          testProps.get(StringIdentifier.ID_KEY));
-    }
+    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
+++ b/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
@@ -43,6 +43,7 @@ import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.catalog.CatalogManager;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
@@ -309,10 +310,7 @@ public class TestMetalakeManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
-      Assertions.assertEquals(
-          org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
-          testProps.get(StringIdentifier.ID_KEY));
-    }
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
+++ b/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
@@ -310,7 +310,8 @@ public class TestMetalakeManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertEquals(
-        HiddenPropertyMaskUtils.MASKED_VALUE, testProps.get(StringIdentifier.ID_KEY));
+    Assertions.assertTrue(
+        !testProps.containsKey(StringIdentifier.ID_KEY)
+            || HiddenPropertyMaskUtils.MASKED_VALUE.equals(testProps.get(StringIdentifier.ID_KEY)));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
+++ b/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
@@ -309,6 +309,10 @@ public class TestMetalakeManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
+    if (testProps.containsKey(StringIdentifier.ID_KEY)) {
+      Assertions.assertEquals(
+          org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
+          testProps.get(StringIdentifier.ID_KEY));
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeNormalizeDispatcher.java
@@ -20,11 +20,15 @@ package org.apache.gravitino.metalake;
 
 import static org.apache.gravitino.Entity.SYSTEM_METALAKE_RESERVED_NAME;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.Map;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.Metalake;
+import org.apache.gravitino.MetalakeChange;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore;
 import org.junit.jupiter.api.AfterAll;
@@ -113,5 +117,33 @@ public class TestMetalakeNormalizeDispatcher {
       Assertions.assertEquals(
           "The metalake name '" + illegalName + "' is illegal.", exception.getMessage());
     }
+  }
+
+  @Test
+  public void testCreateMetalakeRejectsMaskedPlaceholder() {
+    NameIdentifier ident = NameIdentifier.of("masked_metalake");
+    Map<String, String> props = ImmutableMap.of("custom", HiddenPropertyMaskUtils.MASKED_VALUE);
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> metalakeNormalizeDispatcher.createMetalake(ident, null, props));
+    Assertions.assertTrue(exception.getMessage().contains("custom"));
+    Assertions.assertTrue(exception.getMessage().contains(HiddenPropertyMaskUtils.MASKED_VALUE));
+  }
+
+  @Test
+  public void testAlterMetalakeRejectsMaskedPlaceholder() {
+    NameIdentifier ident = NameIdentifier.of("masked_alter_metalake");
+    metalakeNormalizeDispatcher.createMetalake(ident, null, null);
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                metalakeNormalizeDispatcher.alterMetalake(
+                    ident,
+                    MetalakeChange.setProperty("custom", HiddenPropertyMaskUtils.MASKED_VALUE)));
+    Assertions.assertTrue(exception.getMessage().contains("custom"));
   }
 }

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test/jdbc/FlinkJdbcMysqlCatalogIT.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test/jdbc/FlinkJdbcMysqlCatalogIT.java
@@ -154,9 +154,13 @@ public abstract class FlinkJdbcMysqlCatalogIT extends FlinkCommonIT {
     org.apache.gravitino.Catalog gravitinoCatalog = metalake.loadCatalog(catalogName);
     Map<String, String> properties = gravitinoCatalog.properties();
     Assertions.assertEquals(mysqlUrl, properties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_URL));
-    // jdbc-user and jdbc-password are hidden properties and not returned by catalog.properties()
-    Assertions.assertFalse(properties.containsKey(JdbcPropertiesConstants.GRAVITINO_JDBC_USER));
-    Assertions.assertFalse(properties.containsKey(JdbcPropertiesConstants.GRAVITINO_JDBC_PASSWORD));
+    // jdbc-user and jdbc-password are hidden and returned as masked placeholders.
+    Assertions.assertEquals(
+        org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
+        properties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_USER));
+    Assertions.assertEquals(
+        org.apache.gravitino.connector.HiddenPropertyMaskUtils.MASKED_VALUE,
+        properties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_PASSWORD));
     Assertions.assertEquals(mysqlDefaultDatabase, properties.get(FLINK_BYPASS_DEFAULT_DATABASE));
     Assertions.assertEquals(
         "com.mysql.jdbc.Driver", properties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_DRIVER));

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceNameSpaceOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceNameSpaceOperations.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.CatalogChange;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.SchemaChange;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.exceptions.CatalogInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
@@ -277,7 +278,7 @@ public class GravitinoLanceNameSpaceOperations implements LanceNamespaceOperatio
         CatalogChange[] changes =
             buildChanges(
                 properties,
-                removeInUseProperty(catalog.properties()),
+                filterInternalProperties(catalog.properties()),
                 CatalogChange::setProperty,
                 CatalogChange::removeProperty,
                 CatalogChange[]::new);
@@ -289,9 +290,18 @@ public class GravitinoLanceNameSpaceOperations implements LanceNamespaceOperatio
     }
   }
 
-  private Map<String, String> removeInUseProperty(Map<String, String> properties) {
+  /**
+   * Drop server-managed properties from the overwrite baseline so we do not emit removeProperty for
+   * reserved keys such as {@code in-use} or {@code gravitino.identifier} (returned as a masked
+   * placeholder in API responses).
+   */
+  private Map<String, String> filterInternalProperties(Map<String, String> properties) {
+    if (properties == null) {
+      return Collections.emptyMap();
+    }
     return properties.entrySet().stream()
         .filter(e -> !e.getKey().equalsIgnoreCase(Catalog.PROPERTY_IN_USE))
+        .filter(e -> !StringIdentifier.ID_KEY.equals(e.getKey()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
@@ -327,7 +337,7 @@ public class GravitinoLanceNameSpaceOperations implements LanceNamespaceOperatio
         SchemaChange[] changes =
             buildChanges(
                 properties,
-                schema.properties(),
+                filterInternalProperties(schema.properties()),
                 SchemaChange::setProperty,
                 SchemaChange::removeProperty,
                 SchemaChange[]::new);

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00002_alter_table.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00002_alter_table.txt
@@ -18,6 +18,7 @@ DROP COLUMN
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/gt_db1.db/tb01',
    num_files = '0',
@@ -36,6 +37,7 @@ RENAME COLUMN
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/gt_db1.db/tb01',
    num_files = '0',
@@ -54,6 +56,7 @@ SET COLUMN TYPE
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/gt_db1.db/tb01',
    num_files = '0',
@@ -72,6 +75,7 @@ COMMENT
 )
 COMMENT 'test table comments'
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/gt_db1.db/tb01',
    num_files = '0',
@@ -90,6 +94,7 @@ COMMENT
 )
 COMMENT 'test table comments'
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/gt_db1.db/tb01',
    num_files = '0',
@@ -109,6 +114,7 @@ ADD COLUMN
 )
 COMMENT 'test table comments'
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/gt_db1.db/tb01',
    num_files = '0',

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00006_datatype.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00006_datatype.txt
@@ -22,6 +22,7 @@ CREATE TABLE
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/gt_db1.db/tb01',
    output_format = 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00007_varchar.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00007_varchar.txt
@@ -10,6 +10,7 @@ CREATE TABLE
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/varchar_db1.db/tb01',
    output_format = 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
@@ -26,6 +27,7 @@ CREATE TABLE
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/varchar_db1.db/tb02',
    output_format = 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
@@ -44,6 +46,7 @@ CREATE TABLE
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/varchar_db1.db/tb04',
    output_format = 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
@@ -60,6 +63,7 @@ CREATE TABLE
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/varchar_db1.db/tb05',
    output_format = 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
@@ -76,6 +80,7 @@ CREATE TABLE
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/varchar_db1.db/tb06',
    output_format = 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
@@ -92,6 +97,7 @@ CREATE TABLE
 )
 COMMENT ''
 WITH (
+   external = '******',
    input_format = 'org.apache.hadoop.mapred.TextInputFormat',
    location = 'hdfs://%/user/hive/warehouse/varchar_db1.db/tb07',
    output_format = 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00008_alter_catalog.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00008_alter_catalog.txt
@@ -1,17 +1,17 @@
 CALL
 
-"gt_mysql_xxx1","jdbc-mysql","{""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false""}"
+"gt_mysql_xxx1","jdbc-mysql","{""gravitino.identifier"":""******"",""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""******"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""******""}"
 
 CALL
 
-"gt_mysql_xxx1","jdbc-mysql","{""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""test_key"":""test_value"",""trino.bypass.join-pushdown.strategy"":""EAGER""}"
+"gt_mysql_xxx1","jdbc-mysql","{""gravitino.identifier"":""******"",""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""******"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""******"",""test_key"":""test_value"",""trino.bypass.join-pushdown.strategy"":""EAGER""}"
 
 CALL
 
-"gt_mysql_xxx1","jdbc-mysql","{""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""test_key"":""test_value""}"
+"gt_mysql_xxx1","jdbc-mysql","{""gravitino.identifier"":""******"",""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""******"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""******"",""test_key"":""test_value""}"
 
 CALL
 
-"gt_mysql_xxx1","jdbc-mysql","{""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""trino.bypass.join-pushdown.strategy"":""EAGER""}"
+"gt_mysql_xxx1","jdbc-mysql","{""gravitino.identifier"":""******"",""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""******"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""******"",""trino.bypass.join-pushdown.strategy"":""EAGER""}"
 
 CALL


### PR DESCRIPTION
### What changes were proposed in this pull request?

Return hidden credential-related properties (for example `jdbc-user`, `jdbc-password`, and S3 secret keys) with a masked placeholder (`******`) instead of omitting them from API responses.

The changes include:

1. Add `HiddenPropertyMaskUtils` with `MASKED_VALUE = "******"`.
2. Apply read-path masking in `BaseCatalog`, `MetalakeManager`, and all `EntityCombined*` property maps.
3. Reject create/alter requests that set any property value to `******` via `PropertiesMetadataHelpers` validation so clients cannot persist the read-path placeholder as a real secret.
4. Update related unit tests.

Internal credential paths such as `propertiesWithCredentialProviders()` still use plaintext values.

When `gravitino.catalog.credential.backfillToProperties=true`, catalog properties still return plaintext for backward compatibility with legacy connectors.

**Note:** Web UI still needs a follow-up change to treat `******` as a placeholder and omit unchanged secret fields on submit.

### Why are the changes needed?

Hidden secret fields were removed from catalog/entity property responses, so the UI could not tell whether a credential property was set and could not reliably submit an updated value on the edit page.

Returning a masked placeholder keeps secrets out of API responses while preserving property keys for clients such as the catalog edit UI. Rejecting masked values on write enforces a clear API contract: clients must omit unchanged secrets or submit new plaintext values.

Fix: #12580

### Does this PR introduce _any_ user-facing change?

Yes. Hidden credential properties are now returned with value `******` instead of being omitted from catalog, metalake, schema, table, fileset, and other entity property responses. Create and alter requests that set a property to `******` fail with `IllegalArgumentException`.

### How was this patch tested?

```bash
./gradlew :core:spotlessApply :catalogs:catalog-jdbc-common:spotlessApply

./gradlew :core:test \
  --tests 'org.apache.gravitino.connector.TestHiddenPropertyMaskUtils' \
  --tests 'org.apache.gravitino.catalog.TestPropertiesMetadataHelpers' \
  --tests 'org.apache.gravitino.catalog.TestCatalogManager.testAlterCatalogRejectsMaskedHiddenProperty' \
  --tests 'org.apache.gravitino.catalog.TestCatalogManager.testCreateCatalogRejectsMaskedHiddenProperty' \
  --tests 'org.apache.gravitino.meta.TestEntityCombinedObject' \
  --tests 'org.apache.gravitino.catalog.TestEntityCombinedFileset' \
  --tests 'org.apache.gravitino.metalake.TestMetalakeNormalizeDispatcher.testCreateMetalakeRejectsMaskedPlaceholder' \
  --tests 'org.apache.gravitino.metalake.TestMetalakeNormalizeDispatcher.testAlterMetalakeRejectsMaskedPlaceholder' \
  --tests 'org.apache.gravitino.catalog.TestSchemaOperationDispatcher.testCreateAndAlterSchemaRejectMaskedPlaceholder' \
  --tests 'org.apache.gravitino.catalog.TestFilesetOperationDispatcher.testCreateAndAlterFilesetRejectMaskedPlaceholder' \
  --tests 'org.apache.gravitino.catalog.TestTopicOperationDispatcher.testCreateAndAlterTopicRejectMaskedPlaceholder' \
  --tests 'org.apache.gravitino.catalog.TestTableOperationDispatcher.testCreateAndAlterTableRejectMaskedPlaceholder'

./gradlew :catalogs:catalog-jdbc-common:test \
  --tests 'org.apache.gravitino.catalog.jdbc.TestJdbcCatalogCredential'
```
