### PR TITLE
[#12645] feat(secret): Support setSecretBinding/setSecretReference on catalog/schema alter

### DIFF
--- a/api/src/main/java/org/apache/gravitino/CatalogChange.java
+++ b/api/src/main/java/org/apache/gravitino/CatalogChange.java
@@ -20,6 +20,8 @@ package org.apache.gravitino;
 
 import java.util.Objects;
 import org.apache.gravitino.annotation.Evolving;
+import org.apache.gravitino.secret.SecretBinding;
+import org.apache.gravitino.secret.SecretReference;
 
 /**
  * A catalog change is a change to a catalog. It can be used to rename a catalog, update the comment
@@ -67,6 +69,28 @@ public interface CatalogChange {
    */
   static CatalogChange removeProperty(String property) {
     return new RemoveProperty(property);
+  }
+
+  /**
+   * Creates a new catalog change to bind a write-through secret for a property.
+   *
+   * @param property The property name to bind.
+   * @param binding The write-through binding ({@code provider} + {@code plaintext}).
+   * @return The catalog change.
+   */
+  static CatalogChange setSecretBinding(String property, SecretBinding binding) {
+    return new SetSecretBinding(property, binding);
+  }
+
+  /**
+   * Creates a new catalog change to bind an external secret reference for a property.
+   *
+   * @param property The property name to bind.
+   * @param reference The external secret locator ({@code provider} + {@code attributes}).
+   * @return The catalog change.
+   */
+  static CatalogChange setSecretReference(String property, SecretReference reference) {
+    return new SetSecretReference(property, reference);
   }
 
   /** A catalog change to rename the catalog. */
@@ -298,6 +322,100 @@ public interface CatalogChange {
     @Override
     public String toString() {
       return "REMOVEPROPERTY " + property;
+    }
+  }
+
+  /** A catalog change to bind a write-through secret for a property. */
+  final class SetSecretBinding implements CatalogChange {
+    private final String property;
+    private final SecretBinding binding;
+
+    private SetSecretBinding(String property, SecretBinding binding) {
+      this.property = property;
+      this.binding = binding;
+    }
+
+    /**
+     * Retrieves the property name being bound.
+     *
+     * @return The property name.
+     */
+    public String getProperty() {
+      return property;
+    }
+
+    /**
+     * Retrieves the write-through binding.
+     *
+     * @return The secret binding.
+     */
+    public SecretBinding getBinding() {
+      return binding;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SetSecretBinding that = (SetSecretBinding) o;
+      return Objects.equals(property, that.property) && Objects.equals(binding, that.binding);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(property, binding);
+    }
+
+    @Override
+    public String toString() {
+      return "SETSECRETBINDING " + property + " " + binding;
+    }
+  }
+
+  /** A catalog change to bind an external secret reference for a property. */
+  final class SetSecretReference implements CatalogChange {
+    private final String property;
+    private final SecretReference reference;
+
+    private SetSecretReference(String property, SecretReference reference) {
+      this.property = property;
+      this.reference = reference;
+    }
+
+    /**
+     * Retrieves the property name being bound.
+     *
+     * @return The property name.
+     */
+    public String getProperty() {
+      return property;
+    }
+
+    /**
+     * Retrieves the external secret reference.
+     *
+     * @return The secret reference.
+     */
+    public SecretReference getReference() {
+      return reference;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SetSecretReference that = (SetSecretReference) o;
+      return Objects.equals(property, that.property) && Objects.equals(reference, that.reference);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(property, reference);
+    }
+
+    @Override
+    public String toString() {
+      return "SETSECRETREFERENCE " + property + " " + reference;
     }
   }
 }

--- a/api/src/main/java/org/apache/gravitino/SchemaChange.java
+++ b/api/src/main/java/org/apache/gravitino/SchemaChange.java
@@ -22,6 +22,8 @@ package org.apache.gravitino;
 
 import java.util.Objects;
 import org.apache.gravitino.annotation.Evolving;
+import org.apache.gravitino.secret.SecretBinding;
+import org.apache.gravitino.secret.SecretReference;
 
 /** NamespaceChange class to set the property and value pairs for the namespace. */
 @Evolving
@@ -46,6 +48,28 @@ public interface SchemaChange {
    */
   static SchemaChange removeProperty(String property) {
     return new RemoveProperty(property);
+  }
+
+  /**
+   * Creates a schema change to bind a write-through secret for a property.
+   *
+   * @param property The property name to bind.
+   * @param binding The write-through binding ({@code provider} + {@code plaintext}).
+   * @return The SchemaChange object.
+   */
+  static SchemaChange setSecretBinding(String property, SecretBinding binding) {
+    return new SetSecretBinding(property, binding);
+  }
+
+  /**
+   * Creates a schema change to bind an external secret reference for a property.
+   *
+   * @param property The property name to bind.
+   * @param reference The external secret locator ({@code provider} + {@code attributes}).
+   * @return The SchemaChange object.
+   */
+  static SchemaChange setSecretReference(String property, SecretReference reference) {
+    return new SetSecretReference(property, reference);
   }
 
   /** SchemaChange class to set the property and value pairs for the schema. */
@@ -166,6 +190,100 @@ public interface SchemaChange {
     @Override
     public String toString() {
       return "REMOVEPROPERTY " + property;
+    }
+  }
+
+  /** SchemaChange to bind a write-through secret for a property. */
+  final class SetSecretBinding implements SchemaChange {
+    private final String property;
+    private final SecretBinding binding;
+
+    private SetSecretBinding(String property, SecretBinding binding) {
+      this.property = property;
+      this.binding = binding;
+    }
+
+    /**
+     * Retrieves the property name being bound.
+     *
+     * @return The property name.
+     */
+    public String getProperty() {
+      return property;
+    }
+
+    /**
+     * Retrieves the write-through binding.
+     *
+     * @return The secret binding.
+     */
+    public SecretBinding getBinding() {
+      return binding;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SetSecretBinding that = (SetSecretBinding) o;
+      return Objects.equals(property, that.property) && Objects.equals(binding, that.binding);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(property, binding);
+    }
+
+    @Override
+    public String toString() {
+      return "SETSECRETBINDING " + property + " " + binding;
+    }
+  }
+
+  /** SchemaChange to bind an external secret reference for a property. */
+  final class SetSecretReference implements SchemaChange {
+    private final String property;
+    private final SecretReference reference;
+
+    private SetSecretReference(String property, SecretReference reference) {
+      this.property = property;
+      this.reference = reference;
+    }
+
+    /**
+     * Retrieves the property name being bound.
+     *
+     * @return The property name.
+     */
+    public String getProperty() {
+      return property;
+    }
+
+    /**
+     * Retrieves the external secret reference.
+     *
+     * @return The secret reference.
+     */
+    public SecretReference getReference() {
+      return reference;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SetSecretReference that = (SetSecretReference) o;
+      return Objects.equals(property, that.property) && Objects.equals(reference, that.reference);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(property, reference);
+    }
+
+    @Override
+    public String toString() {
+      return "SETSECRETREFERENCE " + property + " " + reference;
     }
   }
 }

--- a/api/src/main/java/org/apache/gravitino/file/FilesetChange.java
+++ b/api/src/main/java/org/apache/gravitino/file/FilesetChange.java
@@ -20,6 +20,8 @@ package org.apache.gravitino.file;
 
 import java.util.Objects;
 import org.apache.gravitino.annotation.Evolving;
