### PR TITLE
[#12607] feat(server): Add Semantic Model create and load REST APIs

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/SemanticModelCreateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/SemanticModelCreateRequest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.common.base.Preconditions;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.dto.semantic.SemanticModelDefinitionDTO;
+import org.apache.gravitino.rest.RESTRequest;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+
+/** Represents a request to create a Semantic Model. */
+@Getter
+@EqualsAndHashCode
+@ToString
+@Builder
+@Jacksonized
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"name", "comment", "definition", "properties"})
+public class SemanticModelCreateRequest implements RESTRequest {
+
+  @JsonProperty("name")
+  private final String name;
+
+  @Nullable
+  @JsonProperty("comment")
+  private final String comment;
+
+  @JsonProperty("definition")
+  private final SemanticModelDefinitionDTO definition;
+
+  @JsonProperty("properties")
+  private final Map<String, String> properties;
+
+  /** Default constructor for Jackson deserialization. */
+  public SemanticModelCreateRequest() {
+    this(null, null, null, null);
+  }
+
+  /**
+   * Creates a Semantic Model create request.
+   *
+   * @param name The Semantic Model name.
+   * @param comment The comment, or {@code null} if it is not set.
+   * @param definition The required Semantic Model definition.
+   * @param properties The required Gravitino-specific properties.
+   */
+  public SemanticModelCreateRequest(
+      String name,
+      @Nullable String comment,
+      SemanticModelDefinitionDTO definition,
+      Map<String, String> properties) {
+    this.name = name;
+    this.comment = comment;
+    this.definition = definition;
+    this.properties = properties;
+  }
+
+  @Override
+  public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(name), "\"name\" field is required and cannot be empty");
+    Preconditions.checkArgument(
+        definition != null, "\"definition\" field is required and cannot be null");
+    Preconditions.checkArgument(
+        properties != null, "\"properties\" field is required and cannot be null");
+
+    toDefinition();
+  }
+
+  /**
+   * Converts the definition in this request to an API definition.
+   *
+   * @return The Semantic Model definition.
+   * @throws IllegalArgumentException If a definition field is invalid.
+   */
+  public SemanticModelDefinition toDefinition() {
+    return definition.toDefinition();
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/responses/SemanticModelResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/SemanticModelResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.dto.semantic.SemanticModelDTO;
+
+/** Represents a response containing one Semantic Model. */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString
+public class SemanticModelResponse extends BaseResponse {
+
+  @JsonProperty("semanticModel")
+  private final SemanticModelDTO semanticModel;
+
+  /** Default constructor for Jackson deserialization. */
+  public SemanticModelResponse() {
+    super();
+    this.semanticModel = null;
+  }
+
+  /**
+   * Creates a successful Semantic Model response.
+   *
+   * @param semanticModel The Semantic Model DTO.
+   */
+  public SemanticModelResponse(SemanticModelDTO semanticModel) {
+    super(0);
+    this.semanticModel = semanticModel;
+  }
+
+  @Override
+  public void validate() throws IllegalArgumentException {
+    super.validate();
+    Preconditions.checkArgument(semanticModel != null, "semanticModel must not be null");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(semanticModel.name()),
+        "semanticModel 'name' must not be null or empty");
+    semanticModel.definition();
+    Preconditions.checkArgument(
+        semanticModel.auditInfo() != null, "semanticModel 'audit' must not be null");
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/AIContextDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/AIContextDTO.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.apache.gravitino.semantic.AIContext;
+
+/** DTO for the string-or-object Semantic Model AI context union. */
+@Getter
+@EqualsAndHashCode
+@JsonSerialize(using = AIContextDTO.Serializer.class)
+@JsonDeserialize(using = AIContextDTO.Deserializer.class)
+public class AIContextDTO {
+
+  @Nullable private final String text;
+  @Nullable private final AIContextObjectDTO object;
+
+  private AIContextDTO(@Nullable String text, @Nullable AIContextObjectDTO object) {
+    this.text = text;
+    this.object = object;
+  }
+
+  /**
+   * Creates a builder for an AI context DTO.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Creates an AI context DTO from an API model.
+   *
+   * @param aiContext The API AI context.
+   * @return The AI context DTO.
+   */
+  public static AIContextDTO fromAIContext(AIContext aiContext) {
+    if (aiContext.isText()) {
+      return builder().withText(aiContext.text()).build();
+    }
+    return builder().withObject(AIContextObjectDTO.fromAIContextObject(aiContext.object())).build();
+  }
+
+  /**
+   * Converts this DTO to an API AI context.
+   *
+   * @return The API AI context.
+   */
+  public AIContext toAIContext() {
+    if (text != null) {
+      return AIContext.of(text);
+    }
+    Preconditions.checkArgument(object != null, "AI context object must not be null");
+    return AIContext.of(object.toAIContextObject());
+  }
+
+  /** Builder for {@link AIContextDTO}. */
+  public static final class Builder {
+
+    @Nullable private String text;
+    @Nullable private AIContextObjectDTO object;
+
+    private Builder() {}
+
+    /**
+     * Sets the string variant.
+     *
+     * @param text The string AI context.
+     * @return This builder.
+     */
+    public Builder withText(@Nullable String text) {
+      this.text = text;
+      return this;
+    }
+
+    /**
+     * Sets the object variant.
+     *
+     * @param object The structured AI context.
+     * @return This builder.
+     */
+    public Builder withObject(@Nullable AIContextObjectDTO object) {
+      this.object = object;
+      return this;
+    }
+
+    /**
+     * Builds an AI context DTO.
+     *
+     * @return The AI context DTO.
+     */
+    public AIContextDTO build() {
+      Preconditions.checkArgument(
+          (text == null) != (object == null),
+          "AI context must contain exactly one of text or object");
+      return new AIContextDTO(text, object);
+    }
+  }
+
+  /** Serializes the AI context union as its contained string or object. */
+  public static final class Serializer extends JsonSerializer<AIContextDTO> {
+
+    @Override
+    public void serialize(
+        AIContextDTO value, JsonGenerator generator, SerializerProvider serializers)
+        throws IOException {
+      if (value.text != null && value.object == null) {
+        generator.writeString(value.text);
+      } else if (value.text == null && value.object != null) {
+        generator.writeObject(value.object);
+      } else {
+        throw JsonMappingException.from(
+            generator, "AI context must contain exactly one of text or object");
+      }
+    }
+  }
+
+  /** Deserializes an AI context union from a string or object. */
+  public static final class Deserializer extends JsonDeserializer<AIContextDTO> {
+
+    @Override
+    public AIContextDTO deserialize(JsonParser parser, DeserializationContext context)
+        throws IOException {
+      JsonToken token = parser.currentToken();
+      if (token == null) {
+        token = parser.nextToken();
+      }
+      if (token == JsonToken.VALUE_STRING) {
+        return builder().withText(parser.getText()).build();
+      }
+      if (token == JsonToken.START_OBJECT) {
+        AIContextObjectDTO object = parser.getCodec().readValue(parser, AIContextObjectDTO.class);
+        return builder().withObject(object).build();
+      }
+      throw JsonMappingException.from(parser, "AI context must be a string or object");
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/AIContextObjectDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/AIContextObjectDTO.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.AIContextObject;
+
+/** DTO for structured Semantic Model AI context. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"instructions", "synonyms", "examples"})
+@JsonDeserialize(using = AIContextObjectDTO.Deserializer.class)
+public class AIContextObjectDTO {
+
+  @Nullable
+  @JsonProperty("instructions")
+  private String instructions;
+
+  @Nullable
+  @JsonProperty("synonyms")
+  private String[] synonyms;
+
+  @Nullable
+  @JsonProperty("examples")
+  private String[] examples;
+
+  @JsonIgnore
+  @Getter(AccessLevel.NONE)
+  @Builder.Default
+  private Map<String, Object> additionalProperties = new LinkedHashMap<>();
+
+  /**
+   * Creates a structured AI context DTO from an API model.
+   *
+   * @param aiContextObject The API AI context object.
+   * @return The structured AI context DTO.
+   */
+  public static AIContextObjectDTO fromAIContextObject(AIContextObject aiContextObject) {
+    return builder()
+        .withInstructions(aiContextObject.instructions())
+        .withSynonyms(aiContextObject.synonyms())
+        .withExamples(aiContextObject.examples())
+        .withAdditionalProperties(new LinkedHashMap<>(aiContextObject.additionalProperties()))
+        .build();
+  }
+
+  /**
+   * Converts this DTO to an API AI context object.
+   *
+   * @return The API AI context object.
+   */
+  public AIContextObject toAIContextObject() {
+    return AIContextObject.builder()
+        .withInstructions(instructions)
+        .withSynonyms(synonyms)
+        .withExamples(examples)
+        .withAdditionalProperties(
+            additionalProperties == null ? Collections.emptyMap() : additionalProperties)
+        .build();
+  }
+
+  /**
+   * Returns unknown AI-context properties in their input order.
+   *
+   * @return The additional properties.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties == null ? Collections.emptyMap() : additionalProperties;
+  }
+
+  /** Deserializes structured AI context while retaining unknown JSON values and their order. */
+  public static final class Deserializer extends JsonDeserializer<AIContextObjectDTO> {
+
+    @Override
+    public AIContextObjectDTO deserialize(JsonParser parser, DeserializationContext context)
+        throws IOException {
+      if (!parser.hasToken(JsonToken.START_OBJECT)) {
+        throw JsonMappingException.from(parser, "Structured AI context must be an object");
+      }
+
+      String instructions = null;
+      String[] synonyms = null;
+      String[] examples = null;
+      Map<String, Object> additionalProperties = new LinkedHashMap<>();
+      while (parser.nextToken() != JsonToken.END_OBJECT) {
+        if (!parser.hasToken(JsonToken.FIELD_NAME)) {
+          throw JsonMappingException.from(parser, "Expected an AI context property name");
+        }
+        String name = parser.currentName();
+        JsonToken valueToken = parser.nextToken();
+        switch (name) {
+          case "instructions":
+            instructions = readString(parser, valueToken, name);
+            break;
+          case "synonyms":
+            synonyms = readStringArray(parser, valueToken, name);
+            break;
+          case "examples":
+            examples = readStringArray(parser, valueToken, name);
+            break;
+          default:
+            additionalProperties.put(name, readJsonValue(parser, valueToken));
+        }
+      }
+
+      return AIContextObjectDTO.builder()
+          .withInstructions(instructions)
+          .withSynonyms(synonyms)
+          .withExamples(examples)
+          .withAdditionalProperties(additionalProperties)
+          .build();
+    }
+
+    private static String readString(JsonParser parser, JsonToken token, String name)
+        throws IOException {
+      if (token != JsonToken.VALUE_STRING) {
+        throw JsonMappingException.from(parser, name + " must be a string");
+      }
+      return parser.getText();
+    }
+
+    private static String[] readStringArray(JsonParser parser, JsonToken token, String name)
+        throws IOException {
+      if (token != JsonToken.START_ARRAY) {
+        throw JsonMappingException.from(parser, name + " must be an array of strings");
+      }
+      List<String> values = new ArrayList<>();
+      while (parser.nextToken() != JsonToken.END_ARRAY) {
+        values.add(readString(parser, parser.currentToken(), name));
+      }
+      return values.toArray(new String[0]);
+    }
+
+    @Nullable
+    private static Object readJsonValue(JsonParser parser, JsonToken token) throws IOException {
+      switch (token) {
+        case VALUE_NULL:
+          return null;
+        case VALUE_STRING:
+          return parser.getText();
+        case VALUE_TRUE:
+          return Boolean.TRUE;
+        case VALUE_FALSE:
+          return Boolean.FALSE;
+        case VALUE_NUMBER_INT:
+          return parser.getBigIntegerValue();
+        case VALUE_NUMBER_FLOAT:
+          return parser.getDecimalValue();
+        case START_OBJECT:
+          return readJsonObject(parser);
+        case START_ARRAY:
+          return readJsonArray(parser);
+        default:
+          throw JsonMappingException.from(parser, "Unsupported AI context JSON token: " + token);
+      }
+    }
+
+    private static Map<String, Object> readJsonObject(JsonParser parser) throws IOException {
+      Map<String, Object> values = new LinkedHashMap<>();
+      while (parser.nextToken() != JsonToken.END_OBJECT) {
+        if (!parser.hasToken(JsonToken.FIELD_NAME)) {
+          throw JsonMappingException.from(parser, "Expected an AI context object property name");
+        }
+        String name = parser.currentName();
+        values.put(name, readJsonValue(parser, parser.nextToken()));
+      }
+      return values;
+    }
+
+    private static List<Object> readJsonArray(JsonParser parser) throws IOException {
+      List<Object> values = new ArrayList<>();
+      while (parser.nextToken() != JsonToken.END_ARRAY) {
+        values.add(readJsonValue(parser, parser.currentToken()));
+      }
+      return values;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/CustomExtensionDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/CustomExtensionDTO.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.CustomExtension;
+
+/** DTO for a vendor-specific Semantic Model extension. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CustomExtensionDTO {
+
+  @JsonProperty("vendor_name")
+  private String vendorName;
+
+  @JsonProperty("data")
+  private String data;
+
+  /**
+   * Creates a custom extension DTO from an API model.
+   *
+   * @param extension The API custom extension.
+   * @return The custom extension DTO.
+   */
+  public static CustomExtensionDTO fromCustomExtension(CustomExtension extension) {
+    return builder().withVendorName(extension.vendorName()).withData(extension.data()).build();
+  }
+
+  /**
+   * Converts this DTO to an API custom extension.
+   *
+   * @return The API custom extension.
+   */
+  public CustomExtension toCustomExtension() {
+    return CustomExtension.builder().withVendorName(vendorName).withData(data).build();
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/DatasetDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/DatasetDTO.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.Field;
+
+/** DTO for a dataset in a Semantic Model definition. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DatasetDTO {
+
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("source")
+  @JsonSerialize(using = JsonUtils.NameIdentifierSerializer.class)
+  @JsonDeserialize(using = JsonUtils.NameIdentifierDeserializer.class)
+  private NameIdentifier source;
+
+  @Nullable
+  @JsonProperty("primary_key")
+  private String[] primaryKey;
+
+  @Nullable
+  @JsonProperty("unique_keys")
+  private String[][] uniqueKeys;
+
+  @Nullable
+  @JsonProperty("description")
+  private String description;
+
+  @Nullable
+  @JsonProperty("ai_context")
+  private AIContextDTO aiContext;
+
+  @Nullable
+  @JsonProperty("fields")
+  private FieldDTO[] fields;
+
+  @Nullable
+  @JsonProperty("custom_extensions")
+  private CustomExtensionDTO[] customExtensions;
+
+  /**
+   * Creates a dataset DTO from an API model.
+   *
+   * @param dataset The API dataset.
+   * @return The dataset DTO.
+   */
+  public static DatasetDTO fromDataset(Dataset dataset) {
+    AIContext sourceAIContext = dataset.aiContext();
+    return builder()
+        .withName(dataset.name())
+        .withSource(dataset.source())
+        .withPrimaryKey(dataset.primaryKey())
+        .withUniqueKeys(dataset.uniqueKeys())
+        .withDescription(dataset.description())
+        .withAIContext(sourceAIContext == null ? null : AIContextDTO.fromAIContext(sourceAIContext))
+        .withFields(
+            SemanticDTOUtils.convertArray(dataset.fields(), FieldDTO::fromField, FieldDTO[]::new))
+        .withCustomExtensions(
+            SemanticDTOUtils.convertArray(
+                dataset.customExtensions(),
+                CustomExtensionDTO::fromCustomExtension,
+                CustomExtensionDTO[]::new))
+        .build();
+  }
+
+  /**
+   * Converts this DTO to an API dataset.
+   *
+   * @return The API dataset.
+   */
+  public Dataset toDataset() {
+    Field[] convertedFields =
+        SemanticDTOUtils.convertArray(fields, FieldDTO::toField, Field[]::new);
+    CustomExtension[] convertedExtensions =
+        SemanticDTOUtils.convertArray(
+            customExtensions, CustomExtensionDTO::toCustomExtension, CustomExtension[]::new);
+    return Dataset.builder()
+        .withName(name)
+        .withSource(source)
+        .withPrimaryKey(primaryKey)
+        .withUniqueKeys(uniqueKeys)
+        .withDescription(description)
+        .withAIContext(aiContext == null ? null : aiContext.toAIContext())
+        .withFields(convertedFields)
+        .withCustomExtensions(convertedExtensions)
+        .build();
+  }
+
+  /** Builder for {@link DatasetDTO}. */
+  public static class DatasetDTOBuilder {
+
+    /**
+     * Sets the optional AI context.
+     *
+     * @param aiContext The AI context DTO.
+     * @return This builder.
+     */
+    public DatasetDTOBuilder withAIContext(@Nullable AIContextDTO aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/DialectExpressionDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/DialectExpressionDTO.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.DialectExpression;
+
+/** DTO for an expression written in a specific Semantic Model dialect. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DialectExpressionDTO {
+
+  @JsonProperty("dialect")
+  private String dialect;
+
+  @JsonProperty("expression")
+  private String expression;
+
+  /**
+   * Creates a dialect expression DTO from an API model.
+   *
+   * @param dialectExpression The API dialect expression.
+   * @return The dialect expression DTO.
+   */
+  public static DialectExpressionDTO fromDialectExpression(DialectExpression dialectExpression) {
+    return builder()
+        .withDialect(dialectExpression.dialect())
+        .withExpression(dialectExpression.expression())
+        .build();
+  }
+
+  /**
+   * Converts this DTO to an API dialect expression.
+   *
+   * @return The API dialect expression.
+   */
+  public DialectExpression toDialectExpression() {
+    return DialectExpression.builder().withDialect(dialect).withExpression(expression).build();
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/DimensionDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/DimensionDTO.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.Dimension;
+
+/** DTO for Semantic Model dimension metadata. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DimensionDTO {
+
+  @Nullable
+  @JsonProperty("is_time")
+  private Boolean isTime;
+
+  /**
+   * Creates a dimension DTO from an API model.
+   *
+   * @param dimension The API dimension.
+   * @return The dimension DTO.
+   */
+  public static DimensionDTO fromDimension(Dimension dimension) {
+    return builder().withIsTime(dimension.isTime()).build();
+  }
+
+  /**
+   * Converts this DTO to API dimension metadata.
+   *
+   * @return The API dimension metadata.
+   */
+  public Dimension toDimension() {
+    return Dimension.builder().withIsTime(isTime).build();
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/ExpressionDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/ExpressionDTO.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Expression;
+
+/** DTO for a multi-dialect Semantic Model expression. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ExpressionDTO {
+
+  @JsonProperty("dialects")
+  private DialectExpressionDTO[] dialects;
+
+  /**
+   * Creates an expression DTO from an API model.
+   *
+   * @param expression The API expression.
+   * @return The expression DTO.
+   */
+  public static ExpressionDTO fromExpression(Expression expression) {
+    return builder()
+        .withDialects(
+            SemanticDTOUtils.convertArray(
+                expression.dialects(),
+                DialectExpressionDTO::fromDialectExpression,
+                DialectExpressionDTO[]::new))
+        .build();
+  }
+
+  /**
+   * Converts this DTO to an API expression.
+   *
+   * @return The API expression.
+   */
+  public Expression toExpression() {
+    DialectExpression[] convertedDialects =
+        SemanticDTOUtils.convertArray(
+            dialects, DialectExpressionDTO::toDialectExpression, DialectExpression[]::new);
+    return Expression.builder().withDialects(convertedDialects).build();
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/FieldDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/FieldDTO.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.DataType;
+import org.apache.gravitino.semantic.Dimension;
+import org.apache.gravitino.semantic.Field;
+
+/** DTO for a field in a Semantic Model dataset. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FieldDTO {
+
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("expression")
+  private ExpressionDTO expression;
+
+  @Nullable
+  @JsonProperty("dimension")
+  private DimensionDTO dimension;
+
+  @Nullable
+  @JsonProperty("label")
+  private String label;
+
+  @Nullable
+  @JsonProperty("description")
+  private String description;
+
+  @Nullable
+  @JsonProperty("datatype")
+  @JsonSerialize(using = SemanticDTOUtils.DataTypeSerializer.class)
+  @JsonDeserialize(using = SemanticDTOUtils.DataTypeDeserializer.class)
+  private DataType datatype;
+
+  @Nullable
+  @JsonProperty("ai_context")
+  private AIContextDTO aiContext;
+
+  @Nullable
+  @JsonProperty("custom_extensions")
+  private CustomExtensionDTO[] customExtensions;
+
+  /**
+   * Creates a field DTO from an API model.
+   *
+   * @param field The API field.
+   * @return The field DTO.
+   */
+  public static FieldDTO fromField(Field field) {
+    Dimension sourceDimension = field.dimension();
+    AIContext sourceAIContext = field.aiContext();
+    return builder()
+        .withName(field.name())
+        .withExpression(ExpressionDTO.fromExpression(field.expression()))
+        .withDimension(sourceDimension == null ? null : DimensionDTO.fromDimension(sourceDimension))
+        .withLabel(field.label())
+        .withDescription(field.description())
+        .withDatatype(field.datatype())
+        .withAIContext(sourceAIContext == null ? null : AIContextDTO.fromAIContext(sourceAIContext))
+        .withCustomExtensions(
+            SemanticDTOUtils.convertArray(
+                field.customExtensions(),
+                CustomExtensionDTO::fromCustomExtension,
+                CustomExtensionDTO[]::new))
+        .build();
+  }
+
+  /**
+   * Converts this DTO to an API field.
+   *
+   * @return The API field.
+   */
+  public Field toField() {
+    CustomExtension[] convertedExtensions =
+        SemanticDTOUtils.convertArray(
+            customExtensions, CustomExtensionDTO::toCustomExtension, CustomExtension[]::new);
+    return Field.builder()
+        .withName(name)
+        .withExpression(expression == null ? null : expression.toExpression())
+        .withDimension(dimension == null ? null : dimension.toDimension())
+        .withLabel(label)
+        .withDescription(description)
+        .withDatatype(datatype)
+        .withAIContext(aiContext == null ? null : aiContext.toAIContext())
+        .withCustomExtensions(convertedExtensions)
+        .build();
+  }
+
+  /** Builder for {@link FieldDTO}. */
+  public static class FieldDTOBuilder {
+
+    /**
+     * Sets the optional AI context.
+     *
+     * @param aiContext The AI context DTO.
+     * @return This builder.
+     */
+    public FieldDTOBuilder withAIContext(@Nullable AIContextDTO aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/MetricDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/MetricDTO.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.DataType;
+import org.apache.gravitino.semantic.Metric;
+
+/** DTO for a model-scoped Semantic Model metric. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MetricDTO {
+
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("expression")
+  private ExpressionDTO expression;
+
+  @Nullable
+  @JsonProperty("description")
+  private String description;
+
+  @Nullable
+  @JsonProperty("datatype")
+  @JsonSerialize(using = SemanticDTOUtils.DataTypeSerializer.class)
+  @JsonDeserialize(using = SemanticDTOUtils.DataTypeDeserializer.class)
+  private DataType datatype;
+
+  @Nullable
+  @JsonProperty("ai_context")
+  private AIContextDTO aiContext;
+
+  @Nullable
+  @JsonProperty("custom_extensions")
+  private CustomExtensionDTO[] customExtensions;
+
+  /**
+   * Creates a metric DTO from an API model.
+   *
+   * @param metric The API metric.
+   * @return The metric DTO.
+   */
+  public static MetricDTO fromMetric(Metric metric) {
+    AIContext sourceAIContext = metric.aiContext();
+    return builder()
+        .withName(metric.name())
+        .withExpression(ExpressionDTO.fromExpression(metric.expression()))
+        .withDescription(metric.description())
+        .withDatatype(metric.datatype())
+        .withAIContext(sourceAIContext == null ? null : AIContextDTO.fromAIContext(sourceAIContext))
+        .withCustomExtensions(
+            SemanticDTOUtils.convertArray(
+                metric.customExtensions(),
+                CustomExtensionDTO::fromCustomExtension,
+                CustomExtensionDTO[]::new))
+        .build();
+  }
+
+  /**
+   * Converts this DTO to an API metric.
+   *
+   * @return The API metric.
+   */
+  public Metric toMetric() {
+    CustomExtension[] convertedExtensions =
+        SemanticDTOUtils.convertArray(
+            customExtensions, CustomExtensionDTO::toCustomExtension, CustomExtension[]::new);
+    return Metric.builder()
+        .withName(name)
+        .withExpression(expression == null ? null : expression.toExpression())
+        .withDescription(description)
+        .withDatatype(datatype)
+        .withAIContext(aiContext == null ? null : aiContext.toAIContext())
+        .withCustomExtensions(convertedExtensions)
+        .build();
+  }
+
+  /** Builder for {@link MetricDTO}. */
+  public static class MetricDTOBuilder {
+
+    /**
+     * Sets the optional AI context.
+     *
+     * @param aiContext The AI context DTO.
+     * @return This builder.
+     */
+    public MetricDTOBuilder withAIContext(@Nullable AIContextDTO aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/RelationshipDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/RelationshipDTO.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Relationship;
+
+/** DTO for a relationship between Semantic Model datasets. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RelationshipDTO {
+
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("from")
+  private String from;
+
+  @JsonProperty("to")
+  private String to;
+
+  @JsonProperty("from_columns")
+  private String[] fromColumns;
+
+  @JsonProperty("to_columns")
+  private String[] toColumns;
+
+  @Nullable
+  @JsonProperty("ai_context")
+  private AIContextDTO aiContext;
+
+  @Nullable
+  @JsonProperty("custom_extensions")
+  private CustomExtensionDTO[] customExtensions;
+
+  /**
+   * Creates a relationship DTO from an API model.
+   *
+   * @param relationship The API relationship.
+   * @return The relationship DTO.
+   */
+  public static RelationshipDTO fromRelationship(Relationship relationship) {
+    AIContext sourceAIContext = relationship.aiContext();
+    return builder()
+        .withName(relationship.name())
+        .withFrom(relationship.from())
+        .withTo(relationship.to())
+        .withFromColumns(relationship.fromColumns())
+        .withToColumns(relationship.toColumns())
+        .withAIContext(sourceAIContext == null ? null : AIContextDTO.fromAIContext(sourceAIContext))
+        .withCustomExtensions(
+            SemanticDTOUtils.convertArray(
+                relationship.customExtensions(),
+                CustomExtensionDTO::fromCustomExtension,
+                CustomExtensionDTO[]::new))
+        .build();
+  }
+
+  /**
+   * Converts this DTO to an API relationship.
+   *
+   * @return The API relationship.
+   */
+  public Relationship toRelationship() {
+    CustomExtension[] convertedExtensions =
+        SemanticDTOUtils.convertArray(
+            customExtensions, CustomExtensionDTO::toCustomExtension, CustomExtension[]::new);
+    return Relationship.builder()
+        .withName(name)
+        .withFrom(from)
+        .withTo(to)
+        .withFromColumns(fromColumns)
+        .withToColumns(toColumns)
+        .withAIContext(aiContext == null ? null : aiContext.toAIContext())
+        .withCustomExtensions(convertedExtensions)
+        .build();
+  }
+
+  /** Builder for {@link RelationshipDTO}. */
+  public static class RelationshipDTOBuilder {
+
+    /**
+     * Sets the optional AI context.
+     *
+     * @param aiContext The AI context DTO.
+     * @return This builder.
+     */
+    public RelationshipDTOBuilder withAIContext(@Nullable AIContextDTO aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/SemanticDTOUtils.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/SemanticDTOUtils.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import javax.annotation.Nullable;
+import org.apache.gravitino.semantic.DataType;
+
+final class SemanticDTOUtils {
+
+  private SemanticDTOUtils() {}
+
+  @Nullable
+  static <S, T> T[] convertArray(
+      @Nullable S[] values, Function<S, T> converter, IntFunction<T[]> arrayFactory) {
+    if (values == null) {
+      return null;
+    }
+
+    T[] converted = arrayFactory.apply(values.length);
+    for (int index = 0; index < values.length; index++) {
+      converted[index] = values[index] == null ? null : converter.apply(values[index]);
+    }
+    return converted;
+  }
+
+  static final class DataTypeSerializer extends JsonSerializer<DataType> {
+
+    @Override
+    public void serialize(DataType value, JsonGenerator generator, SerializerProvider serializers)
+        throws IOException {
+      generator.writeString(dataTypeName(value));
+    }
+  }
+
+  static final class DataTypeDeserializer extends JsonDeserializer<DataType> {
+
+    @Override
+    public DataType deserialize(JsonParser parser, DeserializationContext context)
+        throws IOException {
+      String value = requireString(parser, "DataType");
+      switch (value) {
+        case "String":
+          return DataType.STRING;
+        case "Integer":
+          return DataType.INTEGER;
+        case "Decimal":
+          return DataType.DECIMAL;
+        case "Float":
+          return DataType.FLOAT;
+        case "Boolean":
+          return DataType.BOOLEAN;
+        case "Date":
+          return DataType.DATE;
+        case "Time":
+          return DataType.TIME;
+        case "DateTime":
+          return DataType.DATE_TIME;
+        case "DateTimeTz":
+          return DataType.DATE_TIME_TZ;
+        case "Opaque":
+          return DataType.OPAQUE;
+        default:
+          throw JsonMappingException.from(parser, "Unknown Semantic Model data type: " + value);
+      }
+    }
+  }
+
+  private static String requireString(JsonParser parser, String type) throws IOException {
+    if (!parser.hasToken(JsonToken.VALUE_STRING)) {
+      throw JsonMappingException.from(
+          parser, type + " must be encoded as a string, but found " + parser.currentToken());
+    }
+    return parser.getText();
+  }
+
+  private static String dataTypeName(DataType dataType) {
+    switch (dataType) {
+      case STRING:
+        return "String";
+      case INTEGER:
+        return "Integer";
+      case DECIMAL:
+        return "Decimal";
+      case FLOAT:
+        return "Float";
+      case BOOLEAN:
+        return "Boolean";
+      case DATE:
+        return "Date";
+      case TIME:
+        return "Time";
+      case DATE_TIME:
+        return "DateTime";
+      case DATE_TIME_TZ:
+        return "DateTimeTz";
+      case OPAQUE:
+        return "Opaque";
+      default:
+        throw new IllegalArgumentException("Unsupported Semantic Model data type: " + dataType);
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/SemanticModelDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/SemanticModelDTO.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.dto.AuditDTO;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+
+/** DTO for a schema-scoped Semantic Model. */
+@EqualsAndHashCode
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"name", "comment", "definition", "properties", "audit"})
+public class SemanticModelDTO implements SemanticModel {
+
+  @JsonProperty("name")
+  private String name;
+
+  @Nullable
+  @JsonProperty("comment")
+  private String comment;
+
+  @JsonProperty("definition")
+  private SemanticModelDefinitionDTO definition;
+
+  @JsonProperty("properties")
+  private Map<String, String> properties;
+
+  @JsonProperty("audit")
+  private AuditDTO audit;
+
+  private SemanticModelDTO() {}
+
+  private SemanticModelDTO(
+      String name,
+      @Nullable String comment,
+      SemanticModelDefinitionDTO definition,
+      @Nullable Map<String, String> properties,
+      AuditDTO audit) {
+    this.name = name;
+    this.comment = comment;
+    this.definition = definition;
+    this.properties = immutableProperties(properties);
+    this.audit = audit;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  @Nullable
+  public String comment() {
+    return comment;
+  }
+
+  @Override
+  public SemanticModelDefinition definition() {
+    Preconditions.checkArgument(definition != null, "definition must not be null");
+    return definition.toDefinition();
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return immutableProperties(properties);
+  }
+
+  @Override
+  public AuditDTO auditInfo() {
+    return audit;
+  }
+
+  /**
+   * Creates a builder for a Semantic Model DTO.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Builder for {@link SemanticModelDTO}. */
+  public static final class Builder {
+
+    private String name;
+    @Nullable private String comment;
+    private SemanticModelDefinitionDTO definition;
+    @Nullable private Map<String, String> properties;
+    private AuditDTO audit;
+
+    private Builder() {}
+
+    /**
+     * Sets the Semantic Model name.
+     *
+     * @param name The Semantic Model name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the Semantic Model comment.
+     *
+     * @param comment The comment, or {@code null} if it is not set.
+     * @return This builder.
+     */
+    public Builder withComment(@Nullable String comment) {
+      this.comment = comment;
+      return this;
+    }
+
+    /**
+     * Sets the Semantic Model definition.
+     *
+     * @param definition The complete definition DTO.
+     * @return This builder.
+     */
+    public Builder withDefinition(SemanticModelDefinitionDTO definition) {
+      this.definition = definition;
+      return this;
+    }
+
+    /**
+     * Sets the Gravitino-specific Semantic Model properties.
+     *
+     * @param properties The properties, or {@code null} if none are set.
+     * @return This builder.
+     */
+    public Builder withProperties(@Nullable Map<String, String> properties) {
+      this.properties = properties;
+      return this;
+    }
+
+    /**
+     * Sets the Semantic Model audit information.
+     *
+     * @param audit The audit information.
+     * @return This builder.
+     */
+    public Builder withAudit(AuditDTO audit) {
+      this.audit = audit;
+      return this;
+    }
+
+    /**
+     * Builds a Semantic Model DTO.
+     *
+     * @return The Semantic Model DTO.
+     * @throws IllegalArgumentException If a required field or nested DTO is invalid.
+     */
+    public SemanticModelDTO build() {
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name cannot be null or empty");
+      Preconditions.checkArgument(definition != null, "definition cannot be null");
+      Preconditions.checkArgument(audit != null, "audit cannot be null");
+
+      SemanticModelDefinition convertedDefinition = definition.toDefinition();
+      return new SemanticModelDTO(
+          name,
+          comment,
+          SemanticModelDefinitionDTO.fromDefinition(convertedDefinition),
+          properties,
+          audit);
+    }
+  }
+
+  private static Map<String, String> immutableProperties(@Nullable Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/semantic/SemanticModelDefinitionDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/semantic/SemanticModelDefinitionDTO.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+
+/** DTO for the complete persisted definition of a Semantic Model. */
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"ai_context", "datasets", "relationships", "metrics", "custom_extensions"})
+public class SemanticModelDefinitionDTO {
+
+  @Nullable
+  @JsonProperty("ai_context")
+  private AIContextDTO aiContext;
+
+  @JsonProperty("datasets")
+  private DatasetDTO[] datasets;
+
+  @Nullable
+  @JsonProperty("relationships")
+  private RelationshipDTO[] relationships;
+
+  @Nullable
+  @JsonProperty("metrics")
+  private MetricDTO[] metrics;
+
+  @Nullable
+  @JsonProperty("custom_extensions")
+  private CustomExtensionDTO[] customExtensions;
+
+  /**
+   * Creates a persistence DTO from an API Semantic Model definition.
+   *
+   * @param definition The API Semantic Model definition.
+   * @return The persistence DTO.
+   */
+  public static SemanticModelDefinitionDTO fromDefinition(SemanticModelDefinition definition) {
+    AIContext sourceAIContext = definition.aiContext();
+    return builder()
+        .withAIContext(sourceAIContext == null ? null : AIContextDTO.fromAIContext(sourceAIContext))
+        .withDatasets(
+            SemanticDTOUtils.convertArray(
+                definition.datasets(), DatasetDTO::fromDataset, DatasetDTO[]::new))
+        .withRelationships(
+            SemanticDTOUtils.convertArray(
+                definition.relationships(),
+                RelationshipDTO::fromRelationship,
+                RelationshipDTO[]::new))
+        .withMetrics(
+            SemanticDTOUtils.convertArray(
+                definition.metrics(), MetricDTO::fromMetric, MetricDTO[]::new))
+        .withCustomExtensions(
+            SemanticDTOUtils.convertArray(
+                definition.customExtensions(),
+                CustomExtensionDTO::fromCustomExtension,
+                CustomExtensionDTO[]::new))
+        .build();
+  }
+
+  /**
+   * Converts this persistence DTO to an API Semantic Model definition.
+   *
+   * @return The API Semantic Model definition.
+   */
+  public SemanticModelDefinition toDefinition() {
+    Dataset[] convertedDatasets =
+        SemanticDTOUtils.convertArray(datasets, DatasetDTO::toDataset, Dataset[]::new);
+    Relationship[] convertedRelationships =
+        SemanticDTOUtils.convertArray(
+            relationships, RelationshipDTO::toRelationship, Relationship[]::new);
+    Metric[] convertedMetrics =
+        SemanticDTOUtils.convertArray(metrics, MetricDTO::toMetric, Metric[]::new);
+    CustomExtension[] convertedExtensions =
+        SemanticDTOUtils.convertArray(
+            customExtensions, CustomExtensionDTO::toCustomExtension, CustomExtension[]::new);
+    return SemanticModelDefinition.builder()
+        .withAIContext(aiContext == null ? null : aiContext.toAIContext())
+        .withDatasets(convertedDatasets)
+        .withRelationships(convertedRelationships)
+        .withMetrics(convertedMetrics)
+        .withCustomExtensions(convertedExtensions)
+        .build();
+  }
+
+  /** Builder for {@link SemanticModelDefinitionDTO}. */
+  public static class SemanticModelDefinitionDTOBuilder {
+
+    /**
+     * Sets the optional AI context.
+     *
+     * @param aiContext The AI context DTO.
+     * @return This builder.
+     */
+    public SemanticModelDefinitionDTOBuilder withAIContext(@Nullable AIContextDTO aiContext) {
+      this.aiContext = aiContext;
+      return this;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/util/DTOConverters.java
+++ b/common/src/main/java/org/apache/gravitino/dto/util/DTOConverters.java
@@ -88,6 +88,8 @@ import org.apache.gravitino.dto.rel.partitions.IdentityPartitionDTO;
 import org.apache.gravitino.dto.rel.partitions.ListPartitionDTO;
 import org.apache.gravitino.dto.rel.partitions.PartitionDTO;
 import org.apache.gravitino.dto.rel.partitions.RangePartitionDTO;
+import org.apache.gravitino.dto.semantic.SemanticModelDTO;
+import org.apache.gravitino.dto.semantic.SemanticModelDefinitionDTO;
 import org.apache.gravitino.dto.stats.StatisticDTO;
 import org.apache.gravitino.dto.tag.MetadataObjectDTO;
 import org.apache.gravitino.dto.tag.TagDTO;
@@ -128,6 +130,7 @@ import org.apache.gravitino.rel.partitions.Partition;
 import org.apache.gravitino.rel.partitions.Partitions;
 import org.apache.gravitino.rel.partitions.RangePartition;
 import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.semantic.SemanticModel;
 import org.apache.gravitino.stats.Statistic;
 import org.apache.gravitino.tag.Tag;
 import org.apache.gravitino.tag.TagValueConstraint;
@@ -313,6 +316,22 @@ public class DTOConverters {
         .withDefaultSchema(view.defaultSchema())
         .withProperties(view.properties())
         .withAudit(toDTO(view.auditInfo()))
+        .build();
+  }
+
+  /**
+   * Converts a {@link SemanticModel} implementation to a {@link SemanticModelDTO}.
+   *
+   * @param semanticModel The Semantic Model implementation.
+   * @return The Semantic Model DTO.
+   */
+  public static SemanticModelDTO toDTO(SemanticModel semanticModel) {
+    return SemanticModelDTO.builder()
+        .withName(semanticModel.name())
+        .withComment(semanticModel.comment())
+        .withDefinition(SemanticModelDefinitionDTO.fromDefinition(semanticModel.definition()))
+        .withProperties(semanticModel.properties())
+        .withAudit(toDTO(semanticModel.auditInfo()))
         .build();
   }
 

--- a/common/src/test/java/org/apache/gravitino/dto/requests/TestSemanticModelCreateRequest.java
+++ b/common/src/test/java/org/apache/gravitino/dto/requests/TestSemanticModelCreateRequest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.dto.semantic.SemanticModelDefinitionDTO;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+
+public class TestSemanticModelCreateRequest {
+
+  @Test
+  public void testWrappedDefinitionJsonAndConversion() throws JsonProcessingException {
+    String json =
+        "{"
+            + "\"name\":\"sales_model\","
+            + "\"comment\":\"Governed sales definitions\","
+            + "\"definition\":{"
+            + "\"ai_context\":\"Use governed metrics\","
+            + "\"datasets\":[{\"name\":\"orders\","
+            + "\"source\":{\"namespace\":[\"sales\",\"mart\"],\"name\":\"orders\"}}],"
+            + "\"relationships\":[],"
+            + "\"metrics\":[],"
+            + "\"custom_extensions\":[]},"
+            + "\"properties\":{}"
+            + "}";
+
+    SemanticModelCreateRequest request =
+        JsonUtils.objectMapper().readValue(json, SemanticModelCreateRequest.class);
+    request.validate();
+    SemanticModelDefinition definition = request.toDefinition();
+
+    assertEquals("sales_model", request.getName());
+    assertEquals("Use governed metrics", definition.aiContext().text());
+    assertEquals(1, definition.datasets().length);
+    assertEquals("orders", definition.datasets()[0].name());
+    assertEquals(0, definition.relationships().length);
+    assertEquals(0, definition.metrics().length);
+    assertEquals(0, definition.customExtensions().length);
+
+    JsonNode serialized =
+        JsonUtils.objectMapper().readTree(JsonUtils.objectMapper().writeValueAsString(request));
+    assertTrue(serialized.has("definition"));
+    assertTrue(serialized.path("definition").has("ai_context"));
+    assertTrue(serialized.path("definition").has("datasets"));
+    assertTrue(serialized.has("properties"));
+    assertFalse(serialized.has("datasets"));
+  }
+
+  @Test
+  public void testRequiredFieldValidation() {
+    SemanticModelDefinitionDTO definition =
+        SemanticModelDefinitionDTO.fromDefinition(
+            SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset()}).build());
+
+    IllegalArgumentException missingName =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new SemanticModelCreateRequest(null, null, definition, Map.of()).validate());
+    assertEquals("\"name\" field is required and cannot be empty", missingName.getMessage());
+
+    IllegalArgumentException missingDefinition =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new SemanticModelCreateRequest("sales_model", null, null, Map.of()).validate());
+    assertEquals(
+        "\"definition\" field is required and cannot be null", missingDefinition.getMessage());
+
+    IllegalArgumentException missingProperties =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new SemanticModelCreateRequest("sales_model", null, definition, null).validate());
+    assertEquals(
+        "\"properties\" field is required and cannot be null", missingProperties.getMessage());
+  }
+
+  @Test
+  public void testUnknownDefinitionFieldsAreRejected() {
+    String unknownTopLevel =
+        "{"
+            + "\"name\":\"sales_model\","
+            + "\"definition\":{\"datasets\":[{\"name\":\"orders\","
+            + "\"source\":{\"namespace\":[\"sales\",\"mart\"],\"name\":\"orders\"}}]},"
+            + "\"properties\":{},"
+            + "\"unknown\":true"
+            + "}";
+    String unknownDataset =
+        "{"
+            + "\"name\":\"sales_model\","
+            + "\"definition\":{\"datasets\":[{\"name\":\"orders\","
+            + "\"source\":{\"namespace\":[\"sales\",\"mart\"],\"name\":\"orders\"},"
+            + "\"unknown\":true}]},"
+            + "\"properties\":{}"
+            + "}";
+
+    assertThrows(
+        JsonProcessingException.class,
+        () ->
+            JsonUtils.objectMapper().readValue(unknownTopLevel, SemanticModelCreateRequest.class));
+    assertThrows(
+        JsonProcessingException.class,
+        () -> JsonUtils.objectMapper().readValue(unknownDataset, SemanticModelCreateRequest.class));
+  }
+
+  @Test
+  public void testNestedNullMembersAreRejected() throws JsonProcessingException {
+    String json =
+        "{"
+            + "\"name\":\"sales_model\","
+            + "\"definition\":{\"datasets\":[null]},"
+            + "\"properties\":{}"
+            + "}";
+    SemanticModelCreateRequest request =
+        JsonUtils.objectMapper().readValue(json, SemanticModelCreateRequest.class);
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, request::validate);
+    assertEquals("datasets[0] must not be null", exception.getMessage());
+  }
+
+  private static Dataset dataset() {
+    return Dataset.builder()
+        .withName("orders")
+        .withSource(NameIdentifier.of("sales", "mart", "orders"))
+        .build();
+  }
+}

--- a/common/src/test/java/org/apache/gravitino/dto/responses/TestSemanticModelResponse.java
+++ b/common/src/test/java/org/apache/gravitino/dto/responses/TestSemanticModelResponse.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.responses;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.dto.AuditDTO;
+import org.apache.gravitino.dto.semantic.SemanticModelDTO;
+import org.apache.gravitino.dto.semantic.SemanticModelDefinitionDTO;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+
+public class TestSemanticModelResponse {
+
+  @Test
+  public void testResponseSerDeAndValidate() throws JsonProcessingException {
+    SemanticModelResponse response = new SemanticModelResponse(semanticModelDTO());
+
+    String json = JsonUtils.objectMapper().writeValueAsString(response);
+    JsonNode root = JsonUtils.objectMapper().readTree(json);
+    JsonNode semanticModel = root.path("semanticModel");
+    assertTrue(root.has("semanticModel"));
+    assertFalse(root.has("semantic_model"));
+    assertTrue(semanticModel.has("definition"));
+    assertTrue(semanticModel.path("definition").has("datasets"));
+    assertFalse(semanticModel.has("datasets"));
+
+    SemanticModelResponse deserialized =
+        JsonUtils.objectMapper().readValue(json, SemanticModelResponse.class);
+    deserialized.validate();
+    assertEquals("sales_model", deserialized.getSemanticModel().name());
+    assertEquals("orders", deserialized.getSemanticModel().definition().datasets()[0].name());
+  }
+
+  @Test
+  public void testResponseRequiresSemanticModel() {
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, new SemanticModelResponse()::validate);
+    assertEquals("semanticModel must not be null", exception.getMessage());
+  }
+
+  @Test
+  public void testResponseValidatesSemanticModelMembers() throws JsonProcessingException {
+    String definition =
+        "{\"datasets\":[{\"name\":\"orders\",\"source\":{"
+            + "\"namespace\":[\"sales\",\"mart\"],\"name\":\"orders\"}}]}";
+    SemanticModelResponse missingName =
+        readResponse(
+            "{\"code\":0,\"semanticModel\":{\"definition\":" + definition + ",\"audit\":{}}}");
+    SemanticModelResponse missingDefinition =
+        readResponse("{\"code\":0,\"semanticModel\":{\"name\":\"sales_model\",\"audit\":{}}}");
+    SemanticModelResponse missingAudit =
+        readResponse(
+            "{\"code\":0,\"semanticModel\":{\"name\":\"sales_model\",\"definition\":"
+                + definition
+                + "}}");
+
+    assertEquals(
+        "semanticModel 'name' must not be null or empty",
+        assertThrows(IllegalArgumentException.class, missingName::validate).getMessage());
+    assertEquals(
+        "definition must not be null",
+        assertThrows(IllegalArgumentException.class, missingDefinition::validate).getMessage());
+    assertEquals(
+        "semanticModel 'audit' must not be null",
+        assertThrows(IllegalArgumentException.class, missingAudit::validate).getMessage());
+  }
+
+  private static SemanticModelDTO semanticModelDTO() {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .build();
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset}).build();
+    AuditDTO audit =
+        AuditDTO.builder()
+            .withCreator("tester")
+            .withCreateTime(Instant.parse("2026-08-11T00:00:00Z"))
+            .build();
+    return SemanticModelDTO.builder()
+        .withName("sales_model")
+        .withDefinition(SemanticModelDefinitionDTO.fromDefinition(definition))
+        .withProperties(Map.of())
+        .withAudit(audit)
+        .build();
+  }
+
+  private static SemanticModelResponse readResponse(String json) throws JsonProcessingException {
+    return JsonUtils.objectMapper().readValue(json, SemanticModelResponse.class);
+  }
+}

--- a/common/src/test/java/org/apache/gravitino/dto/semantic/TestSemanticModelDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/semantic/TestSemanticModelDTO.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.dto.AuditDTO;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+
+public class TestSemanticModelDTO {
+
+  @Test
+  public void testNestedDefinitionJsonRoundTrip() throws JsonProcessingException {
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withAIContext(AIContext.of("Use governed metrics"))
+            .withDatasets(new Dataset[] {dataset("orders")})
+            .withRelationships(new Relationship[0])
+            .withMetrics(new Metric[0])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+    SemanticModelDTO dto =
+        SemanticModelDTO.builder()
+            .withName("sales_model")
+            .withComment("Governed sales definitions")
+            .withDefinition(SemanticModelDefinitionDTO.fromDefinition(definition))
+            .withProperties(Map.of("owner", "finance"))
+            .withAudit(audit())
+            .build();
+
+    String json = JsonUtils.objectMapper().writeValueAsString(dto);
+    JsonNode root = JsonUtils.objectMapper().readTree(json);
+
+    assertEquals("sales_model", root.path("name").textValue());
+    assertTrue(root.has("definition"));
+    assertEquals("Use governed metrics", root.path("definition").path("ai_context").textValue());
+    assertTrue(root.path("definition").has("datasets"));
+    assertTrue(root.path("definition").has("relationships"));
+    assertTrue(root.has("properties"));
+    assertTrue(root.has("audit"));
+    assertFalse(root.has("datasets"));
+
+    SemanticModelDTO deserialized =
+        JsonUtils.objectMapper().readValue(json, SemanticModelDTO.class);
+    assertEquals("sales_model", deserialized.name());
+    assertEquals("Governed sales definitions", deserialized.comment());
+    assertEquals(definition, deserialized.definition());
+    assertEquals(Map.of("owner", "finance"), deserialized.properties());
+    assertNotNull(deserialized.auditInfo());
+  }
+
+  @Test
+  public void testDefinitionAndPropertiesAreDefensive() {
+    Dataset orders = dataset("orders");
+    DatasetDTO[] datasets = {DatasetDTO.fromDataset(orders)};
+    SemanticModelDefinitionDTO definition =
+        SemanticModelDefinitionDTO.builder().withDatasets(datasets).build();
+    Map<String, String> properties = new LinkedHashMap<>();
+    properties.put("owner", "finance");
+
+    SemanticModelDTO dto =
+        SemanticModelDTO.builder()
+            .withName("sales_model")
+            .withDefinition(definition)
+            .withProperties(properties)
+            .withAudit(audit())
+            .build();
+
+    datasets[0] = DatasetDTO.fromDataset(dataset("customers"));
+    properties.put("owner", "sales");
+    Dataset[] returnedDatasets = dto.definition().datasets();
+    returnedDatasets[0] = dataset("customers");
+
+    assertEquals(orders, dto.definition().datasets()[0]);
+    assertEquals(Map.of("owner", "finance"), dto.properties());
+    assertThrows(UnsupportedOperationException.class, () -> dto.properties().put("k", "v"));
+  }
+
+  @Test
+  public void testAbsentDefinitionCollectionsRemainAbsent() throws JsonProcessingException {
+    String json =
+        "{"
+            + "\"name\":\"sales_model\","
+            + "\"definition\":{\"datasets\":[{\"name\":\"orders\","
+            + "\"source\":{\"namespace\":[\"sales\",\"mart\"],\"name\":\"orders\"}}]},"
+            + "\"audit\":{}"
+            + "}";
+
+    SemanticModelDTO dto = JsonUtils.objectMapper().readValue(json, SemanticModelDTO.class);
+    assertNull(dto.definition().relationships());
+    assertNull(dto.definition().metrics());
+    assertNull(dto.definition().customExtensions());
+    assertTrue(dto.properties().isEmpty());
+
+    String unknown = json.substring(0, json.length() - 1) + ",\"unknown\":true}";
+    assertThrows(
+        JsonProcessingException.class,
+        () -> JsonUtils.objectMapper().readValue(unknown, SemanticModelDTO.class));
+  }
+
+  @Test
+  public void testBuilderValidation() {
+    SemanticModelDefinitionDTO definition = definitionDTO("orders");
+    IllegalArgumentException missingName =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> SemanticModelDTO.builder().withDefinition(definition).withAudit(audit()).build());
+    assertEquals("name cannot be null or empty", missingName.getMessage());
+
+    IllegalArgumentException missingDefinition =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> SemanticModelDTO.builder().withName("sales_model").withAudit(audit()).build());
+    assertEquals("definition cannot be null", missingDefinition.getMessage());
+
+    SemanticModelDefinitionDTO invalidDefinition =
+        SemanticModelDefinitionDTO.builder().withDatasets(new DatasetDTO[] {null}).build();
+    IllegalArgumentException nullDataset =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                SemanticModelDTO.builder()
+                    .withName("sales_model")
+                    .withDefinition(invalidDefinition)
+                    .withAudit(audit())
+                    .build());
+    assertEquals("datasets[0] must not be null", nullDataset.getMessage());
+  }
+
+  private static SemanticModelDefinitionDTO definitionDTO(String datasetName) {
+    return SemanticModelDefinitionDTO.fromDefinition(
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {dataset(datasetName)})
+            .build());
+  }
+
+  private static Dataset dataset(String name) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .build();
+  }
+
+  private static AuditDTO audit() {
+    return AuditDTO.builder()
+        .withCreator("tester")
+        .withCreateTime(Instant.parse("2026-08-11T00:00:00Z"))
+        .build();
+  }
+}

--- a/common/src/test/java/org/apache/gravitino/dto/semantic/TestSemanticModelDefinitionDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/semantic/TestSemanticModelDefinitionDTO.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.semantic;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.AIContextObject;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.DataType;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dialects;
+import org.apache.gravitino.semantic.Dimension;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+
+public class TestSemanticModelDefinitionDTO {
+
+  private final ObjectMapper objectMapper = JsonUtils.objectMapper();
+  private final ObjectMapper persistenceMapper = JsonUtils.anyFieldMapper();
+
+  @Test
+  public void testDefinitionConversionAndJsonRoundTrip() throws JsonProcessingException {
+    SemanticModelDefinition definition = definition();
+    SemanticModelDefinitionDTO dto = SemanticModelDefinitionDTO.fromDefinition(definition);
+
+    String json = persistenceMapper.writeValueAsString(dto);
+    JsonNode root = persistenceMapper.readTree(json);
+    JsonNode dataset = root.path("datasets").get(0);
+    JsonNode field = dataset.path("fields").get(0);
+    JsonNode relationship = root.path("relationships").get(0);
+
+    assertTrue(root.has("ai_context"));
+    assertTrue(root.has("custom_extensions"));
+    assertFalse(root.has("aiContext"));
+    assertFalse(json.contains("customExtensions"));
+    assertEquals(List.of("sales", "mart"), stringValues(dataset.path("source").path("namespace")));
+    assertEquals("orders", dataset.path("source").path("name").textValue());
+    assertTrue(dataset.has("primary_key"));
+    assertTrue(dataset.has("unique_keys"));
+    assertTrue(dataset.has("ai_context"));
+    assertEquals("DateTimeTz", field.path("datatype").textValue());
+    assertTrue(field.path("dimension").path("is_time").booleanValue());
+    assertEquals(
+        "ANSI_SQL", field.path("expression").path("dialects").get(0).path("dialect").textValue());
+    assertTrue(relationship.has("from_columns"));
+    assertTrue(relationship.has("to_columns"));
+    assertEquals("example", root.path("custom_extensions").get(0).path("vendor_name").textValue());
+
+    JsonNode aiContext = root.path("ai_context");
+    assertEquals(
+        List.of(
+            "instructions", "synonyms", "examples", "priority", "semantic_hints", "nullable_hint"),
+        fieldNames(aiContext));
+    assertEquals(List.of("first", "second"), fieldNames(aiContext.path("semantic_hints")));
+    assertTrue(aiContext.path("nullable_hint").isNull());
+
+    SemanticModelDefinitionDTO deserialized =
+        persistenceMapper.readValue(json, SemanticModelDefinitionDTO.class);
+    assertEquals(dto, deserialized);
+    assertEquals(definition, deserialized.toDefinition());
+    assertEquals(json, persistenceMapper.writeValueAsString(deserialized));
+  }
+
+  @Test
+  public void testAIContextUnionAndUnknownPropertyOrder() throws JsonProcessingException {
+    AIContextDTO textContext = AIContextDTO.fromAIContext(AIContext.of(""));
+    String textJson = objectMapper.writeValueAsString(textContext);
+    assertEquals("\"\"", textJson);
+    assertEquals(
+        AIContext.of(""), objectMapper.readValue(textJson, AIContextDTO.class).toAIContext());
+
+    String objectJson =
+        "{\"instructions\":\"Use governed data\","
+            + "\"first_unknown\":{\"alpha\":1,\"beta\":2},"
+            + "\"synonyms\":[\"governed\"],"
+            + "\"second_unknown\":[true,null],"
+            + "\"precise\":0.123456789012345678901234567890}";
+    AIContextDTO objectContext = objectMapper.readValue(objectJson, AIContextDTO.class);
+
+    assertNull(objectContext.getText());
+    assertEquals(
+        List.of("first_unknown", "second_unknown", "precise"),
+        new ArrayList<>(objectContext.getObject().getAdditionalProperties().keySet()));
+    assertEquals(
+        new BigDecimal("0.123456789012345678901234567890"),
+        objectContext.getObject().getAdditionalProperties().get("precise"));
+    assertEquals(
+        List.of("alpha", "beta"),
+        new ArrayList<>(
+            ((Map<?, ?>) objectContext.getObject().getAdditionalProperties().get("first_unknown"))
+                .keySet()));
+    assertEquals(
+        BigInteger.ONE,
+        ((Map<?, ?>) objectContext.getObject().getAdditionalProperties().get("first_unknown"))
+            .get("alpha"));
+
+    AIContextDTO converted = AIContextDTO.fromAIContext(objectContext.toAIContext());
+    assertEquals(
+        List.of("first_unknown", "second_unknown", "precise"),
+        new ArrayList<>(converted.getObject().getAdditionalProperties().keySet()));
+    assertEquals(
+        List.of("instructions", "synonyms", "first_unknown", "second_unknown", "precise"),
+        fieldNames(objectMapper.readTree(objectMapper.writeValueAsString(converted))));
+    assertEquals(
+        objectContext.getObject().getAdditionalProperties(),
+        converted.getObject().getAdditionalProperties());
+    assertTrue(
+        objectMapper.writeValueAsString(converted).contains("0.123456789012345678901234567890"));
+
+    assertThrows(
+        JsonProcessingException.class, () -> objectMapper.readValue("42", AIContextDTO.class));
+  }
+
+  @Test
+  public void testAbsentAndEmptyArraysRemainDistinct() throws JsonProcessingException {
+    Dataset absentDataset =
+        Dataset.builder()
+            .withName("absent")
+            .withSource(NameIdentifier.of("sales", "mart", "absent"))
+            .build();
+    SemanticModelDefinition absentDefinition =
+        SemanticModelDefinition.builder().withDatasets(new Dataset[] {absentDataset}).build();
+    SemanticModelDefinitionDTO absent = SemanticModelDefinitionDTO.fromDefinition(absentDefinition);
+    String absentJson = objectMapper.writeValueAsString(absent);
+
+    assertFalse(absentJson.contains("fields"));
+    assertFalse(absentJson.contains("relationships"));
+    assertEquals(absentDefinition, absent.toDefinition());
+
+    Dataset emptyDataset =
+        Dataset.builder()
+            .withName("empty")
+            .withSource(NameIdentifier.of("sales", "mart", "empty"))
+            .withPrimaryKey(new String[0])
+            .withUniqueKeys(new String[0][])
+            .withFields(new Field[0])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+    SemanticModelDefinition emptyDefinition =
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {emptyDataset})
+            .withRelationships(new Relationship[0])
+            .withMetrics(new Metric[0])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+    SemanticModelDefinitionDTO empty = SemanticModelDefinitionDTO.fromDefinition(emptyDefinition);
+    JsonNode emptyJson = objectMapper.readTree(objectMapper.writeValueAsString(empty));
+
+    assertArrayEquals(new Relationship[0], empty.toDefinition().relationships());
+    assertTrue(emptyJson.path("relationships").isEmpty());
+    assertTrue(emptyJson.path("datasets").get(0).path("fields").isEmpty());
+    assertEquals(emptyDefinition, empty.toDefinition());
+  }
+
+  @Test
+  public void testExactDataTypeJsonValuesAndOpenDialect() throws JsonProcessingException {
+    Map<DataType, String> dataTypeValues = new LinkedHashMap<>();
+    dataTypeValues.put(DataType.STRING, "String");
+    dataTypeValues.put(DataType.INTEGER, "Integer");
+    dataTypeValues.put(DataType.DECIMAL, "Decimal");
+    dataTypeValues.put(DataType.FLOAT, "Float");
+    dataTypeValues.put(DataType.BOOLEAN, "Boolean");
+    dataTypeValues.put(DataType.DATE, "Date");
+    dataTypeValues.put(DataType.TIME, "Time");
+    dataTypeValues.put(DataType.DATE_TIME, "DateTime");
+    dataTypeValues.put(DataType.DATE_TIME_TZ, "DateTimeTz");
+    dataTypeValues.put(DataType.OPAQUE, "Opaque");
+
+    for (Map.Entry<DataType, String> entry : dataTypeValues.entrySet()) {
+      MetricDTO metric =
+          MetricDTO.builder()
+              .withName("metric")
+              .withExpression(ExpressionDTO.fromExpression(expression("value")))
+              .withDatatype(entry.getKey())
+              .build();
+      String json = objectMapper.writeValueAsString(metric);
+      assertEquals(entry.getValue(), objectMapper.readTree(json).path("datatype").textValue());
+      assertEquals(entry.getKey(), objectMapper.readValue(json, MetricDTO.class).getDatatype());
+    }
+
+    DialectExpressionDTO dialectExpression =
+        DialectExpressionDTO.builder().withDialect("TRINO").withExpression("value").build();
+    String json = objectMapper.writeValueAsString(dialectExpression);
+    assertEquals("TRINO", objectMapper.readTree(json).path("dialect").textValue());
+    assertEquals("TRINO", objectMapper.readValue(json, DialectExpressionDTO.class).getDialect());
+  }
+
+  @Test
+  public void testUnknownPropertiesAreOnlyAllowedInAIContext() {
+    String dataset =
+        "{\"name\":\"orders\","
+            + "\"source\":{\"namespace\":[\"sales\",\"mart\"],\"name\":\"orders\"},"
+            + "\"unknown\":true}";
+
+    assertThrows(
+        JsonProcessingException.class, () -> objectMapper.readValue(dataset, DatasetDTO.class));
+  }
+
+  private static SemanticModelDefinition definition() {
+    Map<String, Object> semanticHints = new LinkedHashMap<>();
+    semanticHints.put("first", "prefer certified metrics");
+    semanticHints.put("second", List.of("month", "region"));
+    Map<String, Object> additionalProperties = new LinkedHashMap<>();
+    additionalProperties.put("priority", 1);
+    additionalProperties.put("semantic_hints", semanticHints);
+    additionalProperties.put("nullable_hint", null);
+
+    AIContextObject aiContextObject =
+        AIContextObject.builder()
+            .withInstructions("Use governed data")
+            .withSynonyms(new String[] {"sales", "revenue"})
+            .withExamples(new String[] {"Revenue by month"})
+            .withAdditionalProperties(additionalProperties)
+            .build();
+    CustomExtension extension =
+        CustomExtension.builder()
+            .withVendorName("example")
+            .withData("{\"semantic_type\":\"money\"}")
+            .build();
+    Field orderTime =
+        Field.builder()
+            .withName("order_time")
+            .withExpression(expression("order_time"))
+            .withDimension(Dimension.builder().withIsTime(true).build())
+            .withLabel("Order time")
+            .withDescription("Order creation time")
+            .withDatatype(DataType.DATE_TIME_TZ)
+            .withAIContext(AIContext.of("Use the business timezone"))
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+    Field amount =
+        Field.builder()
+            .withName("amount")
+            .withExpression(expression("order_amount"))
+            .withDimension(Dimension.builder().withIsTime(false).build())
+            .withDatatype(DataType.DECIMAL)
+            .build();
+    Dataset orders =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withPrimaryKey(new String[] {"order_id"})
+            .withUniqueKeys(new String[][] {{"order_id"}, {"external_id", "source_system"}})
+            .withDescription("Governed orders")
+            .withAIContext(AIContext.of(aiContextObject))
+            .withFields(new Field[] {orderTime, amount})
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+    Dataset customers =
+        Dataset.builder()
+            .withName("customers")
+            .withSource(NameIdentifier.of("sales", "mart", "customers"))
+            .build();
+    Relationship relationship =
+        Relationship.builder()
+            .withName("orders_to_customers")
+            .withFrom("orders")
+            .withTo("customers")
+            .withFromColumns(new String[] {"customer_id"})
+            .withToColumns(new String[] {"id"})
+            .withAIContext(AIContext.of("Join orders to the canonical customer"))
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+    Metric revenue =
+        Metric.builder()
+            .withName("revenue")
+            .withExpression(expression("SUM(order_amount)"))
+            .withDescription("Total recognized revenue")
+            .withDatatype(DataType.DECIMAL)
+            .withAIContext(AIContext.of("Use for booked revenue"))
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+
+    return SemanticModelDefinition.builder()
+        .withAIContext(AIContext.of(aiContextObject))
+        .withDatasets(new Dataset[] {orders, customers})
+        .withRelationships(new Relationship[] {relationship})
+        .withMetrics(new Metric[] {revenue})
+        .withCustomExtensions(new CustomExtension[] {extension})
+        .build();
+  }
+
+  private static Expression expression(String value) {
+    return Expression.builder()
+        .withDialects(
+            new DialectExpression[] {
+              DialectExpression.builder()
+                  .withDialect(Dialects.ANSI_SQL)
+                  .withExpression(value)
+                  .build(),
+              DialectExpression.builder()
+                  .withDialect(Dialects.BIGQUERY)
+                  .withExpression(value)
+                  .build()
+            })
+        .build();
+  }
+
+  private static List<String> fieldNames(JsonNode object) {
+    List<String> names = new ArrayList<>();
+    Iterator<String> fields = object.fieldNames();
+    fields.forEachRemaining(names::add);
+    return names;
+  }
+
+  private static List<String> stringValues(JsonNode array) {
+    List<String> values = new ArrayList<>();
+    array.forEach(value -> values.add(value.textValue()));
+    return values;
+  }
+}

--- a/common/src/test/java/org/apache/gravitino/dto/util/TestSemanticModelDTOConverter.java
+++ b/common/src/test/java/org/apache/gravitino/dto/util/TestSemanticModelDTOConverter.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.gravitino.Audit;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.dto.AuditDTO;
+import org.apache.gravitino.dto.semantic.SemanticModelDTO;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dialects;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+
+public class TestSemanticModelDTOConverter {
+
+  @Test
+  public void testConvertSemanticModelToDTO() {
+    Dataset orders = dataset("orders");
+    Dataset customers = dataset("customers");
+    Relationship relationship =
+        Relationship.builder()
+            .withName("orders_to_customers")
+            .withFrom("orders")
+            .withTo("customers")
+            .withFromColumns(new String[] {"customer_id"})
+            .withToColumns(new String[] {"id"})
+            .build();
+    Metric metric =
+        Metric.builder()
+            .withName("revenue")
+            .withExpression(expression("SUM(orders.amount)"))
+            .build();
+    CustomExtension extension =
+        CustomExtension.builder().withVendorName("example").withData("{}").build();
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withAIContext(AIContext.of("Use governed metrics"))
+            .withDatasets(new Dataset[] {orders, customers})
+            .withRelationships(new Relationship[] {relationship})
+            .withMetrics(new Metric[] {metric})
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+    AuditDTO audit = audit();
+
+    SemanticModel semanticModel =
+        new SemanticModel() {
+          @Override
+          public String name() {
+            return "sales_model";
+          }
+
+          @Override
+          @Nullable
+          public String comment() {
+            return "Governed sales definitions";
+          }
+
+          @Override
+          public SemanticModelDefinition definition() {
+            return definition;
+          }
+
+          @Override
+          public Map<String, String> properties() {
+            return Map.of("owner", "finance");
+          }
+
+          @Override
+          public Audit auditInfo() {
+            return audit;
+          }
+        };
+
+    SemanticModelDTO dto = DTOConverters.toDTO(semanticModel);
+
+    assertEquals("sales_model", dto.name());
+    assertEquals("Governed sales definitions", dto.comment());
+    assertEquals(definition, dto.definition());
+    assertEquals(Map.of("owner", "finance"), dto.properties());
+    assertEquals(audit, dto.auditInfo());
+  }
+
+  private static Dataset dataset(String name) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .build();
+  }
+
+  private static Expression expression(String value) {
+    return Expression.builder()
+        .withDialects(
+            new DialectExpression[] {
+              DialectExpression.builder()
+                  .withDialect(Dialects.ANSI_SQL)
+                  .withExpression(value)
+                  .build()
+            })
+        .build();
+  }
+
+  private static AuditDTO audit() {
+    return AuditDTO.builder()
+        .withCreator("tester")
+        .withCreateTime(Instant.parse("2026-08-11T00:00:00Z"))
+        .build();
+  }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   implementation(libs.concurrent.trees)
   implementation(libs.guava)
   implementation(libs.h2db)
+  implementation(libs.jackson.databind)
   implementation(libs.jackson.jaxrs.json.provider) // This is required by lance
   implementation(libs.lance) {
     exclude(group = "com.fasterxml.jackson.core", module = "*") // provided by gravitino

--- a/core/src/main/java/org/apache/gravitino/Entity.java
+++ b/core/src/main/java/org/apache/gravitino/Entity.java
@@ -110,6 +110,7 @@ public interface Entity extends Serializable {
     SCHEMA,
     TABLE,
     VIEW,
+    SEMANTIC_MODEL,
     COLUMN,
     FILESET,
     TOPIC,

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -47,6 +47,9 @@ import org.apache.gravitino.catalog.PartitionOperationDispatcher;
 import org.apache.gravitino.catalog.SchemaDispatcher;
 import org.apache.gravitino.catalog.SchemaNormalizeDispatcher;
 import org.apache.gravitino.catalog.SchemaOperationDispatcher;
+import org.apache.gravitino.catalog.SemanticModelDispatcher;
+import org.apache.gravitino.catalog.SemanticModelNormalizeDispatcher;
+import org.apache.gravitino.catalog.SemanticModelOperationDispatcher;
 import org.apache.gravitino.catalog.TableDispatcher;
 import org.apache.gravitino.catalog.TableNormalizeDispatcher;
 import org.apache.gravitino.catalog.TableOperationDispatcher;
@@ -151,6 +154,8 @@ public class GravitinoEnv {
   private ModelDispatcher modelDispatcher;
 
   private FunctionDispatcher functionDispatcher;
+
+  private SemanticModelDispatcher semanticModelDispatcher;
 
   private ViewDispatcher viewDispatcher;
   private ViewDispatcher internalViewDispatcher;
@@ -339,6 +344,15 @@ public class GravitinoEnv {
    */
   public FunctionDispatcher functionDispatcher() {
     return functionDispatcher;
+  }
+
+  /**
+   * Get the Semantic Model dispatcher associated with the Gravitino environment.
+   *
+   * @return The Semantic Model dispatcher.
+   */
+  public SemanticModelDispatcher semanticModelDispatcher() {
+    return semanticModelDispatcher;
   }
 
   /**
@@ -868,6 +882,15 @@ public class GravitinoEnv {
     ViewEventDispatcher viewEventDispatcher =
         new ViewEventDispatcher(eventBus, viewNormalizeDispatcher);
     this.viewDispatcher = viewEventDispatcher;
+
+    // Semantic Model operation chain: SemanticModelNormalizeDispatcher ->
+    // SemanticModelOperationDispatcher -> ManagedSemanticModelOperations.
+    // TODO: Add event and hook layers with Semantic Model server integration.
+    SemanticModelOperationDispatcher semanticModelOperationDispatcher =
+        new SemanticModelOperationDispatcher(
+            catalogManager, internalSchemaDispatcher, entityStore, idGenerator, secretManager);
+    this.semanticModelDispatcher =
+        new SemanticModelNormalizeDispatcher(semanticModelOperationDispatcher, catalogManager);
 
     this.statisticDispatcher =
         new StatisticEventDispatcher(

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -885,10 +885,11 @@ public class GravitinoEnv {
 
     // Semantic Model operation chain: SemanticModelNormalizeDispatcher ->
     // SemanticModelOperationDispatcher -> ManagedSemanticModelOperations.
-    // TODO: Add event and hook layers with Semantic Model server integration.
+    // TODO(#12595): Add Semantic Model event dispatching before server integration.
+    // TODO(#12594): Add Semantic Model ownership and privilege hooks.
     SemanticModelOperationDispatcher semanticModelOperationDispatcher =
         new SemanticModelOperationDispatcher(
-            catalogManager, internalSchemaDispatcher, entityStore, idGenerator, secretManager);
+            catalogManager, schemaOperationDispatcher, entityStore, idGenerator, secretManager);
     this.semanticModelDispatcher =
         new SemanticModelNormalizeDispatcher(semanticModelOperationDispatcher, catalogManager);
 

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -889,7 +889,13 @@ public class GravitinoEnv {
     // TODO(#12594): Add Semantic Model ownership and privilege hooks.
     SemanticModelOperationDispatcher semanticModelOperationDispatcher =
         new SemanticModelOperationDispatcher(
-            catalogManager, schemaOperationDispatcher, entityStore, idGenerator, secretManager);
+            catalogManager,
+            schemaOperationDispatcher,
+            internalTableDispatcher,
+            internalViewDispatcher,
+            entityStore,
+            idGenerator,
+            secretManager);
     this.semanticModelDispatcher =
         new SemanticModelNormalizeDispatcher(semanticModelOperationDispatcher, catalogManager);
 

--- a/core/src/main/java/org/apache/gravitino/cache/BaseEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/BaseEntityCache.java
@@ -58,6 +58,7 @@ public abstract class BaseEntityCache implements EntityCache {
           Entity.EntityType.CATALOG,
           Entity.EntityType.SCHEMA,
           Entity.EntityType.TABLE,
+          Entity.EntityType.SEMANTIC_MODEL,
           Entity.EntityType.TOPIC,
           Entity.EntityType.VIEW,
           Entity.EntityType.FILESET,

--- a/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
@@ -152,13 +152,7 @@ public class CapabilityHelpers {
       Namespace namespace, Capability.Scope identScope, Capability capabilities) {
     String metalake = namespace.level(0);
     String catalog = namespace.level(1);
-    if (identScope == Capability.Scope.TABLE
-        || identScope == Capability.Scope.VIEW
-        || identScope == Capability.Scope.FILESET
-        || identScope == Capability.Scope.TOPIC
-        || identScope == Capability.Scope.MODEL
-        || identScope == Capability.Scope.FUNCTION
-        || identScope == Capability.Scope.SEMANTIC_MODEL) {
+    if (hasSchemaParent(identScope)) {
       String schema = namespace.level(namespace.length() - 1);
       schema = applyCaseSensitiveOnName(Capability.Scope.SCHEMA, schema, capabilities);
       return Namespace.of(metalake, catalog, schema);
@@ -224,17 +218,27 @@ public class CapabilityHelpers {
       Namespace namespace, Capability.Scope identScope, Capability capabilities) {
     String metalake = namespace.level(0);
     String catalog = namespace.level(1);
-    if (identScope == Capability.Scope.TABLE
-        || identScope == Capability.Scope.VIEW
-        || identScope == Capability.Scope.FILESET
-        || identScope == Capability.Scope.TOPIC
-        || identScope == Capability.Scope.FUNCTION
-        || identScope == Capability.Scope.SEMANTIC_MODEL) {
+    if (hasSchemaParent(identScope)) {
       String schema = namespace.level(namespace.length() - 1);
       schema = applyCapabilitiesOnName(Capability.Scope.SCHEMA, schema, capabilities);
       return Namespace.of(metalake, catalog, schema);
     }
     return namespace;
+  }
+
+  private static boolean hasSchemaParent(Capability.Scope resourceScope) {
+    switch (resourceScope) {
+      case TABLE:
+      case VIEW:
+      case FILESET:
+      case TOPIC:
+      case MODEL:
+      case FUNCTION:
+      case SEMANTIC_MODEL:
+        return true;
+      default:
+        return false;
+    }
   }
 
   private static Index applyCapabilities(Index index, Capability capabilities) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
@@ -157,7 +157,8 @@ public class CapabilityHelpers {
         || identScope == Capability.Scope.FILESET
         || identScope == Capability.Scope.TOPIC
         || identScope == Capability.Scope.MODEL
-        || identScope == Capability.Scope.FUNCTION) {
+        || identScope == Capability.Scope.FUNCTION
+        || identScope == Capability.Scope.SEMANTIC_MODEL) {
       String schema = namespace.level(namespace.length() - 1);
       schema = applyCaseSensitiveOnName(Capability.Scope.SCHEMA, schema, capabilities);
       return Namespace.of(metalake, catalog, schema);
@@ -227,7 +228,8 @@ public class CapabilityHelpers {
         || identScope == Capability.Scope.VIEW
         || identScope == Capability.Scope.FILESET
         || identScope == Capability.Scope.TOPIC
-        || identScope == Capability.Scope.FUNCTION) {
+        || identScope == Capability.Scope.FUNCTION
+        || identScope == Capability.Scope.SEMANTIC_MODEL) {
       String schema = namespace.level(namespace.length() - 1);
       schema = applyCapabilitiesOnName(Capability.Scope.SCHEMA, schema, capabilities);
       return Namespace.of(metalake, catalog, schema);
@@ -499,7 +501,7 @@ public class CapabilityHelpers {
         column.defaultValue());
   }
 
-  private static String applyCapabilitiesOnName(
+  static String applyCapabilitiesOnName(
       Capability.Scope scope, String name, Capability capabilities) {
     applyNameSpecification(scope, name, capabilities);
     return applyCaseSensitiveOnName(scope, name, capabilities);

--- a/core/src/main/java/org/apache/gravitino/catalog/ManagedSemanticModelOperations.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ManagedSemanticModelOperations.java
@@ -18,58 +18,73 @@
  */
 package org.apache.gravitino.catalog;
 
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.time.Instant;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
 import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.SemanticModelEntity;
 import org.apache.gravitino.semantic.SemanticModel;
 import org.apache.gravitino.semantic.SemanticModelCatalog;
 import org.apache.gravitino.semantic.SemanticModelChange;
 import org.apache.gravitino.semantic.SemanticModelDefinition;
 import org.apache.gravitino.storage.IdGenerator;
+import org.apache.gravitino.utils.PrincipalUtils;
 
-/**
- * Provides storage-level Semantic Model operations backed by Gravitino's {@link EntityStore}.
- *
- * <p>The framework establishes the managed-operation boundary. Semantic Model entity persistence
- * and lifecycle implementations will be added in a follow-up change.
- */
+/** EntityStore-backed operations for Gravitino-managed Semantic Models. */
 public class ManagedSemanticModelOperations implements SemanticModelCatalog {
 
-  @SuppressWarnings("UnusedVariable")
   private final EntityStore store;
-
-  @SuppressWarnings("UnusedVariable")
   private final IdGenerator idGenerator;
+  private final BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator;
 
   /**
    * Creates managed Semantic Model operations.
    *
    * @param store The EntityStore used for persistence.
    * @param idGenerator The stable entity ID generator.
+   * @param writeValidator The complete definition and source validator for write operations.
    */
-  public ManagedSemanticModelOperations(EntityStore store, IdGenerator idGenerator) {
+  public ManagedSemanticModelOperations(
+      EntityStore store,
+      IdGenerator idGenerator,
+      BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator) {
+    Preconditions.checkArgument(store != null, "EntityStore must not be null");
+    Preconditions.checkArgument(idGenerator != null, "IdGenerator must not be null");
+    Preconditions.checkArgument(writeValidator != null, "Write validator must not be null");
     this.store = store;
     this.idGenerator = idGenerator;
+    this.writeValidator = writeValidator;
   }
 
   @Override
   public NameIdentifier[] listSemanticModels(Namespace namespace) throws NoSuchSchemaException {
-    // TODO: Implement when SemanticModelEntity is available.
+    // TODO: Implement in the Semantic Model list/alter/drop capability.
     throw new UnsupportedOperationException(
-        "listSemanticModels: SemanticModelEntity is not yet implemented");
+        "listSemanticModels: list/alter/drop capability is not implemented");
   }
 
   @Override
   public SemanticModel loadSemanticModel(NameIdentifier ident) throws NoSuchSemanticModelException {
-    // TODO: Implement when SemanticModelEntity is available.
-    throw new UnsupportedOperationException(
-        "loadSemanticModel: SemanticModelEntity is not yet implemented");
+    try {
+      return store.get(ident, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class);
+    } catch (NoSuchEntityException e) {
+      throw new NoSuchSemanticModelException(e, "Semantic Model %s does not exist", ident);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load Semantic Model " + ident, e);
+    }
   }
 
   @Override
@@ -80,24 +95,51 @@ public class ManagedSemanticModelOperations implements SemanticModelCatalog {
       Map<String, String> properties)
       throws NoSuchSchemaException, SemanticModelAlreadyExistsException,
           IllegalSemanticModelException {
-    // TODO: Implement when SemanticModelEntity is available.
-    throw new UnsupportedOperationException(
-        "createSemanticModel: SemanticModelEntity is not yet implemented");
+    Preconditions.checkArgument(properties != null, "Properties must not be null");
+
+    writeValidator.accept(ident, definition);
+
+    Instant now = Instant.now();
+    SemanticModelEntity entity =
+        SemanticModelEntity.builder()
+            .withId(idGenerator.nextId())
+            .withName(ident.name())
+            .withNamespace(ident.namespace())
+            .withComment(comment)
+            .withDefinition(definition)
+            .withProperties(properties)
+            .withAuditInfo(
+                AuditInfo.builder()
+                    .withCreator(PrincipalUtils.getCurrentUserName())
+                    .withCreateTime(now)
+                    .build())
+            .build();
+
+    try {
+      store.put(entity, false /* overwrite */);
+      return entity;
+    } catch (NoSuchEntityException e) {
+      throw new NoSuchSchemaException(e, "Schema %s does not exist", ident.namespace());
+    } catch (EntityAlreadyExistsException e) {
+      throw new SemanticModelAlreadyExistsException(e, "Semantic Model %s already exists", ident);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create Semantic Model " + ident, e);
+    }
   }
 
   @Override
   public SemanticModel alterSemanticModel(NameIdentifier ident, SemanticModelChange... changes)
       throws NoSuchSemanticModelException, SemanticModelAlreadyExistsException,
           IllegalSemanticModelException {
-    // TODO: Implement when SemanticModelEntity is available.
+    // TODO: Implement in the Semantic Model list/alter/drop capability.
     throw new UnsupportedOperationException(
-        "alterSemanticModel: SemanticModelEntity is not yet implemented");
+        "alterSemanticModel: list/alter/drop capability is not implemented");
   }
 
   @Override
   public boolean dropSemanticModel(NameIdentifier ident) {
-    // TODO: Implement when SemanticModelEntity is available.
+    // TODO: Implement in the Semantic Model list/alter/drop capability.
     throw new UnsupportedOperationException(
-        "dropSemanticModel: SemanticModelEntity is not yet implemented");
+        "dropSemanticModel: list/alter/drop capability is not implemented");
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/ManagedSemanticModelOperations.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ManagedSemanticModelOperations.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelCatalog;
+import org.apache.gravitino.semantic.SemanticModelChange;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.IdGenerator;
+
+/**
+ * Provides storage-level Semantic Model operations backed by Gravitino's {@link EntityStore}.
+ *
+ * <p>The framework establishes the managed-operation boundary. Semantic Model entity persistence
+ * and lifecycle implementations will be added in a follow-up change.
+ */
+public class ManagedSemanticModelOperations implements SemanticModelCatalog {
+
+  @SuppressWarnings("UnusedVariable")
+  private final EntityStore store;
+
+  @SuppressWarnings("UnusedVariable")
+  private final IdGenerator idGenerator;
+
+  /**
+   * Creates managed Semantic Model operations.
+   *
+   * @param store The EntityStore used for persistence.
+   * @param idGenerator The stable entity ID generator.
+   */
+  public ManagedSemanticModelOperations(EntityStore store, IdGenerator idGenerator) {
+    this.store = store;
+    this.idGenerator = idGenerator;
+  }
+
+  @Override
+  public NameIdentifier[] listSemanticModels(Namespace namespace) throws NoSuchSchemaException {
+    // TODO: Implement when SemanticModelEntity is available.
+    throw new UnsupportedOperationException(
+        "listSemanticModels: SemanticModelEntity is not yet implemented");
+  }
+
+  @Override
+  public SemanticModel loadSemanticModel(NameIdentifier ident) throws NoSuchSemanticModelException {
+    // TODO: Implement when SemanticModelEntity is available.
+    throw new UnsupportedOperationException(
+        "loadSemanticModel: SemanticModelEntity is not yet implemented");
+  }
+
+  @Override
+  public SemanticModel createSemanticModel(
+      NameIdentifier ident,
+      @Nullable String comment,
+      SemanticModelDefinition definition,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, SemanticModelAlreadyExistsException,
+          IllegalSemanticModelException {
+    // TODO: Implement when SemanticModelEntity is available.
+    throw new UnsupportedOperationException(
+        "createSemanticModel: SemanticModelEntity is not yet implemented");
+  }
+
+  @Override
+  public SemanticModel alterSemanticModel(NameIdentifier ident, SemanticModelChange... changes)
+      throws NoSuchSemanticModelException, SemanticModelAlreadyExistsException,
+          IllegalSemanticModelException {
+    // TODO: Implement when SemanticModelEntity is available.
+    throw new UnsupportedOperationException(
+        "alterSemanticModel: SemanticModelEntity is not yet implemented");
+  }
+
+  @Override
+  public boolean dropSemanticModel(NameIdentifier ident) {
+    // TODO: Implement when SemanticModelEntity is available.
+    throw new UnsupportedOperationException(
+        "dropSemanticModel: SemanticModelEntity is not yet implemented");
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/catalog/SemanticModelDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SemanticModelDispatcher.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import org.apache.gravitino.semantic.SemanticModelCatalog;
+
+/** A dispatcher specialization for schema-scoped Semantic Model operations. */
+public interface SemanticModelDispatcher extends SemanticModelCatalog {}

--- a/core/src/main/java/org/apache/gravitino/catalog/SemanticModelNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SemanticModelNormalizeDispatcher.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
+import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilitiesOnName;
+import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
+import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelChange;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+
+/** Normalizes Semantic Model parents while retaining Gravitino-owned model naming rules. */
+public class SemanticModelNormalizeDispatcher implements SemanticModelDispatcher {
+
+  private final SemanticModelDispatcher dispatcher;
+  private final CatalogManager catalogManager;
+
+  /**
+   * Creates a Semantic Model normalization dispatcher.
+   *
+   * @param dispatcher The underlying dispatcher.
+   * @param catalogManager The catalog manager used to load parent naming capabilities.
+   */
+  public SemanticModelNormalizeDispatcher(
+      SemanticModelDispatcher dispatcher, CatalogManager catalogManager) {
+    this.dispatcher = dispatcher;
+    this.catalogManager = catalogManager;
+  }
+
+  @Override
+  public NameIdentifier[] listSemanticModels(Namespace namespace) throws NoSuchSchemaException {
+    return dispatcher.listSemanticModels(normalizeParentForLookup(namespace));
+  }
+
+  @Override
+  public SemanticModel loadSemanticModel(NameIdentifier ident) throws NoSuchSemanticModelException {
+    return dispatcher.loadSemanticModel(normalizeForLookup(ident));
+  }
+
+  @Override
+  public boolean semanticModelExists(NameIdentifier ident) {
+    return dispatcher.semanticModelExists(normalizeForLookup(ident));
+  }
+
+  @Override
+  public SemanticModel createSemanticModel(
+      NameIdentifier ident,
+      @Nullable String comment,
+      SemanticModelDefinition definition,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, SemanticModelAlreadyExistsException,
+          IllegalSemanticModelException {
+    return dispatcher.createSemanticModel(
+        normalizeForCreate(ident), comment, definition, properties);
+  }
+
+  @Override
+  public SemanticModel alterSemanticModel(NameIdentifier ident, SemanticModelChange... changes)
+      throws NoSuchSemanticModelException, SemanticModelAlreadyExistsException,
+          IllegalSemanticModelException {
+    Preconditions.checkArgument(
+        changes != null && changes.length > 0, "At least one change is required");
+    SemanticModelChange[] normalizedChanges =
+        Arrays.stream(changes).map(this::normalizeChange).toArray(SemanticModelChange[]::new);
+    return dispatcher.alterSemanticModel(normalizeForLookup(ident), normalizedChanges);
+  }
+
+  @Override
+  public boolean dropSemanticModel(NameIdentifier ident) {
+    return dispatcher.dropSemanticModel(normalizeForLookup(ident));
+  }
+
+  private Namespace normalizeParentForLookup(Namespace namespace) {
+    Capability capability = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
+    return applyCaseSensitive(namespace, Capability.Scope.SEMANTIC_MODEL, capability);
+  }
+
+  private NameIdentifier normalizeForLookup(NameIdentifier ident) {
+    return NameIdentifier.of(normalizeParentForLookup(ident.namespace()), ident.name());
+  }
+
+  private NameIdentifier normalizeForCreate(NameIdentifier ident) {
+    Capability capability = getCapability(ident, catalogManager);
+    Namespace namespace =
+        applyCapabilities(ident.namespace(), Capability.Scope.SEMANTIC_MODEL, capability);
+    return NameIdentifier.of(namespace, normalizeSemanticModelName(ident.name()));
+  }
+
+  private SemanticModelChange normalizeChange(SemanticModelChange change) {
+    if (change instanceof SemanticModelChange.RenameSemanticModel) {
+      return SemanticModelChange.rename(
+          normalizeSemanticModelName(
+              ((SemanticModelChange.RenameSemanticModel) change).getNewName()));
+    }
+    return change;
+  }
+
+  private String normalizeSemanticModelName(String name) {
+    return applyCapabilitiesOnName(Capability.Scope.SEMANTIC_MODEL, name, Capability.DEFAULT);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/catalog/SemanticModelOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SemanticModelOperationDispatcher.java
@@ -48,6 +48,8 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
    *
    * @param catalogManager The catalog manager.
    * @param schemaDispatcher The schema operation dispatcher used for parent validation.
+   * @param tableDispatcher The internal table dispatcher used for source validation.
+   * @param viewDispatcher The internal view dispatcher used for source validation.
    * @param store The EntityStore used for Semantic Model persistence.
    * @param idGenerator The stable entity ID generator.
    * @param secretManager The secret manager required by the operation dispatcher base class.
@@ -55,13 +57,18 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
   public SemanticModelOperationDispatcher(
       CatalogManager catalogManager,
       SchemaDispatcher schemaDispatcher,
+      TableDispatcher tableDispatcher,
+      ViewDispatcher viewDispatcher,
       EntityStore store,
       IdGenerator idGenerator,
       SecretManager secretManager) {
     super(catalogManager, store, idGenerator, secretManager);
     this.catalogManager = catalogManager;
     this.schemaDispatcher = schemaDispatcher;
-    this.managedOperations = new ManagedSemanticModelOperations(store, idGenerator);
+    SemanticModelValidator validator =
+        new SemanticModelValidator(catalogManager, tableDispatcher, viewDispatcher);
+    this.managedOperations =
+        new ManagedSemanticModelOperations(store, idGenerator, validator::validateForWrite);
   }
 
   @Override
@@ -89,7 +96,6 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
       Map<String, String> properties)
       throws NoSuchSchemaException, SemanticModelAlreadyExistsException,
           IllegalSemanticModelException {
-    Preconditions.checkArgument(definition != null, "Definition must not be null");
     Preconditions.checkArgument(properties != null, "Properties must not be null");
     checkRelationalCatalog(ident.namespace());
     NameIdentifier schemaIdent = schemaIdentifier(ident);

--- a/core/src/main/java/org/apache/gravitino/catalog/SemanticModelOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SemanticModelOperationDispatcher.java
@@ -19,7 +19,6 @@
 package org.apache.gravitino.catalog;
 
 import com.google.common.base.Preconditions;
-import java.util.Arrays;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.gravitino.Catalog;
@@ -30,8 +29,6 @@ import org.apache.gravitino.exceptions.IllegalSemanticModelException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
 import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
-import org.apache.gravitino.lock.LockType;
-import org.apache.gravitino.lock.TreeLockUtils;
 import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.semantic.SemanticModel;
 import org.apache.gravitino.semantic.SemanticModelChange;
@@ -50,7 +47,7 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
    * Creates a Semantic Model operation dispatcher.
    *
    * @param catalogManager The catalog manager.
-   * @param schemaDispatcher The internal schema dispatcher used for parent validation.
+   * @param schemaDispatcher The schema operation dispatcher used for parent validation.
    * @param store The EntityStore used for Semantic Model persistence.
    * @param idGenerator The stable entity ID generator.
    * @param secretManager The secret manager required by the operation dispatcher base class.
@@ -72,8 +69,7 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
     checkRelationalCatalog(namespace);
     NameIdentifier schemaIdent = NameIdentifier.of(namespace.levels());
     schemaDispatcher.loadSchema(schemaIdent);
-    return TreeLockUtils.doWithTreeLock(
-        schemaIdent, LockType.READ, () -> managedOperations.listSemanticModels(namespace));
+    return managedOperations.listSemanticModels(namespace);
   }
 
   @Override
@@ -82,8 +78,7 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
     if (!schemaDispatcher.schemaExists(schemaIdentifier(ident))) {
       throw new NoSuchSemanticModelException("Semantic Model %s does not exist", ident);
     }
-    return TreeLockUtils.doWithTreeLock(
-        ident, LockType.READ, () -> managedOperations.loadSemanticModel(ident));
+    return managedOperations.loadSemanticModel(ident);
   }
 
   @Override
@@ -99,30 +94,19 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
     checkRelationalCatalog(ident.namespace());
     NameIdentifier schemaIdent = schemaIdentifier(ident);
     schemaDispatcher.loadSchema(schemaIdent);
-    return TreeLockUtils.doWithTreeLock(
-        schemaIdent,
-        LockType.WRITE,
-        () -> managedOperations.createSemanticModel(ident, comment, definition, properties));
+    return managedOperations.createSemanticModel(ident, comment, definition, properties);
   }
 
   @Override
   public SemanticModel alterSemanticModel(NameIdentifier ident, SemanticModelChange... changes)
       throws NoSuchSemanticModelException, SemanticModelAlreadyExistsException,
           IllegalSemanticModelException {
-    Preconditions.checkArgument(
-        changes != null && changes.length > 0, "At least one change is required");
     checkRelationalCatalog(ident.namespace());
     NameIdentifier schemaIdent = schemaIdentifier(ident);
     if (!schemaDispatcher.schemaExists(schemaIdent)) {
       throw new NoSuchSemanticModelException("Semantic Model %s does not exist", ident);
     }
-
-    boolean renaming =
-        Arrays.stream(changes)
-            .anyMatch(change -> change instanceof SemanticModelChange.RenameSemanticModel);
-    NameIdentifier lockIdent = renaming ? schemaIdent : ident;
-    return TreeLockUtils.doWithTreeLock(
-        lockIdent, LockType.WRITE, () -> managedOperations.alterSemanticModel(ident, changes));
+    return managedOperations.alterSemanticModel(ident, changes);
   }
 
   @Override
@@ -131,8 +115,7 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
     if (!schemaDispatcher.schemaExists(schemaIdentifier(ident))) {
       return false;
     }
-    return TreeLockUtils.doWithTreeLock(
-        ident, LockType.WRITE, () -> managedOperations.dropSemanticModel(ident));
+    return managedOperations.dropSemanticModel(ident);
   }
 
   private void checkRelationalCatalog(Namespace namespace) {

--- a/core/src/main/java/org/apache/gravitino/catalog/SemanticModelOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SemanticModelOperationDispatcher.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.lock.LockType;
+import org.apache.gravitino.lock.TreeLockUtils;
+import org.apache.gravitino.secret.SecretManager;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelChange;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.IdGenerator;
+
+/** Dispatches always-managed Semantic Model operations to Gravitino's EntityStore. */
+public class SemanticModelOperationDispatcher extends OperationDispatcher
+    implements SemanticModelDispatcher {
+
+  private final CatalogManager catalogManager;
+  private final SchemaDispatcher schemaDispatcher;
+  private final ManagedSemanticModelOperations managedOperations;
+
+  /**
+   * Creates a Semantic Model operation dispatcher.
+   *
+   * @param catalogManager The catalog manager.
+   * @param schemaDispatcher The internal schema dispatcher used for parent validation.
+   * @param store The EntityStore used for Semantic Model persistence.
+   * @param idGenerator The stable entity ID generator.
+   * @param secretManager The secret manager required by the operation dispatcher base class.
+   */
+  public SemanticModelOperationDispatcher(
+      CatalogManager catalogManager,
+      SchemaDispatcher schemaDispatcher,
+      EntityStore store,
+      IdGenerator idGenerator,
+      SecretManager secretManager) {
+    super(catalogManager, store, idGenerator, secretManager);
+    this.catalogManager = catalogManager;
+    this.schemaDispatcher = schemaDispatcher;
+    this.managedOperations = new ManagedSemanticModelOperations(store, idGenerator);
+  }
+
+  @Override
+  public NameIdentifier[] listSemanticModels(Namespace namespace) throws NoSuchSchemaException {
+    checkRelationalCatalog(namespace);
+    NameIdentifier schemaIdent = NameIdentifier.of(namespace.levels());
+    schemaDispatcher.loadSchema(schemaIdent);
+    return TreeLockUtils.doWithTreeLock(
+        schemaIdent, LockType.READ, () -> managedOperations.listSemanticModels(namespace));
+  }
+
+  @Override
+  public SemanticModel loadSemanticModel(NameIdentifier ident) throws NoSuchSemanticModelException {
+    checkRelationalCatalog(ident.namespace());
+    if (!schemaDispatcher.schemaExists(schemaIdentifier(ident))) {
+      throw new NoSuchSemanticModelException("Semantic Model %s does not exist", ident);
+    }
+    return TreeLockUtils.doWithTreeLock(
+        ident, LockType.READ, () -> managedOperations.loadSemanticModel(ident));
+  }
+
+  @Override
+  public SemanticModel createSemanticModel(
+      NameIdentifier ident,
+      @Nullable String comment,
+      SemanticModelDefinition definition,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, SemanticModelAlreadyExistsException,
+          IllegalSemanticModelException {
+    Preconditions.checkArgument(definition != null, "Definition must not be null");
+    Preconditions.checkArgument(properties != null, "Properties must not be null");
+    checkRelationalCatalog(ident.namespace());
+    NameIdentifier schemaIdent = schemaIdentifier(ident);
+    schemaDispatcher.loadSchema(schemaIdent);
+    return TreeLockUtils.doWithTreeLock(
+        schemaIdent,
+        LockType.WRITE,
+        () -> managedOperations.createSemanticModel(ident, comment, definition, properties));
+  }
+
+  @Override
+  public SemanticModel alterSemanticModel(NameIdentifier ident, SemanticModelChange... changes)
+      throws NoSuchSemanticModelException, SemanticModelAlreadyExistsException,
+          IllegalSemanticModelException {
+    Preconditions.checkArgument(
+        changes != null && changes.length > 0, "At least one change is required");
+    checkRelationalCatalog(ident.namespace());
+    NameIdentifier schemaIdent = schemaIdentifier(ident);
+    if (!schemaDispatcher.schemaExists(schemaIdent)) {
+      throw new NoSuchSemanticModelException("Semantic Model %s does not exist", ident);
+    }
+
+    boolean renaming =
+        Arrays.stream(changes)
+            .anyMatch(change -> change instanceof SemanticModelChange.RenameSemanticModel);
+    NameIdentifier lockIdent = renaming ? schemaIdent : ident;
+    return TreeLockUtils.doWithTreeLock(
+        lockIdent, LockType.WRITE, () -> managedOperations.alterSemanticModel(ident, changes));
+  }
+
+  @Override
+  public boolean dropSemanticModel(NameIdentifier ident) {
+    checkRelationalCatalog(ident.namespace());
+    if (!schemaDispatcher.schemaExists(schemaIdentifier(ident))) {
+      return false;
+    }
+    return TreeLockUtils.doWithTreeLock(
+        ident, LockType.WRITE, () -> managedOperations.dropSemanticModel(ident));
+  }
+
+  private void checkRelationalCatalog(Namespace namespace) {
+    NameIdentifier catalogIdent = NameIdentifier.of(namespace.level(0), namespace.level(1));
+    Catalog catalog = catalogManager.loadCatalog(catalogIdent);
+    if (catalog.type() != Catalog.Type.RELATIONAL) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Catalog %s has type %s and does not support Semantic Model operations",
+              catalogIdent, catalog.type()));
+    }
+  }
+
+  private static NameIdentifier schemaIdentifier(NameIdentifier ident) {
+    return NameIdentifier.of(ident.namespace().levels());
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/catalog/SemanticModelValidator.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SemanticModelValidator.java
@@ -1,0 +1,492 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitiveOnName;
+import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.AIContextObject;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+
+/**
+ * Validates Semantic Model writes using Gravitino's Java value model and catalog metadata.
+ *
+ * <p>At implementation time, Apache Ossie commit {@code 88e0011148283302c9a04cd0287e00e0b9d87354},
+ * whose core specification version is {@code 0.2.0.dev0}, did not publish a reusable Java SDK or
+ * general-purpose Java validator artifact. The Java schema validation in that upstream tree was
+ * converter-specific. Gravitino therefore implements the applicable structural and model-local
+ * rules directly in Java. If a future Ossie release publishes a compatible Java SDK or validator,
+ * Gravitino should evaluate replacing this implementation with that upstream library.
+ *
+ * <p>{@code validateDefinition} is deterministic and performs no catalog I/O. {@code
+ * validateSources} resolves Table and logical View metadata and applies catalog capabilities,
+ * including column case sensitivity. {@code validateForWrite} composes both phases for create and
+ * definition-replacement writes. SQL expression semantics, transitive View semantics, and query
+ * engine compatibility are outside this validator's scope.
+ */
+final class SemanticModelValidator {
+
+  private final CatalogManager catalogManager;
+  private final TableDispatcher tableDispatcher;
+  private final ViewDispatcher viewDispatcher;
+
+  SemanticModelValidator(
+      CatalogManager catalogManager,
+      TableDispatcher tableDispatcher,
+      ViewDispatcher viewDispatcher) {
+    Preconditions.checkArgument(catalogManager != null, "Catalog manager must not be null");
+    Preconditions.checkArgument(tableDispatcher != null, "Table dispatcher must not be null");
+    Preconditions.checkArgument(viewDispatcher != null, "View dispatcher must not be null");
+    this.catalogManager = catalogManager;
+    this.tableDispatcher = tableDispatcher;
+    this.viewDispatcher = viewDispatcher;
+  }
+
+  static void validateDefinition(@Nullable SemanticModelDefinition definition) {
+    if (definition == null) {
+      throw invalid("$", "definition must not be null");
+    }
+
+    validateAIContext(definition.aiContext(), "aiContext");
+
+    Dataset[] datasets = definition.datasets();
+    if (datasets == null || datasets.length == 0) {
+      throw invalid("datasets", "must not be null or empty");
+    }
+
+    Map<String, String> datasetNames = new HashMap<>();
+    for (int index = 0; index < datasets.length; index++) {
+      validateDataset(datasets[index], "datasets[" + index + "]", datasetNames);
+    }
+
+    validateRelationships(definition.relationships(), datasetNames);
+    validateMetrics(definition.metrics());
+    validateCustomExtensions(definition.customExtensions(), "customExtensions");
+  }
+
+  void validateSources(String metalake, SemanticModelDefinition definition) {
+    Dataset[] datasets = definition.datasets();
+    Map<String, SourceColumns> columnsByDataset = new HashMap<>();
+
+    for (int datasetIndex = 0; datasetIndex < datasets.length; datasetIndex++) {
+      Dataset dataset = datasets[datasetIndex];
+      String datasetPath = "datasets[" + datasetIndex + "]";
+      NameIdentifier fullSource =
+          qualifySource(metalake, dataset.source(), datasetPath + ".source");
+      SourceColumns sourceColumns = loadSourceColumns(fullSource, datasetPath + ".source");
+      columnsByDataset.put(dataset.name(), sourceColumns);
+
+      validateSourceColumns(dataset.primaryKey(), datasetPath + ".primaryKey", sourceColumns);
+      String[][] uniqueKeys = dataset.uniqueKeys();
+      if (uniqueKeys != null) {
+        for (int keyIndex = 0; keyIndex < uniqueKeys.length; keyIndex++) {
+          validateSourceColumns(
+              uniqueKeys[keyIndex], datasetPath + ".uniqueKeys[" + keyIndex + "]", sourceColumns);
+        }
+      }
+    }
+
+    Relationship[] relationships = definition.relationships();
+    if (relationships == null) {
+      return;
+    }
+    for (int relationshipIndex = 0; relationshipIndex < relationships.length; relationshipIndex++) {
+      Relationship relationship = relationships[relationshipIndex];
+      String path = "relationships[" + relationshipIndex + "]";
+      SourceColumns fromColumns = columnsByDataset.get(relationship.from());
+      SourceColumns toColumns = columnsByDataset.get(relationship.to());
+      if (fromColumns == null || toColumns == null) {
+        throw invalid(
+            path, "relationship endpoints must reference datasets in the same Semantic Model");
+      }
+      validateSourceColumns(relationship.fromColumns(), path + ".fromColumns", fromColumns);
+      validateSourceColumns(relationship.toColumns(), path + ".toColumns", toColumns);
+    }
+  }
+
+  void validateForWrite(
+      NameIdentifier semanticModelIdent, @Nullable SemanticModelDefinition definition) {
+    if (semanticModelIdent == null || semanticModelIdent.namespace().length() != 3) {
+      throw invalid("$", "Semantic Model identifier must use metalake.catalog.schema.name");
+    }
+    validateDefinition(definition);
+    validateSources(semanticModelIdent.namespace().level(0), definition);
+  }
+
+  private static void validateDataset(
+      @Nullable Dataset dataset, String path, Map<String, String> datasetNames) {
+    if (dataset == null) {
+      throw invalid(path, "must not be null");
+    }
+
+    String namePath = path + ".name";
+    validateRequiredString(dataset.name(), namePath);
+    validateUniqueName(dataset.name(), namePath, "dataset", datasetNames);
+    validateSource(dataset.source(), path + ".source");
+    validateOptionalColumnNames(dataset.primaryKey(), path + ".primaryKey");
+    validateUniqueKeys(dataset.uniqueKeys(), path + ".uniqueKeys");
+    validateAIContext(dataset.aiContext(), path + ".aiContext");
+    validateFields(dataset.fields(), path + ".fields");
+    validateCustomExtensions(dataset.customExtensions(), path + ".customExtensions");
+  }
+
+  private static void validateSource(@Nullable NameIdentifier source, String path) {
+    if (source == null) {
+      throw invalid(path, "must not be null");
+    }
+    if (source.namespace().length() != 2) {
+      throw invalid(
+          path, "must contain exactly catalog.schema.name, but was '" + source.toString() + "'");
+    }
+  }
+
+  private static void validateUniqueKeys(@Nullable String[][] uniqueKeys, String path) {
+    if (uniqueKeys == null) {
+      return;
+    }
+
+    for (int index = 0; index < uniqueKeys.length; index++) {
+      String keyPath = path + "[" + index + "]";
+      String[] uniqueKey = uniqueKeys[index];
+      if (uniqueKey == null || uniqueKey.length == 0) {
+        throw invalid(keyPath, "must not be null or empty");
+      }
+      validateColumnNames(uniqueKey, keyPath, false);
+    }
+  }
+
+  private static void validateFields(@Nullable Field[] fields, String path) {
+    if (fields == null) {
+      return;
+    }
+
+    Map<String, String> fieldNames = new HashMap<>();
+    for (int index = 0; index < fields.length; index++) {
+      String fieldPath = path + "[" + index + "]";
+      Field field = fields[index];
+      if (field == null) {
+        throw invalid(fieldPath, "must not be null");
+      }
+
+      String namePath = fieldPath + ".name";
+      validateRequiredString(field.name(), namePath);
+      validateUniqueName(field.name(), namePath, "field", fieldNames);
+      validateExpression(field.expression(), fieldPath + ".expression");
+      validateAIContext(field.aiContext(), fieldPath + ".aiContext");
+      validateCustomExtensions(field.customExtensions(), fieldPath + ".customExtensions");
+    }
+  }
+
+  private static void validateRelationships(
+      @Nullable Relationship[] relationships, Map<String, String> datasetNames) {
+    if (relationships == null) {
+      return;
+    }
+
+    Map<String, String> relationshipNames = new HashMap<>();
+    for (int index = 0; index < relationships.length; index++) {
+      String path = "relationships[" + index + "]";
+      Relationship relationship = relationships[index];
+      if (relationship == null) {
+        throw invalid(path, "must not be null");
+      }
+
+      String namePath = path + ".name";
+      validateRequiredString(relationship.name(), namePath);
+      validateUniqueName(relationship.name(), namePath, "relationship", relationshipNames);
+      validateEndpoint(relationship.from(), path + ".from", datasetNames);
+      validateEndpoint(relationship.to(), path + ".to", datasetNames);
+
+      String[] fromColumns = relationship.fromColumns();
+      String[] toColumns = relationship.toColumns();
+      validateColumnNames(fromColumns, path + ".fromColumns", false);
+      validateColumnNames(toColumns, path + ".toColumns", false);
+      if (fromColumns.length != toColumns.length) {
+        throw invalid(
+            path + ".toColumns",
+            "must contain "
+                + fromColumns.length
+                + " columns to match "
+                + path
+                + ".fromColumns, but contained "
+                + toColumns.length);
+      }
+      validateAIContext(relationship.aiContext(), path + ".aiContext");
+      validateCustomExtensions(relationship.customExtensions(), path + ".customExtensions");
+    }
+  }
+
+  private static void validateEndpoint(
+      @Nullable String endpoint, String path, Map<String, String> datasetNames) {
+    validateRequiredString(endpoint, path);
+    if (!datasetNames.containsKey(endpoint)) {
+      throw invalid(
+          path,
+          "unknown dataset '"
+              + endpoint
+              + "'; relationship endpoints must reference datasets in the same model");
+    }
+  }
+
+  private static void validateMetrics(@Nullable Metric[] metrics) {
+    if (metrics == null) {
+      return;
+    }
+
+    Map<String, String> metricNames = new HashMap<>();
+    for (int index = 0; index < metrics.length; index++) {
+      String path = "metrics[" + index + "]";
+      Metric metric = metrics[index];
+      if (metric == null) {
+        throw invalid(path, "must not be null");
+      }
+
+      String namePath = path + ".name";
+      validateRequiredString(metric.name(), namePath);
+      validateUniqueName(metric.name(), namePath, "metric", metricNames);
+      validateExpression(metric.expression(), path + ".expression");
+      validateAIContext(metric.aiContext(), path + ".aiContext");
+      validateCustomExtensions(metric.customExtensions(), path + ".customExtensions");
+    }
+  }
+
+  private static void validateExpression(@Nullable Expression expression, String path) {
+    if (expression == null) {
+      throw invalid(path, "must not be null");
+    }
+
+    DialectExpression[] dialectExpressions = expression.dialects();
+    if (dialectExpressions == null || dialectExpressions.length == 0) {
+      throw invalid(path + ".dialects", "must not be null or empty");
+    }
+
+    Map<String, String> dialectPaths = new HashMap<>();
+    for (int index = 0; index < dialectExpressions.length; index++) {
+      String dialectExpressionPath = path + ".dialects[" + index + "]";
+      DialectExpression dialectExpression = dialectExpressions[index];
+      if (dialectExpression == null) {
+        throw invalid(dialectExpressionPath, "must not be null");
+      }
+
+      String dialect = dialectExpression.dialect();
+      String dialectPath = dialectExpressionPath + ".dialect";
+      validateRequiredString(dialect, dialectPath);
+      String firstPath = dialectPaths.putIfAbsent(dialect, dialectPath);
+      if (firstPath != null) {
+        throw invalid(
+            dialectPath, "duplicate dialect '" + dialect + "'; first declared at " + firstPath);
+      }
+      validateRequiredString(dialectExpression.expression(), dialectExpressionPath + ".expression");
+    }
+  }
+
+  private static void validateAIContext(@Nullable AIContext aiContext, String path) {
+    if (aiContext == null) {
+      return;
+    }
+
+    String text = aiContext.text();
+    AIContextObject object = aiContext.object();
+    if ((text == null) == (object == null)) {
+      throw invalid(path, "must contain exactly one string or object value");
+    }
+    if (object == null) {
+      return;
+    }
+
+    validateStringElements(object.synonyms(), path + ".synonyms");
+    validateStringElements(object.examples(), path + ".examples");
+    if (object.additionalProperties() == null) {
+      throw invalid(path + ".additionalProperties", "must not be null");
+    }
+    for (String name : object.additionalProperties().keySet()) {
+      if (name == null) {
+        throw invalid(path + ".additionalProperties", "property name must not be null");
+      }
+    }
+  }
+
+  private static void validateColumnNames(
+      @Nullable String[] columns, String path, boolean allowEmpty) {
+    if (columns == null || (!allowEmpty && columns.length == 0)) {
+      throw invalid(path, allowEmpty ? "must not be null" : "must not be null or empty");
+    }
+    for (int index = 0; index < columns.length; index++) {
+      validateRequiredString(columns[index], path + "[" + index + "]");
+    }
+  }
+
+  private static void validateOptionalColumnNames(@Nullable String[] columns, String path) {
+    if (columns == null) {
+      return;
+    }
+    for (int index = 0; index < columns.length; index++) {
+      validateRequiredString(columns[index], path + "[" + index + "]");
+    }
+  }
+
+  private static void validateStringElements(@Nullable String[] values, String path) {
+    if (values == null) {
+      return;
+    }
+    for (int index = 0; index < values.length; index++) {
+      if (values[index] == null) {
+        throw invalid(path + "[" + index + "]", "must not be null");
+      }
+    }
+  }
+
+  private static void validateCustomExtensions(
+      @Nullable CustomExtension[] customExtensions, String path) {
+    if (customExtensions == null) {
+      return;
+    }
+    for (int index = 0; index < customExtensions.length; index++) {
+      String extensionPath = path + "[" + index + "]";
+      CustomExtension extension = customExtensions[index];
+      if (extension == null) {
+        throw invalid(extensionPath, "must not be null");
+      }
+      if (extension.vendorName() == null) {
+        throw invalid(extensionPath + ".vendorName", "must not be null");
+      }
+      if (extension.data() == null) {
+        throw invalid(extensionPath + ".data", "must not be null");
+      }
+    }
+  }
+
+  private static void validateRequiredString(@Nullable String value, String path) {
+    if (value == null || value.isEmpty()) {
+      throw invalid(path, "must not be null or empty");
+    }
+  }
+
+  private static void validateUniqueName(
+      String name, String path, String memberType, Map<String, String> names) {
+    String firstPath = names.putIfAbsent(name, path);
+    if (firstPath != null) {
+      throw invalid(
+          path, "duplicate " + memberType + " name '" + name + "'; first declared at " + firstPath);
+    }
+  }
+
+  private static NameIdentifier qualifySource(
+      String metalake, NameIdentifier source, String sourcePath) {
+    if (source == null || source.namespace().length() != 2) {
+      throw invalid(sourcePath, "source must use catalog.schema.name");
+    }
+    return NameIdentifier.of(
+        Namespace.of(metalake, source.namespace().level(0), source.namespace().level(1)),
+        source.name());
+  }
+
+  private SourceColumns loadSourceColumns(NameIdentifier source, String sourcePath) {
+    try {
+      Table table = tableDispatcher.loadTable(source);
+      return sourceColumns(source, table == null ? null : table.columns());
+    } catch (NotFoundException | UnsupportedOperationException tableNotFound) {
+      try {
+        View view = viewDispatcher.loadView(source);
+        return sourceColumns(source, view == null ? null : view.columns());
+      } catch (NotFoundException | UnsupportedOperationException viewNotFound) {
+        throw new IllegalSemanticModelException(
+            viewNotFound,
+            "%s: source %s does not exist as a Table or logical View",
+            sourcePath,
+            source);
+      }
+    }
+  }
+
+  private SourceColumns sourceColumns(NameIdentifier source, Column[] columns) {
+    Capability capability = getCapability(source, catalogManager);
+    Function<String, String> normalizeColumn =
+        name -> applyCaseSensitiveOnName(Capability.Scope.COLUMN, name, capability);
+    Set<String> names =
+        columns == null
+            ? Collections.emptySet()
+            : Arrays.stream(columns)
+                .map(Column::name)
+                .map(normalizeColumn)
+                .collect(Collectors.toSet());
+    return new SourceColumns(source, names, normalizeColumn);
+  }
+
+  private static void validateSourceColumns(
+      @Nullable String[] columns, String path, SourceColumns sourceColumns) {
+    if (columns == null) {
+      return;
+    }
+    for (int columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+      String column = columns[columnIndex];
+      if (!sourceColumns.contains(column)) {
+        throw new IllegalSemanticModelException(
+            "%s[%s]: column '%s' does not exist in source %s",
+            path, columnIndex, column, sourceColumns.source);
+      }
+    }
+  }
+
+  private static IllegalSemanticModelException invalid(String path, String detail) {
+    return new IllegalSemanticModelException("%s: %s", path, detail);
+  }
+
+  private static final class SourceColumns {
+    private final NameIdentifier source;
+    private final Set<String> columns;
+    private final Function<String, String> normalizeColumn;
+
+    private SourceColumns(
+        NameIdentifier source, Set<String> columns, Function<String, String> normalizeColumn) {
+      this.source = source;
+      this.columns = columns;
+      this.normalizeColumn = normalizeColumn;
+    }
+
+    private boolean contains(String column) {
+      return columns.contains(normalizeColumn.apply(column));
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/connector/capability/Capability.java
+++ b/core/src/main/java/org/apache/gravitino/connector/capability/Capability.java
@@ -43,7 +43,8 @@ public interface Capability {
     TOPIC,
     PARTITION,
     MODEL,
-    FUNCTION
+    FUNCTION,
+    SEMANTIC_MODEL
   }
 
   /**
@@ -179,7 +180,7 @@ public interface Capability {
 
     @Override
     public CapabilityResult managedStorage(Scope scope) {
-      if (scope == Scope.FUNCTION) {
+      if (scope == Scope.FUNCTION || scope == Scope.SEMANTIC_MODEL) {
         return CapabilityResult.SUPPORTED;
       }
 

--- a/core/src/main/java/org/apache/gravitino/meta/SemanticModelEntity.java
+++ b/core/src/main/java/org/apache/gravitino/meta/SemanticModelEntity.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.meta;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import lombok.ToString;
+import org.apache.gravitino.Auditable;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.Field;
+import org.apache.gravitino.HasIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+
+/** A metadata-store entity representing a schema-scoped Semantic Model. */
+@ToString
+public class SemanticModelEntity implements Entity, Auditable, HasIdentifier, SemanticModel {
+
+  /** The unique ID field of the Semantic Model entity. */
+  public static final Field ID =
+      Field.required("id", Long.class, "The unique id of the Semantic Model entity.");
+
+  /** The name field of the Semantic Model entity. */
+  public static final Field NAME =
+      Field.required("name", String.class, "The name of the Semantic Model entity.");
+
+  /** The namespace field of the Semantic Model entity. */
+  public static final Field NAMESPACE =
+      Field.required("namespace", Namespace.class, "The namespace of the Semantic Model entity.");
+
+  /** The optional comment field of the Semantic Model entity. */
+  public static final Field COMMENT =
+      Field.optional(
+          "comment", String.class, "The comment or description of the Semantic Model entity.");
+
+  /** The immutable definition field of the Semantic Model entity. */
+  public static final Field DEFINITION =
+      Field.required(
+          "definition",
+          SemanticModelDefinition.class,
+          "The immutable definition of the Semantic Model entity.");
+
+  /** The properties field of the Semantic Model entity. */
+  public static final Field PROPERTIES =
+      Field.optional("properties", Map.class, "The properties of the Semantic Model entity.");
+
+  /** The audit information field of the Semantic Model entity. */
+  public static final Field AUDIT_INFO =
+      Field.required(
+          "audit_info", AuditInfo.class, "The audit details of the Semantic Model entity.");
+
+  private Long id;
+  private String name;
+  private Namespace namespace;
+  private SemanticModelDefinition definition;
+  private Map<String, String> properties = Collections.emptyMap();
+  private AuditInfo auditInfo;
+
+  @Nullable private String comment;
+
+  private SemanticModelEntity() {}
+
+  /**
+   * Returns the fields and values of this Semantic Model entity.
+   *
+   * <p>The definition is immutable and the properties map is immutable, so the returned values
+   * cannot mutate this entity.
+   *
+   * @return An unmodifiable map of fields and values.
+   */
+  @Override
+  public Map<Field, Object> fields() {
+    Map<Field, Object> fields = Maps.newHashMap();
+    fields.put(ID, id);
+    fields.put(NAME, name);
+    fields.put(NAMESPACE, namespace);
+    fields.put(COMMENT, comment);
+    fields.put(DEFINITION, definition);
+    fields.put(PROPERTIES, properties);
+    fields.put(AUDIT_INFO, auditInfo);
+    return Collections.unmodifiableMap(fields);
+  }
+
+  /**
+   * Returns the Semantic Model name.
+   *
+   * @return The Semantic Model name.
+   */
+  @Override
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Returns the unique ID of the Semantic Model entity.
+   *
+   * @return The unique ID.
+   */
+  @Override
+  public Long id() {
+    return id;
+  }
+
+  /**
+   * Returns the namespace of the Semantic Model entity.
+   *
+   * @return The namespace.
+   */
+  @Override
+  public Namespace namespace() {
+    return namespace;
+  }
+
+  /**
+   * Returns the Semantic Model comment.
+   *
+   * @return The comment, or {@code null} if it is not set.
+   */
+  @Nullable
+  @Override
+  public String comment() {
+    return comment;
+  }
+
+  /**
+   * Returns the immutable Semantic Model definition.
+   *
+   * @return The Semantic Model definition.
+   */
+  @Override
+  public SemanticModelDefinition definition() {
+    return definition;
+  }
+
+  /**
+   * Returns the immutable Gravitino-specific properties of the Semantic Model.
+   *
+   * @return The properties, or an empty map if none are set.
+   */
+  @Override
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  /**
+   * Returns the audit information of the Semantic Model entity.
+   *
+   * @return The audit information.
+   */
+  @Override
+  public AuditInfo auditInfo() {
+    return auditInfo;
+  }
+
+  /**
+   * Returns the Semantic Model entity type.
+   *
+   * @return {@link EntityType#SEMANTIC_MODEL}.
+   */
+  @Override
+  public EntityType type() {
+    return EntityType.SEMANTIC_MODEL;
+  }
+
+  /**
+   * Validates all declared entity fields.
+   *
+   * @throws IllegalArgumentException If a required field is missing or has the wrong type.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    Entity.super.validate();
+  }
+
+  /**
+   * Compares this entity with another object for value equality.
+   *
+   * @param other The object to compare with.
+   * @return {@code true} if the objects are equal, otherwise {@code false}.
+   */
+  @Override
+  public boolean equals(@Nullable Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof SemanticModelEntity)) {
+      return false;
+    }
+    SemanticModelEntity that = (SemanticModelEntity) other;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(namespace, that.namespace)
+        && Objects.equals(comment, that.comment)
+        && Objects.equals(definition, that.definition)
+        && Objects.equals(properties, that.properties)
+        && Objects.equals(auditInfo, that.auditInfo);
+  }
+
+  /**
+   * Returns the value-based hash code of this entity.
+   *
+   * @return The hash code.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, namespace, comment, definition, properties, auditInfo);
+  }
+
+  /**
+   * Creates a builder for a Semantic Model entity.
+   *
+   * @return A new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** A builder for {@link SemanticModelEntity}. */
+  public static class Builder {
+
+    private final SemanticModelEntity semanticModel;
+
+    private Builder() {
+      semanticModel = new SemanticModelEntity();
+    }
+
+    /**
+     * Sets the unique ID of the Semantic Model entity.
+     *
+     * @param id The unique ID.
+     * @return This builder.
+     */
+    public Builder withId(Long id) {
+      semanticModel.id = id;
+      return this;
+    }
+
+    /**
+     * Sets the name of the Semantic Model entity.
+     *
+     * @param name The Semantic Model name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      semanticModel.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the namespace of the Semantic Model entity.
+     *
+     * @param namespace The namespace.
+     * @return This builder.
+     */
+    public Builder withNamespace(Namespace namespace) {
+      semanticModel.namespace = namespace;
+      return this;
+    }
+
+    /**
+     * Sets the optional Semantic Model comment.
+     *
+     * @param comment The comment, or {@code null} to leave it unset.
+     * @return This builder.
+     */
+    public Builder withComment(@Nullable String comment) {
+      semanticModel.comment = comment;
+      return this;
+    }
+
+    /**
+     * Sets the immutable Semantic Model definition.
+     *
+     * @param definition The Semantic Model definition.
+     * @return This builder.
+     */
+    public Builder withDefinition(SemanticModelDefinition definition) {
+      semanticModel.definition = definition;
+      return this;
+    }
+
+    /**
+     * Sets the Gravitino-specific properties.
+     *
+     * @param properties The properties, or {@code null} for no properties.
+     * @return This builder.
+     */
+    public Builder withProperties(@Nullable Map<String, String> properties) {
+      semanticModel.properties =
+          properties == null ? Collections.emptyMap() : ImmutableMap.copyOf(properties);
+      return this;
+    }
+
+    /**
+     * Sets the audit information of the Semantic Model entity.
+     *
+     * @param auditInfo The audit information.
+     * @return This builder.
+     */
+    public Builder withAuditInfo(AuditInfo auditInfo) {
+      semanticModel.auditInfo = auditInfo;
+      return this;
+    }
+
+    /**
+     * Builds and validates the Semantic Model entity.
+     *
+     * @return The built Semantic Model entity.
+     * @throws IllegalArgumentException If a required field is missing or has the wrong type.
+     */
+    public SemanticModelEntity build() {
+      semanticModel.validate();
+      return semanticModel;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
@@ -62,6 +62,7 @@ import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.meta.PolicyEntity;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.SchemaEntity;
+import org.apache.gravitino.meta.SemanticModelEntity;
 import org.apache.gravitino.meta.StatisticEntity;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.meta.TagEntity;
@@ -86,6 +87,7 @@ import org.apache.gravitino.storage.relational.service.OwnerMetaService;
 import org.apache.gravitino.storage.relational.service.PolicyMetaService;
 import org.apache.gravitino.storage.relational.service.RoleMetaService;
 import org.apache.gravitino.storage.relational.service.SchemaMetaService;
+import org.apache.gravitino.storage.relational.service.SemanticModelMetaService;
 import org.apache.gravitino.storage.relational.service.StatisticMetaService;
 import org.apache.gravitino.storage.relational.service.TableColumnMetaService;
 import org.apache.gravitino.storage.relational.service.TableMetaService;
@@ -279,6 +281,8 @@ public class JDBCBackend implements RelationalBackend, SupportsOrphanedRelationC
         return (E) JobMetaService.getInstance().getJobByIdentifier(ident);
       case VIEW:
         return (E) ViewMetaService.getInstance().getViewByIdentifier(ident);
+      case SEMANTIC_MODEL:
+        return (E) SemanticModelMetaService.getInstance().getSemanticModelByIdentifier(ident);
       default:
         throw new UnsupportedEntityTypeException(
             "Unsupported entity type: %s for get operation", entityType);
@@ -1005,6 +1009,9 @@ public class JDBCBackend implements RelationalBackend, SupportsOrphanedRelationC
       JobMetaService.getInstance().insertJob((JobEntity) e, overwritten);
     } else if (e instanceof ViewEntity) {
       ViewMetaService.getInstance().insertView((ViewEntity) e, overwritten);
+    } else if (e instanceof SemanticModelEntity) {
+      SemanticModelMetaService.getInstance()
+          .insertSemanticModel((SemanticModelEntity) e, overwritten);
     } else if (e instanceof GenericEntity) {
       GenericEntity genericEntity = (GenericEntity) e;
       throw new UnsupportedEntityTypeException(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
@@ -539,6 +539,9 @@ public class JDBCBackend implements RelationalBackend, SupportsOrphanedRelationC
         return ViewMetaService.getInstance()
             .deleteViewMetasByLegacyTimeline(
                 legacyTimeline, GARBAGE_COLLECTOR_SINGLE_DELETION_LIMIT);
+      case SEMANTIC_MODEL:
+        // TODO: Delegate to SemanticModelMetaService when relational persistence is added.
+        return 0;
       case AUDIT:
         return 0;
         // TODO: Implement hard delete logic for these entity types.
@@ -577,6 +580,10 @@ public class JDBCBackend implements RelationalBackend, SupportsOrphanedRelationC
       case JOB:
       case VIEW:
         // These entity types have not implemented multi-versions, so we can skip.
+        return 0;
+
+      case SEMANTIC_MODEL:
+        // TODO: Delegate to SemanticModelMetaService when relational persistence is added.
         return 0;
 
       case FILESET:

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStoreIdResolver.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStoreIdResolver.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.storage.relational.service.ModelMetaService;
 import org.apache.gravitino.storage.relational.service.PolicyMetaService;
 import org.apache.gravitino.storage.relational.service.RoleMetaService;
 import org.apache.gravitino.storage.relational.service.SchemaMetaService;
+import org.apache.gravitino.storage.relational.service.SemanticModelMetaService;
 import org.apache.gravitino.storage.relational.service.TableColumnMetaService;
 import org.apache.gravitino.storage.relational.service.TableMetaService;
 import org.apache.gravitino.storage.relational.service.TagMetaService;
@@ -69,7 +70,8 @@ public class RelationalEntityStoreIdResolver implements EntityIdResolver {
           Entity.EntityType.MODEL,
           Entity.EntityType.COLUMN,
           Entity.EntityType.FUNCTION,
-          Entity.EntityType.VIEW);
+          Entity.EntityType.VIEW,
+          Entity.EntityType.SEMANTIC_MODEL);
 
   @Override
   public NamespacedEntityId getEntityIds(NameIdentifier nameIdentifier, Entity.EntityType type) {
@@ -234,6 +236,17 @@ public class RelationalEntityStoreIdResolver implements EntityIdResolver {
                 .getViewIdBySchemaIdAndName(schemaIds.getSchemaId(), nameIdentifier.name());
         return new NamespacedEntityId(
             viewId, schemaIds.getMetalakeId(), schemaIds.getCatalogId(), schemaIds.getSchemaId());
+
+      case SEMANTIC_MODEL:
+        long semanticModelId =
+            SemanticModelMetaService.getInstance()
+                .getSemanticModelIdBySchemaIdAndName(
+                    schemaIds.getSchemaId(), nameIdentifier.name());
+        return new NamespacedEntityId(
+            semanticModelId,
+            schemaIds.getMetalakeId(),
+            schemaIds.getCatalogId(),
+            schemaIds.getSchemaId());
 
       case FUNCTION:
         long functionId =

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelMetaMapper.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.One;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.SelectProvider;
+
+/** A MyBatis mapper for Semantic Model create and load operations. */
+public interface SemanticModelMetaMapper {
+
+  /** The Semantic Model identity table name. */
+  String TABLE_NAME = "semantic_model_meta";
+
+  /** The Semantic Model version snapshot table name. */
+  String VERSION_TABLE_NAME = "semantic_model_version_info";
+
+  /** Declares the nested result mapping for a Semantic Model version snapshot. */
+  @Results(
+      id = "mapToSemanticModelVersionInfoPO",
+      value = {
+        @Result(property = "id", column = "id", id = true),
+        @Result(property = "metalakeId", column = "version_metalake_id"),
+        @Result(property = "catalogId", column = "version_catalog_id"),
+        @Result(property = "schemaId", column = "version_schema_id"),
+        @Result(property = "semanticModelId", column = "version_semantic_model_id"),
+        @Result(property = "version", column = "version"),
+        @Result(property = "semanticModelName", column = "version_semantic_model_name"),
+        @Result(property = "semanticModelComment", column = "semantic_model_comment"),
+        @Result(property = "semanticModelDefinition", column = "semantic_model_definition"),
+        @Result(property = "properties", column = "properties"),
+        @Result(property = "auditInfo", column = "version_audit_info"),
+        @Result(property = "deletedAt", column = "version_deleted_at")
+      })
+  @Select("SELECT 1")
+  SemanticModelVersionInfoPO mapToSemanticModelVersionInfoPO();
+
+  /** Selects an active Semantic Model ID by schema ID and name. */
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelIdBySchemaIdAndName")
+  Long selectSemanticModelIdBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName);
+
+  /** Selects a current Semantic Model snapshot by schema ID and name. */
+  @Results(
+      id = "semanticModelPOResultMap",
+      value = {
+        @Result(property = "semanticModelId", column = "semantic_model_id", id = true),
+        @Result(property = "semanticModelName", column = "semantic_model_name"),
+        @Result(property = "metalakeId", column = "metalake_id"),
+        @Result(property = "catalogId", column = "catalog_id"),
+        @Result(property = "schemaId", column = "schema_id"),
+        @Result(property = "currentVersion", column = "current_version"),
+        @Result(property = "lastVersion", column = "last_version"),
+        @Result(property = "auditInfo", column = "audit_info"),
+        @Result(property = "deletedAt", column = "deleted_at"),
+        @Result(
+            property = "semanticModelVersionInfoPO",
+            javaType = SemanticModelVersionInfoPO.class,
+            column =
+                "{id,version_metalake_id,version_catalog_id,version_schema_id,"
+                    + "version_semantic_model_id,version,version_semantic_model_name,"
+                    + "semantic_model_comment,semantic_model_definition,properties,"
+                    + "version_audit_info,version_deleted_at}",
+            one = @One(resultMap = "mapToSemanticModelVersionInfoPO"))
+      })
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelMetaBySchemaIdAndName")
+  SemanticModelPO selectSemanticModelMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName);
+
+  /** Selects a current Semantic Model snapshot by fully qualified name. */
+  @ResultMap("semanticModelPOResultMap")
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelByFullQualifiedName")
+  SemanticModelPO selectSemanticModelByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("semanticModelName") String semanticModelName);
+
+  /** Inserts a Semantic Model identity row. */
+  @InsertProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "insertSemanticModelMeta")
+  void insertSemanticModelMeta(@Param("semanticModelMeta") SemanticModelPO semanticModelPO);
+
+  /** Inserts or overwrites a Semantic Model identity row. */
+  @InsertProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "insertSemanticModelMetaOnDuplicateKeyUpdate")
+  void insertSemanticModelMetaOnDuplicateKeyUpdate(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelMetaSQLProviderFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.provider.base.SemanticModelMetaBaseSQLProvider;
+import org.apache.gravitino.storage.relational.mapper.provider.postgresql.SemanticModelMetaPostgreSQLProvider;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.annotations.Param;
+
+/** Selects database-specific SQL providers for Semantic Model create and load operations. */
+public class SemanticModelMetaSQLProviderFactory {
+
+  private static final Map<JDBCBackendType, SemanticModelMetaBaseSQLProvider>
+      SEMANTIC_MODEL_META_SQL_PROVIDER_MAP =
+          ImmutableMap.of(
+              JDBCBackendType.MYSQL, new SemanticModelMetaMySQLProvider(),
+              JDBCBackendType.H2, new SemanticModelMetaH2Provider(),
+              JDBCBackendType.POSTGRESQL, new SemanticModelMetaPostgreSQLProvider());
+
+  /** Returns the SQL provider for the configured relational backend. */
+  public static SemanticModelMetaBaseSQLProvider getProvider() {
+    String databaseId =
+        SqlSessionFactoryHelper.getInstance()
+            .getSqlSessionFactory()
+            .getConfiguration()
+            .getDatabaseId();
+    return SEMANTIC_MODEL_META_SQL_PROVIDER_MAP.get(JDBCBackendType.fromString(databaseId));
+  }
+
+  static class SemanticModelMetaMySQLProvider extends SemanticModelMetaBaseSQLProvider {}
+
+  static class SemanticModelMetaH2Provider extends SemanticModelMetaBaseSQLProvider {}
+
+  /** Provides SQL for selecting a Semantic Model ID by schema ID and name. */
+  public static String selectSemanticModelIdBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return getProvider().selectSemanticModelIdBySchemaIdAndName(schemaId, semanticModelName);
+  }
+
+  /** Provides SQL for selecting a Semantic Model by schema ID and name. */
+  public static String selectSemanticModelMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return getProvider().selectSemanticModelMetaBySchemaIdAndName(schemaId, semanticModelName);
+  }
+
+  /** Provides SQL for selecting a Semantic Model by fully qualified name. */
+  public static String selectSemanticModelByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("semanticModelName") String semanticModelName) {
+    return getProvider()
+        .selectSemanticModelByFullQualifiedName(
+            metalakeName, catalogName, schemaName, semanticModelName);
+  }
+
+  /** Provides SQL for inserting a Semantic Model identity. */
+  public static String insertSemanticModelMeta(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return getProvider().insertSemanticModelMeta(semanticModelPO);
+  }
+
+  /** Provides SQL for inserting or overwriting a Semantic Model identity. */
+  public static String insertSemanticModelMetaOnDuplicateKeyUpdate(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return getProvider().insertSemanticModelMetaOnDuplicateKeyUpdate(semanticModelPO);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelVersionInfoMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelVersionInfoMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.Param;
+
+/** A MyBatis mapper for creating Semantic Model version snapshots. */
+public interface SemanticModelVersionInfoMapper {
+
+  /** The Semantic Model version snapshot table name. */
+  String TABLE_NAME = "semantic_model_version_info";
+
+  /** Inserts a Semantic Model version snapshot. */
+  @InsertProvider(
+      type = SemanticModelVersionInfoSQLProviderFactory.class,
+      method = "insertSemanticModelVersionInfo")
+  void insertSemanticModelVersionInfo(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO);
+
+  /** Inserts or overwrites a Semantic Model version snapshot. */
+  @InsertProvider(
+      type = SemanticModelVersionInfoSQLProviderFactory.class,
+      method = "insertSemanticModelVersionInfoOnDuplicateKeyUpdate")
+  void insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelVersionInfoSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelVersionInfoSQLProviderFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.provider.base.SemanticModelVersionInfoBaseSQLProvider;
+import org.apache.gravitino.storage.relational.mapper.provider.postgresql.SemanticModelVersionInfoPostgreSQLProvider;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.annotations.Param;
+
+/** Selects database-specific SQL providers for Semantic Model snapshot creation. */
+public class SemanticModelVersionInfoSQLProviderFactory {
+
+  private static final Map<JDBCBackendType, SemanticModelVersionInfoBaseSQLProvider>
+      SEMANTIC_MODEL_VERSION_INFO_SQL_PROVIDER_MAP =
+          ImmutableMap.of(
+              JDBCBackendType.MYSQL, new SemanticModelVersionInfoMySQLProvider(),
+              JDBCBackendType.H2, new SemanticModelVersionInfoH2Provider(),
+              JDBCBackendType.POSTGRESQL, new SemanticModelVersionInfoPostgreSQLProvider());
+
+  /** Returns the SQL provider for the configured relational backend. */
+  public static SemanticModelVersionInfoBaseSQLProvider getProvider() {
+    String databaseId =
+        SqlSessionFactoryHelper.getInstance()
+            .getSqlSessionFactory()
+            .getConfiguration()
+            .getDatabaseId();
+    return SEMANTIC_MODEL_VERSION_INFO_SQL_PROVIDER_MAP.get(JDBCBackendType.fromString(databaseId));
+  }
+
+  static class SemanticModelVersionInfoMySQLProvider
+      extends SemanticModelVersionInfoBaseSQLProvider {}
+
+  static class SemanticModelVersionInfoH2Provider extends SemanticModelVersionInfoBaseSQLProvider {}
+
+  /** Provides SQL for inserting a Semantic Model version snapshot. */
+  public static String insertSemanticModelVersionInfo(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return getProvider().insertSemanticModelVersionInfo(versionInfoPO);
+  }
+
+  /** Provides SQL for inserting or overwriting a Semantic Model version snapshot. */
+  public static String insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return getProvider().insertSemanticModelVersionInfoOnDuplicateKeyUpdate(versionInfoPO);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
@@ -42,6 +42,8 @@ import org.apache.gravitino.storage.relational.mapper.PolicyVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelVersionInfoMapper;
 import org.apache.gravitino.storage.relational.mapper.StatisticMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.TableColumnMapper;
 import org.apache.gravitino.storage.relational.mapper.TableMetaMapper;
@@ -82,6 +84,8 @@ public class DefaultMapperPackageProvider implements MapperPackageProvider {
         RoleMetaMapper.class,
         SchemaMetaMapper.class,
         SecurableObjectMapper.class,
+        SemanticModelMetaMapper.class,
+        SemanticModelVersionInfoMapper.class,
         StatisticMetaMapper.class,
         TableColumnMapper.class,
         TableMetaMapper.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SemanticModelMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SemanticModelMetaBaseSQLProvider.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import static org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper.TABLE_NAME;
+import static org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper.VERSION_TABLE_NAME;
+
+import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.ibatis.annotations.Param;
+
+/** Provides MySQL-compatible SQL for Semantic Model create and load operations. */
+public class SemanticModelMetaBaseSQLProvider {
+
+  private static final String CURRENT_SNAPSHOT_COLUMNS =
+      " smm.semantic_model_id, smm.semantic_model_name, smm.metalake_id,"
+          + " smm.catalog_id, smm.schema_id, smm.current_version, smm.last_version,"
+          + " smm.audit_info, smm.deleted_at, smvi.id,"
+          + " smvi.metalake_id as version_metalake_id,"
+          + " smvi.catalog_id as version_catalog_id,"
+          + " smvi.schema_id as version_schema_id,"
+          + " smvi.semantic_model_id as version_semantic_model_id, smvi.version,"
+          + " smvi.semantic_model_name as version_semantic_model_name,"
+          + " smvi.semantic_model_comment, smvi.semantic_model_definition, smvi.properties,"
+          + " smvi.audit_info as version_audit_info,"
+          + " smvi.deleted_at as version_deleted_at";
+
+  /** Returns SQL for selecting an active Semantic Model ID by schema ID and name. */
+  public String selectSemanticModelIdBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return "SELECT semantic_model_id as semanticModelId FROM "
+        + TABLE_NAME
+        + " WHERE schema_id = #{schemaId}"
+        + " AND semantic_model_name = #{semanticModelName} AND deleted_at = 0";
+  }
+
+  /** Returns SQL for selecting a current Semantic Model snapshot by schema ID and name. */
+  public String selectSemanticModelMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return "SELECT"
+        + CURRENT_SNAPSHOT_COLUMNS
+        + " FROM "
+        + TABLE_NAME
+        + " smm INNER JOIN "
+        + VERSION_TABLE_NAME
+        + " smvi ON smm.semantic_model_id = smvi.semantic_model_id"
+        + " AND smm.current_version = smvi.version"
+        + " WHERE smm.schema_id = #{schemaId}"
+        + " AND smm.semantic_model_name = #{semanticModelName}"
+        + " AND smm.deleted_at = 0 AND smvi.deleted_at = 0";
+  }
+
+  /** Returns SQL for selecting a current Semantic Model by fully qualified name. */
+  public String selectSemanticModelByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("semanticModelName") String semanticModelName) {
+    return """
+        SELECT
+            mm.metalake_id,
+            cm.catalog_id,
+            sm.schema_id,
+            smm.semantic_model_id,
+            smm.semantic_model_name,
+            smm.current_version,
+            smm.last_version,
+            smm.audit_info,
+            smm.deleted_at,
+            smvi.id,
+            smvi.metalake_id as version_metalake_id,
+            smvi.catalog_id as version_catalog_id,
+            smvi.schema_id as version_schema_id,
+            smvi.semantic_model_id as version_semantic_model_id,
+            smvi.version,
+            smvi.semantic_model_name as version_semantic_model_name,
+            smvi.semantic_model_comment,
+            smvi.semantic_model_definition,
+            smvi.properties,
+            smvi.audit_info as version_audit_info,
+            smvi.deleted_at as version_deleted_at
+        FROM
+            %s mm
+        INNER JOIN
+            %s cm ON mm.metalake_id = cm.metalake_id
+            AND cm.catalog_name = #{catalogName}
+            AND cm.deleted_at = 0
+        LEFT JOIN
+            %s sm ON cm.catalog_id = sm.catalog_id
+            AND sm.schema_name = #{schemaName}
+            AND sm.deleted_at = 0
+        LEFT JOIN
+            %s smm ON sm.schema_id = smm.schema_id
+            AND smm.semantic_model_name = #{semanticModelName}
+            AND smm.deleted_at = 0
+        LEFT JOIN
+            %s smvi ON smm.semantic_model_id = smvi.semantic_model_id
+            AND smm.current_version = smvi.version
+            AND smvi.deleted_at = 0
+        WHERE
+            mm.metalake_name = #{metalakeName}
+            AND mm.deleted_at = 0
+        """
+        .formatted(
+            MetalakeMetaMapper.TABLE_NAME,
+            CatalogMetaMapper.TABLE_NAME,
+            SchemaMetaMapper.TABLE_NAME,
+            TABLE_NAME,
+            VERSION_TABLE_NAME);
+  }
+
+  /** Returns SQL for inserting a Semantic Model identity row. */
+  public String insertSemanticModelMeta(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return "INSERT INTO "
+        + TABLE_NAME
+        + " (semantic_model_id, semantic_model_name, metalake_id, catalog_id, schema_id,"
+        + " current_version, last_version, audit_info, deleted_at)"
+        + " VALUES (#{semanticModelMeta.semanticModelId},"
+        + " #{semanticModelMeta.semanticModelName}, #{semanticModelMeta.metalakeId},"
+        + " #{semanticModelMeta.catalogId}, #{semanticModelMeta.schemaId},"
+        + " #{semanticModelMeta.currentVersion}, #{semanticModelMeta.lastVersion},"
+        + " #{semanticModelMeta.auditInfo}, #{semanticModelMeta.deletedAt})";
+  }
+
+  /** Returns SQL for inserting or overwriting a Semantic Model identity row. */
+  public String insertSemanticModelMetaOnDuplicateKeyUpdate(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return insertSemanticModelMeta(semanticModelPO)
+        + " ON DUPLICATE KEY UPDATE"
+        + " semantic_model_name = #{semanticModelMeta.semanticModelName},"
+        + " metalake_id = #{semanticModelMeta.metalakeId},"
+        + " catalog_id = #{semanticModelMeta.catalogId},"
+        + " schema_id = #{semanticModelMeta.schemaId},"
+        + " current_version = #{semanticModelMeta.currentVersion},"
+        + " last_version = #{semanticModelMeta.lastVersion},"
+        + " audit_info = #{semanticModelMeta.auditInfo},"
+        + " deleted_at = #{semanticModelMeta.deletedAt}";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SemanticModelVersionInfoBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SemanticModelVersionInfoBaseSQLProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import org.apache.gravitino.storage.relational.mapper.SemanticModelVersionInfoMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.ibatis.annotations.Param;
+
+/** Provides MySQL-compatible SQL for creating Semantic Model version snapshots. */
+public class SemanticModelVersionInfoBaseSQLProvider {
+
+  /** Returns SQL for inserting a Semantic Model version snapshot. */
+  public String insertSemanticModelVersionInfo(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return "INSERT INTO "
+        + SemanticModelVersionInfoMapper.TABLE_NAME
+        + " (metalake_id, catalog_id, schema_id, semantic_model_id, version,"
+        + " semantic_model_name, semantic_model_comment, semantic_model_definition,"
+        + " properties, audit_info, deleted_at)"
+        + " VALUES (#{semanticModelVersionInfo.metalakeId},"
+        + " #{semanticModelVersionInfo.catalogId}, #{semanticModelVersionInfo.schemaId},"
+        + " #{semanticModelVersionInfo.semanticModelId}, #{semanticModelVersionInfo.version},"
+        + " #{semanticModelVersionInfo.semanticModelName},"
+        + " #{semanticModelVersionInfo.semanticModelComment},"
+        + " #{semanticModelVersionInfo.semanticModelDefinition},"
+        + " #{semanticModelVersionInfo.properties}, #{semanticModelVersionInfo.auditInfo},"
+        + " #{semanticModelVersionInfo.deletedAt})";
+  }
+
+  /** Returns SQL for inserting or overwriting a Semantic Model version snapshot. */
+  public String insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return insertSemanticModelVersionInfo(versionInfoPO)
+        + " ON DUPLICATE KEY UPDATE"
+        + " semantic_model_name = #{semanticModelVersionInfo.semanticModelName},"
+        + " semantic_model_comment = #{semanticModelVersionInfo.semanticModelComment},"
+        + " semantic_model_definition = #{semanticModelVersionInfo.semanticModelDefinition},"
+        + " properties = #{semanticModelVersionInfo.properties},"
+        + " audit_info = #{semanticModelVersionInfo.auditInfo},"
+        + " deleted_at = #{semanticModelVersionInfo.deletedAt}";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SemanticModelMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SemanticModelMetaPostgreSQLProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import org.apache.gravitino.storage.relational.mapper.provider.base.SemanticModelMetaBaseSQLProvider;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.ibatis.annotations.Param;
+
+/** Provides PostgreSQL SQL for Semantic Model create and load operations. */
+public class SemanticModelMetaPostgreSQLProvider extends SemanticModelMetaBaseSQLProvider {
+
+  @Override
+  public String insertSemanticModelMetaOnDuplicateKeyUpdate(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return insertSemanticModelMeta(semanticModelPO)
+        + " ON CONFLICT (semantic_model_id) DO UPDATE SET"
+        + " semantic_model_name = #{semanticModelMeta.semanticModelName},"
+        + " metalake_id = #{semanticModelMeta.metalakeId},"
+        + " catalog_id = #{semanticModelMeta.catalogId},"
+        + " schema_id = #{semanticModelMeta.schemaId},"
+        + " current_version = #{semanticModelMeta.currentVersion},"
+        + " last_version = #{semanticModelMeta.lastVersion},"
+        + " audit_info = #{semanticModelMeta.auditInfo},"
+        + " deleted_at = #{semanticModelMeta.deletedAt}";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SemanticModelVersionInfoPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SemanticModelVersionInfoPostgreSQLProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import org.apache.gravitino.storage.relational.mapper.provider.base.SemanticModelVersionInfoBaseSQLProvider;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.ibatis.annotations.Param;
+
+/** Provides PostgreSQL SQL for creating Semantic Model version snapshots. */
+public class SemanticModelVersionInfoPostgreSQLProvider
+    extends SemanticModelVersionInfoBaseSQLProvider {
+
+  @Override
+  public String insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return insertSemanticModelVersionInfo(versionInfoPO)
+        + " ON CONFLICT (semantic_model_id, version, deleted_at) DO UPDATE SET"
+        + " semantic_model_name = #{semanticModelVersionInfo.semanticModelName},"
+        + " semantic_model_comment = #{semanticModelVersionInfo.semanticModelComment},"
+        + " semantic_model_definition = #{semanticModelVersionInfo.semanticModelDefinition},"
+        + " properties = #{semanticModelVersionInfo.properties},"
+        + " audit_info = #{semanticModelVersionInfo.auditInfo},"
+        + " deleted_at = #{semanticModelVersionInfo.deletedAt}";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelDefinitionSerDe.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelDefinitionSerDe.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.base.CaseFormat;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.AIContextObject;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.DataType;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dimension;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+
+/**
+ * Serializes immutable Semantic Model API values for relational storage without depending on REST
+ * DTOs.
+ */
+final class SemanticModelDefinitionSerDe {
+
+  private static final ObjectMapper MAPPER = createMapper();
+
+  private SemanticModelDefinitionSerDe() {}
+
+  static String serialize(SemanticModelDefinition definition) throws JsonProcessingException {
+    return MAPPER.writeValueAsString(definition);
+  }
+
+  static SemanticModelDefinition deserialize(String json) throws JsonProcessingException {
+    return MAPPER.readValue(json, SemanticModelDefinition.class);
+  }
+
+  private static ObjectMapper createMapper() {
+    SimpleModule module =
+        new SimpleModule()
+            .addSerializer(AIContext.class, new AIContextSerializer())
+            .addDeserializer(AIContext.class, new AIContextDeserializer())
+            .addSerializer(DataType.class, new DataTypeSerializer())
+            .addDeserializer(DataType.class, new DataTypeDeserializer())
+            .addSerializer(NameIdentifier.class, new JsonUtils.NameIdentifierSerializer())
+            .addDeserializer(NameIdentifier.class, new JsonUtils.NameIdentifierDeserializer());
+
+    ObjectMapper mapper =
+        JsonUtils.anyFieldMapper()
+            .copy()
+            .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+            .setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .configure(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES, false)
+            .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+            .enable(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS)
+            .registerModule(module);
+    addBuilderMixIns(
+        mapper,
+        SemanticModelDefinition.class,
+        SemanticModelDefinitionMixIn.class,
+        SemanticModelDefinition.Builder.class);
+    addBuilderMixIns(mapper, Dataset.class, DatasetMixIn.class, Dataset.Builder.class);
+    addBuilderMixIns(
+        mapper, Relationship.class, RelationshipMixIn.class, Relationship.Builder.class);
+    addBuilderMixIns(mapper, Metric.class, MetricMixIn.class, Metric.Builder.class);
+    addBuilderMixIns(mapper, Field.class, FieldMixIn.class, Field.Builder.class);
+    addBuilderMixIns(mapper, Expression.class, ExpressionMixIn.class, Expression.Builder.class);
+    addBuilderMixIns(
+        mapper,
+        DialectExpression.class,
+        DialectExpressionMixIn.class,
+        DialectExpression.Builder.class);
+    addBuilderMixIns(mapper, Dimension.class, DimensionMixIn.class, Dimension.Builder.class);
+    addBuilderMixIns(
+        mapper, CustomExtension.class, CustomExtensionMixIn.class, CustomExtension.Builder.class);
+    return mapper;
+  }
+
+  private static void addBuilderMixIns(
+      ObjectMapper mapper, Class<?> valueClass, Class<?> mixInClass, Class<?> builderClass) {
+    mapper.addMixIn(valueClass, mixInClass);
+    mapper.addMixIn(builderClass, BuilderMixIn.class);
+  }
+
+  @JsonPOJOBuilder(withPrefix = "with")
+  private abstract static class BuilderMixIn {}
+
+  @JsonDeserialize(builder = SemanticModelDefinition.Builder.class)
+  private abstract static class SemanticModelDefinitionMixIn {}
+
+  @JsonDeserialize(builder = Dataset.Builder.class)
+  private abstract static class DatasetMixIn {}
+
+  @JsonDeserialize(builder = Relationship.Builder.class)
+  private abstract static class RelationshipMixIn {}
+
+  @JsonDeserialize(builder = Metric.Builder.class)
+  private abstract static class MetricMixIn {}
+
+  @JsonDeserialize(builder = Field.Builder.class)
+  private abstract static class FieldMixIn {}
+
+  @JsonDeserialize(builder = Expression.Builder.class)
+  private abstract static class ExpressionMixIn {}
+
+  @JsonDeserialize(builder = DialectExpression.Builder.class)
+  private abstract static class DialectExpressionMixIn {}
+
+  @JsonDeserialize(builder = Dimension.Builder.class)
+  private abstract static class DimensionMixIn {}
+
+  @JsonDeserialize(builder = CustomExtension.Builder.class)
+  private abstract static class CustomExtensionMixIn {}
+
+  private static final class AIContextSerializer extends JsonSerializer<AIContext> {
+
+    @Override
+    public void serialize(AIContext value, JsonGenerator generator, SerializerProvider serializers)
+        throws IOException {
+      if (value.isText()) {
+        generator.writeString(value.text());
+        return;
+      }
+
+      AIContextObject object = value.object();
+      if (object == null) {
+        throw JsonMappingException.from(generator, "Structured AI context must not be null");
+      }
+      generator.writeStartObject();
+      writeOptionalField(generator, "instructions", object.instructions());
+      writeOptionalField(generator, "synonyms", object.synonyms());
+      writeOptionalField(generator, "examples", object.examples());
+      for (Map.Entry<String, Object> entry : object.additionalProperties().entrySet()) {
+        generator.writeObjectField(entry.getKey(), entry.getValue());
+      }
+      generator.writeEndObject();
+    }
+
+    private static void writeOptionalField(JsonGenerator generator, String name, Object value)
+        throws IOException {
+      if (value != null) {
+        generator.writeObjectField(name, value);
+      }
+    }
+  }
+
+  private static final class AIContextDeserializer extends JsonDeserializer<AIContext> {
+
+    @Override
+    public AIContext deserialize(JsonParser parser, DeserializationContext context)
+        throws IOException {
+      if (parser.hasToken(JsonToken.VALUE_STRING)) {
+        return AIContext.of(parser.getText());
+      }
+      if (!parser.hasToken(JsonToken.START_OBJECT)) {
+        throw JsonMappingException.from(parser, "AI context must be a string or object");
+      }
+
+      JsonNode root = parser.getCodec().readTree(parser);
+      AIContextObject.Builder builder =
+          AIContextObject.builder()
+              .withInstructions(textOrNull(root.get("instructions")))
+              .withSynonyms(stringArrayOrNull(root.get("synonyms"), parser))
+              .withExamples(stringArrayOrNull(root.get("examples"), parser));
+
+      Map<String, Object> additionalProperties = new LinkedHashMap<>();
+      Iterator<Map.Entry<String, JsonNode>> fields = root.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        if (!isStandardAIContextProperty(entry.getKey())) {
+          additionalProperties.put(
+              entry.getKey(), parser.getCodec().treeToValue(entry.getValue(), Object.class));
+        }
+      }
+      return AIContext.of(builder.withAdditionalProperties(additionalProperties).build());
+    }
+
+    private static String textOrNull(JsonNode value) {
+      return value == null || value.isNull() ? null : value.textValue();
+    }
+
+    private static String[] stringArrayOrNull(JsonNode value, JsonParser parser)
+        throws JsonProcessingException {
+      return value == null || value.isNull()
+          ? null
+          : parser.getCodec().treeToValue(value, String[].class);
+    }
+
+    private static boolean isStandardAIContextProperty(String name) {
+      return name.equals("instructions") || name.equals("synonyms") || name.equals("examples");
+    }
+  }
+
+  private static final class DataTypeSerializer extends JsonSerializer<DataType> {
+
+    @Override
+    public void serialize(DataType value, JsonGenerator generator, SerializerProvider serializers)
+        throws IOException {
+      generator.writeString(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, value.name()));
+    }
+  }
+
+  private static final class DataTypeDeserializer extends JsonDeserializer<DataType> {
+
+    @Override
+    public DataType deserialize(JsonParser parser, DeserializationContext context)
+        throws IOException {
+      if (!parser.hasToken(JsonToken.VALUE_STRING)) {
+        throw JsonMappingException.from(parser, "Semantic Model data type must be a string");
+      }
+      try {
+        return DataType.valueOf(
+            CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, parser.getText()));
+      } catch (IllegalArgumentException e) {
+        throw JsonMappingException.from(
+            parser, "Unknown Semantic Model data type: " + parser.getText(), e);
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelPO.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import static org.apache.gravitino.storage.relational.utils.POConverters.DEFAULT_DELETED_AT;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.NamespacedEntityId;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.relational.service.EntityIdService;
+
+/** The persistent object for Semantic Model identity metadata and its current version snapshot. */
+@Getter
+@EqualsAndHashCode(exclude = "semanticModelVersionInfoPO")
+@ToString
+public class SemanticModelPO {
+
+  /** The initial version allocated to a newly created Semantic Model. */
+  public static final Long INITIAL_VERSION = 1L;
+
+  private Long semanticModelId;
+  private String semanticModelName;
+  private Long metalakeId;
+  private Long catalogId;
+  private Long schemaId;
+  private String auditInfo;
+  private Long currentVersion;
+  private Long lastVersion;
+  private Long deletedAt;
+  private SemanticModelVersionInfoPO semanticModelVersionInfoPO;
+
+  /** Creates an empty persistent object for MyBatis. */
+  public SemanticModelPO() {}
+
+  /** A Lombok builder for {@link SemanticModelPO}. */
+  public static class SemanticModelPOBuilder {
+    // Lombok generates the builder methods.
+  }
+
+  @lombok.Builder(setterPrefix = "with")
+  private SemanticModelPO(
+      Long semanticModelId,
+      String semanticModelName,
+      Long metalakeId,
+      Long catalogId,
+      Long schemaId,
+      String auditInfo,
+      Long currentVersion,
+      Long lastVersion,
+      Long deletedAt,
+      SemanticModelVersionInfoPO semanticModelVersionInfoPO) {
+    Preconditions.checkArgument(semanticModelId != null, "Semantic Model id is required");
+    Preconditions.checkArgument(semanticModelName != null, "Semantic Model name is required");
+    Preconditions.checkArgument(metalakeId != null, "Metalake id is required");
+    Preconditions.checkArgument(catalogId != null, "Catalog id is required");
+    Preconditions.checkArgument(schemaId != null, "Schema id is required");
+    Preconditions.checkArgument(auditInfo != null, "Audit info is required");
+    Preconditions.checkArgument(currentVersion != null, "Current version is required");
+    Preconditions.checkArgument(lastVersion != null, "Last version is required");
+    Preconditions.checkArgument(deletedAt != null, "Deleted at is required");
+
+    this.semanticModelId = semanticModelId;
+    this.semanticModelName = semanticModelName;
+    this.metalakeId = metalakeId;
+    this.catalogId = catalogId;
+    this.schemaId = schemaId;
+    this.auditInfo = auditInfo;
+    this.currentVersion = currentVersion;
+    this.lastVersion = lastVersion;
+    this.deletedAt = deletedAt;
+    this.semanticModelVersionInfoPO = semanticModelVersionInfoPO;
+  }
+
+  /**
+   * Converts a persistent object and its current version snapshot to a Semantic Model entity.
+   *
+   * @param semanticModelPO The persistent object to convert.
+   * @param namespace The Semantic Model namespace.
+   * @return The converted Semantic Model entity.
+   */
+  public static SemanticModelEntity fromSemanticModelPO(
+      SemanticModelPO semanticModelPO, Namespace namespace) {
+    try {
+      SemanticModelVersionInfoPO versionPO = semanticModelPO.getSemanticModelVersionInfoPO();
+      SemanticModelDefinition definition =
+          SemanticModelDefinitionSerDe.deserialize(versionPO.semanticModelDefinition());
+      Map<String, String> properties =
+          versionPO.properties() == null
+              ? Collections.emptyMap()
+              : JsonUtils.anyFieldMapper()
+                  .readValue(
+                      versionPO.properties(),
+                      JsonUtils.anyFieldMapper()
+                          .getTypeFactory()
+                          .constructMapType(Map.class, String.class, String.class));
+
+      return SemanticModelEntity.builder()
+          .withId(semanticModelPO.getSemanticModelId())
+          .withName(versionPO.semanticModelName())
+          .withNamespace(namespace)
+          .withComment(versionPO.semanticModelComment())
+          .withDefinition(definition)
+          .withProperties(properties)
+          .withAuditInfo(
+              JsonUtils.anyFieldMapper().readValue(semanticModelPO.getAuditInfo(), AuditInfo.class))
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to deserialize Semantic Model JSON", e);
+    }
+  }
+
+  /**
+   * Initializes a new Semantic Model identity and version-one snapshot.
+   *
+   * @param semanticModelEntity The Semantic Model entity.
+   * @param builder The identity persistent-object builder.
+   * @return The initialized persistent object.
+   */
+  public static SemanticModelPO initializeSemanticModelPO(
+      SemanticModelEntity semanticModelEntity, SemanticModelPOBuilder builder) {
+    builder.withCurrentVersion(INITIAL_VERSION).withLastVersion(INITIAL_VERSION);
+    return buildSemanticModelPO(semanticModelEntity, builder, INITIAL_VERSION.intValue());
+  }
+
+  /**
+   * Creates a complete version snapshot for a Semantic Model entity.
+   *
+   * @param semanticModelEntity The Semantic Model entity.
+   * @param namespacedEntityId The resolved schema and ancestor IDs.
+   * @param version The version to allocate.
+   * @return The version snapshot persistent object.
+   */
+  public static SemanticModelVersionInfoPO initializeSemanticModelVersionInfoPO(
+      SemanticModelEntity semanticModelEntity,
+      NamespacedEntityId namespacedEntityId,
+      Integer version) {
+    try {
+      String definitionJson =
+          SemanticModelDefinitionSerDe.serialize(semanticModelEntity.definition());
+      String propertiesJson =
+          semanticModelEntity.properties().isEmpty()
+              ? null
+              : JsonUtils.anyFieldMapper().writeValueAsString(semanticModelEntity.properties());
+
+      return SemanticModelVersionInfoPO.builder()
+          .withSemanticModelId(semanticModelEntity.id())
+          .withMetalakeId(namespacedEntityId.namespaceIds()[0])
+          .withCatalogId(namespacedEntityId.namespaceIds()[1])
+          .withSchemaId(namespacedEntityId.entityId())
+          .withVersion(version)
+          .withSemanticModelName(semanticModelEntity.name())
+          .withSemanticModelComment(semanticModelEntity.comment())
+          .withSemanticModelDefinition(definitionJson)
+          .withProperties(propertiesJson)
+          .withAuditInfo(
+              JsonUtils.anyFieldMapper().writeValueAsString(semanticModelEntity.auditInfo()))
+          .withDeletedAt(DEFAULT_DELETED_AT)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize Semantic Model JSON", e);
+    }
+  }
+
+  /**
+   * Builds a Semantic Model identity persistent object and the requested complete snapshot.
+   *
+   * @param semanticModelEntity The Semantic Model entity.
+   * @param builder The identity persistent-object builder.
+   * @param version The version to allocate.
+   * @return The built persistent object.
+   */
+  public static SemanticModelPO buildSemanticModelPO(
+      SemanticModelEntity semanticModelEntity, SemanticModelPOBuilder builder, Integer version) {
+    try {
+      NamespacedEntityId namespacedEntityId =
+          EntityIdService.getEntityIds(
+              NameIdentifier.of(semanticModelEntity.namespace().levels()),
+              Entity.EntityType.SCHEMA);
+      SemanticModelVersionInfoPO versionPO =
+          initializeSemanticModelVersionInfoPO(semanticModelEntity, namespacedEntityId, version);
+      return builder
+          .withSemanticModelId(semanticModelEntity.id())
+          .withSemanticModelName(semanticModelEntity.name())
+          .withMetalakeId(namespacedEntityId.namespaceIds()[0])
+          .withCatalogId(namespacedEntityId.namespaceIds()[1])
+          .withSchemaId(namespacedEntityId.entityId())
+          .withAuditInfo(
+              JsonUtils.anyFieldMapper().writeValueAsString(semanticModelEntity.auditInfo()))
+          .withSemanticModelVersionInfoPO(versionPO)
+          .withDeletedAt(DEFAULT_DELETED_AT)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize Semantic Model audit info", e);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelVersionInfoPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelVersionInfoPO.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import com.google.common.base.Preconditions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.apache.commons.lang3.StringUtils;
+
+/** The persistent object for a complete Semantic Model version snapshot. */
+@EqualsAndHashCode
+@Getter
+@ToString
+@Accessors(fluent = true)
+public class SemanticModelVersionInfoPO {
+
+  private Long id;
+  private Long metalakeId;
+  private Long catalogId;
+  private Long schemaId;
+  private Long semanticModelId;
+  private Integer version;
+  private String semanticModelName;
+  private String semanticModelComment;
+  private String semanticModelDefinition;
+  private String properties;
+  private String auditInfo;
+  private Long deletedAt;
+
+  /** Creates an empty persistent object for MyBatis. */
+  public SemanticModelVersionInfoPO() {}
+
+  @lombok.Builder(setterPrefix = "with")
+  private SemanticModelVersionInfoPO(
+      Long id,
+      Long metalakeId,
+      Long catalogId,
+      Long schemaId,
+      Long semanticModelId,
+      Integer version,
+      String semanticModelName,
+      String semanticModelComment,
+      String semanticModelDefinition,
+      String properties,
+      String auditInfo,
+      Long deletedAt) {
+    Preconditions.checkArgument(metalakeId != null, "Metalake id is required");
+    Preconditions.checkArgument(catalogId != null, "Catalog id is required");
+    Preconditions.checkArgument(schemaId != null, "Schema id is required");
+    Preconditions.checkArgument(semanticModelId != null, "Semantic Model id is required");
+    Preconditions.checkArgument(version != null, "Semantic Model version is required");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(semanticModelName), "Semantic Model name cannot be empty");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(semanticModelDefinition),
+        "Semantic Model definition cannot be empty");
+    Preconditions.checkArgument(StringUtils.isNotBlank(auditInfo), "Audit info cannot be empty");
+    Preconditions.checkArgument(deletedAt != null, "Deleted at is required");
+
+    this.id = id;
+    this.metalakeId = metalakeId;
+    this.catalogId = catalogId;
+    this.schemaId = schemaId;
+    this.semanticModelId = semanticModelId;
+    this.version = version;
+    this.semanticModelName = semanticModelName;
+    this.semanticModelComment = semanticModelComment;
+    this.semanticModelDefinition = semanticModelDefinition;
+    this.properties = properties;
+    this.auditInfo = auditInfo;
+    this.deletedAt = deletedAt;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -504,10 +504,10 @@ public class SchemaMetaService {
   }
 
   /**
-   * Holds the parent schema row while a table, view, fileset, function, model, model version, or
-   * topic is written, so a child cannot be added below a schema that is going away. The lock is
-   * shared, so children of the same schema can still be written in parallel; dropping the schema
-   * takes the row exclusively and therefore waits for them.
+   * Holds the parent schema row while a table, view, fileset, function, model, model version,
+   * Semantic Model, or topic is written, so a child cannot be added below a schema that is going
+   * away. The lock is shared, so children of the same schema can still be written in parallel;
+   * dropping the schema takes the row exclusively and therefore waits for them.
    */
   void lockSchemaForEntityWrite(
       NameIdentifier entityIdentifier,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SemanticModelMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SemanticModelMetaService.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.service;
+
+import static org.apache.gravitino.metrics.source.MetricsSource.GRAVITINO_RELATIONAL_STORE_METRIC_NAME;
+import static org.apache.gravitino.storage.relational.po.SemanticModelPO.fromSemanticModelPO;
+import static org.apache.gravitino.storage.relational.po.SemanticModelPO.initializeSemanticModelPO;
+
+import java.io.IOException;
+import java.util.Locale;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.metrics.Monitored;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelVersionInfoMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+
+/** Provides relational create and load operations for Semantic Model metadata. */
+public class SemanticModelMetaService {
+
+  private static final SemanticModelMetaService INSTANCE = new SemanticModelMetaService();
+
+  private final BasePOStorageOps<SemanticModelPO, SemanticModelMetaMapper> ops;
+
+  /** Returns the singleton Semantic Model metadata service. */
+  public static SemanticModelMetaService getInstance() {
+    return INSTANCE;
+  }
+
+  private SemanticModelMetaService() {
+    this.ops = new HierarchicalConversionPOStorageOps<>(new SemanticModelPOStorageOps());
+  }
+
+  /**
+   * Resolves a Semantic Model stable ID by schema ID and name.
+   *
+   * @param schemaId The parent schema ID.
+   * @param semanticModelName The Semantic Model name.
+   * @return The stable Semantic Model ID.
+   * @throws NoSuchEntityException If the Semantic Model does not exist.
+   */
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "getSemanticModelIdBySchemaIdAndName")
+  public Long getSemanticModelIdBySchemaIdAndName(long schemaId, String semanticModelName) {
+    Long semanticModelId =
+        SessionUtils.getWithoutCommit(
+            SemanticModelMetaMapper.class,
+            mapper -> mapper.selectSemanticModelIdBySchemaIdAndName(schemaId, semanticModelName));
+    if (semanticModelId == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.SEMANTIC_MODEL.name().toLowerCase(Locale.ROOT),
+          semanticModelName);
+    }
+    return semanticModelId;
+  }
+
+  /**
+   * Loads the current Semantic Model by identifier.
+   *
+   * @param identifier The Semantic Model identifier.
+   * @return The current Semantic Model entity.
+   * @throws NoSuchEntityException If the Semantic Model does not exist.
+   */
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "getSemanticModelByIdentifier")
+  public SemanticModelEntity getSemanticModelByIdentifier(NameIdentifier identifier) {
+    SemanticModelPO semanticModelPO = getSemanticModelPOByIdentifier(identifier);
+    return fromSemanticModelPO(semanticModelPO, identifier.namespace());
+  }
+
+  /**
+   * Inserts a Semantic Model identity and its version-one snapshot atomically.
+   *
+   * @param semanticModelEntity The Semantic Model entity.
+   * @param overwrite Whether to overwrite rows for the same stable ID.
+   * @throws IOException If relational persistence fails.
+   */
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "insertSemanticModel")
+  public void insertSemanticModel(SemanticModelEntity semanticModelEntity, boolean overwrite)
+      throws IOException {
+    NameIdentifierUtil.checkSemanticModel(semanticModelEntity.nameIdentifier());
+    try {
+      SemanticModelPO po =
+          initializeSemanticModelPO(semanticModelEntity, SemanticModelPO.builder());
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              SchemaMetaService.getInstance()
+                  .lockSchemaForEntityWrite(
+                      semanticModelEntity.nameIdentifier(),
+                      po.getSchemaId(),
+                      po.getCatalogId(),
+                      po.getMetalakeId()),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  SemanticModelMetaMapper.class, mapper -> ops.insertPO(mapper, po, overwrite)),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  SemanticModelVersionInfoMapper.class,
+                  mapper -> {
+                    if (overwrite) {
+                      mapper.insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+                          po.getSemanticModelVersionInfoPO());
+                    } else {
+                      mapper.insertSemanticModelVersionInfo(po.getSemanticModelVersionInfoPO());
+                    }
+                  }));
+    } catch (RuntimeException re) {
+      ExceptionUtils.checkSQLException(
+          re, Entity.EntityType.SEMANTIC_MODEL, semanticModelEntity.nameIdentifier().toString());
+      throw re;
+    }
+  }
+
+  /** Returns the persistent-object operations used by this service. */
+  public BasePOStorageOps<SemanticModelPO, SemanticModelMetaMapper> ops() {
+    return ops;
+  }
+
+  private SemanticModelPO getSemanticModelPOByIdentifier(NameIdentifier identifier) {
+    NameIdentifierUtil.checkSemanticModel(identifier);
+    SemanticModelPO semanticModelPO =
+        SessionUtils.getWithoutCommit(
+            SemanticModelMetaMapper.class,
+            mapper ->
+                POStorageReadRouting.getPO(
+                    mapper, identifier, ops, Entity.EntityType.SEMANTIC_MODEL));
+    if (semanticModelPO == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.SEMANTIC_MODEL.name().toLowerCase(Locale.ROOT),
+          identifier.name());
+    }
+    return semanticModelPO;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SemanticModelPOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SemanticModelPOStorageOps.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.service;
+
+import java.util.Locale;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+
+/** Provides relational persistent-object operations required to create and load Semantic Models. */
+public class SemanticModelPOStorageOps
+    extends BasePOStorageOps<SemanticModelPO, SemanticModelMetaMapper> {
+
+  /** Creates Semantic Model persistent-object operations. */
+  public SemanticModelPOStorageOps() {}
+
+  @Override
+  public void insertPO(
+      SemanticModelMetaMapper mapper, SemanticModelPO semanticModelPO, boolean overwrite) {
+    if (overwrite) {
+      mapper.insertSemanticModelMetaOnDuplicateKeyUpdate(semanticModelPO);
+    } else {
+      mapper.insertSemanticModelMeta(semanticModelPO);
+    }
+  }
+
+  @Override
+  public SemanticModelPO getPO(
+      SemanticModelMetaMapper mapper, Long parentId, String semanticModelName) {
+    return mapper.selectSemanticModelMetaBySchemaIdAndName(parentId, semanticModelName);
+  }
+
+  @Override
+  public SemanticModelPO getPOByFullName(
+      SemanticModelMetaMapper mapper, NameIdentifier identifier) {
+    Namespace namespace = identifier.namespace();
+    SemanticModelPO po =
+        mapper.selectSemanticModelByFullQualifiedName(
+            namespace.level(0), namespace.level(1), namespace.level(2), identifier.name());
+    if (po == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.CATALOG.name().toLowerCase(Locale.ROOT),
+          namespace.level(1));
+    }
+    if (po.getSchemaId() == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.SCHEMA.name().toLowerCase(Locale.ROOT),
+          namespace.level(2));
+    }
+    if (po.getSemanticModelId() == null) {
+      return null;
+    }
+    return po;
+  }
+
+  @Override
+  public boolean supportsParentIdRelationalRead() {
+    return true;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
@@ -63,6 +63,7 @@ public class MetadataObjectUtil {
           .put(MetadataObject.Type.JOB_TEMPLATE, Entity.EntityType.JOB_TEMPLATE)
           .put(MetadataObject.Type.JOB, Entity.EntityType.JOB)
           .put(MetadataObject.Type.VIEW, Entity.EntityType.VIEW)
+          .put(MetadataObject.Type.SEMANTIC_MODEL, Entity.EntityType.SEMANTIC_MODEL)
           .put(MetadataObject.Type.FUNCTION, Entity.EntityType.FUNCTION)
           .build();
 
@@ -126,6 +127,7 @@ public class MetadataObjectUtil {
       case JOB_TEMPLATE:
         return NameIdentifierUtil.ofJobTemplate(metalakeName, metadataObject.name());
       case VIEW:
+      case SEMANTIC_MODEL:
       case CATALOG:
       case SCHEMA:
       case TABLE:

--- a/core/src/main/java/org/apache/gravitino/utils/NameIdentifierUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/NameIdentifierUtil.java
@@ -121,6 +121,20 @@ public class NameIdentifierUtil {
   }
 
   /**
+   * Create the semantic model {@link NameIdentifier} with the given parent names.
+   *
+   * @param metalake The metalake name
+   * @param catalog The catalog name
+   * @param schema The schema name
+   * @param semanticModel The semantic model name
+   * @return The created semantic model {@link NameIdentifier}
+   */
+  public static NameIdentifier ofSemanticModel(
+      String metalake, String catalog, String schema, String semanticModel) {
+    return NameIdentifier.of(metalake, catalog, schema, semanticModel);
+  }
+
+  /**
    * Create the tag {@link NameIdentifier} with the given metalake and tag name.
    *
    * @param metalake The metalake name
@@ -506,6 +520,17 @@ public class NameIdentifierUtil {
   }
 
   /**
+   * Check the given {@link NameIdentifier} is a semantic model identifier. Throw an {@link
+   * IllegalNameIdentifierException} if it's not.
+   *
+   * @param ident The semantic model {@link NameIdentifier} to check.
+   */
+  public static void checkSemanticModel(NameIdentifier ident) {
+    NameIdentifier.check(ident != null, "Semantic model identifier must not be null");
+    NamespaceUtil.checkSemanticModel(ident.namespace());
+  }
+
+  /**
    * Check the given {@link NameIdentifier} is a column identifier. Throw an {@link
    * IllegalNameIdentifierException} if it's not.
    *
@@ -631,6 +656,13 @@ public class NameIdentifierUtil {
         checkView(ident);
         String viewParent = dot.join(ident.namespace().level(1), ident.namespace().level(2));
         return MetadataObjects.of(viewParent, ident.name(), MetadataObject.Type.VIEW);
+
+      case SEMANTIC_MODEL:
+        checkSemanticModel(ident);
+        String semanticModelParent =
+            dot.join(ident.namespace().level(1), ident.namespace().level(2));
+        return MetadataObjects.of(
+            semanticModelParent, ident.name(), MetadataObject.Type.SEMANTIC_MODEL);
 
       case COLUMN:
         checkColumn(ident);
@@ -897,6 +929,7 @@ public class NameIdentifierUtil {
 
       case TABLE:
       case VIEW:
+      case SEMANTIC_MODEL:
       case FILESET:
       case MODEL:
       case TOPIC:

--- a/core/src/main/java/org/apache/gravitino/utils/NamespaceUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/NamespaceUtil.java
@@ -85,6 +85,18 @@ public class NamespaceUtil {
   }
 
   /**
+   * Create a namespace for a semantic model.
+   *
+   * @param metalake The metalake name
+   * @param catalog The catalog name
+   * @param schema The schema name
+   * @return A namespace for a semantic model
+   */
+  public static Namespace ofSemanticModel(String metalake, String catalog, String schema) {
+    return Namespace.of(metalake, catalog, schema);
+  }
+
+  /**
    * Create a namespace for tag.
    *
    * @param metalake The metalake name
@@ -306,6 +318,19 @@ public class NamespaceUtil {
     check(
         namespace != null && namespace.length() == 3,
         "View namespace must be non-null and have 3 levels, the input namespace is %s",
+        namespace);
+  }
+
+  /**
+   * Check if the given semantic model namespace is legal, throw an {@link
+   * IllegalNamespaceException} if it's illegal.
+   *
+   * @param namespace The semantic model namespace
+   */
+  public static void checkSemanticModel(Namespace namespace) {
+    check(
+        namespace != null && namespace.length() == 3,
+        "Semantic model namespace must be non-null and have 3 levels, the input namespace is %s",
         namespace);
   }
 

--- a/core/src/test/java/org/apache/gravitino/cache/TestBaseEntityCache.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestBaseEntityCache.java
@@ -47,6 +47,7 @@ public class TestBaseEntityCache {
           Entity.EntityType.CATALOG,
           Entity.EntityType.SCHEMA,
           Entity.EntityType.TABLE,
+          Entity.EntityType.SEMANTIC_MODEL,
           Entity.EntityType.TOPIC,
           Entity.EntityType.VIEW,
           Entity.EntityType.FILESET,

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCapabilityHelpers.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCapabilityHelpers.java
@@ -158,6 +158,20 @@ public class TestCapabilityHelpers {
   }
 
   @Test
+  void testModelUsesSchemaNamespaceCapabilities() {
+    Namespace namespace = Namespace.of("metalake", "catalog", "mixedSchema");
+
+    Assertions.assertEquals(
+        Namespace.of("metalake", "catalog", "MIXEDSCHEMA"),
+        CapabilityHelpers.applyCapabilities(
+            namespace, Capability.Scope.MODEL, UPPERCASE_CAPABILITY));
+    Assertions.assertEquals(
+        Namespace.of("metalake", "catalog", "MIXEDSCHEMA"),
+        CapabilityHelpers.applyCaseSensitive(
+            namespace, Capability.Scope.MODEL, UPPERCASE_CAPABILITY));
+  }
+
+  @Test
   void testSemanticModelUsesManagedStorageByDefault() {
     Assertions.assertTrue(
         Capability.DEFAULT.managedStorage(Capability.Scope.SEMANTIC_MODEL).supported());

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCapabilityHelpers.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCapabilityHelpers.java
@@ -142,4 +142,24 @@ public class TestCapabilityHelpers {
 
     Assertions.assertEquals("My Table", result.name());
   }
+
+  @Test
+  void testSemanticModelUsesSchemaNamespaceCapabilities() {
+    Namespace namespace = Namespace.of("metalake", "catalog", "mixedSchema");
+
+    Assertions.assertEquals(
+        Namespace.of("metalake", "catalog", "MIXEDSCHEMA"),
+        CapabilityHelpers.applyCapabilities(
+            namespace, Capability.Scope.SEMANTIC_MODEL, UPPERCASE_CAPABILITY));
+    Assertions.assertEquals(
+        Namespace.of("metalake", "catalog", "MIXEDSCHEMA"),
+        CapabilityHelpers.applyCaseSensitive(
+            namespace, Capability.Scope.SEMANTIC_MODEL, UPPERCASE_CAPABILITY));
+  }
+
+  @Test
+  void testSemanticModelUsesManagedStorageByDefault() {
+    Assertions.assertTrue(
+        Capability.DEFAULT.managedStorage(Capability.Scope.SEMANTIC_MODEL).supported());
+  }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperations.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperations.java
@@ -18,39 +18,210 @@
  */
 package org.apache.gravitino.catalog;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.SemanticModel;
 import org.apache.gravitino.semantic.SemanticModelChange;
 import org.apache.gravitino.semantic.SemanticModelDefinition;
 import org.apache.gravitino.storage.IdGenerator;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.memory.TestMemoryEntityStore.InMemoryEntityStore;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 public class TestManagedSemanticModelOperations {
 
   private static final Namespace NAMESPACE = Namespace.of("metalake", "catalog", "schema");
-  private static final NameIdentifier IDENT = NameIdentifier.of(NAMESPACE, "model");
-
-  private final ManagedSemanticModelOperations operations =
-      new ManagedSemanticModelOperations(mock(EntityStore.class), mock(IdGenerator.class));
+  private static final NameIdentifier IDENT = NameIdentifier.of(NAMESPACE, "sales_model");
 
   @Test
-  public void testOperationsRemainUnsupportedUntilEntityPersistenceIsAdded() {
-    SemanticModelDefinition definition = mock(SemanticModelDefinition.class);
+  public void testCreateThenLoadFromMemoryStore() {
+    InMemoryEntityStore store = new InMemoryEntityStore();
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(
+            store, new RandomIdGenerator(), (ident, definition) -> {});
+
+    SemanticModel created =
+        operations.createSemanticModel(
+            IDENT, "Sales model", definition("orders"), Map.of("domain", "sales"));
+    SemanticModel loaded = operations.loadSemanticModel(IDENT);
+
+    assertSame(created, loaded);
+    assertEquals("sales_model", loaded.name());
+    assertEquals("Sales model", loaded.comment());
+    assertEquals(definition("orders"), loaded.definition());
+    assertEquals(Map.of("domain", "sales"), loaded.properties());
+    assertNotNull(loaded.auditInfo().creator());
+    assertNotNull(loaded.auditInfo().createTime());
+  }
+
+  @Test
+  public void testValidationAndPersistenceOrder() throws IOException {
+    EntityStore store = mock(EntityStore.class);
+    IdGenerator idGenerator = mock(IdGenerator.class);
+    @SuppressWarnings("unchecked")
+    BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator = mock(BiConsumer.class);
+    when(idGenerator.nextId()).thenReturn(7L);
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(store, idGenerator, writeValidator);
+    SemanticModelDefinition definition = definition("orders");
+
+    SemanticModel created =
+        operations.createSemanticModel(IDENT, null, definition, Map.of("key", "value"));
+
+    InOrder order = inOrder(writeValidator, idGenerator, store);
+    order.verify(writeValidator).accept(IDENT, definition);
+    order.verify(idGenerator).nextId();
+    order.verify(store).put(any(SemanticModelEntity.class), eq(false));
+    assertEquals(7L, ((SemanticModelEntity) created).id());
+  }
+
+  @Test
+  public void testWriteValidationPrecedesEntityConstructionAndPersistence() {
+    @SuppressWarnings("unchecked")
+    BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator = mock(BiConsumer.class);
+    IllegalSemanticModelException failure =
+        new IllegalSemanticModelException("Semantic Model definition is invalid");
+    doThrow(failure).when(writeValidator).accept(eq(IDENT), any(SemanticModelDefinition.class));
+    EntityStore store = mock(EntityStore.class);
+    IdGenerator idGenerator = mock(IdGenerator.class);
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(store, idGenerator, writeValidator);
+
+    assertSame(
+        failure,
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () -> operations.createSemanticModel(IDENT, null, definition("orders"), Map.of())));
+    verifyNoInteractions(idGenerator, store);
+  }
+
+  @Test
+  public void testLoadDoesNotRunAnyValidation() throws IOException {
+    EntityStore store = mock(EntityStore.class);
+    @SuppressWarnings("unchecked")
+    BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator = mock(BiConsumer.class);
+    SemanticModelEntity entity = entity();
+    when(store.get(IDENT, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class))
+        .thenReturn(entity);
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(store, mock(IdGenerator.class), writeValidator);
+
+    assertSame(entity, operations.loadSemanticModel(IDENT));
+
+    verifyNoInteractions(writeValidator);
+  }
+
+  @Test
+  public void testCreateExceptionMapping() throws IOException {
+    assertCreateFailure(new NoSuchEntityException("Missing parent"), NoSuchSchemaException.class);
+    assertCreateFailure(
+        new EntityAlreadyExistsException("Already exists"),
+        SemanticModelAlreadyExistsException.class);
+
+    IOException ioFailure = new IOException("Write failed");
+    RuntimeException wrapped = assertCreateFailure(ioFailure, RuntimeException.class);
+    assertSame(ioFailure, wrapped.getCause());
+  }
+
+  @Test
+  public void testLoadExceptionMapping() throws IOException {
+    EntityStore store = mock(EntityStore.class);
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(
+            store, mock(IdGenerator.class), (ident, definition) -> {});
+
+    when(store.get(IDENT, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class))
+        .thenThrow(new NoSuchEntityException("Missing model"));
+    assertThrows(NoSuchSemanticModelException.class, () -> operations.loadSemanticModel(IDENT));
+
+    IOException ioFailure = new IOException("Read failed");
+    doThrow(ioFailure)
+        .when(store)
+        .get(IDENT, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class);
+    RuntimeException wrapped =
+        assertThrows(RuntimeException.class, () -> operations.loadSemanticModel(IDENT));
+    assertSame(ioFailure, wrapped.getCause());
+  }
+
+  @Test
+  public void testRemainingCapabilitiesAreExplicitlyUnsupported() {
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(
+            mock(EntityStore.class), mock(IdGenerator.class), (ident, definition) -> {});
 
     assertThrows(
         UnsupportedOperationException.class, () -> operations.listSemanticModels(NAMESPACE));
-    assertThrows(UnsupportedOperationException.class, () -> operations.loadSemanticModel(IDENT));
     assertThrows(
         UnsupportedOperationException.class,
-        () -> operations.createSemanticModel(IDENT, null, definition, Map.of()));
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> operations.alterSemanticModel(IDENT, SemanticModelChange.updateComment("updated")));
+        () ->
+            operations.alterSemanticModel(
+                IDENT, SemanticModelChange.updateComment("Not implemented")));
     assertThrows(UnsupportedOperationException.class, () -> operations.dropSemanticModel(IDENT));
+  }
+
+  private static RuntimeException assertCreateFailure(
+      Exception failure, Class<? extends RuntimeException> expectedType) throws IOException {
+    EntityStore store = mock(EntityStore.class);
+    doThrow(failure).when(store).put(any(SemanticModelEntity.class), eq(false));
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(store, () -> 1L, (ident, definition) -> {});
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class,
+            () -> operations.createSemanticModel(IDENT, null, definition("orders"), Map.of()));
+    assertInstanceOf(expectedType, thrown);
+    return thrown;
+  }
+
+  private static SemanticModelEntity entity() {
+    return SemanticModelEntity.builder()
+        .withId(1L)
+        .withName(IDENT.name())
+        .withNamespace(IDENT.namespace())
+        .withDefinition(definition("orders"))
+        .withAuditInfo(AuditInfo.EMPTY)
+        .build();
+  }
+
+  private static SemanticModelDefinition definition(String datasetName) {
+    return SemanticModelDefinition.builder()
+        .withDatasets(new Dataset[] {dataset(datasetName)})
+        .build();
+  }
+
+  private static Dataset dataset(String name) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .build();
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperations.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperations.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.semantic.SemanticModelChange;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.IdGenerator;
+import org.junit.jupiter.api.Test;
+
+public class TestManagedSemanticModelOperations {
+
+  private static final Namespace NAMESPACE = Namespace.of("metalake", "catalog", "schema");
+  private static final NameIdentifier IDENT = NameIdentifier.of(NAMESPACE, "model");
+
+  private final ManagedSemanticModelOperations operations =
+      new ManagedSemanticModelOperations(mock(EntityStore.class), mock(IdGenerator.class));
+
+  @Test
+  public void testOperationsRemainUnsupportedUntilEntityPersistenceIsAdded() {
+    SemanticModelDefinition definition = mock(SemanticModelDefinition.class);
+
+    assertThrows(
+        UnsupportedOperationException.class, () -> operations.listSemanticModels(NAMESPACE));
+    assertThrows(UnsupportedOperationException.class, () -> operations.loadSemanticModel(IDENT));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> operations.createSemanticModel(IDENT, null, definition, Map.of()));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> operations.alterSemanticModel(IDENT, SemanticModelChange.updateComment("updated")));
+    assertThrows(UnsupportedOperationException.class, () -> operations.dropSemanticModel(IDENT));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperationsJDBC.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperationsJDBC.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.cache.NoOpsCache;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.relational.RelationalEntityStore;
+import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.utils.NamespaceUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/** Verifies managed create and load through a real relational persistence backend. */
+public class TestManagedSemanticModelOperationsJDBC extends TestJDBCBackend {
+
+  private final AtomicInteger writeValidationCount = new AtomicInteger();
+
+  private Config previousConfig;
+  private NameIdentifier modelIdent;
+  private ManagedSemanticModelOperations operations;
+
+  @BeforeAll
+  public void captureEnvironmentConfig() {
+    previousConfig = GravitinoEnv.getInstance().config();
+  }
+
+  @BeforeEach
+  public void prepareManagedOperations() throws IOException, IllegalAccessException {
+    writeValidationCount.set(0);
+    String metalake = "managed_semantic_model_metalake";
+    String catalog = "managed_semantic_model_catalog";
+    String schema = "managed_semantic_model_schema";
+    createAndInsertMakeLake(metalake);
+    createAndInsertCatalog(metalake, catalog);
+    createAndInsertSchema(metalake, catalog, schema);
+
+    Namespace namespace = NamespaceUtil.ofSemanticModel(metalake, catalog, schema);
+    modelIdent = NameIdentifier.of(namespace, "sales_model");
+
+    Config config = new Config(false) {};
+    config.set(Configs.CACHE_ENABLED, false);
+    RelationalEntityStore store = new RelationalEntityStore();
+    FieldUtils.writeField(store, "backend", backend, true);
+    FieldUtils.writeField(store, "cache", new NoOpsCache(config), true);
+    operations =
+        new ManagedSemanticModelOperations(
+            store,
+            RandomIdGenerator.INSTANCE,
+            (ident, definition) -> writeValidationCount.incrementAndGet());
+  }
+
+  @AfterEach
+  public void restoreEnvironmentConfig() throws IllegalAccessException {
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "config", previousConfig, true);
+  }
+
+  @TestTemplate
+  public void testCreateThenLoadRoundTrip() throws IOException {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("source_catalog", "source_schema", "orders"))
+            .withPrimaryKey(new String[0])
+            .withUniqueKeys(new String[0][])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {dataset})
+            .withRelationships(new Relationship[0])
+            .withMetrics((Metric[]) null)
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+
+    SemanticModel created =
+        operations.createSemanticModel(
+            modelIdent, "Persisted model", definition, Map.of("domain", "sales"));
+    SemanticModel loaded = operations.loadSemanticModel(modelIdent);
+
+    assertNotSame(created, loaded);
+    assertEquals(created, loaded);
+    assertEquals(definition, loaded.definition());
+    assertEquals(1, writeValidationCount.get());
+    assertTrue(backend.exists(modelIdent, Entity.EntityType.SEMANTIC_MODEL));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelNormalizeDispatcher.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelChange;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestSemanticModelNormalizeDispatcher {
+
+  private static final Namespace INPUT_NAMESPACE =
+      Namespace.of("metalake", "catalog", "MixedSchema");
+  private static final Namespace NORMALIZED_NAMESPACE =
+      Namespace.of("metalake", "catalog", "MIXEDSCHEMA");
+  private static final NameIdentifier INPUT_IDENT =
+      NameIdentifier.of(INPUT_NAMESPACE, "SalesModel");
+  private static final NameIdentifier NORMALIZED_IDENT =
+      NameIdentifier.of(NORMALIZED_NAMESPACE, "SalesModel");
+
+  private SemanticModelDispatcher delegate;
+  private SemanticModelNormalizeDispatcher dispatcher;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    delegate = mock(SemanticModelDispatcher.class);
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    CatalogManager.CatalogWrapper wrapper = mock(CatalogManager.CatalogWrapper.class);
+    when(wrapper.capabilities()).thenReturn(new ParentNormalizingCapability());
+    when(catalogManager.loadCatalogAndWrap(NameIdentifier.of("metalake", "catalog")))
+        .thenReturn(wrapper);
+    dispatcher = new SemanticModelNormalizeDispatcher(delegate, catalogManager);
+  }
+
+  @Test
+  public void testParentUsesCatalogCapabilityButModelUsesStableRules() {
+    SemanticModelDefinition definition = definition();
+    SemanticModel model = mock(SemanticModel.class);
+    when(delegate.createSemanticModel(NORMALIZED_IDENT, "comment", definition, Map.of()))
+        .thenReturn(model);
+    when(delegate.loadSemanticModel(NORMALIZED_IDENT)).thenReturn(model);
+    when(delegate.semanticModelExists(NORMALIZED_IDENT)).thenReturn(true);
+    when(delegate.listSemanticModels(NORMALIZED_NAMESPACE))
+        .thenReturn(new NameIdentifier[] {NORMALIZED_IDENT});
+    when(delegate.dropSemanticModel(NORMALIZED_IDENT)).thenReturn(true);
+
+    assertEquals(
+        model, dispatcher.createSemanticModel(INPUT_IDENT, "comment", definition, Map.of()));
+    assertEquals(model, dispatcher.loadSemanticModel(INPUT_IDENT));
+    assertTrue(dispatcher.semanticModelExists(INPUT_IDENT));
+    assertEquals(NORMALIZED_IDENT, dispatcher.listSemanticModels(INPUT_NAMESPACE)[0]);
+    assertTrue(dispatcher.dropSemanticModel(INPUT_IDENT));
+
+    verify(delegate).createSemanticModel(NORMALIZED_IDENT, "comment", definition, Map.of());
+    verify(delegate).loadSemanticModel(NORMALIZED_IDENT);
+    verify(delegate).semanticModelExists(NORMALIZED_IDENT);
+    verify(delegate).listSemanticModels(NORMALIZED_NAMESPACE);
+    verify(delegate).dropSemanticModel(NORMALIZED_IDENT);
+  }
+
+  @Test
+  public void testRenameUsesStableSemanticModelRules() {
+    SemanticModel model = mock(SemanticModel.class);
+    SemanticModelChange rename = SemanticModelChange.rename("RevenueModel");
+    when(delegate.alterSemanticModel(NORMALIZED_IDENT, rename)).thenReturn(model);
+
+    assertEquals(model, dispatcher.alterSemanticModel(INPUT_IDENT, rename));
+    verify(delegate).alterSemanticModel(NORMALIZED_IDENT, rename);
+
+    NameIdentifier invalidIdent = NameIdentifier.of(INPUT_NAMESPACE, "invalid model");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> dispatcher.createSemanticModel(invalidIdent, null, definition(), Map.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            dispatcher.alterSemanticModel(
+                INPUT_IDENT, SemanticModelChange.rename("invalid model")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> dispatcher.alterSemanticModel(INPUT_IDENT, new SemanticModelChange[0]));
+  }
+
+  private static SemanticModelDefinition definition() {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .build();
+    return SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset}).build();
+  }
+
+  private static final class ParentNormalizingCapability implements Capability {
+
+    @Override
+    public CapabilityResult caseSensitiveOnName(Scope scope) {
+      return CapabilityResult.unsupported("Normalize names for this test");
+    }
+
+    @Override
+    public String normalizeName(Scope scope, String name) {
+      if (scope == Scope.SCHEMA) {
+        return name.toUpperCase(Locale.ROOT);
+      }
+      if (scope == Scope.SEMANTIC_MODEL) {
+        return name.toLowerCase(Locale.ROOT);
+      }
+      return name;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelOperationDispatcher.java
@@ -21,33 +21,46 @@ package org.apache.gravitino.catalog;
 import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
 import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
 import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Config;
-import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
+import org.apache.gravitino.exceptions.ConnectionFailedException;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
-import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
 import org.apache.gravitino.lock.LockManager;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.View;
 import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModel;
 import org.apache.gravitino.semantic.SemanticModelChange;
 import org.apache.gravitino.semantic.SemanticModelDefinition;
-import org.apache.gravitino.storage.IdGenerator;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.memory.TestMemoryEntityStore.InMemoryEntityStore;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,13 +68,23 @@ import org.junit.jupiter.api.Test;
 public class TestSemanticModelOperationDispatcher {
 
   private static final String METALAKE = "metalake";
-  private static final NameIdentifier CATALOG_IDENT = NameIdentifier.of(METALAKE, "catalog");
-  private static final Namespace NAMESPACE = Namespace.of(METALAKE, "catalog", "schema");
+  private static final NameIdentifier METADATA_CATALOG_IDENT =
+      NameIdentifier.of(METALAKE, "metadata_catalog");
+  private static final NameIdentifier SOURCE_CATALOG_IDENT = NameIdentifier.of(METALAKE, "sales");
+  private static final Namespace NAMESPACE =
+      Namespace.of(METALAKE, "metadata_catalog", "semantic_schema");
   private static final NameIdentifier SCHEMA_IDENT = NameIdentifier.of(NAMESPACE.levels());
   private static final NameIdentifier MODEL_IDENT = NameIdentifier.of(NAMESPACE, "sales_model");
+  private static final NameIdentifier ORDERS_SOURCE =
+      NameIdentifier.of(Namespace.of(METALAKE, "sales", "mart"), "orders");
+  private static final NameIdentifier CUSTOMERS_SOURCE =
+      NameIdentifier.of(Namespace.of(METALAKE, "sales", "mart"), "customers");
 
   private CatalogManager catalogManager;
   private SchemaDispatcher schemaDispatcher;
+  private TableDispatcher tableDispatcher;
+  private ViewDispatcher viewDispatcher;
+  private InMemoryEntityStore store;
   private SemanticModelOperationDispatcher dispatcher;
 
   @BeforeAll
@@ -77,10 +100,14 @@ public class TestSemanticModelOperationDispatcher {
   public void setUp() throws Exception {
     catalogManager = mock(CatalogManager.class);
     schemaDispatcher = mock(SchemaDispatcher.class);
+    tableDispatcher = mock(TableDispatcher.class);
+    viewDispatcher = mock(ViewDispatcher.class);
+    store = new InMemoryEntityStore();
 
+    useSourceCapability(Capability.DEFAULT);
     Catalog catalog = mock(Catalog.class);
     when(catalog.type()).thenReturn(Catalog.Type.RELATIONAL);
-    when(catalogManager.loadCatalog(CATALOG_IDENT)).thenReturn(catalog);
+    when(catalogManager.loadCatalog(METADATA_CATALOG_IDENT)).thenReturn(catalog);
     when(schemaDispatcher.loadSchema(SCHEMA_IDENT)).thenReturn(mock(Schema.class));
     when(schemaDispatcher.schemaExists(SCHEMA_IDENT)).thenReturn(true);
 
@@ -88,97 +115,270 @@ public class TestSemanticModelOperationDispatcher {
         new SemanticModelOperationDispatcher(
             catalogManager,
             schemaDispatcher,
-            mock(EntityStore.class),
-            mock(IdGenerator.class),
+            tableDispatcher,
+            viewDispatcher,
+            store,
+            new RandomIdGenerator(),
             mock(SecretManager.class));
   }
 
   @Test
-  public void testFrameworkValidatesParentAndDelegatesToManagedOperations() {
-    UnsupportedOperationException listFailure =
-        assertThrows(
-            UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
-    assertTrue(listFailure.getMessage().startsWith("listSemanticModels:"));
+  public void testCreateWithTableAndLogicalViewSourcesThenLoad() {
+    doReturn(tableWithColumns("order_id", "customer_id"))
+        .when(tableDispatcher)
+        .loadTable(ORDERS_SOURCE);
+    when(tableDispatcher.loadTable(CUSTOMERS_SOURCE))
+        .thenThrow(new NoSuchTableException("Table does not exist"));
+    doReturn(viewWithColumns("customer_id")).when(viewDispatcher).loadView(CUSTOMERS_SOURCE);
 
-    UnsupportedOperationException createFailure =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), Map.of()));
-    assertTrue(createFailure.getMessage().startsWith("createSemanticModel:"));
+    SemanticModel created =
+        dispatcher.createSemanticModel(MODEL_IDENT, "Sales", validDefinition(), Map.of());
 
-    UnsupportedOperationException loadFailure =
-        assertThrows(
-            UnsupportedOperationException.class, () -> dispatcher.loadSemanticModel(MODEL_IDENT));
-    assertTrue(loadFailure.getMessage().startsWith("loadSemanticModel:"));
-
-    UnsupportedOperationException alterFailure =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                dispatcher.alterSemanticModel(
-                    MODEL_IDENT, SemanticModelChange.updateComment("updated")));
-    assertTrue(alterFailure.getMessage().startsWith("alterSemanticModel:"));
-
-    UnsupportedOperationException dropFailure =
-        assertThrows(
-            UnsupportedOperationException.class, () -> dispatcher.dropSemanticModel(MODEL_IDENT));
-    assertTrue(dropFailure.getMessage().startsWith("dropSemanticModel:"));
-
-    verify(schemaDispatcher, times(2)).loadSchema(SCHEMA_IDENT);
-    verify(schemaDispatcher, times(3)).schemaExists(SCHEMA_IDENT);
+    assertEquals("sales_model", created.name());
+    assertEquals(2, created.definition().datasets().length);
+    assertSame(created, dispatcher.loadSemanticModel(MODEL_IDENT));
+    verify(tableDispatcher).loadTable(ORDERS_SOURCE);
+    verify(tableDispatcher).loadTable(CUSTOMERS_SOURCE);
+    verify(viewDispatcher).loadView(CUSTOMERS_SOURCE);
   }
 
   @Test
-  public void testMissingSchemaPreservesTypedResults() {
+  public void testLoadDoesNotRevalidatePersistedSources() {
+    doReturn(tableWithColumns("order_id", "customer_id"))
+        .when(tableDispatcher)
+        .loadTable(ORDERS_SOURCE);
+    when(tableDispatcher.loadTable(CUSTOMERS_SOURCE))
+        .thenThrow(new NoSuchTableException("Table does not exist"));
+    doReturn(viewWithColumns("customer_id")).when(viewDispatcher).loadView(CUSTOMERS_SOURCE);
+    SemanticModel created =
+        dispatcher.createSemanticModel(MODEL_IDENT, null, validDefinition(), Map.of());
+
+    when(tableDispatcher.loadTable(ORDERS_SOURCE))
+        .thenThrow(new ConnectionFailedException("Source is now unavailable"));
+    when(viewDispatcher.loadView(CUSTOMERS_SOURCE))
+        .thenThrow(new ConnectionFailedException("Source is now unavailable"));
+    clearInvocations(tableDispatcher, viewDispatcher);
+
+    assertSame(created, dispatcher.loadSemanticModel(MODEL_IDENT));
+    verifyNoInteractions(tableDispatcher, viewDispatcher);
+  }
+
+  @Test
+  public void testPrimaryUniqueAndRelationshipColumnsAreValidated() {
+    doReturn(tableWithColumns("order_id", "customer_id"))
+        .when(tableDispatcher)
+        .loadTable(ORDERS_SOURCE);
+    doReturn(tableWithColumns("customer_id")).when(tableDispatcher).loadTable(CUSTOMERS_SOURCE);
+
+    Dataset badPrimary =
+        dataset("orders", "orders", new String[] {"missing"}, new String[][] {{"customer_id"}});
+    assertSourceColumnFailure(definition(badPrimary), "primaryKey[0]");
+
+    Dataset badUnique =
+        dataset("orders", "orders", new String[] {"order_id"}, new String[][] {{"missing"}});
+    assertSourceColumnFailure(definition(badUnique), "uniqueKeys[0][0]");
+
+    Relationship badRelationship =
+        Relationship.builder()
+            .withName("orders_to_customers")
+            .withFrom("orders")
+            .withTo("customers")
+            .withFromColumns(new String[] {"missing"})
+            .withToColumns(new String[] {"customer_id"})
+            .build();
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withDatasets(
+                new Dataset[] {
+                  dataset("orders", "orders", null, null),
+                  dataset("customers", "customers", null, null)
+                })
+            .withRelationships(new Relationship[] {badRelationship})
+            .build();
+    assertSourceColumnFailure(definition, "relationships[0].fromColumns[0]");
+  }
+
+  @Test
+  public void testCatalogColumnCaseSensitivityIsHonored() throws Exception {
+    doReturn(tableWithColumns("ORDER_ID")).when(tableDispatcher).loadTable(ORDERS_SOURCE);
+    SemanticModelDefinition lowerCaseReference =
+        definition(dataset("orders", "orders", new String[] {"order_id"}, null));
+
+    IllegalSemanticModelException caseSensitiveFailure =
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () ->
+                dispatcher.createSemanticModel(
+                    MODEL_IDENT, null, lowerCaseReference, Map.of("mode", "sensitive")));
+    assertTrue(caseSensitiveFailure.getMessage().contains("primaryKey[0]"));
+
+    useSourceCapability(new CaseInsensitiveColumnsCapability());
+    SemanticModel created =
+        dispatcher.createSemanticModel(
+            MODEL_IDENT, null, lowerCaseReference, Map.of("mode", "insensitive"));
+    assertEquals("orders", created.definition().datasets()[0].name());
+  }
+
+  @Test
+  public void testMissingSourceIsRejectedBeforePersistence() {
+    NameIdentifier missingSource =
+        NameIdentifier.of(Namespace.of(METALAKE, "sales", "mart"), "missing");
+    when(tableDispatcher.loadTable(missingSource))
+        .thenThrow(new NoSuchTableException("Table does not exist"));
+    when(viewDispatcher.loadView(missingSource))
+        .thenThrow(new NoSuchViewException("View does not exist"));
+    SemanticModelDefinition definition =
+        definition(dataset("missing", "missing", null, new String[0][]));
+
+    IllegalSemanticModelException failure =
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition, Map.of()));
+
+    assertTrue(failure.getMessage().contains("does not exist as a Table or logical View"));
+    assertFalse(dispatcher.semanticModelExists(MODEL_IDENT));
+  }
+
+  @Test
+  public void testSchemaAndConnectionFailuresRemainTyped() {
     when(schemaDispatcher.loadSchema(SCHEMA_IDENT))
         .thenThrow(new NoSuchSchemaException("Schema does not exist"));
-    when(schemaDispatcher.schemaExists(SCHEMA_IDENT)).thenReturn(false);
-
-    assertThrows(NoSuchSchemaException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
     assertThrows(
         NoSuchSchemaException.class,
-        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), Map.of()));
-    assertThrows(
-        NoSuchSemanticModelException.class, () -> dispatcher.loadSemanticModel(MODEL_IDENT));
-    assertThrows(
-        NoSuchSemanticModelException.class,
-        () ->
-            dispatcher.alterSemanticModel(
-                MODEL_IDENT, SemanticModelChange.updateComment("updated")));
-    assertFalse(dispatcher.dropSemanticModel(MODEL_IDENT));
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, validDefinition(), Map.of()));
+
+    doReturn(mock(Schema.class)).when(schemaDispatcher).loadSchema(SCHEMA_IDENT);
+    ConnectionFailedException failure = new ConnectionFailedException("Catalog unavailable");
+    when(tableDispatcher.loadTable(ORDERS_SOURCE)).thenThrow(failure);
+    assertSame(
+        failure,
+        assertThrows(
+            ConnectionFailedException.class,
+            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, validDefinition(), Map.of())));
+    verify(viewDispatcher, never()).loadView(ORDERS_SOURCE);
+    assertFalse(dispatcher.semanticModelExists(MODEL_IDENT));
   }
 
   @Test
   public void testNonRelationalCatalogIsRejectedBeforeSchemaLookup() {
     Catalog catalog = mock(Catalog.class);
     when(catalog.type()).thenReturn(Catalog.Type.FILESET);
-    when(catalogManager.loadCatalog(CATALOG_IDENT)).thenReturn(catalog);
+    when(catalogManager.loadCatalog(METADATA_CATALOG_IDENT)).thenReturn(catalog);
 
-    UnsupportedOperationException failure =
-        assertThrows(
-            UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
-
-    assertTrue(failure.getMessage().contains("does not support Semantic Model operations"));
+    assertThrows(
+        UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
     verify(schemaDispatcher, never()).loadSchema(SCHEMA_IDENT);
   }
 
   @Test
-  public void testInvalidInputsAreRejectedBeforeCatalogLookup() {
+  public void testRemainingManagedCapabilitiesStayUnsupported() {
     assertThrows(
-        IllegalArgumentException.class,
-        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, null, Map.of()));
+        UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
     assertThrows(
-        IllegalArgumentException.class,
-        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), null));
-    verify(catalogManager, never()).loadCatalog(CATALOG_IDENT);
+        UnsupportedOperationException.class,
+        () ->
+            dispatcher.alterSemanticModel(
+                MODEL_IDENT, SemanticModelChange.updateComment("Not implemented")));
+    assertThrows(
+        UnsupportedOperationException.class, () -> dispatcher.dropSemanticModel(MODEL_IDENT));
   }
 
-  private static SemanticModelDefinition definition() {
-    Dataset dataset =
-        Dataset.builder()
-            .withName("orders")
-            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+  @Test
+  public void testNullDefinitionIsRejectedByValidator() {
+    assertThrows(
+        IllegalSemanticModelException.class,
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, null, Map.of()));
+    assertFalse(dispatcher.semanticModelExists(MODEL_IDENT));
+  }
+
+  @Test
+  public void testNullPropertiesAreRejectedBeforeCatalogLookup() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, validDefinition(), null));
+    verify(catalogManager, never()).loadCatalog(METADATA_CATALOG_IDENT);
+  }
+
+  private void useSourceCapability(Capability capability) throws Exception {
+    CatalogManager.CatalogWrapper wrapper = mock(CatalogManager.CatalogWrapper.class);
+    when(wrapper.capabilities()).thenReturn(capability);
+    when(catalogManager.loadCatalogAndWrap(SOURCE_CATALOG_IDENT)).thenReturn(wrapper);
+  }
+
+  private void assertSourceColumnFailure(
+      SemanticModelDefinition definition, String expectedMessageFragment) {
+    IllegalSemanticModelException failure =
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition, Map.of()));
+    assertTrue(failure.getMessage().contains(expectedMessageFragment));
+    assertFalse(dispatcher.semanticModelExists(MODEL_IDENT));
+  }
+
+  private static SemanticModelDefinition validDefinition() {
+    Dataset orders =
+        dataset("orders", "orders", new String[] {"order_id"}, new String[][] {{"customer_id"}});
+    Dataset customers =
+        dataset("customers", "customers", new String[] {"customer_id"}, new String[0][]);
+    Relationship relationship =
+        Relationship.builder()
+            .withName("orders_to_customers")
+            .withFrom("orders")
+            .withTo("customers")
+            .withFromColumns(new String[] {"customer_id"})
+            .withToColumns(new String[] {"customer_id"})
             .build();
+    return SemanticModelDefinition.builder()
+        .withDatasets(new Dataset[] {orders, customers})
+        .withRelationships(new Relationship[] {relationship})
+        .build();
+  }
+
+  private static SemanticModelDefinition definition(Dataset dataset) {
     return SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset}).build();
+  }
+
+  private static Dataset dataset(
+      String name, String source, String[] primaryKey, String[][] uniqueKeys) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", source))
+        .withPrimaryKey(primaryKey)
+        .withUniqueKeys(uniqueKeys)
+        .build();
+  }
+
+  private static Table tableWithColumns(String... names) {
+    Table table = mock(Table.class);
+    Column[] tableColumns = columns(names);
+    when(table.columns()).thenReturn(tableColumns);
+    return table;
+  }
+
+  private static View viewWithColumns(String... names) {
+    View view = mock(View.class);
+    Column[] viewColumns = columns(names);
+    when(view.columns()).thenReturn(viewColumns);
+    return view;
+  }
+
+  private static Column[] columns(String... names) {
+    Column[] columns = new Column[names.length];
+    for (int index = 0; index < names.length; index++) {
+      columns[index] = mock(Column.class);
+      when(columns[index].name()).thenReturn(names[index]);
+    }
+    return columns;
+  }
+
+  private static final class CaseInsensitiveColumnsCapability implements Capability {
+
+    @Override
+    public CapabilityResult caseSensitiveOnName(Scope scope) {
+      if (scope == Scope.COLUMN) {
+        return CapabilityResult.unsupported("Column names are case-insensitive");
+      }
+      return CapabilityResult.SUPPORTED;
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelOperationDispatcher.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
+import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
+import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.Schema;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.lock.LockManager;
+import org.apache.gravitino.secret.SecretManager;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.SemanticModelChange;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.IdGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestSemanticModelOperationDispatcher {
+
+  private static final String METALAKE = "metalake";
+  private static final NameIdentifier CATALOG_IDENT = NameIdentifier.of(METALAKE, "catalog");
+  private static final Namespace NAMESPACE = Namespace.of(METALAKE, "catalog", "schema");
+  private static final NameIdentifier SCHEMA_IDENT = NameIdentifier.of(NAMESPACE.levels());
+  private static final NameIdentifier MODEL_IDENT = NameIdentifier.of(NAMESPACE, "sales_model");
+
+  private CatalogManager catalogManager;
+  private SchemaDispatcher schemaDispatcher;
+  private SemanticModelOperationDispatcher dispatcher;
+
+  @BeforeAll
+  public static void initializeLockManager() throws IllegalAccessException {
+    Config config = mock(Config.class);
+    doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
+    doReturn(1000L).when(config).get(TREE_LOCK_MIN_NODE_IN_MEMORY);
+    doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    catalogManager = mock(CatalogManager.class);
+    schemaDispatcher = mock(SchemaDispatcher.class);
+
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.type()).thenReturn(Catalog.Type.RELATIONAL);
+    when(catalogManager.loadCatalog(CATALOG_IDENT)).thenReturn(catalog);
+    when(schemaDispatcher.loadSchema(SCHEMA_IDENT)).thenReturn(mock(Schema.class));
+    when(schemaDispatcher.schemaExists(SCHEMA_IDENT)).thenReturn(true);
+
+    dispatcher =
+        new SemanticModelOperationDispatcher(
+            catalogManager,
+            schemaDispatcher,
+            mock(EntityStore.class),
+            mock(IdGenerator.class),
+            mock(SecretManager.class));
+  }
+
+  @Test
+  public void testFrameworkValidatesParentAndDelegatesToManagedOperations() {
+    UnsupportedOperationException listFailure =
+        assertThrows(
+            UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
+    assertTrue(listFailure.getMessage().startsWith("listSemanticModels:"));
+
+    UnsupportedOperationException createFailure =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), Map.of()));
+    assertTrue(createFailure.getMessage().startsWith("createSemanticModel:"));
+
+    UnsupportedOperationException loadFailure =
+        assertThrows(
+            UnsupportedOperationException.class, () -> dispatcher.loadSemanticModel(MODEL_IDENT));
+    assertTrue(loadFailure.getMessage().startsWith("loadSemanticModel:"));
+
+    UnsupportedOperationException alterFailure =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                dispatcher.alterSemanticModel(
+                    MODEL_IDENT, SemanticModelChange.updateComment("updated")));
+    assertTrue(alterFailure.getMessage().startsWith("alterSemanticModel:"));
+
+    UnsupportedOperationException dropFailure =
+        assertThrows(
+            UnsupportedOperationException.class, () -> dispatcher.dropSemanticModel(MODEL_IDENT));
+    assertTrue(dropFailure.getMessage().startsWith("dropSemanticModel:"));
+
+    verify(schemaDispatcher, times(2)).loadSchema(SCHEMA_IDENT);
+    verify(schemaDispatcher, times(3)).schemaExists(SCHEMA_IDENT);
+  }
+
+  @Test
+  public void testMissingSchemaPreservesTypedResults() {
+    when(schemaDispatcher.loadSchema(SCHEMA_IDENT))
+        .thenThrow(new NoSuchSchemaException("Schema does not exist"));
+    when(schemaDispatcher.schemaExists(SCHEMA_IDENT)).thenReturn(false);
+
+    assertThrows(NoSuchSchemaException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
+    assertThrows(
+        NoSuchSchemaException.class,
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), Map.of()));
+    assertThrows(
+        NoSuchSemanticModelException.class, () -> dispatcher.loadSemanticModel(MODEL_IDENT));
+    assertThrows(
+        NoSuchSemanticModelException.class,
+        () ->
+            dispatcher.alterSemanticModel(
+                MODEL_IDENT, SemanticModelChange.updateComment("updated")));
+    assertFalse(dispatcher.dropSemanticModel(MODEL_IDENT));
+  }
+
+  @Test
+  public void testNonRelationalCatalogIsRejectedBeforeSchemaLookup() {
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.type()).thenReturn(Catalog.Type.FILESET);
+    when(catalogManager.loadCatalog(CATALOG_IDENT)).thenReturn(catalog);
+
+    UnsupportedOperationException failure =
+        assertThrows(
+            UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
+
+    assertTrue(failure.getMessage().contains("does not support Semantic Model operations"));
+    verify(schemaDispatcher, never()).loadSchema(SCHEMA_IDENT);
+  }
+
+  @Test
+  public void testInvalidInputsAreRejectedBeforeCatalogLookup() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, null, Map.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> dispatcher.alterSemanticModel(MODEL_IDENT, new SemanticModelChange[0]));
+
+    verify(catalogManager, never()).loadCatalog(CATALOG_IDENT);
+  }
+
+  private static SemanticModelDefinition definition() {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .build();
+    return SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset}).build();
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelOperationDispatcher.java
@@ -170,10 +170,6 @@ public class TestSemanticModelOperationDispatcher {
     assertThrows(
         IllegalArgumentException.class,
         () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), null));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> dispatcher.alterSemanticModel(MODEL_IDENT, new SemanticModelChange[0]));
-
     verify(catalogManager, never()).loadCatalog(CATALOG_IDENT);
   }
 

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelValidator.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelValidator.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.AIContextObject;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dialects;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestSemanticModelValidator {
+
+  @Test
+  public void testValidCompleteDefinitionWithoutExternalResolution() {
+    CustomExtension extension = extension();
+    Dataset orders =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("missing_catalog", "missing_schema", "orders"))
+            .withPrimaryKey(new String[] {"order_id"})
+            .withUniqueKeys(new String[][] {{"order_id"}, {"external_id", "source"}})
+            .withFields(
+                new Field[] {
+                  field("id", expression("order_id")), field("amount", expression("amount"))
+                })
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+    Dataset customers =
+        Dataset.builder()
+            .withName("customers")
+            .withSource(NameIdentifier.of("missing_catalog", "missing_schema", "customers"))
+            .withFields(new Field[] {field("id", expression("customer_id"))})
+            .build();
+    Relationship relationship =
+        relationship(
+            "orders_to_customers",
+            "orders",
+            "customers",
+            new String[] {"customer_id", "tenant_id"},
+            new String[] {"id", "tenant_id"});
+    Metric metric =
+        Metric.builder()
+            .withName("total_revenue")
+            .withExpression(
+                multiDialectExpression(
+                    "SUM(orders.amount) /* text is intentionally uninterpreted */",
+                    "SUM(orders.amount)"))
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {orders, customers})
+            .withRelationships(new Relationship[] {relationship})
+            .withMetrics(new Metric[] {metric})
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(definition));
+  }
+
+  @ParameterizedTest
+  @MethodSource("validAIContexts")
+  public void testAIContextAcceptsTextAndObjectVariants(AIContext aiContext) {
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withAIContext(aiContext)
+            .withDatasets(new Dataset[] {dataset("orders")})
+            .build();
+
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(definition));
+  }
+
+  @Test
+  public void testDefinitionValidationAcceptsCustomDialectsWithoutParsingSql() {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withFields(
+                new Field[] {
+                  field(
+                      "order_id",
+                      Expression.builder()
+                          .withDialects(
+                              new DialectExpression[] {
+                                dialect("TRINO", "not parsed by metadata validation"),
+                                dialect("trino", "also preserved exactly")
+                              })
+                          .build())
+                })
+            .build();
+
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(definition(dataset)));
+  }
+
+  @Test
+  public void testValidateForWriteComposesDefinitionAndSourceValidation() throws Exception {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    TableDispatcher tableDispatcher = mock(TableDispatcher.class);
+    ViewDispatcher viewDispatcher = mock(ViewDispatcher.class);
+    CatalogManager.CatalogWrapper wrapper = mock(CatalogManager.CatalogWrapper.class);
+    when(wrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    when(catalogManager.loadCatalogAndWrap(NameIdentifier.of("metalake", "sales")))
+        .thenReturn(wrapper);
+
+    Column column = mock(Column.class);
+    when(column.name()).thenReturn("order_id");
+    Table table = mock(Table.class);
+    when(table.columns()).thenReturn(new Column[] {column});
+    NameIdentifier source = NameIdentifier.of(Namespace.of("metalake", "sales", "mart"), "orders");
+    when(tableDispatcher.loadTable(source)).thenReturn(table);
+
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withPrimaryKey(new String[] {"order_id"})
+            .build();
+    NameIdentifier model =
+        NameIdentifier.of(Namespace.of("metalake", "metadata", "models"), "sales_model");
+    SemanticModelValidator validator =
+        new SemanticModelValidator(catalogManager, tableDispatcher, viewDispatcher);
+
+    assertDoesNotThrow(() -> validator.validateForWrite(model, definition(dataset)));
+    verify(tableDispatcher).loadTable(source);
+    verifyNoInteractions(viewDispatcher);
+  }
+
+  @Test
+  public void testDefinitionFailurePreventsSourceResolution() {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    TableDispatcher tableDispatcher = mock(TableDispatcher.class);
+    ViewDispatcher viewDispatcher = mock(ViewDispatcher.class);
+    SemanticModelValidator validator =
+        new SemanticModelValidator(catalogManager, tableDispatcher, viewDispatcher);
+    NameIdentifier model =
+        NameIdentifier.of(Namespace.of("metalake", "metadata", "models"), "sales_model");
+
+    assertThrows(
+        IllegalSemanticModelException.class,
+        () -> validator.validateForWrite(model, definition(dataset("orders"), dataset("orders"))));
+    verifyNoInteractions(catalogManager, tableDispatcher, viewDispatcher);
+  }
+
+  @Test
+  public void testOptionalArraysDistinguishAbsentAndExplicitEmpty() {
+    SemanticModelDefinition absent =
+        SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset("orders")}).build();
+    Dataset explicitEmptyDataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withPrimaryKey(new String[0])
+            .withUniqueKeys(new String[0][])
+            .withFields(new Field[0])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+    SemanticModelDefinition explicitEmpty =
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {explicitEmptyDataset})
+            .withRelationships(new Relationship[0])
+            .withMetrics(new Metric[0])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(absent));
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(explicitEmpty));
+  }
+
+  @Test
+  public void testDefinitionAndDatasetStructure() {
+    assertInvalid(null, "$: definition must not be null");
+
+    SemanticModelDefinition nullDataset = mock(SemanticModelDefinition.class);
+    when(nullDataset.datasets()).thenReturn(new Dataset[] {null});
+    assertInvalid(nullDataset, "datasets[0]: must not be null");
+
+    assertInvalid(
+        definition(dataset("orders"), dataset("orders")),
+        "datasets[1].name: duplicate dataset name 'orders'; first declared at datasets[0].name");
+
+    Dataset shortSource =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "orders"))
+            .build();
+    assertInvalid(
+        definition(shortSource),
+        "datasets[0].source: must contain exactly catalog.schema.name, but was 'sales.orders'");
+  }
+
+  @Test
+  public void testAIContextMustContainExactlyOneTypedVariant() {
+    AIContext invalidContext = mock(AIContext.class);
+    when(invalidContext.text()).thenReturn(null);
+    when(invalidContext.object()).thenReturn(null);
+    SemanticModelDefinition invalidDefinition = mock(SemanticModelDefinition.class);
+    when(invalidDefinition.aiContext()).thenReturn(invalidContext);
+    when(invalidDefinition.datasets()).thenReturn(new Dataset[] {dataset("orders")});
+
+    assertInvalid(invalidDefinition, "aiContext: must contain exactly one string or object value");
+
+    AIContext bothVariants = mock(AIContext.class);
+    when(bothVariants.text()).thenReturn("Use certified definitions");
+    when(bothVariants.object()).thenReturn(AIContextObject.builder().build());
+    when(invalidDefinition.aiContext()).thenReturn(bothVariants);
+    assertInvalid(invalidDefinition, "aiContext: must contain exactly one string or object value");
+  }
+
+  @Test
+  public void testFieldNamesAreUniquePerDataset() {
+    Dataset duplicateFields =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withFields(
+                new Field[] {field("id", expression("id")), field("id", expression("order_id"))})
+            .build();
+
+    assertInvalid(
+        definition(duplicateFields),
+        "datasets[0].fields[1].name: duplicate field name 'id'; first declared at "
+            + "datasets[0].fields[0].name");
+
+    assertDoesNotThrow(
+        () ->
+            SemanticModelValidator.validateDefinition(
+                definition(datasetWithField("orders", "id"), datasetWithField("customers", "id"))));
+  }
+
+  @Test
+  public void testDatasetKeyShapesAreDefensivelyValidated() {
+    Dataset invalidPrimary = mockDataset("orders");
+    when(invalidPrimary.primaryKey()).thenReturn(new String[] {null});
+    assertInvalid(
+        definition(invalidPrimary), "datasets[0].primaryKey[0]: must not be null or empty");
+
+    Dataset invalidUnique = mockDataset("orders");
+    when(invalidUnique.uniqueKeys()).thenReturn(new String[][] {new String[0]});
+    assertInvalid(
+        definition(invalidUnique), "datasets[0].uniqueKeys[0]: must not be null or empty");
+  }
+
+  @Test
+  public void testRelationshipNamesEndpointsAndColumns() {
+    Dataset orders = dataset("orders");
+    Dataset customers = dataset("customers");
+    Relationship relationship = relationship("by_customer", "orders", "customers");
+
+    assertInvalid(
+        definition(
+            new Dataset[] {orders, customers},
+            new Relationship[] {relationship, relationship},
+            null),
+        "relationships[1].name: duplicate relationship name 'by_customer'; first declared at "
+            + "relationships[0].name");
+    assertInvalid(
+        definition(
+            new Dataset[] {orders},
+            new Relationship[] {relationship("missing", "orders", "customers")},
+            null),
+        "relationships[0].to: unknown dataset 'customers'; relationship endpoints must reference "
+            + "datasets in the same model");
+
+    Relationship mismatched = mock(Relationship.class);
+    when(mismatched.name()).thenReturn("mismatched");
+    when(mismatched.from()).thenReturn("orders");
+    when(mismatched.to()).thenReturn("customers");
+    when(mismatched.fromColumns()).thenReturn(new String[] {"customer_id", "tenant_id"});
+    when(mismatched.toColumns()).thenReturn(new String[] {"id"});
+    assertInvalid(
+        definition(new Dataset[] {orders, customers}, new Relationship[] {mismatched}, null),
+        "relationships[0].toColumns: must contain 2 columns to match "
+            + "relationships[0].fromColumns, but contained 1");
+  }
+
+  @Test
+  public void testMetricNamesAndExpressions() {
+    Metric revenue = metric("revenue", expression("SUM(amount)"));
+    assertInvalid(
+        definition(new Dataset[] {dataset("orders")}, null, new Metric[] {revenue, revenue}),
+        "metrics[1].name: duplicate metric name 'revenue'; first declared at metrics[0].name");
+
+    DialectExpression ansi = dialect(Dialects.ANSI_SQL, "SUM(amount)");
+    Expression duplicateDialect = mock(Expression.class);
+    when(duplicateDialect.dialects()).thenReturn(new DialectExpression[] {ansi, ansi});
+    assertInvalid(
+        definition(
+            new Dataset[] {dataset("orders")},
+            null,
+            new Metric[] {metric("revenue", duplicateDialect)}),
+        "metrics[0].expression.dialects[1].dialect: duplicate dialect 'ANSI_SQL'; first declared "
+            + "at metrics[0].expression.dialects[0].dialect");
+  }
+
+  @Test
+  public void testNullNestedMembersAreDefensivelyValidated() {
+    Dataset nullField = mockDataset("orders");
+    when(nullField.fields()).thenReturn(new Field[] {null});
+    assertInvalid(definition(nullField), "datasets[0].fields[0]: must not be null");
+
+    SemanticModelDefinition nullRelationship = mock(SemanticModelDefinition.class);
+    when(nullRelationship.datasets()).thenReturn(new Dataset[] {dataset("orders")});
+    when(nullRelationship.relationships()).thenReturn(new Relationship[] {null});
+    assertInvalid(nullRelationship, "relationships[0]: must not be null");
+
+    SemanticModelDefinition nullMetric = mock(SemanticModelDefinition.class);
+    when(nullMetric.datasets()).thenReturn(new Dataset[] {dataset("orders")});
+    when(nullMetric.metrics()).thenReturn(new Metric[] {null});
+    assertInvalid(nullMetric, "metrics[0]: must not be null");
+  }
+
+  private static void assertInvalid(
+      @Nullable SemanticModelDefinition definition, String expectedMessage) {
+    IllegalSemanticModelException exception =
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () -> SemanticModelValidator.validateDefinition(definition));
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+
+  private static Stream<AIContext> validAIContexts() {
+    return Stream.of(
+        AIContext.of("Use certified definitions"),
+        AIContext.of(
+            AIContextObject.builder()
+                .withInstructions("Use certified definitions")
+                .withSynonyms(new String[] {"sales", "bookings"})
+                .withExamples(new String[] {"Revenue by day"})
+                .build()));
+  }
+
+  private static SemanticModelDefinition definition(Dataset... datasets) {
+    return SemanticModelDefinition.builder().withDatasets(datasets).build();
+  }
+
+  private static SemanticModelDefinition definition(
+      Dataset[] datasets, @Nullable Relationship[] relationships, @Nullable Metric[] metrics) {
+    return SemanticModelDefinition.builder()
+        .withDatasets(datasets)
+        .withRelationships(relationships)
+        .withMetrics(metrics)
+        .build();
+  }
+
+  private static Dataset dataset(String name) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .build();
+  }
+
+  private static Dataset datasetWithField(String name, String fieldName) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .withFields(new Field[] {field(fieldName, expression(fieldName))})
+        .build();
+  }
+
+  private static Dataset mockDataset(String name) {
+    Dataset dataset = mock(Dataset.class);
+    when(dataset.name()).thenReturn(name);
+    when(dataset.source()).thenReturn(NameIdentifier.of("sales", "mart", name));
+    return dataset;
+  }
+
+  private static Field field(String name, Expression expression) {
+    return Field.builder().withName(name).withExpression(expression).build();
+  }
+
+  private static Metric metric(String name, Expression expression) {
+    return Metric.builder().withName(name).withExpression(expression).build();
+  }
+
+  private static Relationship relationship(String name, String from, String to) {
+    return relationship(name, from, to, new String[] {"customer_id"}, new String[] {"id"});
+  }
+
+  private static Relationship relationship(
+      String name, String from, String to, String[] fromColumns, String[] toColumns) {
+    return Relationship.builder()
+        .withName(name)
+        .withFrom(from)
+        .withTo(to)
+        .withFromColumns(fromColumns)
+        .withToColumns(toColumns)
+        .build();
+  }
+
+  private static Expression expression(String value) {
+    return Expression.builder()
+        .withDialects(new DialectExpression[] {dialect(Dialects.ANSI_SQL, value)})
+        .build();
+  }
+
+  private static Expression multiDialectExpression(String ansi, String bigQuery) {
+    return Expression.builder()
+        .withDialects(
+            new DialectExpression[] {
+              dialect(Dialects.ANSI_SQL, ansi), dialect(Dialects.BIGQUERY, bigQuery)
+            })
+        .build();
+  }
+
+  private static DialectExpression dialect(String dialect, String expression) {
+    return DialectExpression.builder().withDialect(dialect).withExpression(expression).build();
+  }
+
+  private static CustomExtension extension() {
+    return CustomExtension.builder().withVendorName("example").withData("{}").build();
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/hook/TestModelHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestModelHookDispatcher.java
@@ -120,16 +120,11 @@ public class TestModelHookDispatcher {
         "my_model",
         captor.getValue().name(),
         "Model name passed to setOwner must be lowercased by Capability.Scope.MODEL normalization");
-    // MODEL scope is intentionally excluded from CapabilityHelpers.applyCapabilities(Namespace,
-    // Scope, Capability), so the schema component in the namespace is NOT lowercased -- the
-    // captured parent reflects exactly what ModelNormalizeDispatcher would also pass to the
-    // manager. This assertion locks that behavior in.
     Assertions.assertEquals(
-        "test_catalog.TEST_SCHEMA",
+        "test_catalog.test_schema",
         captor.getValue().parent(),
-        "Model parent must keep its schema component as-is: Capability.Scope.MODEL is excluded"
-            + " from namespace normalization in CapabilityHelpers; if this changes, ownership"
-            + " attachment will diverge from what ModelNormalizeDispatcher passes to the manager");
+        "Model parent passed to setOwner must be lowercased by Capability.Scope.SCHEMA"
+            + " normalization");
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/meta/TestSemanticModelEntity.java
+++ b/core/src/test/java/org/apache/gravitino/meta/TestSemanticModelEntity.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.meta;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dialects;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SemanticModelEntity}. */
+public class TestSemanticModelEntity {
+
+  /** Tests the complete entity field contract and optional defaults. */
+  @Test
+  public void testSemanticModelEntityFields() {
+    SemanticModelDefinition definition = completeDefinition();
+    AuditInfo auditInfo = auditInfo();
+    Map<String, String> properties = Map.of("owner", "analytics");
+
+    SemanticModelEntity entity =
+        SemanticModelEntity.builder()
+            .withId(1L)
+            .withName("sales")
+            .withNamespace(Namespace.of("metalake", "catalog", "schema"))
+            .withComment("Sales model")
+            .withDefinition(definition)
+            .withProperties(properties)
+            .withAuditInfo(auditInfo)
+            .build();
+
+    assertEquals(1L, entity.id());
+    assertEquals("sales", entity.name());
+    assertEquals(Namespace.of("metalake", "catalog", "schema"), entity.namespace());
+    assertEquals("Sales model", entity.comment());
+    assertSame(definition, entity.definition());
+    assertEquals(properties, entity.properties());
+    assertEquals(auditInfo, entity.auditInfo());
+    assertEquals(Entity.EntityType.SEMANTIC_MODEL, entity.type());
+    assertSame(definition, entity.fields().get(SemanticModelEntity.DEFINITION));
+
+    SemanticModelDefinition minimalDefinition =
+        SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset("orders")}).build();
+    SemanticModelEntity minimalEntity =
+        SemanticModelEntity.builder()
+            .withId(2L)
+            .withName("minimal")
+            .withNamespace(Namespace.of("metalake", "catalog", "schema"))
+            .withDefinition(minimalDefinition)
+            .withProperties(null)
+            .withAuditInfo(auditInfo)
+            .build();
+
+    assertNull(minimalEntity.comment());
+    assertNull(minimalEntity.definition().aiContext());
+    assertNull(minimalEntity.definition().relationships());
+    assertNull(minimalEntity.definition().metrics());
+    assertNull(minimalEntity.definition().customExtensions());
+    assertEquals(Map.of(), minimalEntity.properties());
+  }
+
+  /** Tests that absent and explicitly empty optional arrays remain distinguishable. */
+  @Test
+  public void testPreservesNullAndEmptyOptionalArrays() {
+    Dataset dataset = dataset("orders");
+    SemanticModelDefinition absent =
+        SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset}).build();
+    SemanticModelDefinition empty =
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {dataset})
+            .withRelationships(new Relationship[0])
+            .withMetrics(new Metric[0])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+
+    SemanticModelEntity absentEntity = entity("absent", absent, Map.of());
+    SemanticModelEntity emptyEntity = entity("empty", empty, Map.of());
+
+    assertNull(absentEntity.definition().relationships());
+    assertNull(absentEntity.definition().metrics());
+    assertNull(absentEntity.definition().customExtensions());
+    assertArrayEquals(new Relationship[0], emptyEntity.definition().relationships());
+    assertArrayEquals(new Metric[0], emptyEntity.definition().metrics());
+    assertArrayEquals(new CustomExtension[0], emptyEntity.definition().customExtensions());
+    assertNotEquals(absentEntity.definition(), emptyEntity.definition());
+  }
+
+  /** Tests that definition arrays and properties cannot mutate the entity snapshot. */
+  @Test
+  public void testDefensivelyCopiesStructuredCollections() {
+    Dataset[] datasets = {dataset("orders")};
+    Relationship[] relationships = {relationship("orders_to_customers")};
+    Metric[] metrics = {metric("order_count")};
+    CustomExtension[] extensions = {extension("example")};
+    Map<String, String> properties = new HashMap<>();
+    properties.put("owner", "analytics");
+
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withAIContext(AIContext.of("Certified sales definitions"))
+            .withDatasets(datasets)
+            .withRelationships(relationships)
+            .withMetrics(metrics)
+            .withCustomExtensions(extensions)
+            .build();
+    SemanticModelEntity entity = entity("sales", definition, properties);
+
+    datasets[0] = dataset("changed");
+    relationships[0] = relationship("changed");
+    metrics[0] = metric("changed");
+    extensions[0] = extension("changed");
+    properties.put("owner", "changed");
+
+    assertEquals("orders", entity.definition().datasets()[0].name());
+    assertEquals("orders_to_customers", entity.definition().relationships()[0].name());
+    assertEquals("order_count", entity.definition().metrics()[0].name());
+    assertEquals("example", entity.definition().customExtensions()[0].vendorName());
+    assertEquals("analytics", entity.properties().get("owner"));
+
+    Dataset[] returnedDatasets = entity.definition().datasets();
+    Relationship[] returnedRelationships = entity.definition().relationships();
+    Metric[] returnedMetrics = entity.definition().metrics();
+    CustomExtension[] returnedExtensions = entity.definition().customExtensions();
+    returnedDatasets[0] = dataset("returned");
+    returnedRelationships[0] = relationship("returned");
+    returnedMetrics[0] = metric("returned");
+    returnedExtensions[0] = extension("returned");
+
+    assertEquals("orders", entity.definition().datasets()[0].name());
+    assertEquals("orders_to_customers", entity.definition().relationships()[0].name());
+    assertEquals("order_count", entity.definition().metrics()[0].name());
+    assertEquals("example", entity.definition().customExtensions()[0].vendorName());
+    assertNotSame(entity.definition().datasets(), entity.definition().datasets());
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> entity.properties().put("new-property", "value"));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> entity.fields().put(SemanticModelEntity.COMMENT, "changed"));
+  }
+
+  /** Tests value-based equality and hash codes. */
+  @Test
+  public void testEqualsAndHashCode() {
+    SemanticModelDefinition definition = completeDefinition();
+    AuditInfo auditInfo = auditInfo();
+
+    SemanticModelEntity first =
+        SemanticModelEntity.builder()
+            .withId(1L)
+            .withName("sales")
+            .withNamespace(Namespace.of("metalake", "catalog", "schema"))
+            .withComment("Sales model")
+            .withDefinition(definition)
+            .withProperties(Map.of("owner", "analytics"))
+            .withAuditInfo(auditInfo)
+            .build();
+    SemanticModelEntity equal =
+        SemanticModelEntity.builder()
+            .withId(1L)
+            .withName("sales")
+            .withNamespace(Namespace.of("metalake", "catalog", "schema"))
+            .withComment("Sales model")
+            .withDefinition(definition)
+            .withProperties(Map.of("owner", "analytics"))
+            .withAuditInfo(auditInfo)
+            .build();
+    SemanticModelEntity different = entity("marketing", definition, Map.of());
+
+    assertEquals(first, equal);
+    assertEquals(first.hashCode(), equal.hashCode());
+    assertNotEquals(first, different);
+    assertNotEquals(first, new Object());
+  }
+
+  /** Tests validation of required entity fields. */
+  @Test
+  public void testRequiredFieldValidation() {
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset("orders")}).build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            SemanticModelEntity.builder()
+                .withId(1L)
+                .withName("sales")
+                .withDefinition(definition)
+                .withAuditInfo(auditInfo())
+                .build());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            SemanticModelEntity.builder()
+                .withId(1L)
+                .withName("sales")
+                .withNamespace(Namespace.of("metalake", "catalog", "schema"))
+                .withAuditInfo(auditInfo())
+                .build());
+  }
+
+  private static SemanticModelEntity entity(
+      String name, SemanticModelDefinition definition, Map<String, String> properties) {
+    return SemanticModelEntity.builder()
+        .withId(1L)
+        .withName(name)
+        .withNamespace(Namespace.of("metalake", "catalog", "schema"))
+        .withComment("Sales model")
+        .withDefinition(definition)
+        .withProperties(properties)
+        .withAuditInfo(auditInfo())
+        .build();
+  }
+
+  private static SemanticModelDefinition completeDefinition() {
+    return SemanticModelDefinition.builder()
+        .withAIContext(AIContext.of("Certified sales definitions"))
+        .withDatasets(new Dataset[] {dataset("orders")})
+        .withRelationships(new Relationship[] {relationship("orders_to_customers")})
+        .withMetrics(new Metric[] {metric("order_count")})
+        .withCustomExtensions(new CustomExtension[] {extension("example")})
+        .build();
+  }
+
+  private static Dataset dataset(String name) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .build();
+  }
+
+  private static Relationship relationship(String name) {
+    return Relationship.builder()
+        .withName(name)
+        .withFrom("orders")
+        .withTo("customers")
+        .withFromColumns(new String[] {"customer_id"})
+        .withToColumns(new String[] {"id"})
+        .build();
+  }
+
+  private static Metric metric(String name) {
+    return Metric.builder()
+        .withName(name)
+        .withExpression(
+            Expression.builder()
+                .withDialects(
+                    new DialectExpression[] {
+                      DialectExpression.builder()
+                          .withDialect(Dialects.ANSI_SQL)
+                          .withExpression("COUNT(*)")
+                          .build()
+                    })
+                .build())
+        .build();
+  }
+
+  private static CustomExtension extension(String vendorName) {
+    return CustomExtension.builder().withVendorName(vendorName).withData("{}").build();
+  }
+
+  private static AuditInfo auditInfo() {
+    return AuditInfo.builder()
+        .withCreator("tester")
+        .withCreateTime(Instant.parse("2026-08-11T00:00:00Z"))
+        .build();
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestSemanticModelJDBCBackend.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestSemanticModelJDBCBackend.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.AIContextObject;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.DataType;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dimension;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelVersionInfoMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
+import org.apache.gravitino.utils.NamespaceUtil;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.TestTemplate;
+
+/** Tests Semantic Model create and load persistence through {@link JDBCBackend}. */
+public class TestSemanticModelJDBCBackend extends TestJDBCBackend {
+
+  @TestTemplate
+  public void testCreateAndLoadRoundTrip() throws IOException {
+    Namespace namespace = createParents("round_trip");
+    SemanticModelEntity absent =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "absent_optional_model",
+            false,
+            ImmutableMap.of("domain", "sales"));
+    SemanticModelEntity empty =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "empty_optional_model",
+            true,
+            ImmutableMap.of());
+
+    backend.insert(absent, false);
+    backend.insert(empty, false);
+
+    SemanticModelEntity loadedAbsent =
+        backend.get(absent.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL);
+    SemanticModelEntity loadedEmpty =
+        backend.get(empty.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL);
+
+    assertEquals(absent, loadedAbsent);
+    assertEquals(empty, loadedEmpty);
+    assertNull(loadedAbsent.definition().relationships());
+    assertNull(loadedAbsent.definition().metrics());
+    assertEquals(0, loadedEmpty.definition().relationships().length);
+    assertEquals(0, loadedEmpty.definition().metrics().length);
+    assertTrue(loadedEmpty.properties().isEmpty());
+    assertEquals(
+        new BigDecimal("1.50"),
+        loadedAbsent.definition().aiContext().object().additionalProperties().get("threshold"));
+    assertNull(loadedAbsent.definition().aiContext().object().examples());
+    assertEquals(0, loadedAbsent.definition().aiContext().object().synonyms().length);
+  }
+
+  @TestTemplate
+  public void testDuplicateAndMissingEntities() throws IOException {
+    Namespace namespace = createParents("duplicate");
+    SemanticModelEntity original =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "sales_model",
+            false,
+            ImmutableMap.of("owner", "analytics"));
+    backend.insert(original, false);
+
+    SemanticModelEntity duplicate =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            original.name(),
+            true,
+            ImmutableMap.of());
+    assertThrows(EntityAlreadyExistsException.class, () -> backend.insert(duplicate, false));
+    assertEquals(
+        original, backend.get(original.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL));
+
+    NameIdentifier missingModel = NameIdentifier.of(namespace, "missing_model");
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> backend.get(missingModel, Entity.EntityType.SEMANTIC_MODEL));
+
+    String suffix = Long.toUnsignedString(RandomIdGenerator.INSTANCE.nextId());
+    String metalakeName = "missing_parent_metalake_" + suffix;
+    String catalogName = "missing_parent_catalog_" + suffix;
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+    Namespace missingParentNamespace =
+        NamespaceUtil.ofSemanticModel(metalakeName, catalogName, "missing_schema");
+    SemanticModelEntity missingParent =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            missingParentNamespace,
+            "orphan_model",
+            false,
+            ImmutableMap.of());
+
+    assertThrows(NoSuchEntityException.class, () -> backend.insert(missingParent, false));
+    assertEquals(0, countRows("semantic_model_meta", missingParent.id()));
+    assertEquals(0, countRows("semantic_model_version_info", missingParent.id()));
+  }
+
+  @TestTemplate
+  public void testCreateRollsBackIdentityWhenSnapshotInsertFails() throws IOException {
+    Namespace namespace = createParents("transaction");
+    SemanticModelEntity semanticModel =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "transaction_model",
+            false,
+            ImmutableMap.of("domain", "finance"));
+    SemanticModelPO po =
+        SemanticModelPO.initializeSemanticModelPO(semanticModel, SemanticModelPO.builder());
+    SessionUtils.doWithCommit(
+        SemanticModelVersionInfoMapper.class,
+        mapper -> mapper.insertSemanticModelVersionInfo(po.getSemanticModelVersionInfoPO()));
+
+    assertThrows(EntityAlreadyExistsException.class, () -> backend.insert(semanticModel, false));
+    assertEquals(0, countRows("semantic_model_meta", semanticModel.id()));
+    assertEquals(1, countRows("semantic_model_version_info", semanticModel.id()));
+  }
+
+  private Namespace createParents(String prefix) throws IOException {
+    String suffix = Long.toUnsignedString(RandomIdGenerator.INSTANCE.nextId());
+    String metalakeName = prefix + "_metalake_" + suffix;
+    String catalogName = prefix + "_catalog_" + suffix;
+    String schemaName = prefix + "_schema_" + suffix;
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+    createAndInsertSchema(metalakeName, catalogName, schemaName);
+    return NamespaceUtil.ofSemanticModel(metalakeName, catalogName, schemaName);
+  }
+
+  private SemanticModelEntity semanticModel(
+      Long id,
+      Namespace namespace,
+      String name,
+      boolean explicitEmpty,
+      Map<String, String> properties) {
+    AIContextObject context =
+        AIContextObject.builder()
+            .withInstructions("Use certified sales definitions")
+            .withSynonyms(new String[0])
+            .withAdditionalProperties(
+                Map.of("threshold", new BigDecimal("1.50"), "nested", List.of(new BigInteger("3"))))
+            .build();
+    Field field =
+        Field.builder()
+            .withName("ordered_at")
+            .withExpression(
+                Expression.builder()
+                    .withDialects(
+                        new DialectExpression[] {
+                          DialectExpression.builder()
+                              .withDialect("ansi")
+                              .withExpression("ordered_at")
+                              .build()
+                        })
+                    .build())
+            .withDimension(Dimension.builder().withIsTime(true).build())
+            .withDatatype(DataType.DATE_TIME_TZ)
+            .build();
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withPrimaryKey(new String[0])
+            .withFields(new Field[] {field})
+            .build();
+    SemanticModelDefinition.Builder definitionBuilder =
+        SemanticModelDefinition.builder()
+            .withAIContext(AIContext.of(context))
+            .withDatasets(new Dataset[] {dataset});
+    if (explicitEmpty) {
+      definitionBuilder
+          .withRelationships(new Relationship[0])
+          .withMetrics(new Metric[0])
+          .withCustomExtensions(new CustomExtension[0]);
+    }
+
+    return SemanticModelEntity.builder()
+        .withId(id)
+        .withName(name)
+        .withNamespace(namespace)
+        .withComment(explicitEmpty ? null : "Governed sales definitions")
+        .withDefinition(definitionBuilder.build())
+        .withProperties(properties)
+        .withAuditInfo(AUDIT_INFO)
+        .build();
+  }
+
+  private int countRows(String tableName, Long semanticModelId) {
+    String sql =
+        String.format(
+            "SELECT count(*) FROM %s WHERE semantic_model_id = %d", tableName, semanticModelId);
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      assertTrue(resultSet.next());
+      return resultSet.getInt(1);
+    } catch (SQLException e) {
+      throw new RuntimeException("Failed to count Semantic Model rows", e);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
+++ b/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
@@ -85,6 +85,12 @@ public class TestMetadataObjectUtil {
         Entity.EntityType.FUNCTION,
         MetadataObjectUtil.toEntityType(
             MetadataObjects.of("catalog.schema", "function", MetadataObject.Type.FUNCTION)));
+
+    Assertions.assertEquals(
+        Entity.EntityType.SEMANTIC_MODEL,
+        MetadataObjectUtil.toEntityType(
+            MetadataObjects.of(
+                "catalog.schema", "sales_model", MetadataObject.Type.SEMANTIC_MODEL)));
   }
 
   @Test
