### PR TITLE
[#12642] fix(authz): add missing supportsScheme to JdbcCredentialProvider

### DIFF
--- a/core/src/main/java/org/apache/gravitino/credential/JdbcCredentialProvider.java
+++ b/core/src/main/java/org/apache/gravitino/credential/JdbcCredentialProvider.java
@@ -50,6 +50,11 @@ public class JdbcCredentialProvider implements CredentialProvider {
     return JdbcCredential.JDBC_CREDENTIAL_TYPE;
   }
 
+  @Override
+  public boolean supportsScheme(String scheme) {
+    return "jdbc".equalsIgnoreCase(scheme);
+  }
+
   @Nullable
   @Override
   public Credential getCredential(CredentialContext context) {

--- a/core/src/test/java/org/apache/gravitino/credential/TestCatalogCredentialManager.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestCatalogCredentialManager.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.credential;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestCatalogCredentialManager {
+
+  @Test
+  void testSelectsStorageCredentialWhenJdbcProviderIsAlsoConfigured() {
+    String s3Path = "s3://bucket/warehouse/table";
+    Map<String, String> catalogProperties =
+        ImmutableMap.of(
+            CredentialConstants.CREDENTIAL_PROVIDERS,
+            String.join(
+                ",", DummyCredentialProvider.CREDENTIAL_TYPE, JdbcCredential.JDBC_CREDENTIAL_TYPE),
+            JdbcCredential.GRAVITINO_JDBC_USER,
+            "test-user",
+            JdbcCredential.GRAVITINO_JDBC_PASSWORD,
+            "test-password");
+
+    try (CatalogCredentialManager credentialManager =
+        new CatalogCredentialManager("test-catalog", catalogProperties)) {
+      PathBasedCredentialContext context =
+          new PathBasedCredentialContext("test-user", ImmutableSet.of(), ImmutableSet.of(s3Path));
+
+      Credential credential =
+          credentialManager
+              .getCredentialByPath(s3Path, context)
+              .orElseThrow(() -> new AssertionError("Expected a storage credential"));
+
+      Assertions.assertInstanceOf(DummyCredentialProvider.DummyCredential.class, credential);
+      Assertions.assertTrue(
+          credentialManager.getCredentialProvider(JdbcCredential.JDBC_CREDENTIAL_TYPE).isPresent());
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the missing `supportsScheme` override to `JdbcCredentialProvider`, so it
only claims support for the `jdbc` scheme instead of inheriting the default
`return true` from the `CredentialProvider` interface.

Add `TestCatalogCredentialManager` to cover path-based provider selection when
a catalog has multiple provider types, and add a `supportsScheme` unit test in
`TestJdbcCredentialProvider`.

### Why are the changes needed?

When an Iceberg catalog uses a JDBC backend and stores table data in object
storage (e.g. S3), both `jdbc-user-password` and `s3-secret-key` credential
providers are configured. The path-based credential lookup in
`CatalogCredentialManager#getCredentialByPath` selects a provider by URI scheme.

Because `JdbcCredentialProvider` did not override `supportsScheme`, it inherited
the default implementation that returns `true` for every scheme. As a result,
a request for an S3 table path matched two providers and threw:

```
UnsupportedOperationException: Multiple credential providers found for path
s3://bucket/warehouse/table with scheme s3:
[s3-secret-key, jdbc-user-password]
```

Restricting the JDBC provider to the `jdbc` scheme resolves the conflict, while
type-based JDBC credential fetching remains unaffected.

Fix: #12642

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew spotlessApply`
- `./gradlew :core:test \
  --tests org.apache.gravitino.credential.TestJdbcCredentialProvider \
  --tests org.apache.gravitino.credential.TestCatalogCredentialManager \
  -PskipITs`