+import org.apache.gravitino.secret.SecretBinding;
+import org.apache.gravitino.secret.SecretReference;
 
 /**
  * A fileset change is a change to a fileset. It can be used to rename a fileset, update the comment
@@ -67,6 +69,28 @@ public interface FilesetChange {
    */
   static FilesetChange removeProperty(String property) {
     return new RemoveProperty(property);
+  }
+
+  /**
+   * Creates a new fileset change to bind a write-through secret for a property.
+   *
+   * @param property The property name to bind.
+   * @param binding The write-through binding ({@code provider} + {@code plaintext}).
+   * @return The fileset change.
+   */
+  static FilesetChange setSecretBinding(String property, SecretBinding binding) {
+    return new SetSecretBinding(property, binding);
+  }
+
+  /**
+   * Creates a new fileset change to bind an external secret reference for a property.
+   *
+   * @param property The property name to bind.
+   * @param reference The external secret locator ({@code provider} + {@code attributes}).
+   * @return The fileset change.
+   */
+  static FilesetChange setSecretReference(String property, SecretReference reference) {
+    return new SetSecretReference(property, reference);
   }
 
   /**
@@ -309,6 +333,100 @@ public interface FilesetChange {
     @Override
     public String toString() {
       return "REMOVEPROPERTY " + property;
+    }
+  }
+
+  /** A fileset change to bind a write-through secret for a property. */
+  final class SetSecretBinding implements FilesetChange {
+    private final String property;
+    private final SecretBinding binding;
+
+    private SetSecretBinding(String property, SecretBinding binding) {
+      this.property = property;
+      this.binding = binding;
+    }
+
+    /**
+     * Retrieves the property name being bound.
+     *
+     * @return The property name.
+     */
+    public String getProperty() {
+      return property;
+    }
+
+    /**
+     * Retrieves the write-through binding.
+     *
+     * @return The secret binding.
+     */
+    public SecretBinding getBinding() {
+      return binding;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SetSecretBinding that = (SetSecretBinding) o;
+      return Objects.equals(property, that.property) && Objects.equals(binding, that.binding);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(property, binding);
+    }
+
+    @Override
+    public String toString() {
+      return "SETSECRETBINDING " + property + " " + binding;
+    }
+  }
+
+  /** A fileset change to bind an external secret reference for a property. */
+  final class SetSecretReference implements FilesetChange {
+    private final String property;
+    private final SecretReference reference;
+
+    private SetSecretReference(String property, SecretReference reference) {
+      this.property = property;
+      this.reference = reference;
+    }
+
+    /**
+     * Retrieves the property name being bound.
+     *
+     * @return The property name.
+     */
+    public String getProperty() {
+      return property;
+    }
+
+    /**
+     * Retrieves the external secret reference.
+     *
+     * @return The secret reference.
+     */
+    public SecretReference getReference() {
+      return reference;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SetSecretReference that = (SetSecretReference) o;
+      return Objects.equals(property, that.property) && Objects.equals(reference, that.reference);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(property, reference);
+    }
+
+    @Override
+    public String toString() {
+      return "SETSECRETREFERENCE " + property + " " + reference;
     }
   }
 

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/DTOConverters.java
@@ -187,6 +187,21 @@ class DTOConverters {
       return new CatalogUpdateRequest.RemoveCatalogPropertyRequest(
           ((CatalogChange.RemoveProperty) change).getProperty());
 
+    } else if (change instanceof CatalogChange.SetSecretBinding) {
+      CatalogChange.SetSecretBinding setSecretBinding = (CatalogChange.SetSecretBinding) change;
+      return new CatalogUpdateRequest.SetCatalogSecretBindingRequest(
+          setSecretBinding.getProperty(),
+          setSecretBinding.getBinding().provider(),
+          setSecretBinding.getBinding().plaintext());
+
+    } else if (change instanceof CatalogChange.SetSecretReference) {
+      CatalogChange.SetSecretReference setSecretReference =
+          (CatalogChange.SetSecretReference) change;
+      return new CatalogUpdateRequest.SetCatalogSecretReferenceRequest(
+          setSecretReference.getProperty(),
+          setSecretReference.getReference().provider(),
+          setSecretReference.getReference().attributes());
+
     } else {
       throw new IllegalArgumentException(
           "Unknown change type: " + change.getClass().getSimpleName());
@@ -202,6 +217,20 @@ class DTOConverters {
     } else if (change instanceof SchemaChange.RemoveProperty) {
       return new SchemaUpdateRequest.RemoveSchemaPropertyRequest(
           ((SchemaChange.RemoveProperty) change).getProperty());
+
+    } else if (change instanceof SchemaChange.SetSecretBinding) {
+      SchemaChange.SetSecretBinding setSecretBinding = (SchemaChange.SetSecretBinding) change;
+      return new SchemaUpdateRequest.SetSchemaSecretBindingRequest(
+          setSecretBinding.getProperty(),
+          setSecretBinding.getBinding().provider(),
+          setSecretBinding.getBinding().plaintext());
+
+    } else if (change instanceof SchemaChange.SetSecretReference) {
+      SchemaChange.SetSecretReference setSecretReference = (SchemaChange.SetSecretReference) change;
+      return new SchemaUpdateRequest.SetSchemaSecretReferenceRequest(
+          setSecretReference.getProperty(),
+          setSecretReference.getReference().provider(),
+          setSecretReference.getReference().attributes());
 
     } else {
       throw new IllegalArgumentException(

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/DTOConverters.java
@@ -263,6 +263,19 @@ class DTOConverters {
     } else if (change instanceof FilesetChange.RemoveProperty) {
       return new FilesetUpdateRequest.RemoveFilesetPropertiesRequest(
           ((FilesetChange.RemoveProperty) change).getProperty());
+    } else if (change instanceof FilesetChange.SetSecretBinding) {
+      FilesetChange.SetSecretBinding setSecretBinding = (FilesetChange.SetSecretBinding) change;
+      return new FilesetUpdateRequest.SetFilesetSecretBindingRequest(
+          setSecretBinding.getProperty(),
+          setSecretBinding.getBinding().provider(),
+          setSecretBinding.getBinding().plaintext());
+    } else if (change instanceof FilesetChange.SetSecretReference) {
+      FilesetChange.SetSecretReference setSecretReference =
+          (FilesetChange.SetSecretReference) change;
+      return new FilesetUpdateRequest.SetFilesetSecretReferenceRequest(
+          setSecretReference.getProperty(),
+          setSecretReference.getReference().provider(),
+          setSecretReference.getReference().attributes());
     } else {
       throw new IllegalArgumentException(
           "Unknown change type: " + change.getClass().getSimpleName());

--- a/clients/client-python/gravitino/api/catalog_change.py
+++ b/clients/client-python/gravitino/api/catalog_change.py
@@ -17,6 +17,8 @@
 
 from abc import ABC
 
+from gravitino.api.secret import SecretBinding, SecretReference
+
 
 class CatalogChange(ABC):
     """
@@ -72,6 +74,32 @@ class CatalogChange(ABC):
             The catalog change.
         """
         return CatalogChange.RemoveProperty(catalog_property)
+
+    @staticmethod
+    def set_secret_binding(catalog_property, binding: SecretBinding):
+        """Creates a catalog change to bind a write-through secret for a property.
+
+        Args:
+            catalog_property: The property name to bind.
+            binding: The write-through secret binding.
+
+        Returns:
+            The catalog change.
+        """
+        return CatalogChange.SetSecretBinding(catalog_property, binding)
+
+    @staticmethod
+    def set_secret_reference(catalog_property, reference: SecretReference):
+        """Creates a catalog change to bind an external secret reference for a property.
+
+        Args:
+            catalog_property: The property name to bind.
+            reference: The external secret reference.
+
+        Returns:
+            The catalog change.
+        """
+        return CatalogChange.SetSecretReference(catalog_property, reference)
 
     class RenameCatalog:
         """A catalog change to rename the catalog."""
@@ -265,3 +293,61 @@ class CatalogChange(ABC):
                  A string summary of the property removal operation.
             """
             return f"REMOVEPROPERTY {self._property}"
+
+    class SetSecretBinding:
+        """A catalog change to bind a write-through secret for a property."""
+
+        def __init__(self, catalog_property, binding: SecretBinding):
+            self._property = catalog_property
+            self._binding = binding
+
+        def property(self):
+            """Retrieves the property name being bound."""
+            return self._property
+
+        def binding(self):
+            """Retrieves the write-through secret binding."""
+            return self._binding
+
+        def __eq__(self, other) -> bool:
+            if not isinstance(other, CatalogChange.SetSecretBinding):
+                return False
+            return (
+                self._property == other.property()
+                and self._binding == other.binding()
+            )
+
+        def __hash__(self):
+            return hash((self._property, self._binding))
+
+        def __str__(self):
+            return f"SETSECRETBINDING {self._property} {self._binding}"
+
+    class SetSecretReference:
+        """A catalog change to bind an external secret reference for a property."""
+
+        def __init__(self, catalog_property, reference: SecretReference):
+            self._property = catalog_property
+            self._reference = reference
+
+        def property(self):
+            """Retrieves the property name being bound."""
+            return self._property
+
+        def reference(self):
+            """Retrieves the external secret reference."""
+            return self._reference
+
+        def __eq__(self, other) -> bool:
+            if not isinstance(other, CatalogChange.SetSecretReference):
+                return False
+            return (
+                self._property == other.property()
+                and self._reference == other.reference()
+            )
+
+        def __hash__(self):
+            return hash((self._property, self._reference))
+
+        def __str__(self):
+            return f"SETSECRETREFERENCE {self._property} {self._reference}"

--- a/clients/client-python/gravitino/api/file/fileset_change.py
+++ b/clients/client-python/gravitino/api/file/fileset_change.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 
 from dataclasses_json import config
 
+from gravitino.api.secret import SecretBinding, SecretReference
+
 
 class FilesetChange(ABC):
     """A fileset change is a change to a fileset. It can be used to rename a fileset, update the comment
@@ -86,6 +88,16 @@ class FilesetChange(ABC):
             Please use `update_comment(str)` with null value as the argument instead.
         """
         return FilesetChange.UpdateFilesetComment(None)
+
+    @staticmethod
+    def set_secret_binding(fileset_property, binding: SecretBinding):
+        """Creates a fileset change to bind a write-through secret for a property."""
+        return FilesetChange.SetSecretBinding(fileset_property, binding)
+
+    @staticmethod
+    def set_secret_reference(fileset_property, reference: SecretReference):
+        """Creates a fileset change to bind an external secret reference for a property."""
+        return FilesetChange.SetSecretReference(fileset_property, reference)
 
     @dataclass
     class RenameFileset:
@@ -317,3 +329,57 @@ class FilesetChange(ABC):
                  A string summary of the comment removal operation.
             """
             return "REMOVECOMMENT"
+
+    @dataclass
+    class SetSecretBinding:
+        """A fileset change to bind a write-through secret for a property."""
+
+        _property: str = field(metadata=config(field_name="property"))
+        _binding: SecretBinding = field(metadata=config(field_name="binding"))
+
+        def property(self):
+            return self._property
+
+        def binding(self):
+            return self._binding
+
+        def __eq__(self, other) -> bool:
+            if not isinstance(other, FilesetChange.SetSecretBinding):
+                return False
+            return (
+                self._property == other.property()
+                and self._binding == other.binding()
+            )
+
+        def __hash__(self):
+            return hash((self._property, self._binding))
+
+        def __str__(self):
+            return f"SETSECRETBINDING {self._property} {self._binding}"
+
+    @dataclass
+    class SetSecretReference:
+        """A fileset change to bind an external secret reference for a property."""
+
+        _property: str = field(metadata=config(field_name="property"))
+        _reference: SecretReference = field(metadata=config(field_name="reference"))
+
+        def property(self):
+            return self._property
+
+        def reference(self):
+            return self._reference
+
+        def __eq__(self, other) -> bool:
+            if not isinstance(other, FilesetChange.SetSecretReference):
+                return False
+            return (
+                self._property == other.property()
+                and self._reference == other.reference()
+            )
+
+        def __hash__(self):
+            return hash((self._property, self._reference))
+
+        def __str__(self):
+            return f"SETSECRETREFERENCE {self._property} {self._reference}"

--- a/clients/client-python/gravitino/api/schema_change.py
+++ b/clients/client-python/gravitino/api/schema_change.py
@@ -17,8 +17,11 @@
 
 from abc import ABC
 from dataclasses import dataclass, field
+from typing import Dict
 
 from dataclasses_json import config
+
+from gravitino.api.secret import SecretBinding, SecretReference
 
 
 class SchemaChange(ABC):
@@ -48,6 +51,16 @@ class SchemaChange(ABC):
             The SchemaChange object.
         """
         return SchemaChange.RemoveProperty(schema_property)
+
+    @staticmethod
+    def set_secret_binding(schema_property: str, binding: SecretBinding):
+        """Creates a schema change to bind a write-through secret for a property."""
+        return SchemaChange.SetSecretBinding(schema_property, binding)
+
+    @staticmethod
+    def set_secret_reference(schema_property: str, reference: SecretReference):
+        """Creates a schema change to bind an external secret reference for a property."""
+        return SchemaChange.SetSecretReference(schema_property, reference)
 
     @dataclass
     class SetProperty:
@@ -149,3 +162,57 @@ class SchemaChange(ABC):
                  A string summary of the property removal operation.
             """
             return f"REMOVEPROPERTY {self._property}"
+
+    @dataclass
+    class SetSecretBinding:
+        """SchemaChange class to bind a write-through secret for a property."""
+
+        _property: str = field(metadata=config(field_name="property"))
+        _binding: SecretBinding = field(metadata=config(field_name="binding"))
+
+        def property(self):
+            return self._property
+
+        def binding(self):
+            return self._binding
+
+        def __eq__(self, other):
+            if not isinstance(other, SchemaChange.SetSecretBinding):
+                return False
+            return (
+                self._property == other.property()
+                and self._binding == other.binding()
+            )
+
+        def __hash__(self):
+            return hash((self._property, self._binding))
+
+        def __str__(self):
+            return f"SETSECRETBINDING {self._property} {self._binding}"
+
+    @dataclass
+    class SetSecretReference:
+        """SchemaChange class to bind an external secret reference for a property."""
+
+        _property: str = field(metadata=config(field_name="property"))
+        _reference: SecretReference = field(metadata=config(field_name="reference"))
+
+        def property(self):
+            return self._property
+
+        def reference(self):
+            return self._reference
+
+        def __eq__(self, other):
+            if not isinstance(other, SchemaChange.SetSecretReference):
+                return False
+            return (
+                self._property == other.property()
+                and self._reference == other.reference()
+            )
+
+        def __hash__(self):
+            return hash((self._property, self._reference))
+
+        def __str__(self):
+            return f"SETSECRETREFERENCE {self._property} {self._reference}"

--- a/clients/client-python/gravitino/client/base_schema_catalog.py
+++ b/clients/client-python/gravitino/client/base_schema_catalog.py
@@ -369,6 +369,16 @@ class BaseSchemaCatalog(
             )
         if isinstance(change, SchemaChange.RemoveProperty):
             return SchemaUpdateRequest.RemoveSchemaPropertyRequest(change.property())
+        if isinstance(change, SchemaChange.SetSecretBinding):
+            binding = change.binding()
+            return SchemaUpdateRequest.SetSchemaSecretBindingRequest(
+                change.property(), binding.provider, binding.plaintext
+            )
+        if isinstance(change, SchemaChange.SetSecretReference):
+            reference = change.reference()
+            return SchemaUpdateRequest.SetSchemaSecretReferenceRequest(
+                change.property(), reference.provider, reference.attributes
+            )
         raise ValueError(f"Unknown change type: {type(change).__name__}")
 
     def validate(self):

--- a/clients/client-python/gravitino/client/dto_converters.py
+++ b/clients/client-python/gravitino/client/dto_converters.py
@@ -145,6 +145,16 @@ class DTOConverters:
             return CatalogUpdateRequest.RemoveCatalogPropertyRequest(
                 change.get_property()
             )
+        if isinstance(change, CatalogChange.SetSecretBinding):
+            binding = change.binding()
+            return CatalogUpdateRequest.SetCatalogSecretBindingRequest(
+                change.property(), binding.provider, binding.plaintext
+            )
+        if isinstance(change, CatalogChange.SetSecretReference):
+            reference = change.reference()
+            return CatalogUpdateRequest.SetCatalogSecretReferenceRequest(
+                change.property(), reference.provider, reference.attributes
+            )
 
         raise ValueError(f"Unknown change type: {type(change).__name__}")
 

--- a/clients/client-python/gravitino/client/fileset_catalog.py
+++ b/clients/client-python/gravitino/client/fileset_catalog.py
@@ -394,6 +394,16 @@ class FilesetCatalog(
             )
         if isinstance(change, FilesetChange.RemoveProperty):
             return FilesetUpdateRequest.RemoveFilesetPropertyRequest(change.property())
+        if isinstance(change, FilesetChange.SetSecretBinding):
+            binding = change.binding()
+            return FilesetUpdateRequest.SetFilesetSecretBindingRequest(
+                change.property(), binding.provider, binding.plaintext
+            )
+        if isinstance(change, FilesetChange.SetSecretReference):
+            reference = change.reference()
+            return FilesetUpdateRequest.SetFilesetSecretReferenceRequest(
+                change.property(), reference.provider, reference.attributes
+            )
         if isinstance(change, FilesetChange.RemoveComment):
             return FilesetUpdateRequest.UpdateFilesetCommentRequest(None)
         raise ValueError(f"Unknown change type: {type(change).__name__}")

--- a/clients/client-python/gravitino/dto/requests/catalog_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/catalog_update_request.py
@@ -17,11 +17,12 @@
 
 from abc import abstractmethod
 from dataclasses import field, dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 from dataclasses_json import config
 
 from gravitino.api.catalog_change import CatalogChange
+from gravitino.api.secret import SecretBinding, SecretReference
 from gravitino.rest.rest_message import RESTRequest
 
 
@@ -124,3 +125,64 @@ class CatalogUpdateRequest:
         def validate(self):
             if not self._property:
                 raise ValueError('"property" field is required and cannot be empty')
+
+    @dataclass
+    class SetCatalogSecretBindingRequest(CatalogUpdateRequestBase):
+        """Request to bind a write-through secret for a catalog property."""
+
+        _property: Optional[str] = field(metadata=config(field_name="property"))
+        _provider: Optional[str] = field(metadata=config(field_name="provider"))
+        _plaintext: Optional[str] = field(metadata=config(field_name="plaintext"))
+
+        def __init__(self, catalog_property: str, provider: str, plaintext: str):
+            super().__init__("setSecretBinding")
+            self._property = catalog_property
+            self._provider = provider
+            self._plaintext = plaintext
+
+        def catalog_change(self):
+            return CatalogChange.set_secret_binding(
+                self._property,
+                SecretBinding(self._provider, self._plaintext),
+            )
+
+        def validate(self):
+            if not self._property:
+                raise ValueError('"property" field is required and cannot be empty')
+            if not self._provider:
+                raise ValueError('"provider" field is required and cannot be empty')
+            if self._plaintext is None:
+                raise ValueError('"plaintext" field is required and cannot be null')
+
+    @dataclass
+    class SetCatalogSecretReferenceRequest(CatalogUpdateRequestBase):
+        """Request to bind an external secret reference for a catalog property."""
+
+        _property: Optional[str] = field(metadata=config(field_name="property"))
+        _provider: Optional[str] = field(metadata=config(field_name="provider"))
+        _attributes: Optional[Dict[str, str]] = field(
+            metadata=config(field_name="attributes")
+        )
+
+        def __init__(
+            self,
+            catalog_property: str,
+            provider: str,
+            attributes: Optional[Dict[str, str]] = None,
+        ):
+            super().__init__("setSecretReference")
+            self._property = catalog_property
+            self._provider = provider
+            self._attributes = attributes
+
+        def catalog_change(self):
+            return CatalogChange.set_secret_reference(
+                self._property,
+                SecretReference(self._provider, self._attributes or {}),
+            )
+
+        def validate(self):
+            if not self._property:
+                raise ValueError('"property" field is required and cannot be empty')
+            if not self._provider:
+                raise ValueError('"provider" field is required and cannot be empty')

--- a/clients/client-python/gravitino/dto/requests/fileset_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/fileset_update_request.py
@@ -17,10 +17,12 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 from dataclasses_json import config
 
 from gravitino.api.file.fileset_change import FilesetChange
+from gravitino.api.secret import SecretBinding, SecretReference
 from gravitino.rest.rest_message import RESTRequest
 
 
@@ -162,3 +164,64 @@ class FilesetUpdateRequest:
 
         def fileset_change(self):
             return FilesetChange.remove_comment()
+
+    @dataclass
+    class SetFilesetSecretBindingRequest(FilesetUpdateRequestBase):
+        """Represents a request to bind a write-through secret for a fileset property."""
+
+        _property: Optional[str] = field(metadata=config(field_name="property"))
+        _provider: Optional[str] = field(metadata=config(field_name="provider"))
+        _plaintext: Optional[str] = field(metadata=config(field_name="plaintext"))
+
+        def __init__(self, fileset_property: str, provider: str, plaintext: str):
+            super().__init__("setSecretBinding")
+            self._property = fileset_property
+            self._provider = provider
+            self._plaintext = plaintext
+
+        def validate(self):
+            if not self._property:
+                raise ValueError('"property" field is required and cannot be empty')
+            if not self._provider:
+                raise ValueError('"provider" field is required and cannot be empty')
+            if self._plaintext is None:
+                raise ValueError('"plaintext" field is required and cannot be null')
+
+        def fileset_change(self):
+            return FilesetChange.set_secret_binding(
+                self._property,
+                SecretBinding(self._provider, self._plaintext),
+            )
+
+    @dataclass
+    class SetFilesetSecretReferenceRequest(FilesetUpdateRequestBase):
+        """Represents a request to bind an external secret reference for a fileset property."""
+
+        _property: Optional[str] = field(metadata=config(field_name="property"))
+        _provider: Optional[str] = field(metadata=config(field_name="provider"))
+        _attributes: Optional[Dict[str, str]] = field(
+            metadata=config(field_name="attributes")
+        )
+
+        def __init__(
+            self,
+            fileset_property: str,
+            provider: str,
+            attributes: Optional[Dict[str, str]] = None,
+        ):
+            super().__init__("setSecretReference")
+            self._property = fileset_property
+            self._provider = provider
+            self._attributes = attributes
+
+        def validate(self):
+            if not self._property:
+                raise ValueError('"property" field is required and cannot be empty')
+            if not self._provider:
+                raise ValueError('"provider" field is required and cannot be empty')
+
+        def fileset_change(self):
+            return FilesetChange.set_secret_reference(
+                self._property,
+                SecretReference(self._provider, self._attributes or {}),
+            )

--- a/clients/client-python/gravitino/dto/requests/schema_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/schema_update_request.py
@@ -17,10 +17,12 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 from dataclasses_json import config
 
 from gravitino.api.schema_change import SchemaChange
+from gravitino.api.secret import SecretBinding, SecretReference
 from gravitino.rest.rest_message import RESTRequest
 
 
@@ -95,3 +97,64 @@ class SchemaUpdateRequest:
 
         def schema_change(self):
             return SchemaChange.remove_property(self._property)
+
+    @dataclass
+    class SetSchemaSecretBindingRequest(SchemaUpdateRequestBase):
+        """Represents a request to bind a write-through secret for a schema property."""
+
+        _property: Optional[str] = field(metadata=config(field_name="property"))
+        _provider: Optional[str] = field(metadata=config(field_name="provider"))
+        _plaintext: Optional[str] = field(metadata=config(field_name="plaintext"))
+
+        def __init__(self, schema_property: str, provider: str, plaintext: str):
+            super().__init__("setSecretBinding")
+            self._property = schema_property
+            self._provider = provider
+            self._plaintext = plaintext
+
+        def validate(self):
+            if not self._property:
+                raise ValueError('"property" field is required and cannot be empty')
+            if not self._provider:
+                raise ValueError('"provider" field is required and cannot be empty')
+            if self._plaintext is None:
+                raise ValueError('"plaintext" field is required and cannot be null')
+
+        def schema_change(self):
+            return SchemaChange.set_secret_binding(
+                self._property,
+                SecretBinding(self._provider, self._plaintext),
+            )
+
+    @dataclass
+    class SetSchemaSecretReferenceRequest(SchemaUpdateRequestBase):
+        """Represents a request to bind an external secret reference for a schema property."""
+
+        _property: Optional[str] = field(metadata=config(field_name="property"))
+        _provider: Optional[str] = field(metadata=config(field_name="provider"))
+        _attributes: Optional[Dict[str, str]] = field(
+            metadata=config(field_name="attributes")
+        )
+
+        def __init__(
+            self,
+            schema_property: str,
+            provider: str,
+            attributes: Optional[Dict[str, str]] = None,
+        ):
+            super().__init__("setSecretReference")
+            self._property = schema_property
+            self._provider = provider
+            self._attributes = attributes
+
+        def validate(self):
+            if not self._property:
+                raise ValueError('"property" field is required and cannot be empty')
+            if not self._provider:
+                raise ValueError('"provider" field is required and cannot be empty')
+
+        def schema_change(self):
+            return SchemaChange.set_secret_reference(
+                self._property,
+                SecretReference(self._provider, self._attributes or {}),
+            )

--- a/common/src/main/java/org/apache/gravitino/dto/requests/CatalogUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/CatalogUpdateRequest.java
@@ -23,12 +23,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.CatalogChange;
 import org.apache.gravitino.rest.RESTRequest;
+import org.apache.gravitino.secret.SecretBinding;
+import org.apache.gravitino.secret.SecretReference;
 
 /** Represents an interface for catalog update requests. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -43,7 +47,13 @@ import org.apache.gravitino.rest.RESTRequest;
       name = "setProperty"),
   @JsonSubTypes.Type(
       value = CatalogUpdateRequest.RemoveCatalogPropertyRequest.class,
-      name = "removeProperty")
+      name = "removeProperty"),
+  @JsonSubTypes.Type(
+      value = CatalogUpdateRequest.SetCatalogSecretBindingRequest.class,
+      name = "setSecretBinding"),
+  @JsonSubTypes.Type(
+      value = CatalogUpdateRequest.SetCatalogSecretReferenceRequest.class,
+      name = "setSecretReference")
 })
 public interface CatalogUpdateRequest extends RESTRequest {
 
@@ -212,6 +222,119 @@ public interface CatalogUpdateRequest extends RESTRequest {
     @Override
     public CatalogChange catalogChange() {
       return CatalogChange.removeProperty(property);
+    }
+  }
+
+  /** Request to bind a write-through secret for a catalog property. */
+  @EqualsAndHashCode
+  @ToString(exclude = "plaintext")
+  class SetCatalogSecretBindingRequest implements CatalogUpdateRequest {
+
+    @Getter
+    @JsonProperty("property")
+    private final String property;
+
+    @Getter
+    @JsonProperty("provider")
+    private final String provider;
+
+    @Getter
+    @JsonProperty("plaintext")
+    private final String plaintext;
+
+    /**
+     * Constructor for SetCatalogSecretBindingRequest.
+     *
+     * @param property The property to bind.
+     * @param provider The registered secrets-provider instance name.
+     * @param plaintext The plaintext secret to write through.
+     */
+    public SetCatalogSecretBindingRequest(String property, String provider, String plaintext) {
+      this.property = property;
+      this.provider = provider;
+      this.plaintext = plaintext;
+    }
+
+    /** Default constructor for SetCatalogSecretBindingRequest. */
+    public SetCatalogSecretBindingRequest() {
+      this(null, null, null);
+    }
+
+    /**
+     * Validates the fields of the request.
+     *
+     * @throws IllegalArgumentException if required fields are not set.
+     */
+    @Override
+    public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(property), "\"property\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "\"provider\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          plaintext != null, "\"plaintext\" field is required and cannot be null");
+    }
+
+    @Override
+    public CatalogChange catalogChange() {
+      return CatalogChange.setSecretBinding(property, new SecretBinding(provider, plaintext));
+    }
+  }
+
+  /** Request to bind an external secret reference for a catalog property. */
+  @EqualsAndHashCode
+  @ToString
+  class SetCatalogSecretReferenceRequest implements CatalogUpdateRequest {
+
+    @Getter
+    @JsonProperty("property")
+    private final String property;
+
+    @Getter
+    @JsonProperty("provider")
+    private final String provider;
+
+    @Getter
+    @JsonProperty("attributes")
+    private final Map<String, String> attributes;
+
+    /**
+     * Constructor for SetCatalogSecretReferenceRequest.
+     *
+     * @param property The property to bind.
+     * @param provider The registered secrets-provider instance name.
+     * @param attributes Provider-specific locator attributes.
+     */
+    public SetCatalogSecretReferenceRequest(
+        String property, String provider, Map<String, String> attributes) {
+      this.property = property;
+      this.provider = provider;
+      this.attributes = attributes;
+    }
+
+    /** Default constructor for SetCatalogSecretReferenceRequest. */
+    public SetCatalogSecretReferenceRequest() {
+      this(null, null, null);
+    }
+
+    /**
+     * Validates the fields of the request.
+     *
+     * @throws IllegalArgumentException if required fields are not set.
+     */
+    @Override
+    public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(property), "\"property\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "\"provider\" field is required and cannot be empty");
+    }
+
+    @Override
+    public CatalogChange catalogChange() {
+      return CatalogChange.setSecretReference(
+          property,
+          new SecretReference(provider, attributes == null ? ImmutableMap.of() : attributes));
     }
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/FilesetUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/FilesetUpdateRequest.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -31,6 +33,8 @@ import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.rest.RESTRequest;
+import org.apache.gravitino.secret.SecretBinding;
+import org.apache.gravitino.secret.SecretReference;
 
 /** Request to update a fileset. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -48,7 +52,13 @@ import org.apache.gravitino.rest.RESTRequest;
       name = "setProperty"),
   @JsonSubTypes.Type(
       value = FilesetUpdateRequest.RemoveFilesetPropertiesRequest.class,
-      name = "removeProperty")
+      name = "removeProperty"),
+  @JsonSubTypes.Type(
+      value = FilesetUpdateRequest.SetFilesetSecretBindingRequest.class,
+      name = "setSecretBinding"),
+  @JsonSubTypes.Type(
+      value = FilesetUpdateRequest.SetFilesetSecretReferenceRequest.class,
+      name = "setSecretReference")
 })
 public interface FilesetUpdateRequest extends RESTRequest {
 
@@ -204,5 +214,75 @@ public interface FilesetUpdateRequest extends RESTRequest {
      */
     @Override
     public void validate() throws IllegalArgumentException {}
+  }
+
+  /** The fileset update request for binding a write-through secret to a property. */
+  @EqualsAndHashCode
+  @NoArgsConstructor(force = true)
+  @AllArgsConstructor
+  @ToString(exclude = "plaintext")
+  class SetFilesetSecretBindingRequest implements FilesetUpdateRequest {
+
+    @Getter
+    @JsonProperty("property")
+    private final String property;
+
+    @Getter
+    @JsonProperty("provider")
+    private final String provider;
+
+    @Getter
+    @JsonProperty("plaintext")
+    private final String plaintext;
+
+    @Override
+    public FilesetChange filesetChange() {
+      return FilesetChange.setSecretBinding(property, new SecretBinding(provider, plaintext));
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(property), "\"property\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "\"provider\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          plaintext != null, "\"plaintext\" field is required and cannot be null");
+    }
+  }
+
+  /** The fileset update request for binding an external secret reference to a property. */
+  @EqualsAndHashCode
+  @NoArgsConstructor(force = true)
+  @AllArgsConstructor
+  @ToString
+  class SetFilesetSecretReferenceRequest implements FilesetUpdateRequest {
+
+    @Getter
+    @JsonProperty("property")
+    private final String property;
+
+    @Getter
+    @JsonProperty("provider")
+    private final String provider;
+
+    @Getter
+    @JsonProperty("attributes")
+    private final Map<String, String> attributes;
+
+    @Override
+    public FilesetChange filesetChange() {
+      return FilesetChange.setSecretReference(
+          property,
+          new SecretReference(provider, attributes == null ? ImmutableMap.of() : attributes));
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(property), "\"property\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "\"provider\" field is required and cannot be empty");
+    }
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/SchemaUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/SchemaUpdateRequest.java
@@ -23,12 +23,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.rest.RESTRequest;
+import org.apache.gravitino.secret.SecretBinding;
+import org.apache.gravitino.secret.SecretReference;
 
 /** Represents a request to update a schema. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -39,7 +43,13 @@ import org.apache.gravitino.rest.RESTRequest;
       name = "setProperty"),
   @JsonSubTypes.Type(
       value = SchemaUpdateRequest.RemoveSchemaPropertyRequest.class,
-      name = "removeProperty")
+      name = "removeProperty"),
+  @JsonSubTypes.Type(
+      value = SchemaUpdateRequest.SetSchemaSecretBindingRequest.class,
+      name = "setSecretBinding"),
+  @JsonSubTypes.Type(
+      value = SchemaUpdateRequest.SetSchemaSecretReferenceRequest.class,
+      name = "setSecretReference")
 })
 public interface SchemaUpdateRequest extends RESTRequest {
 
@@ -145,6 +155,119 @@ public interface SchemaUpdateRequest extends RESTRequest {
     @Override
     public SchemaChange schemaChange() {
       return SchemaChange.removeProperty(property);
+    }
+  }
+
+  /** Represents a request to bind a write-through secret for a schema property. */
+  @EqualsAndHashCode
+  @ToString(exclude = "plaintext")
+  class SetSchemaSecretBindingRequest implements SchemaUpdateRequest {
+
+    @Getter
+    @JsonProperty("property")
+    private final String property;
+
+    @Getter
+    @JsonProperty("provider")
+    private final String provider;
+
+    @Getter
+    @JsonProperty("plaintext")
+    private final String plaintext;
+
+    /**
+     * Creates a new SetSchemaSecretBindingRequest.
+     *
+     * @param property The property to bind.
+     * @param provider The registered secrets-provider instance name.
+     * @param plaintext The plaintext secret to write through.
+     */
+    public SetSchemaSecretBindingRequest(String property, String provider, String plaintext) {
+      this.property = property;
+      this.provider = provider;
+      this.plaintext = plaintext;
+    }
+
+    /** Default constructor for Jackson deserialization. */
+    public SetSchemaSecretBindingRequest() {
+      this(null, null, null);
+    }
+
+    /**
+     * Validates the request.
+     *
+     * @throws IllegalArgumentException If the request is invalid, this exception is thrown.
+     */
+    @Override
+    public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(property), "\"property\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "\"provider\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          plaintext != null, "\"plaintext\" field is required and cannot be null");
+    }
+
+    @Override
+    public SchemaChange schemaChange() {
+      return SchemaChange.setSecretBinding(property, new SecretBinding(provider, plaintext));
+    }
+  }
+
+  /** Represents a request to bind an external secret reference for a schema property. */
+  @EqualsAndHashCode
+  @ToString
+  class SetSchemaSecretReferenceRequest implements SchemaUpdateRequest {
+
+    @Getter
+    @JsonProperty("property")
+    private final String property;
+
+    @Getter
+    @JsonProperty("provider")
+    private final String provider;
+
+    @Getter
+    @JsonProperty("attributes")
+    private final Map<String, String> attributes;
+
+    /**
+     * Creates a new SetSchemaSecretReferenceRequest.
+     *
+     * @param property The property to bind.
+     * @param provider The registered secrets-provider instance name.
+     * @param attributes Provider-specific locator attributes.
+     */
+    public SetSchemaSecretReferenceRequest(
+        String property, String provider, Map<String, String> attributes) {
+      this.property = property;
+      this.provider = provider;
+      this.attributes = attributes;
+    }
+
+    /** Default constructor for Jackson deserialization. */
+    public SetSchemaSecretReferenceRequest() {
+      this(null, null, null);
+    }
+
+    /**
+     * Validates the request.
+     *
+     * @throws IllegalArgumentException If the request is invalid, this exception is thrown.
+     */
+    @Override
+    public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(property), "\"property\" field is required and cannot be empty");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "\"provider\" field is required and cannot be empty");
+    }
+
+    @Override
+    public SchemaChange schemaChange() {
+      return SchemaChange.setSecretReference(
+          property,
+          new SecretReference(provider, attributes == null ? ImmutableMap.of() : attributes));
     }
   }
 }

