### PR TITLE
feat: dispatch events for catalog connection tests

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
@@ -47,6 +47,9 @@ import org.apache.gravitino.listener.api.event.DropCatalogPreEvent;
 import org.apache.gravitino.listener.api.event.EnableCatalogEvent;
 import org.apache.gravitino.listener.api.event.EnableCatalogFailureEvent;
 import org.apache.gravitino.listener.api.event.EnableCatalogPreEvent;
+import org.apache.gravitino.listener.api.event.TestConnectionEvent;
+import org.apache.gravitino.listener.api.event.TestConnectionFailureEvent;
+import org.apache.gravitino.listener.api.event.TestConnectionPreEvent;
 import org.apache.gravitino.listener.api.event.ListCatalogEvent;
 import org.apache.gravitino.listener.api.event.ListCatalogFailureEvent;
 import org.apache.gravitino.listener.api.event.ListCatalogPreEvent;
@@ -218,14 +221,33 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
       String comment,
       Map<String, String> properties)
       throws Exception {
-    // TODO(#12566): Support event dispatching for testConnection
-    dispatcher.testConnection(ident, type, provider, comment, properties);
+    // Do not put properties on the event payload - they may contain credentials (#12566).
+    eventBus.dispatchEvent(
+        new TestConnectionPreEvent(PrincipalUtils.getCurrentUserName(), ident));
+    try {
+      dispatcher.testConnection(ident, type, provider, comment, properties);
+      eventBus.dispatchEvent(
+          new TestConnectionEvent(PrincipalUtils.getCurrentUserName(), ident));
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new TestConnectionFailureEvent(PrincipalUtils.getCurrentUserName(), ident, e));
+      throw e;
+    }
   }
 
   @Override
   public void testConnection(NameIdentifier ident) throws Exception {
-    // TODO(#12566): Support event dispatching for testConnection
-    dispatcher.testConnection(ident);
+    eventBus.dispatchEvent(
+        new TestConnectionPreEvent(PrincipalUtils.getCurrentUserName(), ident));
+    try {
+      dispatcher.testConnection(ident);
+      eventBus.dispatchEvent(
+          new TestConnectionEvent(PrincipalUtils.getCurrentUserName(), ident));
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new TestConnectionFailureEvent(PrincipalUtils.getCurrentUserName(), ident, e));
+      throw e;
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
@@ -71,6 +71,7 @@ public enum OperationType {
   LIST_CATALOG,
   ENABLE_CATALOG,
   DISABLE_CATALOG,
+  TEST_CONNECTION_CATALOG,
 
   // Partition event
   ADD_PARTITION,

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TestConnectionEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TestConnectionEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is triggered upon a successful catalog connection test.
+ *
+ * <p>This event intentionally carries only the catalog identifier so connection properties and
+ * credentials are never exposed to listeners.
+ */
+@DeveloperApi
+public final class TestConnectionEvent extends CatalogEvent {
+
+  /**
+   * Constructs an instance of {@code TestConnectionEvent}.
+   *
+   * @param user The username of the individual who initiated the connection test.
+   * @param identifier The identifier of the catalog whose connection was tested.
+   */
+  public TestConnectionEvent(String user, NameIdentifier identifier) {
+    super(user, identifier);
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.TEST_CONNECTION_CATALOG;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TestConnectionFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TestConnectionFailureEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is triggered when a catalog connection test fails.
+ *
+ * <p>This event intentionally carries only the catalog identifier and the failure exception so
+ * connection properties and credentials are never exposed to listeners.
+ */
+@DeveloperApi
+public final class TestConnectionFailureEvent extends CatalogFailureEvent {
+  /**
+   * Constructs an instance of {@code TestConnectionFailureEvent}.
+   *
+   * @param user The username of the individual who initiated the connection test.
+   * @param identifier The identifier of the catalog whose connection test failed.
+   * @param exception The exception that was encountered during the connection test.
+   */
+  public TestConnectionFailureEvent(String user, NameIdentifier identifier, Exception exception) {
+    super(user, identifier, exception);
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.TEST_CONNECTION_CATALOG;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TestConnectionPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TestConnectionPreEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is generated before a catalog connection test.
+ *
+ * <p>This event intentionally carries only the catalog identifier so connection properties and
+ * credentials are never exposed to listeners.
+ */
+@DeveloperApi
+public final class TestConnectionPreEvent extends CatalogPreEvent {
+
+  /**
+   * Constructs an instance of {@code TestConnectionPreEvent}.
+   *
+   * @param user The username of the individual who initiated the connection test.
+   * @param identifier The identifier of the catalog whose connection is being tested.
+   */
+  public TestConnectionPreEvent(String user, NameIdentifier identifier) {
+    super(user, identifier);
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.TEST_CONNECTION_CATALOG;
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestCatalogEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestCatalogEvent.java
@@ -410,4 +410,42 @@ public class TestCatalogEvent {
             });
     return dispatcher;
   }
+
+  @Test
+  void testTestConnectionEvent() throws Exception {
+    NameIdentifier identifier = NameIdentifier.of("metalake", catalog.name());
+    dispatcher.testConnection(
+        identifier, catalog.type(), catalog.provider(), catalog.comment(), catalog.properties());
+    Event event = dummyEventListener.popPostEvent();
+    Assertions.assertEquals(identifier, event.identifier());
+    Assertions.assertEquals(TestConnectionEvent.class, event.getClass());
+    Assertions.assertEquals(OperationType.TEST_CONNECTION_CATALOG, event.operationType());
+    Assertions.assertEquals(OperationStatus.SUCCESS, event.operationStatus());
+
+    PreEvent preEvent = dummyEventListener.popPreEvent();
+    Assertions.assertEquals(identifier, preEvent.identifier());
+    Assertions.assertEquals(TestConnectionPreEvent.class, preEvent.getClass());
+    Assertions.assertEquals(OperationType.TEST_CONNECTION_CATALOG, preEvent.operationType());
+    Assertions.assertEquals(OperationStatus.UNPROCESSED, preEvent.operationStatus());
+  }
+
+  @Test
+  void testTestConnectionFailureEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "fail");
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class,
+        () ->
+            failureDispatcher.testConnection(
+                identifier,
+                catalog.type(),
+                catalog.provider(),
+                catalog.comment(),
+                catalog.properties()));
+    Event event = dummyEventListener.popPostEvent();
+    Assertions.assertEquals(identifier, event.identifier());
+    Assertions.assertEquals(TestConnectionFailureEvent.class, event.getClass());
+    Assertions.assertEquals(OperationType.TEST_CONNECTION_CATALOG, event.operationType());
+    Assertions.assertEquals(OperationStatus.FAILURE, event.operationStatus());
+  }
+
 }


### PR DESCRIPTION
## Summary

feat: dispatch events for catalog connection tests

## Changes

- OperationType: add TEST_CONNECTION_CATALOG
- add TestConnectionPreEvent/Event/FailureEvent without properties payload
- CatalogEventDispatcher: dispatch pre/success/failure for testConnection
- TestCatalogEvent: success and failure coverage for testConnection events

Fixes #12566