@@ -158,6 +164,13 @@ public class TestMetadataObjectUtil {
         MetadataObjectUtil.toEntityIdent(
             "metalake",
             MetadataObjects.of("catalog.schema", "function", MetadataObject.Type.FUNCTION)));
+
+    Assertions.assertEquals(
+        NameIdentifier.of("metalake", "catalog", "schema", "sales_model"),
+        MetadataObjectUtil.toEntityIdent(
+            "metalake",
+            MetadataObjects.of(
+                "catalog.schema", "sales_model", MetadataObject.Type.SEMANTIC_MODEL)));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/utils/TestNameIdentifierUtil.java
+++ b/core/src/test/java/org/apache/gravitino/utils/TestNameIdentifierUtil.java
@@ -142,6 +142,16 @@ public class TestNameIdentifierUtil {
         MetadataObjects.parse("catalog1.schema1.view1", MetadataObject.Type.VIEW);
     assertEquals(viewObject, NameIdentifierUtil.toMetadataObject(view, Entity.EntityType.VIEW));
 
+    // test semantic model
+    NameIdentifier semanticModel =
+        NameIdentifier.of("metalake1", "catalog1", "schema1", "semantic_model1");
+    MetadataObject semanticModelObject =
+        MetadataObjects.parse(
+            "catalog1.schema1.semantic_model1", MetadataObject.Type.SEMANTIC_MODEL);
+    assertEquals(
+        semanticModelObject,
+        NameIdentifierUtil.toMetadataObject(semanticModel, Entity.EntityType.SEMANTIC_MODEL));
+
     // test null
     Throwable e1 =
         assertThrows(
@@ -363,5 +373,18 @@ public class TestNameIdentifierUtil {
         NameIdentifierUtil.buildNameIdentifier(Entity.EntityType.VIEW, viewName, viewEntities);
     assertEquals(NameIdentifier.of(metalake, catalog, schema, viewName), viewIdent);
     assertEquals(viewName, viewIdent.name());
+
+    // Test 14: Build a SEMANTIC_MODEL identifier
+    String semanticModelName = "my_semantic_model";
+    Map<Entity.EntityType, String> semanticModelEntities = Maps.newHashMap();
+    semanticModelEntities.put(Entity.EntityType.METALAKE, metalake);
+    semanticModelEntities.put(Entity.EntityType.CATALOG, catalog);
+    semanticModelEntities.put(Entity.EntityType.SCHEMA, schema);
+    NameIdentifier semanticModelIdent =
+        NameIdentifierUtil.buildNameIdentifier(
+            Entity.EntityType.SEMANTIC_MODEL, semanticModelName, semanticModelEntities);
+    assertEquals(
+        NameIdentifier.of(metalake, catalog, schema, semanticModelName), semanticModelIdent);
+    assertEquals(semanticModelName, semanticModelIdent.name());
   }
 }

--- a/core/src/test/java/org/apache/gravitino/utils/TestNamespaceUtil.java
+++ b/core/src/test/java/org/apache/gravitino/utils/TestNamespaceUtil.java
@@ -91,6 +91,17 @@ public class TestNamespaceUtil {
             IllegalNamespaceException.class, () -> NamespaceUtil.checkView(abcd));
     Assertions.assertTrue(
         excep6.getMessage().contains("View namespace must be non-null and have 3 levels"));
+
+    // Test semantic model
+    Assertions.assertThrows(
+        IllegalNamespaceException.class, () -> NamespaceUtil.checkSemanticModel(null));
+    Throwable excep7 =
+        Assertions.assertThrows(
+            IllegalNamespaceException.class, () -> NamespaceUtil.checkSemanticModel(abcd));
+    Assertions.assertTrue(
+        excep7
+            .getMessage()
+            .contains("Semantic model namespace must be non-null and have 3 levels"));
   }
 
   @Test