--- a/common/src/test/java/org/apache/gravitino/json/TestRequestJsonSerDe.java
+++ b/common/src/test/java/org/apache/gravitino/json/TestRequestJsonSerDe.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.dto.requests.CatalogCreateRequest;
 import org.apache.gravitino.dto.requests.CatalogUpdateRequest;
+import org.apache.gravitino.dto.requests.FilesetUpdateRequest;
 import org.apache.gravitino.dto.requests.MetalakeCreateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdatesRequest;
@@ -155,5 +156,23 @@ public class TestRequestJsonSerDe {
     CatalogUpdateRequest deserReq3 =
         JsonUtils.objectMapper().readValue(serJson3, CatalogUpdateRequest.class);
     Assertions.assertEquals(req3, deserReq3);
+  }
+
+  @Test
+  public void testFilesetUpdateRequestSerDe() throws JsonProcessingException {
+    FilesetUpdateRequest req =
+        new FilesetUpdateRequest.SetFilesetSecretBindingRequest("password", "env", "secret");
+    String serJson = JsonUtils.objectMapper().writeValueAsString(req);
+    FilesetUpdateRequest deserReq =
+        JsonUtils.objectMapper().readValue(serJson, FilesetUpdateRequest.class);
+    Assertions.assertEquals(req, deserReq);
+
+    FilesetUpdateRequest req1 =
+        new FilesetUpdateRequest.SetFilesetSecretReferenceRequest(
+            "password", "vault", ImmutableMap.of("path", "secret/data/my-password"));
+    String serJson1 = JsonUtils.objectMapper().writeValueAsString(req1);
+    FilesetUpdateRequest deserReq1 =
+        JsonUtils.objectMapper().readValue(serJson1, FilesetUpdateRequest.class);
+    Assertions.assertEquals(req1, deserReq1);
   }
 }