--- a/design-docs/gravitino-semantic-model-design.md
+++ b/design-docs/gravitino-semantic-model-design.md
@@ -269,10 +269,10 @@ DataType = "String" | "Integer" | "Decimal" | "Float" | "Boolean"
 Create and alter validate the complete candidate object before persistence. Validation is atomic:
 if any check fails, no change is persisted.
 
-1. **Contract validation.** Check required fields, collection cardinality, enum values, string
-   constraints, and the pinned Ossie structure.
-2. **Model-local validation.** Check name uniqueness, relationship endpoints, referenced fields,
-   key shapes, and dialect uniqueness without consulting a catalog.
+1. **Contract validation.** Check required fields, collection cardinality, typed alternatives, string
+   constraints, and the Java contract derived from the pinned Ossie structure.
+2. **Model-local validation.** Check name uniqueness, relationship endpoints, key shapes, and dialect
+   uniqueness without consulting a catalog.
 3. **Catalog validation.** Resolve every Dataset source and validate explicitly named source
    columns. Validation uses the caller's authorization context so it does not disclose metadata the
    caller cannot access.
@@ -293,33 +293,23 @@ engine and remain outside the metadata write path.
 
 #### Ossie Compatibility
 
-The public API is a Gravitino contract derived from Ossie, not a stored YAML or JSON document. For
-compatibility validation, the server projects a candidate object into an in-memory Ossie document:
+The public API is a Gravitino contract derived from Ossie, not a stored YAML or JSON document. The
+runtime write path validates the Java object model directly; it does not project a candidate into an
+Ossie document or invoke JSON Schema validation. At implementation time, Apache Ossie commit
+`88e0011148283302c9a04cd0287e00e0b9d87354` did not publish a reusable Java SDK or general-purpose
+Java validator; its Java schema validation was converter-specific. Gravitino therefore implements
+the applicable structural and model-local rules directly in Java, followed by catalog-backed source
+checks. SQL expression validation is not carried into the metadata write path because execution
+semantics and engine compatibility are outside its scope.
 