--- a/common/src/test/java/org/apache/gravitino/json/TestRequestJsonSerDe.java
+++ b/common/src/test/java/org/apache/gravitino/json/TestRequestJsonSerDe.java
@@ -28,6 +28,7 @@ import org.apache.gravitino.dto.requests.FilesetUpdateRequest;
 import org.apache.gravitino.dto.requests.MetalakeCreateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdatesRequest;
+import org.apache.gravitino.dto.requests.SchemaUpdateRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -156,6 +157,39 @@ public class TestRequestJsonSerDe {
     CatalogUpdateRequest deserReq3 =
         JsonUtils.objectMapper().readValue(serJson3, CatalogUpdateRequest.class);
     Assertions.assertEquals(req3, deserReq3);
+
+    CatalogUpdateRequest req4 =
+        new CatalogUpdateRequest.SetCatalogSecretBindingRequest("password", "env", "secret");
+    String serJson4 = JsonUtils.objectMapper().writeValueAsString(req4);
+    CatalogUpdateRequest deserReq4 =
+        JsonUtils.objectMapper().readValue(serJson4, CatalogUpdateRequest.class);
+    Assertions.assertEquals(req4, deserReq4);
+
+    CatalogUpdateRequest req5 =
+        new CatalogUpdateRequest.SetCatalogSecretReferenceRequest(
+            "password", "vault", ImmutableMap.of("path", "secret/data/my-password"));
+    String serJson5 = JsonUtils.objectMapper().writeValueAsString(req5);
+    CatalogUpdateRequest deserReq5 =
+        JsonUtils.objectMapper().readValue(serJson5, CatalogUpdateRequest.class);
+    Assertions.assertEquals(req5, deserReq5);
+  }
+
+  @Test
+  public void testSchemaUpdateRequestSerDe() throws JsonProcessingException {
+    SchemaUpdateRequest req =
+        new SchemaUpdateRequest.SetSchemaSecretBindingRequest("password", "env", "secret");
+    String serJson = JsonUtils.objectMapper().writeValueAsString(req);
+    SchemaUpdateRequest deserReq =
+        JsonUtils.objectMapper().readValue(serJson, SchemaUpdateRequest.class);
+    Assertions.assertEquals(req, deserReq);
+
+    SchemaUpdateRequest req1 =
+        new SchemaUpdateRequest.SetSchemaSecretReferenceRequest(
+            "password", "vault", ImmutableMap.of("path", "secret/data/my-password"));
+    String serJson1 = JsonUtils.objectMapper().writeValueAsString(req1);
+    SchemaUpdateRequest deserReq1 =
+        JsonUtils.objectMapper().readValue(serJson1, SchemaUpdateRequest.class);
+    Assertions.assertEquals(req1, deserReq1);
   }
 
   @Test

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1257,7 +1257,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    */
   private Pair<CatalogChange[], List<SecretMaterial>> prepareCatalogSecretChanges(
       @Nullable Map<String, String> currentProperties, long entityId, CatalogChange... changes) {
-    Map<String, String> working =
+    Map<String, String> properties =
         currentProperties == null ? new HashMap<>() : new HashMap<>(currentProperties);
     List<CatalogChange> out = new ArrayList<>(changes.length);
     List<SecretMaterial> written = new ArrayList<>();
@@ -1267,23 +1267,23 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
           CatalogChange.SetSecretBinding c = (CatalogChange.SetSecretBinding) change;
           String urn =
               secretManager.alterSetSecretBinding(
-                  working, "catalog", entityId, c.getProperty(), c.getBinding(), written);
+                  properties, "catalog", entityId, c.getProperty(), c.getBinding(), written);
           out.add(CatalogChange.setProperty(c.getProperty(), urn));
         } else if (change instanceof CatalogChange.SetSecretReference) {
           CatalogChange.SetSecretReference c = (CatalogChange.SetSecretReference) change;
           String urn =
               secretManager.alterSetSecretReference(
-                  working, "catalog", entityId, c.getProperty(), c.getReference());
+                  properties, "catalog", entityId, c.getProperty(), c.getReference());
           out.add(CatalogChange.setProperty(c.getProperty(), urn));
         } else if (change instanceof CatalogChange.SetProperty) {
           CatalogChange.SetProperty c = (CatalogChange.SetProperty) change;
           String value =
               secretManager.alterSetProperty(
-                  working, "catalog", entityId, c.getProperty(), c.getValue());
+                  properties, "catalog", entityId, c.getProperty(), c.getValue());
           out.add(CatalogChange.setProperty(c.getProperty(), value));
         } else if (change instanceof CatalogChange.RemoveProperty) {
           CatalogChange.RemoveProperty c = (CatalogChange.RemoveProperty) change;
-          secretManager.alterRemoveProperty(working, "catalog", entityId, c.getProperty());
+          secretManager.alterRemoveProperty(properties, "catalog", entityId, c.getProperty());
           out.add(change);
         } else {
           out.add(change);

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -57,6 +57,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -926,23 +927,41 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         LockType.WRITE,
         () -> {
           try {
-            CatalogEntity updatedCatalog =
-                store.update(
-                    ident,
-                    CatalogEntity.class,
-                    EntityType.CATALOG,
-                    catalog -> {
-                      CatalogEntity.Builder newCatalogBuilder =
-                          newCatalogBuilder(ident.namespace(), catalog);
+            AtomicReference<List<SecretMaterial>> writtenSecretMaterials =
+                new AtomicReference<>(List.of());
+            boolean secretUpdateCommitted = false;
+            CatalogEntity updatedCatalog;
+            try {
+              updatedCatalog =
+                  store.update(
+                      ident,
+                      CatalogEntity.class,
+                      EntityType.CATALOG,
+                      catalog -> {
+                        Pair<CatalogChange[], List<SecretMaterial>> secretResult =
+                            prepareCatalogSecretChanges(
+                                catalog.getProperties(), catalog.id(), changes);
+                        writtenSecretMaterials.set(secretResult.getRight());
+                        CatalogChange[] effectiveChanges = secretResult.getLeft();
 
-                      Map<String, String> newProps =
-                          catalog.getProperties() == null
-                              ? new HashMap<>()
-                              : new HashMap<>(catalog.getProperties());
-                      newCatalogBuilder = updateEntity(newCatalogBuilder, newProps, changes);
+                        CatalogEntity.Builder newCatalogBuilder =
+                            newCatalogBuilder(ident.namespace(), catalog);
 
-                      return newCatalogBuilder.build();
-                    });
+                        Map<String, String> newProps =
+                            catalog.getProperties() == null
+                                ? new HashMap<>()
+                                : new HashMap<>(catalog.getProperties());
+                        newCatalogBuilder =
+                            updateEntity(newCatalogBuilder, newProps, effectiveChanges);
+
+                        return newCatalogBuilder.build();
+                      });
+              secretUpdateCommitted = true;
+            } finally {
+              if (!secretUpdateCommitted) {
+                secretManager.rollbackSecrets(writtenSecretMaterials.get());
+              }
+            }
             // Invalidate after store.update() so that any background thread that tries to reload
             // the old catalog identifier from the store (after the invalidate) will get
             // NoSuchCatalogException instead of stale data. Invalidating before the update creates
@@ -1227,6 +1246,56 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     return mergeConf(newProperties, catalogSpecificConfig);
   }
 
+  /**
+   * Rewrites catalog changes that involve secrets into plain setProperty / removeProperty, writing
+   * secrets as needed. Rolls back any written materials if preparation fails.
+   *
+   * @param currentProperties current catalog properties (may be null)
+   * @param entityId catalog entity id
+   * @param changes catalog changes
+   * @return effective changes and written write-through materials
+   */
+  private Pair<CatalogChange[], List<SecretMaterial>> prepareCatalogSecretChanges(
+      @Nullable Map<String, String> currentProperties, long entityId, CatalogChange... changes) {
+    Map<String, String> working =
+        currentProperties == null ? new HashMap<>() : new HashMap<>(currentProperties);
+    List<CatalogChange> out = new ArrayList<>(changes.length);
+    List<SecretMaterial> written = new ArrayList<>();
+    try {
+      for (CatalogChange change : changes) {
+        if (change instanceof CatalogChange.SetSecretBinding) {
+          CatalogChange.SetSecretBinding c = (CatalogChange.SetSecretBinding) change;
+          String urn =
+              secretManager.alterSetSecretBinding(
+                  working, "catalog", entityId, c.getProperty(), c.getBinding(), written);
+          out.add(CatalogChange.setProperty(c.getProperty(), urn));
+        } else if (change instanceof CatalogChange.SetSecretReference) {
+          CatalogChange.SetSecretReference c = (CatalogChange.SetSecretReference) change;
+          String urn =
+              secretManager.alterSetSecretReference(
+                  working, "catalog", entityId, c.getProperty(), c.getReference());
+          out.add(CatalogChange.setProperty(c.getProperty(), urn));
+        } else if (change instanceof CatalogChange.SetProperty) {
+          CatalogChange.SetProperty c = (CatalogChange.SetProperty) change;
+          String value =
+              secretManager.alterSetProperty(
+                  working, "catalog", entityId, c.getProperty(), c.getValue());
+          out.add(CatalogChange.setProperty(c.getProperty(), value));
+        } else if (change instanceof CatalogChange.RemoveProperty) {
+          CatalogChange.RemoveProperty c = (CatalogChange.RemoveProperty) change;
+          secretManager.alterRemoveProperty(working, "catalog", entityId, c.getProperty());
+          out.add(change);
+        } else {
+          out.add(change);
+        }
+      }
+      return Pair.of(out.toArray(new CatalogChange[0]), List.copyOf(written));
+    } catch (RuntimeException e) {
+      secretManager.rollbackSecrets(written);
+      throw e;
+    }
+  }
+
   private Pair<Map<String, String>, Map<String, String>> getCatalogAlterProperty(
       CatalogChange... catalogChanges) {
     Map<String, String> upserts = Maps.newHashMap();
@@ -1238,6 +1307,15 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
               if (catalogChange instanceof SetProperty) {
                 SetProperty setProperty = (SetProperty) catalogChange;
                 upserts.put(setProperty.getProperty(), setProperty.getValue());
+              } else if (catalogChange instanceof CatalogChange.SetSecretBinding) {
+                CatalogChange.SetSecretBinding setSecretBinding =
+                    (CatalogChange.SetSecretBinding) catalogChange;
+                upserts.put(
+                    setSecretBinding.getProperty(), setSecretBinding.getBinding().plaintext());
+              } else if (catalogChange instanceof CatalogChange.SetSecretReference) {
+                CatalogChange.SetSecretReference setSecretReference =
+                    (CatalogChange.SetSecretReference) catalogChange;
+                upserts.put(setSecretReference.getProperty(), setSecretReference.getProperty());
               } else if (catalogChange instanceof RemoveProperty) {
                 RemoveProperty removeProperty = (RemoveProperty) catalogChange;
                 deletes.put(removeProperty.getProperty(), removeProperty.getProperty());

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -385,7 +385,7 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
    */
   private Pair<FilesetChange[], List<SecretMaterial>> prepareFilesetSecretChanges(
       @Nullable Map<String, String> currentProperties, long entityId, FilesetChange... changes) {
-    Map<String, String> working =
+    Map<String, String> properties =
         currentProperties == null ? new HashMap<>() : new HashMap<>(currentProperties);
     List<FilesetChange> out = new ArrayList<>(changes.length);
     List<SecretMaterial> written = new ArrayList<>();
@@ -395,23 +395,23 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
           FilesetChange.SetSecretBinding c = (FilesetChange.SetSecretBinding) change;
           String urn =
               secretManager.alterSetSecretBinding(
-                  working, "fileset", entityId, c.getProperty(), c.getBinding(), written);
+                  properties, "fileset", entityId, c.getProperty(), c.getBinding(), written);
           out.add(FilesetChange.setProperty(c.getProperty(), urn));
         } else if (change instanceof FilesetChange.SetSecretReference) {
           FilesetChange.SetSecretReference c = (FilesetChange.SetSecretReference) change;
           String urn =
               secretManager.alterSetSecretReference(
-                  working, "fileset", entityId, c.getProperty(), c.getReference());
+                  properties, "fileset", entityId, c.getProperty(), c.getReference());
           out.add(FilesetChange.setProperty(c.getProperty(), urn));
         } else if (change instanceof FilesetChange.SetProperty) {
           FilesetChange.SetProperty c = (FilesetChange.SetProperty) change;
           String value =
               secretManager.alterSetProperty(
-                  working, "fileset", entityId, c.getProperty(), c.getValue());
+                  properties, "fileset", entityId, c.getProperty(), c.getValue());
           out.add(FilesetChange.setProperty(c.getProperty(), value));
         } else if (change instanceof FilesetChange.RemoveProperty) {
           FilesetChange.RemoveProperty c = (FilesetChange.RemoveProperty) change;
-          secretManager.alterRemoveProperty(working, "fileset", entityId, c.getProperty());
+          secretManager.alterRemoveProperty(properties, "fileset", entityId, c.getProperty());
           out.add(change);
         } else {
           out.add(change);

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -21,9 +21,12 @@ package org.apache.gravitino.catalog;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
 import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -227,7 +230,6 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
   @Override
   public Fileset alterFileset(NameIdentifier ident, FilesetChange... changes)
       throws NoSuchFilesetException, IllegalArgumentException {
-    validateAlterProperties(ident, HasPropertyMetadata::filesetPropertiesMetadata, changes);
     NameIdentifier catalogIdent = getCatalogIdentifier(ident);
 
     boolean containsRenameFileset =
@@ -239,12 +241,62 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
         TreeLockUtils.doWithTreeLock(
             nameIdentifierForLock,
             LockType.WRITE,
-            () ->
-                doWithCatalog(
-                    catalogIdent,
-                    c -> c.doWithFilesetOps(f -> f.alterFileset(ident, changes)),
-                    NoSuchFilesetException.class,
-                    IllegalArgumentException.class));
+            () -> {
+              Fileset currentFileset =
+                  doWithCatalog(
+                      catalogIdent,
+                      c -> c.doWithFilesetOps(f -> f.loadFileset(ident)),
+                      NoSuchFilesetException.class);
+              // Prefer FilesetEntity properties for secret URNs (catalog loadFileset may omit
+              // them).
+              FilesetEntity filesetEntity = getEntity(ident, FILESET, FilesetEntity.class);
+              Map<String, String> currentProperties;
+              if (filesetEntity != null
+                  && filesetEntity.properties() != null
+                  && !filesetEntity.properties().isEmpty()) {
+                currentProperties = new HashMap<>(filesetEntity.properties());
+              } else if (currentFileset.properties() != null) {
+                currentProperties = new HashMap<>(currentFileset.properties());
+              } else {
+                currentProperties = new HashMap<>();
+              }
+
+              validateAlterProperties(
+                  ident, HasPropertyMetadata::filesetPropertiesMetadata, changes);
+
+              StringIdentifier currentStringId = getStringIdFromProperties(currentProperties);
+              long filesetId;
+              if (currentStringId != null) {
+                filesetId = currentStringId.id();
+              } else if (filesetEntity != null) {
+                filesetId = filesetEntity.id();
+              } else {
+                filesetId = 0L;
+              }
+
+              List<SecretMaterial> writtenSecretMaterials = List.of();
+              boolean alterCommitted = false;
+              Fileset altered;
+              try {
+                Pair<FilesetChange[], List<SecretMaterial>> secretResult =
+                    prepareFilesetSecretChanges(currentProperties, filesetId, changes);
+                writtenSecretMaterials = secretResult.getRight();
+                FilesetChange[] effectiveChanges = secretResult.getLeft();
+
+                altered =
+                    doWithCatalog(
+                        catalogIdent,
+                        c -> c.doWithFilesetOps(f -> f.alterFileset(ident, effectiveChanges)),
+                        NoSuchFilesetException.class,
+                        IllegalArgumentException.class);
+                alterCommitted = true;
+              } finally {
+                if (!alterCommitted) {
+                  secretManager.rollbackSecrets(writtenSecretMaterials);
+                }
+              }
+              return altered;
+            });
 
     return EntityCombinedFileset.of(alteredFileset)
         .withHiddenProperties(
@@ -317,5 +369,55 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
                 getCatalogIdentifier(ident),
                 c -> c.doWithFilesetOps(f -> f.getFileLocation(ident, subPath, locationName)),
                 NonEmptyEntityException.class));
+  }
+
+  /**
+   * Rewrites fileset changes that involve secrets into plain setProperty / removeProperty, writing
+   * secrets as needed. Rolls back any written materials if preparation fails.
+   *
+   * @param currentProperties current fileset properties (may be null)
+   * @param entityId fileset entity id
+   * @param changes fileset changes
+   * @return effective changes and written write-through materials
+   */
+  private Pair<FilesetChange[], List<SecretMaterial>> prepareFilesetSecretChanges(
+      @Nullable Map<String, String> currentProperties, long entityId, FilesetChange... changes) {
+    Map<String, String> working =
+        currentProperties == null ? new HashMap<>() : new HashMap<>(currentProperties);
+    List<FilesetChange> out = new ArrayList<>(changes.length);
+    List<SecretMaterial> written = new ArrayList<>();
+    try {
+      for (FilesetChange change : changes) {
+        if (change instanceof FilesetChange.SetSecretBinding) {
+          FilesetChange.SetSecretBinding c = (FilesetChange.SetSecretBinding) change;
+          String urn =
+              secretManager.alterSetSecretBinding(
+                  working, "fileset", entityId, c.getProperty(), c.getBinding(), written);
+          out.add(FilesetChange.setProperty(c.getProperty(), urn));
+        } else if (change instanceof FilesetChange.SetSecretReference) {
+          FilesetChange.SetSecretReference c = (FilesetChange.SetSecretReference) change;
+          String urn =
+              secretManager.alterSetSecretReference(
+                  working, "fileset", entityId, c.getProperty(), c.getReference());
+          out.add(FilesetChange.setProperty(c.getProperty(), urn));
+        } else if (change instanceof FilesetChange.SetProperty) {
+          FilesetChange.SetProperty c = (FilesetChange.SetProperty) change;
+          String value =
+              secretManager.alterSetProperty(
+                  working, "fileset", entityId, c.getProperty(), c.getValue());
+          out.add(FilesetChange.setProperty(c.getProperty(), value));
+        } else if (change instanceof FilesetChange.RemoveProperty) {
+          FilesetChange.RemoveProperty c = (FilesetChange.RemoveProperty) change;
+          secretManager.alterRemoveProperty(working, "fileset", entityId, c.getProperty());
+          out.add(change);
+        } else {
+          out.add(change);
+        }
+      }
+      return Pair.of(out.toArray(new FilesetChange[0]), List.copyOf(written));
+    } catch (RuntimeException e) {
+      secretManager.rollbackSecrets(written);
+      throw e;
+    }
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -18,11 +18,13 @@
  */
 package org.apache.gravitino.catalog;
 
+import static org.apache.gravitino.Entity.EntityType.FILESET;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
 import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -42,6 +44,7 @@ import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.lock.LockType;
 import org.apache.gravitino.lock.TreeLockUtils;
+import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.secret.SecretBinding;
 import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.secret.SecretMaterial;

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -244,62 +244,7 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
         TreeLockUtils.doWithTreeLock(
             nameIdentifierForLock,
             LockType.WRITE,
-            () -> {
-              Fileset currentFileset =
-                  doWithCatalog(
-                      catalogIdent,
-                      c -> c.doWithFilesetOps(f -> f.loadFileset(ident)),
-                      NoSuchFilesetException.class);
-              // Prefer FilesetEntity properties for secret URNs (catalog loadFileset may omit
-              // them).
-              FilesetEntity filesetEntity = getEntity(ident, FILESET, FilesetEntity.class);
-              Map<String, String> currentProperties;
-              if (filesetEntity != null
-                  && filesetEntity.properties() != null
-                  && !filesetEntity.properties().isEmpty()) {
-                currentProperties = new HashMap<>(filesetEntity.properties());
-              } else if (currentFileset.properties() != null) {
-                currentProperties = new HashMap<>(currentFileset.properties());
-              } else {
-                currentProperties = new HashMap<>();
-              }
-
-              validateAlterProperties(
-                  ident, HasPropertyMetadata::filesetPropertiesMetadata, changes);
-
-              StringIdentifier currentStringId = getStringIdFromProperties(currentProperties);
-              long filesetId;
-              if (currentStringId != null) {
-                filesetId = currentStringId.id();
-              } else if (filesetEntity != null) {
-                filesetId = filesetEntity.id();
-              } else {
-                filesetId = 0L;
-              }
-
-              List<SecretMaterial> writtenSecretMaterials = List.of();
-              boolean alterCommitted = false;
-              Fileset altered;
-              try {
-                Pair<FilesetChange[], List<SecretMaterial>> secretResult =
-                    prepareFilesetSecretChanges(currentProperties, filesetId, changes);
-                writtenSecretMaterials = secretResult.getRight();
-                FilesetChange[] effectiveChanges = secretResult.getLeft();
-
-                altered =
-                    doWithCatalog(
-                        catalogIdent,
-                        c -> c.doWithFilesetOps(f -> f.alterFileset(ident, effectiveChanges)),
-                        NoSuchFilesetException.class,
-                        IllegalArgumentException.class);
-                alterCommitted = true;
-              } finally {
-                if (!alterCommitted) {
-                  secretManager.rollbackSecrets(writtenSecretMaterials);
-                }
-              }
-              return altered;
-            });
+            () -> alterFilesetUnderLock(ident, catalogIdent, changes));
 
     return EntityCombinedFileset.of(alteredFileset)
         .withHiddenProperties(
@@ -307,6 +252,61 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
                 catalogIdent,
                 HasPropertyMetadata::filesetPropertiesMetadata,
                 alteredFileset.properties()));