-```yaml
-version: 0.2.0.dev0
-semantic_model:
-  - name: sales_model
-    description: Governed sales definitions
-    datasets:
-      - name: orders
-        source: sales.mart.orders
-```
-
-The projection maps the entity name to `SemanticModel.name`, `comment` to `description`, and encodes
-each source `NameIdentifier` using the reversible source grammar above. The request path supplies the
-metalake and is not serialized into Ossie.
-
-The request path does not invoke the upstream Python validator or create an intermediate YAML
-string. The implementation validates the in-memory projection against a Gravitino profile derived
-from the bundled copy of the pinned JSON Schema, then runs Gravitino-specific model-local and
-catalog checks. The profile preserves the pinned structural constraints while treating dialect
-identifiers as open non-empty strings. Upstream validation tools are used only in compatibility
-fixtures that contain Ossie-defined dialects.
+Core contract tests validate the Java value model directly, including both `AIContext` variants,
+name uniqueness, relationship references and column cardinality, and absent versus explicitly empty
+arrays. Gravitino's runtime contract deliberately accepts any non-empty custom dialect identifier and
+preserves it exactly, even when the dialect is outside the pinned upstream schema.
 
 The entity carries no per-model Ossie specification version. Each Gravitino release pins one exact
 upstream schema commit and defines the supported read and write contract. Updating that schema