+  }
+
+  private Fileset alterFilesetUnderLock(
+      NameIdentifier ident, NameIdentifier catalogIdent, FilesetChange... changes) {
+    Fileset currentFileset =
+        doWithCatalog(
+            catalogIdent,
+            c -> c.doWithFilesetOps(f -> f.loadFileset(ident)),
+            NoSuchFilesetException.class);
+    // Prefer FilesetEntity properties for secret URNs (catalog loadFileset may omit them).
+    FilesetEntity filesetEntity = getEntity(ident, FILESET, FilesetEntity.class);
+    Map<String, String> currentProperties;
+    if (filesetEntity != null
+        && filesetEntity.properties() != null
+        && !filesetEntity.properties().isEmpty()) {
+      currentProperties = new HashMap<>(filesetEntity.properties());
+    } else if (currentFileset.properties() != null) {
+      currentProperties = new HashMap<>(currentFileset.properties());
+    } else {
+      currentProperties = new HashMap<>();
+    }
+
+    validateAlterProperties(ident, HasPropertyMetadata::filesetPropertiesMetadata, changes);
+
+    StringIdentifier currentStringId = getStringIdFromProperties(currentProperties);
+    long filesetId;
+    if (currentStringId != null) {
+      filesetId = currentStringId.id();
+    } else if (filesetEntity != null) {
+      filesetId = filesetEntity.id();
+    } else {
+      filesetId = 0L;
+    }
+
+    List<SecretMaterial> writtenSecretMaterials = List.of();
+    boolean alterCommitted = false;
+    try {
+      Pair<FilesetChange[], List<SecretMaterial>> secretResult =
+          prepareFilesetSecretChanges(currentProperties, filesetId, changes);
+      writtenSecretMaterials = secretResult.getRight();
+      FilesetChange[] effectiveChanges = secretResult.getLeft();
+
+      Fileset altered =
+          doWithCatalog(
+              catalogIdent,
+              c -> c.doWithFilesetOps(f -> f.alterFileset(ident, effectiveChanges)),
+              NoSuchFilesetException.class,
+              IllegalArgumentException.class);
+      alterCommitted = true;
+      return altered;
+    } finally {
+      if (!alterCommitted) {
+        secretManager.rollbackSecrets(writtenSecretMaterials);
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -287,6 +287,12 @@ public abstract class OperationDispatcher {
       } else if (item instanceof SchemaChange.SetProperty) {
         SchemaChange.SetProperty setProperty = (SchemaChange.SetProperty) item;
         properties.put(setProperty.getProperty(), setProperty.getValue());
+      } else if (item instanceof SchemaChange.SetSecretBinding) {
+        SchemaChange.SetSecretBinding setSecretBinding = (SchemaChange.SetSecretBinding) item;
+        properties.put(setSecretBinding.getProperty(), setSecretBinding.getBinding().plaintext());
+      } else if (item instanceof SchemaChange.SetSecretReference) {
+        SchemaChange.SetSecretReference setSecretReference = (SchemaChange.SetSecretReference) item;
+        properties.put(setSecretReference.getProperty(), setSecretReference.getProperty());
       } else if (item instanceof FilesetChange.SetProperty) {
         FilesetChange.SetProperty setProperty = (FilesetChange.SetProperty) item;
         properties.put(setProperty.getProperty(), setProperty.getValue());

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -290,6 +290,13 @@ public abstract class OperationDispatcher {
       } else if (item instanceof FilesetChange.SetProperty) {
         FilesetChange.SetProperty setProperty = (FilesetChange.SetProperty) item;
         properties.put(setProperty.getProperty(), setProperty.getValue());
+      } else if (item instanceof FilesetChange.SetSecretBinding) {
+        FilesetChange.SetSecretBinding setSecretBinding = (FilesetChange.SetSecretBinding) item;
+        properties.put(setSecretBinding.getProperty(), setSecretBinding.getBinding().plaintext());
+      } else if (item instanceof FilesetChange.SetSecretReference) {
+        FilesetChange.SetSecretReference setSecretReference =
+            (FilesetChange.SetSecretReference) item;
+        properties.put(setSecretReference.getProperty(), setSecretReference.getProperty());
       } else if (item instanceof TopicChange.SetProperty) {
         TopicChange.SetProperty setProperty = (TopicChange.SetProperty) item;
         properties.put(setProperty.getProperty(), setProperty.getValue());

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -673,7 +673,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
    */
   private Pair<SchemaChange[], List<SecretMaterial>> prepareSchemaSecretChanges(
       @Nullable Map<String, String> currentProperties, long entityId, SchemaChange... changes) {
-    Map<String, String> working =
+    Map<String, String> properties =
         currentProperties == null ? new HashMap<>() : new HashMap<>(currentProperties);
     List<SchemaChange> out = new ArrayList<>(changes.length);
     List<SecretMaterial> written = new ArrayList<>();
@@ -683,23 +683,23 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
           SchemaChange.SetSecretBinding c = (SchemaChange.SetSecretBinding) change;
           String urn =
               secretManager.alterSetSecretBinding(
-                  working, "schema", entityId, c.getProperty(), c.getBinding(), written);
+                  properties, "schema", entityId, c.getProperty(), c.getBinding(), written);
           out.add(SchemaChange.setProperty(c.getProperty(), urn));
         } else if (change instanceof SchemaChange.SetSecretReference) {
           SchemaChange.SetSecretReference c = (SchemaChange.SetSecretReference) change;
           String urn =
               secretManager.alterSetSecretReference(
-                  working, "schema", entityId, c.getProperty(), c.getReference());
+                  properties, "schema", entityId, c.getProperty(), c.getReference());
           out.add(SchemaChange.setProperty(c.getProperty(), urn));
         } else if (change instanceof SchemaChange.SetProperty) {
           SchemaChange.SetProperty c = (SchemaChange.SetProperty) change;
           String value =
               secretManager.alterSetProperty(
-                  working, "schema", entityId, c.getProperty(), c.getValue());
+                  properties, "schema", entityId, c.getProperty(), c.getValue());
           out.add(SchemaChange.setProperty(c.getProperty(), value));
         } else if (change instanceof SchemaChange.RemoveProperty) {
           SchemaChange.RemoveProperty c = (SchemaChange.RemoveProperty) change;
-          secretManager.alterRemoveProperty(working, "schema", entityId, c.getProperty());
+          secretManager.alterRemoveProperty(properties, "schema", entityId, c.getProperty());
           out.add(change);
         } else {
           out.add(change);

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -26,11 +26,13 @@ import static org.apache.gravitino.utils.NameIdentifierUtil.ofFileset;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
@@ -307,12 +309,57 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
         ident,
         LockType.WRITE,
         () -> {
-          validateAlterProperties(ident, HasPropertyMetadata::schemaPropertiesMetadata, changes);
-          Schema alteredSchema =
+          Schema currentSchema =
               doWithCatalog(
                   catalogIdent,
-                  c -> c.doWithSchemaOps(s -> s.alterSchema(ident, changes)),
+                  c -> c.doWithSchemaOps(s -> s.loadSchema(ident)),
                   NoSuchSchemaException.class);
+          // Prefer SchemaEntity properties for secret URNs (catalog loadSchema may omit them).
+          SchemaEntity schemaEntityForSecrets = getEntity(ident, SCHEMA, SchemaEntity.class);
+          Map<String, String> currentProperties;
+          if (schemaEntityForSecrets != null
+              && schemaEntityForSecrets.properties() != null
+              && !schemaEntityForSecrets.properties().isEmpty()) {
+            currentProperties = new HashMap<>(schemaEntityForSecrets.properties());
+          } else if (currentSchema.properties() != null) {
+            currentProperties = new HashMap<>(currentSchema.properties());
+          } else {
+            currentProperties = new HashMap<>();
+          }
+
+          validateAlterProperties(ident, HasPropertyMetadata::schemaPropertiesMetadata, changes);
+
+          StringIdentifier currentStringId = getStringIdFromProperties(currentProperties);
+          long entityIdForSecrets;
+          if (currentStringId != null) {
+            entityIdForSecrets = currentStringId.id();
+          } else if (schemaEntityForSecrets != null) {
+            entityIdForSecrets = schemaEntityForSecrets.id();
+          } else {
+            entityIdForSecrets = 0L;
+          }
+
+          List<SecretMaterial> writtenSecretMaterials = List.of();
+          boolean alterCommitted = false;
+          Schema alteredSchema;
+          SchemaChange[] effectiveChanges;
+          try {
+            Pair<SchemaChange[], List<SecretMaterial>> secretResult =
+                prepareSchemaSecretChanges(currentProperties, entityIdForSecrets, changes);
+            writtenSecretMaterials = secretResult.getRight();
+            effectiveChanges = secretResult.getLeft();
+
+            alteredSchema =
+                doWithCatalog(
+                    catalogIdent,
+                    c -> c.doWithSchemaOps(s -> s.alterSchema(ident, effectiveChanges)),
+                    NoSuchSchemaException.class);
+            alterCommitted = true;
+          } finally {
+            if (!alterCommitted) {
+              secretManager.rollbackSecrets(writtenSecretMaterials);
+            }
+          }
 
           // If the Schema is maintained by the Gravitino's store, we don't have to alter again.
           boolean isManagedSchema = isManagedEntity(catalogIdent, Capability.Scope.SCHEMA);
@@ -361,7 +408,8 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
                                   .withName(schemaEntity.name())
                                   .withNamespace(ident.namespace())
                                   .withProperties(
-                                      propertiesForSchemaEntityAlter(schemaEntity, changes))
+                                      propertiesForSchemaEntityAlter(
+                                          schemaEntity, effectiveChanges))
                                   .withAuditInfo(
                                       AuditInfo.builder()
                                           .withCreator(schemaEntity.auditInfo().creator())
@@ -612,5 +660,55 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
                 HasPropertyMetadata::schemaPropertiesMetadata,
                 schema.properties()))
         .withImported(schemaEntity != null);
+  }
+
+  /**
+   * Rewrites schema changes that involve secrets into plain setProperty / removeProperty, writing
+   * secrets as needed. Rolls back any written materials if preparation fails.
+   *
+   * @param currentProperties current schema properties (may be null)
+   * @param entityId schema entity id
+   * @param changes schema changes
+   * @return effective changes and written write-through materials
+   */
+  private Pair<SchemaChange[], List<SecretMaterial>> prepareSchemaSecretChanges(
+      @Nullable Map<String, String> currentProperties, long entityId, SchemaChange... changes) {
+    Map<String, String> working =
+        currentProperties == null ? new HashMap<>() : new HashMap<>(currentProperties);
+    List<SchemaChange> out = new ArrayList<>(changes.length);
+    List<SecretMaterial> written = new ArrayList<>();
+    try {
+      for (SchemaChange change : changes) {
+        if (change instanceof SchemaChange.SetSecretBinding) {
+          SchemaChange.SetSecretBinding c = (SchemaChange.SetSecretBinding) change;
+          String urn =
+              secretManager.alterSetSecretBinding(
+                  working, "schema", entityId, c.getProperty(), c.getBinding(), written);
+          out.add(SchemaChange.setProperty(c.getProperty(), urn));
+        } else if (change instanceof SchemaChange.SetSecretReference) {
+          SchemaChange.SetSecretReference c = (SchemaChange.SetSecretReference) change;
+          String urn =
+              secretManager.alterSetSecretReference(
+                  working, "schema", entityId, c.getProperty(), c.getReference());
+          out.add(SchemaChange.setProperty(c.getProperty(), urn));
+        } else if (change instanceof SchemaChange.SetProperty) {
+          SchemaChange.SetProperty c = (SchemaChange.SetProperty) change;
+          String value =
+              secretManager.alterSetProperty(
+                  working, "schema", entityId, c.getProperty(), c.getValue());
+          out.add(SchemaChange.setProperty(c.getProperty(), value));
+        } else if (change instanceof SchemaChange.RemoveProperty) {
+          SchemaChange.RemoveProperty c = (SchemaChange.RemoveProperty) change;
+          secretManager.alterRemoveProperty(working, "schema", entityId, c.getProperty());
+          out.add(change);
+        } else {
+          out.add(change);
+        }
+      }
+      return Pair.of(out.toArray(new SchemaChange[0]), List.copyOf(written));
+    } catch (RuntimeException e) {
+      secretManager.rollbackSecrets(written);
+      throw e;
+    }
   }
 }

--- a/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
+++ b/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
@@ -352,10 +352,10 @@ public class SecretManager implements Closeable {
   }
 
   /**
-   * Writes a write-through secret for alter setSecretBinding; updates working properties with the
-   * URN. Appends written materials to {@code written} for caller rollback.
+   * Writes a write-through secret for alter setSecretBinding; updates properties with the URN.
+   * Appends written materials to {@code written} for caller rollback.
    *
-   * @param working mutable working properties map
+   * @param properties mutable properties map updated as changes are applied
    * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
    * @param entityId stable numeric entity id
    * @param property property key
@@ -364,7 +364,7 @@ public class SecretManager implements Closeable {
    * @return the URN string stored in properties
    */
   public String alterSetSecretBinding(
-      Map<String, String> working,
+      Map<String, String> properties,
       String entityType,
       long entityId,
       String property,
@@ -376,7 +376,7 @@ public class SecretManager implements Closeable {
     Map<String, SecretBinding> bindings = ImmutableMap.of(property, binding);
     List<SecretUrn> urns = buildSecretBindingUrns(entityType, entityId, bindings);
     String newUrn = urns.get(0).toString();
-    String current = working.get(property);
+    String current = properties.get(property);
     if (current != null
         && !current.equals(newUrn)
         && SecretPropertyUtils.isWriteThroughForEntity(property, current, entityType, entityId)) {
@@ -385,14 +385,14 @@ public class SecretManager implements Closeable {
     List<SecretMaterial> materials = List.of(new SecretMaterial(urns.get(0), binding.plaintext()));
     writeSecrets(materials);
     written.addAll(materials);
-    SecretPropertyUtils.putSecretUrns(working, urns);
-    return working.get(property);
+    SecretPropertyUtils.putSecretUrns(properties, urns);
+    return properties.get(property);
   }
 
   /**
-   * Puts external-ref URN into working; deletes prior write-through if owned by this entity.
+   * Puts external-ref URN into properties; deletes prior write-through if owned by this entity.
    *
-   * @param working mutable working properties map
+   * @param properties mutable properties map updated as changes are applied
    * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
    * @param entityId stable numeric entity id
    * @param property property key
@@ -400,28 +400,28 @@ public class SecretManager implements Closeable {
    * @return the URN string stored in properties
    */
   public String alterSetSecretReference(
-      Map<String, String> working,
+      Map<String, String> properties,
       String entityType,
       long entityId,
       String property,
       SecretReference reference) {
     Preconditions.checkArgument(StringUtils.isNotBlank(property), "property must not be blank");
     Preconditions.checkArgument(reference != null, "reference must not be null");
-    String current = working.get(property);
+    String current = properties.get(property);
     if (SecretPropertyUtils.isWriteThroughForEntity(property, current, entityType, entityId)) {
       deleteSecretsFromProperties(Map.of(property, current));
     }
     Map<String, SecretReference> refs = ImmutableMap.of(property, reference);
     List<SecretUrn> urns = buildSecretReferenceUrns(refs);
-    SecretPropertyUtils.putSecretUrns(working, urns);
-    return working.get(property);
+    SecretPropertyUtils.putSecretUrns(properties, urns);
+    return properties.get(property);
   }
 
   /**
    * Handles alter setProperty. If current value is a secret URN, rewrite via provider/writeSecrets.
-   * Otherwise puts plaintext into working.
+   * Otherwise puts plaintext into properties.
    *
-   * @param working mutable working properties map
+   * @param properties mutable properties map updated as changes are applied
    * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
    * @param entityId stable numeric entity id
    * @param property property key
@@ -429,13 +429,13 @@ public class SecretManager implements Closeable {
    * @return value to use in SetProperty change (URN or plaintext)
    */
   public String alterSetProperty(
-      Map<String, String> working,
+      Map<String, String> properties,
       String entityType,
       long entityId,
       String property,
       String value) {
     SecretPropertyUtils.validateAlterSetPropertyValue(property, value);
-    String current = working.get(property);
+    String current = properties.get(property);
     if (SecretPropertyUtils.isSecretProperty(property, current)) {
       SecretUrn currentUrn = SecretUrn.parse(current);
       SecretBinding binding = new SecretBinding(currentUrn.providerName(), value);
@@ -444,8 +444,8 @@ public class SecretManager implements Closeable {
         List<SecretUrn> urns = buildSecretBindingUrns(entityType, entityId, bindings);
         List<SecretMaterial> materials = List.of(new SecretMaterial(urns.get(0), value));
         writeSecrets(materials);
-        SecretPropertyUtils.putSecretUrns(working, urns);
-        return working.get(property);
+        SecretPropertyUtils.putSecretUrns(properties, urns);
+        return properties.get(property);
       }
       List<String> segments = currentUrn.identifierSegments();
       Preconditions.checkArgument(
@@ -460,29 +460,29 @@ public class SecretManager implements Closeable {
       }
       SecretUrn writtenUrn =
           getRegistry().getProvider(currentUrn.providerName()).writeSecret(value, attributes);
-      working.put(property, writtenUrn.toString());
+      properties.put(property, writtenUrn.toString());
       return writtenUrn.toString();
     }
-    working.put(property, value);
+    properties.put(property, value);
     return value;
   }
 
   /**
-   * Deletes write-through secret if owned by this entity; removes key from working.
+   * Deletes write-through secret if owned by this entity; removes key from properties.
    *
-   * @param working mutable working properties map
+   * @param properties mutable properties map updated as changes are applied
    * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
    * @param entityId stable numeric entity id
    * @param property property key to remove
    */
   public void alterRemoveProperty(
-      Map<String, String> working, String entityType, long entityId, String property) {
+      Map<String, String> properties, String entityType, long entityId, String property) {
     Preconditions.checkArgument(StringUtils.isNotBlank(property), "property must not be blank");
-    String current = working.get(property);
+    String current = properties.get(property);
     if (SecretPropertyUtils.isWriteThroughForEntity(property, current, entityType, entityId)) {
       deleteSecretsFromProperties(Map.of(property, current));
     }
-    working.remove(property);
+    properties.remove(property);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
+++ b/core/src/main/java/org/apache/gravitino/secret/SecretManager.java
@@ -352,6 +352,140 @@ public class SecretManager implements Closeable {
   }
 
   /**
+   * Writes a write-through secret for alter setSecretBinding; updates working properties with the
+   * URN. Appends written materials to {@code written} for caller rollback.
+   *
+   * @param working mutable working properties map
+   * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
+   * @param entityId stable numeric entity id
+   * @param property property key
+   * @param binding write-through secret binding
+   * @param written list that receives newly written materials for rollback
+   * @return the URN string stored in properties
+   */
+  public String alterSetSecretBinding(
+      Map<String, String> working,
+      String entityType,
+      long entityId,
+      String property,
+      SecretBinding binding,
+      List<SecretMaterial> written) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(property), "property must not be blank");
+    Preconditions.checkArgument(binding != null, "binding must not be null");
+    SecretPropertyUtils.validateAlterSecretBindingPlaintext(binding.plaintext());
+    Map<String, SecretBinding> bindings = ImmutableMap.of(property, binding);
+    List<SecretUrn> urns = buildSecretBindingUrns(entityType, entityId, bindings);
+    String newUrn = urns.get(0).toString();
+    String current = working.get(property);
+    if (current != null
+        && !current.equals(newUrn)
+        && SecretPropertyUtils.isWriteThroughForEntity(property, current, entityType, entityId)) {
+      deleteSecretsFromProperties(Map.of(property, current));
+    }
+    List<SecretMaterial> materials = List.of(new SecretMaterial(urns.get(0), binding.plaintext()));
+    writeSecrets(materials);
+    written.addAll(materials);
+    SecretPropertyUtils.putSecretUrns(working, urns);
+    return working.get(property);
+  }
+
+  /**
+   * Puts external-ref URN into working; deletes prior write-through if owned by this entity.
+   *
+   * @param working mutable working properties map
+   * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
+   * @param entityId stable numeric entity id
+   * @param property property key
+   * @param reference external secret reference
+   * @return the URN string stored in properties
+   */
+  public String alterSetSecretReference(
+      Map<String, String> working,
+      String entityType,
+      long entityId,
+      String property,
+      SecretReference reference) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(property), "property must not be blank");
+    Preconditions.checkArgument(reference != null, "reference must not be null");
+    String current = working.get(property);
+    if (SecretPropertyUtils.isWriteThroughForEntity(property, current, entityType, entityId)) {
+      deleteSecretsFromProperties(Map.of(property, current));
+    }
+    Map<String, SecretReference> refs = ImmutableMap.of(property, reference);
+    List<SecretUrn> urns = buildSecretReferenceUrns(refs);
+    SecretPropertyUtils.putSecretUrns(working, urns);
+    return working.get(property);
+  }
+
+  /**
+   * Handles alter setProperty. If current value is a secret URN, rewrite via provider/writeSecrets.
+   * Otherwise puts plaintext into working.
+   *
+   * @param working mutable working properties map
+   * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
+   * @param entityId stable numeric entity id
+   * @param property property key
+   * @param value new property value (plaintext when rewriting a secret, or plain value)
+   * @return value to use in SetProperty change (URN or plaintext)
+   */
+  public String alterSetProperty(
+      Map<String, String> working,
+      String entityType,
+      long entityId,
+      String property,
+      String value) {
+    SecretPropertyUtils.validateAlterSetPropertyValue(property, value);
+    String current = working.get(property);
+    if (SecretPropertyUtils.isSecretProperty(property, current)) {
+      SecretUrn currentUrn = SecretUrn.parse(current);
+      SecretBinding binding = new SecretBinding(currentUrn.providerName(), value);
+      if (SecretPropertyUtils.isWriteThroughForEntity(property, current, entityType, entityId)) {
+        Map<String, SecretBinding> bindings = ImmutableMap.of(property, binding);
+        List<SecretUrn> urns = buildSecretBindingUrns(entityType, entityId, bindings);
+        List<SecretMaterial> materials = List.of(new SecretMaterial(urns.get(0), value));
+        writeSecrets(materials);
+        SecretPropertyUtils.putSecretUrns(working, urns);
+        return working.get(property);
+      }
+      List<String> segments = currentUrn.identifierSegments();
+      Preconditions.checkArgument(
+          !segments.isEmpty(), "Secret URN must contain identifier segments: %s", currentUrn);
+      Map<String, String> attributes = new HashMap<>();
+      if (segments.size() == 3) {
+        attributes.put(ATTR_ENTITY_TYPE, segments.get(0));
+        attributes.put(ATTR_ENTITY_ID, segments.get(1));
+        attributes.put(ATTR_PROPERTY_KEY, segments.get(2));
+      } else {
+        attributes.put(ATTR_PROPERTY_KEY, property);
+      }
+      SecretUrn writtenUrn =
+          getRegistry().getProvider(currentUrn.providerName()).writeSecret(value, attributes);
+      working.put(property, writtenUrn.toString());
+      return writtenUrn.toString();
+    }
+    working.put(property, value);
+    return value;
+  }
+
+  /**
+   * Deletes write-through secret if owned by this entity; removes key from working.
+   *
+   * @param working mutable working properties map
+   * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
+   * @param entityId stable numeric entity id
+   * @param property property key to remove
+   */
+  public void alterRemoveProperty(
+      Map<String, String> working, String entityType, long entityId, String property) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(property), "property must not be blank");
+    String current = working.get(property);
+    if (SecretPropertyUtils.isWriteThroughForEntity(property, current, entityType, entityId)) {
+      deleteSecretsFromProperties(Map.of(property, current));
+    }
+    working.remove(property);
+  }
+
+  /**
    * Reads plaintext for a secret URN via the provider named in the URN.
    *
    * @param urn the secret URN

--- a/core/src/main/java/org/apache/gravitino/secret/SecretPropertyUtils.java
+++ b/core/src/main/java/org/apache/gravitino/secret/SecretPropertyUtils.java
@@ -133,6 +133,63 @@ public final class SecretPropertyUtils {
   }
 
   /**
+   * Returns whether {@code value} is a write-through secret URN owned by this entity property.
+   *
+   * <p>Write-through URNs use identifier segments {@code entityType:entityId:propertyKey}.
+   *
+   * @param propertyKey the property key
+   * @param value the property value
+   * @param entityType {@code catalog}, {@code schema}, or {@code fileset}
+   * @param entityId the entity id
+   * @return true when the value is a write-through URN for this entity and property
+   */
+  public static boolean isWriteThroughForEntity(
+      @Nullable String propertyKey, @Nullable String value, String entityType, long entityId) {
+    if (!isSecretProperty(propertyKey, value)) {
+      return false;
+    }
+    try {
+      SecretUrn urn = SecretUrn.parse(value);
+      List<String> segments = urn.identifierSegments();
+      return segments.size() == 3
+          && entityType.equals(segments.get(0))
+          && String.valueOf(entityId).equals(segments.get(1))
+          && propertyKey.equals(segments.get(2));
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Validates alter {@code setProperty} plaintext: rejects blank, masked placeholder, and raw URN
+   * strings.
+   *
+   * @param property the property key
+   * @param value the plaintext value
+   */
+  public static void validateAlterSetPropertyValue(String property, String value) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(property), "property must not be blank");
+    Preconditions.checkArgument(StringUtils.isNotBlank(value), "value must not be blank");
+    Preconditions.checkArgument(
+        !"******".equals(value), "setProperty value must not be the masked placeholder ******");
+    Preconditions.checkArgument(
+        !value.startsWith(URN_PREFIX),
+        "setProperty value must not be a secret URN; use setSecretBinding or setSecretReference");
+  }
+
+  /**
+   * Validates alter {@code setSecretBinding} plaintext.
+   *
+   * @param plaintext the plaintext from the binding
+   */
+  public static void validateAlterSecretBindingPlaintext(String plaintext) {
+    Preconditions.checkArgument(plaintext != null, "plaintext must not be null");
+    Preconditions.checkArgument(
+        !"******".equals(plaintext),
+        "setSecretBinding plaintext must not be the masked placeholder ******");
+  }
+
+  /**
    * Returns a mutable property map for create-time assembly, or {@code null} when the caller
    * supplied no properties and no secrets.
    *
@@ -171,6 +228,16 @@ public final class SecretPropertyUtils {
     for (SecretUrn urn : secretUrns) {
       entityProperties.put(urn.propertyKey(), urn.toString());
     }
+  }
+
+  /**
+   * Applies each URN string into {@code properties} under the property key encoded in the URN.
+   *
+   * @param properties mutable entity properties
+   * @param secretUrns secret URNs whose property key is encoded in the URN
+   */
+  public static void applySecretUrns(Map<String, String> properties, List<SecretUrn> secretUrns) {
+    putSecretUrns(properties, secretUrns);
   }
 
   /**

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -1530,7 +1530,51 @@ public class TestCatalogManager {
   }
 
   @Test
-  void testSecretRollback() throws Exception {
+  void testAlterRemovePropertyDeletesWriteThroughSecret() throws Exception {
+    try (SecretManager secrets = memorySecretManager()) {
+      CatalogManager manager =
+          new CatalogManager(config, entityStore, new RandomIdGenerator(), secrets);
+      NameIdentifier ident = NameIdentifier.of("metalake", "secret_catalog_remove");
+      Map<String, String> props =
+          ImmutableMap.of(
+              "provider",
+              "test",
+              PROPERTY_KEY1,
+              "value1",
+              PROPERTY_KEY2,
+              "value2",
+              PROPERTY_KEY5_PREFIX + "1",
+              "value3");
+      Map<String, SecretBinding> bindings =
+          Map.of(PROPERTY_KEY4, new SecretBinding("memory", "s3cr3t"));
+
+      manager.createCatalog(
+          ident, Catalog.Type.RELATIONAL, provider, "comment", props, bindings, Map.of());
+
+      String urn =
+          entityStore
+              .get(ident, EntityType.CATALOG, CatalogEntity.class)
+              .getProperties()
+              .get(PROPERTY_KEY4);
+      Assertions.assertEquals("s3cr3t", secrets.readSecret(SecretUrn.parse(urn)));
+
+      manager.alterCatalog(ident, CatalogChange.removeProperty(PROPERTY_KEY4));
+
+      Assertions.assertFalse(
+          entityStore
+              .get(ident, EntityType.CATALOG, CatalogEntity.class)
+              .getProperties()
+              .containsKey(PROPERTY_KEY4));
+      Assertions.assertThrows(
+          IllegalArgumentException.class, () -> secrets.readSecret(SecretUrn.parse(urn)));
+
+      Assertions.assertTrue(manager.dropCatalog(ident, true));
+      manager.close();
+    }
+  }
+
+  @Test
+  void testCreateSecretRollback() throws Exception {
     try (SecretManager secrets = memorySecretManager()) {
       IdGenerator ids = new AtomicLong(4242L)::getAndIncrement;
       CatalogManager manager = Mockito.spy(new CatalogManager(config, entityStore, ids, secrets));

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFilesetOperationDispatcher.java
@@ -374,6 +374,51 @@ public class TestFilesetOperationDispatcher extends TestOperationDispatcher {
     }
   }
 
+  @Test
+  public void testAlterRemovePropertyDeletesWriteThroughSecret() throws Exception {
+    try (SecretManager secrets = memorySecretManager()) {
+      AtomicLong nextId = new AtomicLong(9100L);
+      IdGenerator ids = nextId::getAndIncrement;
+      FilesetOperationDispatcher filesets =
+          new FilesetOperationDispatcher(catalogManager, entityStore, ids, secrets);
+      new SchemaOperationDispatcher(catalogManager, entityStore, ids, secrets, filesets)
+          .createSchema(
+              NameIdentifier.of(metalake, catalog, "schema_secret_fileset_remove"),
+              "comment",
+              ImmutableMap.of("k1", "v1"));
+
+      NameIdentifier ident =
+          NameIdentifier.of(
+              metalake, catalog, "schema_secret_fileset_remove", "fileset_secret_remove");
+      Map<String, SecretBinding> bindings = Map.of("k2", new SecretBinding("memory", "s3cr3t"));
+      Map<String, String> locations = Map.of(Fileset.LOCATION_NAME_UNKNOWN, "loc");
+      Map<String, String> props = ImmutableMap.of("k1", "v1");
+      long entityId = nextId.get();
+      filesets.createMultipleLocationFileset(
+          ident, "comment", Fileset.Type.MANAGED, locations, props, bindings, Map.of());
+
+      SecretUrn urn =
+          SecretUrn.buildWriteThrough(
+              "memory",
+              Map.of(
+                  SecretConstants.ATTR_ENTITY_TYPE, "fileset",
+                  SecretConstants.ATTR_ENTITY_ID, String.valueOf(entityId),
+                  SecretConstants.ATTR_PROPERTY_KEY, "k2"));
+      Assertions.assertEquals("s3cr3t", secrets.readSecret(urn));
+
+      filesets.alterFileset(ident, FilesetChange.removeProperty("k2"));
+
+      Fileset stored =
+          catalogManager
+              .loadCatalogAndWrap(NameIdentifier.of(metalake, catalog))
+              .doWithFilesetOps(ops -> ops.loadFileset(ident));
+      Assertions.assertFalse(stored.properties().containsKey("k2"));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> secrets.readSecret(urn));
+
+      Assertions.assertTrue(filesets.dropFileset(ident));
+    }
+  }
+
   private static SecretManager memorySecretManager() {
     Config c = new Config(false) {};
     Properties p = new Properties();

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -474,6 +474,38 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
     }
   }
 
+  @Test
+  public void testAlterRemovePropertyDeletesWriteThroughSecret() throws Exception {
+    try (SecretManager secrets = memorySecretManager()) {
+      SchemaOperationDispatcher d =
+          new SchemaOperationDispatcher(
+              catalogManager, entityStore, idGenerator, secrets, mock(FilesetDispatcher.class));
+      NameIdentifier ident = NameIdentifier.of(metalake, catalog, "schema_secret_remove");
+      Map<String, String> props = ImmutableMap.of("k1", "v1");
+      Map<String, SecretBinding> bindings = Map.of("k2", new SecretBinding("memory", "s3cr3t"));
+
+      d.createSchema(ident, "comment", props, bindings, Map.of());
+
+      SchemaEntity entity = entityStore.get(ident, SCHEMA, SchemaEntity.class);
+      SecretUrn urn =
+          SecretUrn.buildWriteThrough(
+              "memory",
+              Map.of(
+                  SecretConstants.ATTR_ENTITY_TYPE, "schema",
+                  SecretConstants.ATTR_ENTITY_ID, String.valueOf(entity.id()),
+                  SecretConstants.ATTR_PROPERTY_KEY, "k2"));
+      Assertions.assertEquals("s3cr3t", secrets.readSecret(urn));
+
+      d.alterSchema(ident, SchemaChange.removeProperty("k2"));
+
+      SchemaEntity updated = entityStore.get(ident, SCHEMA, SchemaEntity.class);
+      Assertions.assertFalse(updated.properties().containsKey("k2"));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> secrets.readSecret(urn));
+
+      Assertions.assertTrue(d.dropSchema(ident, false));
+    }
+  }
+
   private static SecretManager memorySecretManager() {
     Config c = new Config(false) {};
     Properties p = new Properties();

--- a/core/src/test/java/org/apache/gravitino/secret/TestSecretManagerAlter.java
+++ b/core/src/test/java/org/apache/gravitino/secret/TestSecretManagerAlter.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.secret;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.secret.memory.InMemorySecretsProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestSecretManagerAlter {
+
+  @Test
+  void testAlterSetSecretBindingWritesAndReturnsUrn() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      Map<String, String> props = new HashMap<>(Map.of("jdbc-user", "root"));
+      List<SecretMaterial> written = new ArrayList<>();
+      String urn =
+          secretManager.alterSetSecretBinding(
+              props,
+              "catalog",
+              42L,
+              "jdbc-password",
+              new SecretBinding("memory", "s3cr3t"),
+              written);
+
+      Assertions.assertTrue(
+          SecretPropertyUtils.isWriteThroughForEntity("jdbc-password", urn, "catalog", 42L));
+      Assertions.assertEquals(urn, props.get("jdbc-password"));
+      Assertions.assertEquals(1, written.size());
+      Assertions.assertEquals(
+          "s3cr3t",
+          secretManager.getRegistry().getProvider("memory").readSecret(written.get(0).urn()));
+    }
+  }
+
+  @Test
+  void testAlterRemovePropertyDeletesWriteThroughSecret() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      Map<String, String> props = new HashMap<>();
+      List<SecretMaterial> written = new ArrayList<>();
+      String urn =
+          secretManager.alterSetSecretBinding(
+              props, "catalog", 7L, "jdbc-password", new SecretBinding("memory", "old"), written);
+
+      secretManager.alterRemoveProperty(props, "catalog", 7L, "jdbc-password");
+
+      Assertions.assertFalse(props.containsKey("jdbc-password"));
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> secretManager.getRegistry().getProvider("memory").readSecret(SecretUrn.parse(urn)));
+    }
+  }
+
+  @Test
+  void testAlterRemovePropertyKeepsExternalReferenceSecret() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      // External-ref URNs are not entityType:entityId:propertyKey write-through shapes.
+      String externalUrn = "urn:gravitino-secret:memory:path:kv/jdbc-password:jdbc-password";
+      Assertions.assertTrue(SecretPropertyUtils.isSecretProperty("jdbc-password", externalUrn));
+      Assertions.assertFalse(
+          SecretPropertyUtils.isWriteThroughForEntity("jdbc-password", externalUrn, "catalog", 7L));
+
+      Map<String, String> props = new HashMap<>();
+      props.put("jdbc-password", externalUrn);
+
+      // Seed an unrelated write-through secret that must survive removing the external-ref key.
+      List<SecretMaterial> written = new ArrayList<>();
+      String ownedUrn =
+          secretManager.alterSetSecretBinding(
+              new HashMap<>(),
+              "catalog",
+              7L,
+              "other-secret",
+              new SecretBinding("memory", "keep-me"),
+              written);
+
+      secretManager.alterRemoveProperty(props, "catalog", 7L, "jdbc-password");
+
+      Assertions.assertEquals(
+          "keep-me",
+          secretManager.getRegistry().getProvider("memory").readSecret(SecretUrn.parse(ownedUrn)));
+    }
+  }
+
+  @Test
+  void testSchemaAlterRemovePropertyDeletesWriteThroughSecret() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      Map<String, String> props = new HashMap<>();
+      List<SecretMaterial> written = new ArrayList<>();
+      String urn =
+          secretManager.alterSetSecretBinding(
+              props, "schema", 9L, "k2", new SecretBinding("memory", "old"), written);
+
+      secretManager.alterRemoveProperty(props, "schema", 9L, "k2");
+
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> secretManager.getRegistry().getProvider("memory").readSecret(SecretUrn.parse(urn)));
+    }
+  }
+
+  @Test
+  void testFilesetAlterRemovePropertyDeletesWriteThroughSecret() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      Map<String, String> props = new HashMap<>();
+      List<SecretMaterial> written = new ArrayList<>();
+      String urn =
+          secretManager.alterSetSecretBinding(
+              props, "fileset", 11L, "k2", new SecretBinding("memory", "old"), written);
+
+      secretManager.alterRemoveProperty(props, "fileset", 11L, "k2");
+
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> secretManager.getRegistry().getProvider("memory").readSecret(SecretUrn.parse(urn)));
+    }
+  }
+
+  @Test
+  void testRejectMaskedSetPropertyAndRawUrn() {
+    try (SecretManager secretManager = memorySecretManager()) {
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              secretManager.alterSetProperty(
+                  new HashMap<>(), "catalog", 1L, "jdbc-password", "******"));
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              secretManager.alterSetProperty(
+                  new HashMap<>(),
+                  "catalog",
+                  1L,
+                  "jdbc-password",
+                  "urn:gravitino-secret:memory:catalog:1:jdbc-password"));
+    }
+  }
+
+  private static SecretManager memorySecretManager() {
+    Config config = new Config(false) {};
+    Properties properties = new Properties();
+    properties.setProperty(SecretProviderRegistry.GRAVITINO_SECRET_PROVIDERS, "memory");
+    properties.setProperty(
+        SecretProviderRegistry.GRAVITINO_SECRET_PROVIDER_PREFIX
+            + "memory."
+            + SecretProviderRegistry.CLASS_NAME,
+        InMemorySecretsProvider.class.getName());
+    config.loadFromProperties(properties);
+    return new SecretManager(config);
+  }
+}

--- a/docs/open-api/catalogs.yaml
+++ b/docs/open-api/catalogs.yaml
@@ -509,6 +509,8 @@ components:
         - $ref: "#/components/schemas/UpdateCatalogCommentRequest"
         - $ref: "#/components/schemas/SetCatalogPropertyRequest"
         - $ref: "#/components/schemas/RemoveCatalogPropertyRequest"
+        - $ref: "#/components/schemas/SetCatalogSecretBindingRequest"
+        - $ref: "#/components/schemas/SetCatalogSecretReferenceRequest"
       discriminator:
         propertyName: "@type"
         mapping:
@@ -516,6 +518,8 @@ components:
           updateComment: "#/components/schemas/UpdateCatalogCommentRequest"
           setProperty: "#/components/schemas/SetCatalogPropertyRequest"
           removeProperty: "#/components/schemas/RemoveCatalogPropertyRequest"
+          setSecretBinding: "#/components/schemas/SetCatalogSecretBindingRequest"
+          setSecretReference: "#/components/schemas/SetCatalogSecretReferenceRequest"
 
     RenameCatalogRequest:
       type: object
@@ -592,6 +596,67 @@ components:
       example: {
         "@type": "removeProperty",
         "property": "key2"
+      }
+
+    SetCatalogSecretBindingRequest:
+      type: object
+      required:
+        - "@type"
+        - property
+        - provider
+        - plaintext
+      properties:
+        "@type":
+          type: string
+          enum:
+            - setSecretBinding
+        property:
+          type: string
+          description: The property to bind
+        provider:
+          type: string
+          description: Registered secrets-provider instance name
+        plaintext:
+          type: string
+          description: Plaintext secret to write through
+          format: password
+      example: {
+        "@type": "setSecretBinding",
+        "property": "password",
+        "provider": "env",
+        "plaintext": "secret-value"
+      }
+
+    SetCatalogSecretReferenceRequest:
+      type: object
+      required:
+        - "@type"
+        - property
+        - provider
+      properties:
+        "@type":
+          type: string
+          enum:
+            - setSecretReference
+        property:
+          type: string
+          description: The property to bind
+        provider:
+          type: string
+          description: Registered secrets-provider instance name
+        attributes:
+          type: object
+          description: Provider-specific locator keys (empty object if none)
+          additionalProperties:
+            type: string
+          default: {}
+      example: {
+        "@type": "setSecretReference",
+        "property": "password",
+        "provider": "vault",
+        "attributes": {
+          "path": "secret/data/my-password"
+        }
       }
 
 

--- a/docs/open-api/filesets.yaml
+++ b/docs/open-api/filesets.yaml
@@ -379,6 +379,8 @@ components:
         - $ref: "#/components/schemas/SetFilesetPropertyRequest"
         - $ref: "#/components/schemas/UpdateFilesetCommentRequest"
         - $ref: "#/components/schemas/RemoveFilesetPropertyRequest"
+        - $ref: "#/components/schemas/SetFilesetSecretBindingRequest"
+        - $ref: "#/components/schemas/SetFilesetSecretReferenceRequest"
       discriminator:
         propertyName: "@type"
         mapping:
@@ -386,6 +388,8 @@ components:
           setProperty: "#/components/schemas/SetFilesetPropertyRequest"
           updateComment: "#/components/schemas/UpdateFilesetCommentRequest"
           removeProperty: "#/components/schemas/RemoveFilesetPropertyRequest"
+          setSecretBinding: "#/components/schemas/SetFilesetSecretBindingRequest"
+          setSecretReference: "#/components/schemas/SetFilesetSecretReferenceRequest"
 
     RenameFilesetRequest:
       type: object
@@ -466,6 +470,69 @@ components:
       example: {
         "@type": "removeProperty",
         "property": "key1"
+      }
+
+    SetFilesetSecretBindingRequest:
+      type: object
+      required:
+        - "@type"
+        - property
+        - provider
+        - plaintext
+      properties:
+        "@type":
+          type: string
+          description: The type of the update
+          enum:
+            - setSecretBinding
+        property:
+          type: string
+          description: The property to bind
+        provider:
+          type: string
+          description: Registered secrets-provider instance name
+        plaintext:
+          type: string
+          description: Plaintext secret to write through
+          format: password
+      example: {
+        "@type": "setSecretBinding",
+        "property": "password",
+        "provider": "env",
+        "plaintext": "secret-value"
+      }
+
+    SetFilesetSecretReferenceRequest:
+      type: object
+      required:
+        - "@type"
+        - property
+        - provider
+      properties:
+        "@type":
+          type: string
+          description: The type of the update
+          enum:
+            - setSecretReference
+        property:
+          type: string
+          description: The property to bind
+        provider:
+          type: string
+          description: Registered secrets-provider instance name
+        attributes:
+          type: object
+          description: Provider-specific locator keys (empty object if none)
+          additionalProperties:
+            type: string
+          default: {}
+      example: {
+        "@type": "setSecretReference",
+        "property": "password",
+        "provider": "vault",
+        "attributes": {
+          "path": "secret/data/my-password"
+        }
       }
 
     RemoveFilesetCommentRequest:

--- a/docs/open-api/schemas.yaml
+++ b/docs/open-api/schemas.yaml
@@ -249,11 +249,15 @@ components:
       oneOf:
         - $ref: "#/components/schemas/SetSchemaPropertyRequest"
         - $ref: "#/components/schemas/RemoveSchemaPropertyRequest"
+        - $ref: "#/components/schemas/SetSchemaSecretBindingRequest"
+        - $ref: "#/components/schemas/SetSchemaSecretReferenceRequest"
       discriminator:
         propertyName: "@type"
         mapping:
           setProperty: "#/components/schemas/SetSchemaPropertyRequest"
           removeProperty: "#/components/schemas/RemoveSchemaPropertyRequest"
+          setSecretBinding: "#/components/schemas/SetSchemaSecretBindingRequest"
+          setSecretReference: "#/components/schemas/SetSchemaSecretReferenceRequest"
 
     SetSchemaPropertyRequest:
       type: object
@@ -293,6 +297,67 @@ components:
       example: {
         "@type": "removeProperty",
         "property": "key2"
+      }
+
+    SetSchemaSecretBindingRequest:
+      type: object
+      required:
+        - "@type"
+        - property
+        - provider
+        - plaintext
+      properties:
+        "@type":
+          type: string
+          enum:
+            - setSecretBinding
+        property:
+          type: string
+          description: The property to bind
+        provider:
+          type: string
+          description: Registered secrets-provider instance name
+        plaintext:
+          type: string
+          description: Plaintext secret to write through
+          format: password
+      example: {
+        "@type": "setSecretBinding",
+        "property": "password",
+        "provider": "env",
+        "plaintext": "secret-value"
+      }
+
+    SetSchemaSecretReferenceRequest:
+      type: object
+      required:
+        - "@type"
+        - property
+        - provider
+      properties:
+        "@type":
+          type: string
+          enum:
+            - setSecretReference
+        property:
+          type: string
+          description: The property to bind
+        provider:
+          type: string
+          description: Registered secrets-provider instance name
+        attributes:
+          type: object
+          description: Provider-specific locator keys (empty object if none)
+          additionalProperties:
+            type: string
+          default: {}
+      example: {
+        "@type": "setSecretReference",
+        "property": "password",
+        "provider": "vault",
+        "attributes": {
+          "path": "secret/data/my-password"
+        }
       }
 
   responses:


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add catalog / schema alter change types `setSecretBinding` / `setSecretReference` (API, DTOs, OpenAPI, Java/Python clients).
- Wire `CatalogManager` / `SchemaOperationDispatcher` with local `prepare*SecretChanges` loops calling `SecretManager` alter helpers.

> **Depends on** #12646 (fileset alter + `SecretManager` alter helpers). Until #12646 lands, the GitHub diff vs `main` includes fileset changes too. For catalog/schema-only review (~1,256 lines), compare:
> https://github.com/lasdf1234/gravitino/compare/feat/entity-secrets-alter-fileset-apache...feat/entity-secrets-alter-catalog-schema-only-apache

### Why are the changes needed?

Create-time `secretBindings` / `secretReferences` for catalog and schema are already on `main` (#12420). Catalog/schema alter still needs the typed secret update contract from the entity-secrets design (§5.9.4).

Fix: #12645

### Does this PR introduce _any_ user-facing change?

- Yes. Catalog and schema alter APIs / REST update requests gain `setSecretBinding` and `setSecretReference`.

### How was this patch tested?

- Unit tests: `TestSecretManagerAlter`, `TestCatalogManager`, `TestSchemaOperationDispatcher`, `TestRequestJsonSerDe`
- `./gradlew spotlessApply`
- `./gradlew :core:test :common:test -PskipITs` (targeted secret/alter tests)