-requires a Gravitino code change, compatibility fixtures, and storage read tests. If a future
+requires a Gravitino code change, native validator tests, and storage read tests. If a future
 incompatible Ossie contract must coexist with the current one, explicit per-entity versioning
 requires a separate design; it should not be inferred from `custom_extensions`.
 
@@ -353,6 +343,11 @@ Supported `SemanticModelChange` operations are:
 - `setProperty` and `removeProperty`: Update Gravitino-specific properties.
 - `replaceDefinition`: Atomically replaces AI context, datasets, relationships, metrics, and custom
   extensions.
+
+Create and `replaceDefinition` run complete Java definition and catalog-backed source validation
+before persistence. A properties-only alter does not revalidate the definition or visit sources.
+Rename and comment changes also do not visit sources; rename continues through the existing
+identifier normalization contract. List, load, and drop do not run write validation.
 
 Each alter request applies all changes atomically to the current Semantic Model. Rename retains the
 stable entity ID. Owner, tag, and policy changes use their existing governance stores and remain

--- a/server/src/main/java/org/apache/gravitino/server/GravitinoServer.java
+++ b/server/src/main/java/org/apache/gravitino/server/GravitinoServer.java
@@ -33,6 +33,7 @@ import org.apache.gravitino.catalog.FunctionDispatcher;
 import org.apache.gravitino.catalog.ModelDispatcher;
 import org.apache.gravitino.catalog.PartitionDispatcher;
 import org.apache.gravitino.catalog.SchemaDispatcher;
+import org.apache.gravitino.catalog.SemanticModelDispatcher;
 import org.apache.gravitino.catalog.TableDispatcher;
 import org.apache.gravitino.catalog.TopicDispatcher;
 import org.apache.gravitino.catalog.ViewDispatcher;
@@ -162,6 +163,9 @@ public class GravitinoServer extends ResourceConfig {
                 .ranked(1);
             bind(gravitinoEnv.modelDispatcher()).to(ModelDispatcher.class).ranked(1);
             bind(gravitinoEnv.functionDispatcher()).to(FunctionDispatcher.class).ranked(1);
+            bind(gravitinoEnv.semanticModelDispatcher())
+                .to(SemanticModelDispatcher.class)
+                .ranked(1);
             bind(lineageService).to(LineageDispatcher.class).ranked(1);
             bind(gravitinoEnv.jobOperationDispatcher()).to(JobOperationDispatcher.class).ranked(1);
             bind(gravitinoEnv.statisticDispatcher()).to(StatisticDispatcher.class).ranked(1);

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -49,6 +49,7 @@ import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
 import org.apache.gravitino.exceptions.PolicyAlreadyExistsException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
+import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
 import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.exceptions.TagAlreadyAssociatedException;
 import org.apache.gravitino.exceptions.TagAlreadyExistsException;
@@ -158,6 +159,20 @@ public class ExceptionHandlers {
   public static Response handleFunctionException(
       OperationType op, String function, String schema, Exception e) {
     return FunctionExceptionHandler.INSTANCE.handle(op, function, schema, e);
+  }
+
+  /**
+   * Handles an exception raised by a Semantic Model REST operation.
+   *
+   * @param op The operation type.
+   * @param semanticModel The Semantic Model name, or an empty string for a list operation.
+   * @param schema The parent schema name.
+   * @param e The exception to handle.
+   * @return The mapped REST response.
+   */
+  public static Response handleSemanticModelException(
+      OperationType op, String semanticModel, String schema, Exception e) {
+    return SemanticModelExceptionHandler.INSTANCE.handle(op, semanticModel, schema, e);
   }
 
   public static Response handleJobTemplateException(
@@ -982,6 +997,46 @@ public class ExceptionHandlers {
 
       } else {
         return super.handle(op, function, schema, e);
+      }
+    }
+  }
+
+  private static class SemanticModelExceptionHandler extends BaseExceptionHandler {
+    private static final ExceptionHandler INSTANCE = new SemanticModelExceptionHandler();
+
+    private static String getSemanticModelErrorMsg(
+        String semanticModel, String operation, String schema, String reason) {
+      return String.format(
+          "Failed to operate Semantic Model(s)%s operation [%s] under schema [%s], reason [%s]",
+          semanticModel, operation, schema, reason);
+    }
+
+    @Override
+    public Response handle(OperationType op, String semanticModel, String schema, Exception e) {
+      String formatted = StringUtil.isBlank(semanticModel) ? "" : " [" + semanticModel + "]";
+      String errorMsg = getSemanticModelErrorMsg(formatted, op.name(), schema, getErrorMsg(e));
+      LOG.warn(errorMsg, e);
+
+      if (e instanceof IllegalArgumentException) {
+        return Utils.illegalArguments(errorMsg, e);
+
+      } else if (e instanceof NotFoundException) {
+        return Utils.notFound(errorMsg, e);
+
+      } else if (e instanceof SemanticModelAlreadyExistsException) {
+        return Utils.alreadyExists(errorMsg, e);
+
+      } else if (e instanceof ForbiddenException) {
+        return Utils.forbidden(errorMsg, e);
+
+      } else if (e instanceof UnsupportedOperationException) {
+        return Utils.unsupportedOperation(errorMsg, e);
+
+      } else if (e instanceof ConnectionFailedException) {
+        return Utils.connectionFailed(errorMsg, e);
+
+      } else {
+        return super.handle(op, semanticModel, schema, e);
       }
     }
   }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/SemanticModelOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/SemanticModelOperations.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.web.rest;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.catalog.SemanticModelDispatcher;
+import org.apache.gravitino.dto.requests.SemanticModelCreateRequest;
+import org.apache.gravitino.dto.responses.SemanticModelResponse;
+import org.apache.gravitino.dto.util.DTOConverters;
+import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.server.web.Utils;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** REST create and load operations for schema-scoped Semantic Models. */
+@Path("metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/semantic-models")
+public class SemanticModelOperations {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SemanticModelOperations.class);
+
+  private final SemanticModelDispatcher dispatcher;
+
+  @Context private HttpServletRequest httpRequest;
+
+  /**
+   * Creates Semantic Model REST operations.
+   *
+   * @param dispatcher The Semantic Model dispatcher.
+   */
+  @Inject
+  public SemanticModelOperations(SemanticModelDispatcher dispatcher) {
+    this.dispatcher = dispatcher;
+  }
+
+  /**
+   * Creates a Semantic Model.
+   *
+   * @param metalake The metalake name.
+   * @param catalog The catalog name.
+   * @param schema The schema name.
+   * @param request The structured Semantic Model create request.
+   * @return A response containing the created Semantic Model.
+   */
+  @POST
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "create-semantic-model." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "create-semantic-model", absolute = true)
+  public Response createSemanticModel(
+      @PathParam("metalake") String metalake,
+      @PathParam("catalog") String catalog,
+      @PathParam("schema") String schema,
+      SemanticModelCreateRequest request) {
+    String name = request == null ? "" : request.getName();
+    LOG.info(
+        "Received create Semantic Model request: {}.{}.{}.{}", metalake, catalog, schema, name);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            if (request == null) {
+              throw new IllegalArgumentException("Request body must not be null");
+            }
+            request.validate();
+            NameIdentifier ident =
+                NameIdentifierUtil.ofSemanticModel(metalake, catalog, schema, request.getName());
+            SemanticModel semanticModel =
+                dispatcher.createSemanticModel(
+                    ident, request.getComment(), request.toDefinition(), request.getProperties());
+            LOG.info(
+                "Semantic Model created: {}.{}.{}.{}",
+                metalake,
+                catalog,
+                schema,
+                semanticModel.name());
+            return Utils.ok(new SemanticModelResponse(DTOConverters.toDTO(semanticModel)));
+          });
+    } catch (Exception e) {
+      return ExceptionHandlers.handleSemanticModelException(OperationType.CREATE, name, schema, e);
+    }
+  }
+
+  /**
+   * Loads a Semantic Model.
+   *
+   * @param metalake The metalake name.
+   * @param catalog The catalog name.
+   * @param schema The schema name.
+   * @param semanticModel The Semantic Model name.
+   * @return A response containing the loaded Semantic Model.
+   */
+  @GET
+  @Path("{semanticModel}")
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "load-semantic-model." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "load-semantic-model", absolute = true)
+  public Response loadSemanticModel(
+      @PathParam("metalake") String metalake,
+      @PathParam("catalog") String catalog,
+      @PathParam("schema") String schema,
+      @PathParam("semanticModel") String semanticModel) {
+    LOG.info(
+        "Received load Semantic Model request: {}.{}.{}.{}",
+        metalake,
+        catalog,
+        schema,
+        semanticModel);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            NameIdentifier ident =
+                NameIdentifierUtil.ofSemanticModel(metalake, catalog, schema, semanticModel);
+            SemanticModel loaded = dispatcher.loadSemanticModel(ident);
+            LOG.info(
+                "Semantic Model loaded: {}.{}.{}.{}", metalake, catalog, schema, semanticModel);
+            return Utils.ok(new SemanticModelResponse(DTOConverters.toDTO(loaded)));
+          });
+    } catch (Exception e) {
+      return ExceptionHandlers.handleSemanticModelException(
+          OperationType.LOAD, semanticModel, schema, e);
+    }
+  }
+}

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestSemanticModelOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestSemanticModelOperations.java
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.web.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.SemanticModelDispatcher;
+import org.apache.gravitino.dto.requests.SemanticModelCreateRequest;
+import org.apache.gravitino.dto.responses.ErrorConstants;
+import org.apache.gravitino.dto.responses.ErrorResponse;
+import org.apache.gravitino.dto.responses.SemanticModelResponse;
+import org.apache.gravitino.dto.semantic.DatasetDTO;
+import org.apache.gravitino.dto.semantic.SemanticModelDefinitionDTO;
+import org.apache.gravitino.exceptions.ConnectionFailedException;
+import org.apache.gravitino.exceptions.ForbiddenException;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.rest.RESTUtils;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.DataType;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dialects;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+import org.apache.gravitino.utils.NamespaceUtil;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/** Tests the Semantic Model create/load REST resource and its error mappings. */
+public class TestSemanticModelOperations extends BaseOperationsTest {
+
+  private static final String VND_V1_JSON = "application/vnd.gravitino.v1+json";
+
+  private static class MockServletRequestFactory extends ServletRequestFactoryBase {
+    @Override
+    public HttpServletRequest get() {
+      return mock(HttpServletRequest.class);
+    }
+  }
+
+  private final SemanticModelDispatcher dispatcher = mock(SemanticModelDispatcher.class);
+  private final String metalake = "semantic_model_metalake";
+  private final String catalog = "semantic_model_catalog";
+  private final String schema = "semantic_model_schema";
+  private final Namespace namespace = NamespaceUtil.ofSemanticModel(metalake, catalog, schema);
+
+  /** {@inheritDoc} */
+  @Override
+  protected Application configure() {
+    try {
+      forceSet(
+          TestProperties.CONTAINER_PORT, String.valueOf(RESTUtils.findAvailablePort(2000, 3000)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    ResourceConfig resourceConfig = new ResourceConfig();
+    resourceConfig.register(SemanticModelOperations.class);
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            bind(dispatcher).to(SemanticModelDispatcher.class).ranked(2);
+            bindFactory(MockServletRequestFactory.class).to(HttpServletRequest.class);
+          }
+        });
+    return resourceConfig;
+  }
+
+  @BeforeEach
+  void resetDispatcher() {
+    reset(dispatcher);
+  }
+
+  @Test
+  void testLoadSemanticModelReturnsCompleteDefinitionWithoutWrites() {
+    NameIdentifier ident = semanticModelIdentifier("sales");
+    SemanticModel semanticModel = semanticModel("sales", "Sales definitions");
+    when(dispatcher.loadSemanticModel(ident)).thenReturn(semanticModel);
+
+    Response response = get(semanticModelPath() + "/sales");
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    SemanticModelResponse body = response.readEntity(SemanticModelResponse.class);
+    body.validate();
+    Assertions.assertEquals("sales", body.getSemanticModel().name());
+    Assertions.assertEquals("Sales definitions", body.getSemanticModel().comment());
+    Assertions.assertEquals(semanticModel.definition(), body.getSemanticModel().definition());
+    Assertions.assertEquals("orders", body.getSemanticModel().definition().datasets()[0].name());
+    Assertions.assertEquals(
+        "order_total", body.getSemanticModel().definition().metrics()[0].name());
+    Assertions.assertEquals(
+        "acme", body.getSemanticModel().definition().customExtensions()[0].vendorName());
+    Assertions.assertEquals(Map.of("domain", "sales"), body.getSemanticModel().properties());
+    Assertions.assertEquals("tester", body.getSemanticModel().auditInfo().creator());
+    verify(dispatcher).loadSemanticModel(ident);
+    verifyNoMoreInteractions(dispatcher);
+  }
+
+  @Test
+  void testLoadSemanticModelNotFound() {
+    NameIdentifier ident = semanticModelIdentifier("sales");
+    doThrow(new NoSuchSemanticModelException("sales does not exist"))
+        .when(dispatcher)
+        .loadSemanticModel(ident);
+
+    assertError(
+        get(semanticModelPath() + "/sales"),
+        Response.Status.NOT_FOUND,
+        ErrorConstants.NOT_FOUND_CODE,
+        NoSuchSemanticModelException.class.getSimpleName(),
+        "sales does not exist");
+  }
+
+  @Test
+  void testCreateSemanticModelConvertsStructuredDefinition() {
+    NameIdentifier ident = semanticModelIdentifier("sales");
+    SemanticModelDefinition definition = semanticModelDefinition("TRINO");
+    SemanticModelCreateRequest request = createRequest("sales", "Sales definitions", definition);
+    SemanticModel semanticModel = semanticModel("sales", "Sales definitions");
+    when(dispatcher.createSemanticModel(
+            eq(ident),
+            eq("Sales definitions"),
+            any(SemanticModelDefinition.class),
+            eq(Map.of("domain", "sales"))))
+        .thenReturn(semanticModel);
+
+    Response response = post(semanticModelPath(), request);
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    SemanticModelResponse body = response.readEntity(SemanticModelResponse.class);
+    body.validate();
+    Assertions.assertEquals("sales", body.getSemanticModel().name());
+    Assertions.assertEquals(semanticModel.definition(), body.getSemanticModel().definition());
+
+    ArgumentCaptor<SemanticModelDefinition> definitionCaptor =
+        ArgumentCaptor.forClass(SemanticModelDefinition.class);
+    verify(dispatcher)
+        .createSemanticModel(
+            eq(ident),
+            eq("Sales definitions"),
+            definitionCaptor.capture(),
+            eq(Map.of("domain", "sales")));
+    Assertions.assertEquals(definition, definitionCaptor.getValue());
+    Assertions.assertEquals(
+        "TRINO", definitionCaptor.getValue().metrics()[0].expression().dialects()[0].dialect());
+    Assertions.assertEquals(DataType.DECIMAL, definitionCaptor.getValue().metrics()[0].datatype());
+    Assertions.assertEquals(
+        NameIdentifier.of(catalog, schema, "orders"),
+        definitionCaptor.getValue().datasets()[0].source());
+  }
+
+  @Test
+  void testCreateSemanticModelErrors() {
+    SemanticModelDefinition definition = semanticModelDefinition();
+    SemanticModelCreateRequest request = createRequest("sales", "Sales definitions", definition);
+    NameIdentifier ident = semanticModelIdentifier("sales");
+
+    SemanticModelCreateRequest invalidRequest =
+        new SemanticModelCreateRequest("sales", null, null, Map.of());
+    assertError(
+        post(semanticModelPath(), invalidRequest),
+        Response.Status.BAD_REQUEST,
+        ErrorConstants.ILLEGAL_ARGUMENTS_CODE,
+        IllegalArgumentException.class.getSimpleName(),
+        "definition");
+
+    SemanticModelCreateRequest nullDatasetRequest =
+        new SemanticModelCreateRequest(
+            "sales",
+            null,
+            SemanticModelDefinitionDTO.builder().withDatasets(new DatasetDTO[] {null}).build(),
+            Map.of());
+    assertError(
+        post(semanticModelPath(), nullDatasetRequest),
+        Response.Status.BAD_REQUEST,
+        ErrorConstants.ILLEGAL_ARGUMENTS_CODE,
+        IllegalArgumentException.class.getSimpleName(),
+        "datasets[0] must not be null");
+
+    SemanticModelCreateRequest emptyDatasetsRequest =
+        new SemanticModelCreateRequest(
+            "sales",
+            null,
+            SemanticModelDefinitionDTO.builder().withDatasets(new DatasetDTO[0]).build(),
+            Map.of());
+    assertError(
+        post(semanticModelPath(), emptyDatasetsRequest),
+        Response.Status.BAD_REQUEST,
+        ErrorConstants.ILLEGAL_ARGUMENTS_CODE,
+        IllegalArgumentException.class.getSimpleName(),
+        "datasets must not be null or empty");
+
+    doThrow(new NoSuchSchemaException("schema is missing"))
+        .when(dispatcher)
+        .createSemanticModel(
+            eq(ident),
+            eq("Sales definitions"),
+            any(SemanticModelDefinition.class),
+            eq(Map.of("domain", "sales")));
+    assertError(
+        post(semanticModelPath(), request),
+        Response.Status.NOT_FOUND,
+        ErrorConstants.NOT_FOUND_CODE,
+        NoSuchSchemaException.class.getSimpleName(),
+        "schema is missing");
+
+    doThrow(new IllegalSemanticModelException("source column is missing"))
+        .when(dispatcher)
+        .createSemanticModel(
+            eq(ident),
+            eq("Sales definitions"),
+            any(SemanticModelDefinition.class),
+            eq(Map.of("domain", "sales")));
+    assertError(
+        post(semanticModelPath(), request),
+        Response.Status.BAD_REQUEST,
+        ErrorConstants.ILLEGAL_ARGUMENTS_CODE,
+        IllegalSemanticModelException.class.getSimpleName(),
+        "source column is missing");
+
+    doThrow(new SemanticModelAlreadyExistsException("sales already exists"))
+        .when(dispatcher)
+        .createSemanticModel(
+            eq(ident),
+            eq("Sales definitions"),
+            any(SemanticModelDefinition.class),
+            eq(Map.of("domain", "sales")));
+    assertError(
+        post(semanticModelPath(), request),
+        Response.Status.CONFLICT,
+        ErrorConstants.ALREADY_EXISTS_CODE,
+        SemanticModelAlreadyExistsException.class.getSimpleName(),
+        "sales already exists");
+
+    doThrow(new ForbiddenException("source metadata is not visible"))
+        .when(dispatcher)
+        .createSemanticModel(
+            eq(ident),
+            eq("Sales definitions"),
+            any(SemanticModelDefinition.class),
+            eq(Map.of("domain", "sales")));
+    assertError(
+        post(semanticModelPath(), request),
+        Response.Status.FORBIDDEN,
+        ErrorConstants.FORBIDDEN_CODE,
+        ForbiddenException.class.getSimpleName(),
+        "source metadata is not visible");
+
+    doThrow(new ConnectionFailedException("source catalog is unavailable"))
+        .when(dispatcher)
+        .createSemanticModel(
+            eq(ident),
+            eq("Sales definitions"),
+            any(SemanticModelDefinition.class),
+            eq(Map.of("domain", "sales")));
+    ErrorResponse unavailable =
+        assertError(
+            post(semanticModelPath(), request),
+            Response.Status.BAD_GATEWAY,
+            ErrorConstants.CONNECTION_FAILED_CODE,
+            ConnectionFailedException.class.getSimpleName(),
+            "source catalog is unavailable");
+    Assertions.assertNotNull(unavailable.getStack());
+    Assertions.assertFalse(unavailable.getStack().isEmpty());
+  }
+
+  @Test
+  void testCreateSemanticModelRejectsNullBody() {
+    assertError(
+        postJson(semanticModelPath(), "null"),
+        Response.Status.BAD_REQUEST,
+        ErrorConstants.ILLEGAL_ARGUMENTS_CODE,
+        IllegalArgumentException.class.getSimpleName(),
+        "Request body must not be null");
+    verifyNoMoreInteractions(dispatcher);
+  }
+
+  @Test
+  void testCreateSemanticModelMapsUnsupportedCatalog() {
+    SemanticModelCreateRequest request =
+        createRequest("sales", "Sales definitions", semanticModelDefinition());
+    doThrow(new UnsupportedOperationException("catalog is not relational"))
+        .when(dispatcher)
+        .createSemanticModel(
+            eq(semanticModelIdentifier("sales")),
+            eq("Sales definitions"),
+            any(SemanticModelDefinition.class),
+            eq(Map.of("domain", "sales")));
+
+    assertError(
+        post(semanticModelPath(), request),
+        Response.Status.METHOD_NOT_ALLOWED,
+        ErrorConstants.UNSUPPORTED_OPERATION_CODE,
+        UnsupportedOperationException.class.getSimpleName(),
+        "catalog is not relational");
+  }
+
+  private SemanticModelCreateRequest createRequest(
+      String name, String comment, SemanticModelDefinition definition) {
+    return new SemanticModelCreateRequest(
+        name,
+        comment,
+        SemanticModelDefinitionDTO.fromDefinition(definition),
+        Map.of("domain", "sales"));
+  }
+
+  private SemanticModel semanticModel(String name, String comment) {
+    return SemanticModelEntity.builder()
+        .withId(1L)
+        .withName(name)
+        .withNamespace(namespace)
+        .withComment(comment)
+        .withDefinition(semanticModelDefinition())
+        .withProperties(Map.of("domain", "sales"))
+        .withAuditInfo(
+            AuditInfo.builder()
+                .withCreator("tester")
+                .withCreateTime(Instant.parse("2026-08-25T00:00:00Z"))
+                .build())
+        .build();
+  }
+
+  private SemanticModelDefinition semanticModelDefinition() {
+    return semanticModelDefinition(Dialects.ANSI_SQL);
+  }
+
+  private SemanticModelDefinition semanticModelDefinition(String dialect) {
+    Field field =
+        Field.builder()
+            .withName("order_id")
+            .withExpression(expression(dialect, "orders.order_id"))
+            .withDatatype(DataType.STRING)
+            .build();
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of(catalog, schema, "orders"))
+            .withPrimaryKey(new String[] {"order_id"})
+            .withFields(new Field[] {field})
+            .build();
+    Metric metric =
+        Metric.builder()
+            .withName("order_total")
+            .withExpression(expression(dialect, "SUM(orders.amount)"))
+            .withDatatype(DataType.DECIMAL)
+            .build();
+    CustomExtension customExtension =
+        CustomExtension.builder().withVendorName("acme").withData("{\"certified\":true}").build();
+    return SemanticModelDefinition.builder()
+        .withAIContext(AIContext.of("Use certified metrics"))
+        .withDatasets(new Dataset[] {dataset})
+        .withMetrics(new Metric[] {metric})
+        .withCustomExtensions(new CustomExtension[] {customExtension})
+        .build();
+  }
+
+  private static Expression expression(String dialect, String value) {
+    DialectExpression dialectExpression =
+        DialectExpression.builder().withDialect(dialect).withExpression(value).build();
+    return Expression.builder().withDialects(new DialectExpression[] {dialectExpression}).build();
+  }
+
+  private NameIdentifier semanticModelIdentifier(String name) {
+    return NameIdentifierUtil.ofSemanticModel(metalake, catalog, schema, name);
+  }
+
+  private String semanticModelPath() {
+    return "/metalakes/"
+        + metalake
+        + "/catalogs/"
+        + catalog
+        + "/schemas/"
+        + schema
+        + "/semantic-models";
+  }
+
+  private Response get(String path) {
+    return target(path).request(MediaType.APPLICATION_JSON_TYPE).accept(VND_V1_JSON).get();
+  }
+
+  private Response post(String path, SemanticModelCreateRequest request) {
+    return target(path)
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .accept(VND_V1_JSON)
+        .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private Response postJson(String path, String json) {
+    return target(path)
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .accept(VND_V1_JSON)
+        .post(Entity.entity(json, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private static ErrorResponse assertError(
+      Response response,
+      Response.Status expectedStatus,
+      int expectedCode,
+      String expectedType,
+      String expectedMessageFragment) {
+    Assertions.assertEquals(expectedStatus.getStatusCode(), response.getStatus());
+    ErrorResponse error = response.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(expectedCode, error.getCode());
+    Assertions.assertEquals(expectedType, error.getType());
+    Assertions.assertTrue(error.getMessage().contains(expectedMessageFragment));
+    return error;
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds Semantic Model REST APIs for create and load, including request and response DTOs, DTO conversion, server routing, exception mapping, and focused tests.

This draft is stacked on the unmerged Semantic Model Core create/load work for #12604 and Definition DTO PR #12624. The feature commit itself contains only create/load changes under common and server.

### Why are the changes needed?

These APIs expose Semantic Model creation and retrieval through the Gravitino REST server while preserving structured definitions, null-versus-empty values, request validation, and Semantic Model-specific errors.

Fix: #12607

### Does this PR introduce _any_ user-facing change?

Yes. It adds POST create and GET load REST operations for schema-scoped Semantic Models. List, alter, drop, OpenAPI, and client changes are outside this feature commit.

### How was this patch tested?

The following local checks passed:

- Semantic Model create/load DTO and REST focused tests
- ./gradlew :common:check :server:check -PskipITs
- ./gradlew :common:spotlessApply :server:spotlessApply
- git diff --check