### PR TITLE
[#12660] fix(mcp-server): Invoke isort/black console scripts and pin their versions

### DIFF
--- a/mcp-server/build.gradle.kts
+++ b/mcp-server/build.gradle.kts
@@ -46,6 +46,19 @@ val venvPython = when {
     venvDir.resolve("bin/python").absolutePath
 }
 
+// The formatters are invoked through their console scripts rather than `python -m <tool>`:
+// isort 9 no longer ships an `__main__` module, so `python -m isort` cannot be executed.
+fun venvExecutable(name: String): String = when {
+  System.getProperty("os.name").contains("win", ignoreCase = true) ->
+    venvDir.resolve("Scripts/$name.exe").absolutePath
+  else ->
+    venvDir.resolve("bin/$name").absolutePath
+}
+
+// Pinned so that a new formatter release cannot change the outcome of the format check in CI.
+val blackRequirement = "black==26.5.1"
+val isortRequirement = "isort==9.0.0"
+
 tasks {
   register<Exec>("installUv") {
     group = "python"
@@ -160,7 +173,7 @@ tasks {
     workingDir(pythonProjectDir)
 
     doFirst {
-      commandLine(getUvExecutable(), "pip", "install", "--python", venvPython, "black", "isort")
+      commandLine(getUvExecutable(), "pip", "install", "--python", venvPython, blackRequirement, isortRequirement)
     }
 
     doLast {
@@ -213,13 +226,13 @@ tasks {
       // Apply isort
       exec {
         workingDir = pythonProjectDir
-        commandLine(venvPython, "-m", "isort", "mcp_server", "tests")
+        commandLine(venvExecutable("isort"), "mcp_server", "tests")
       }
 
       // Apply Black
       exec {
         workingDir = pythonProjectDir
-        commandLine(venvPython, "-m", "black", "mcp_server", "tests")
+        commandLine(venvExecutable("black"), "mcp_server", "tests")
       }
 
       logger.lifecycle("Python formatting applied (isort + Black)")
@@ -234,7 +247,7 @@ tasks {
     doLast {
       val isortExitCode = exec {
         workingDir = pythonProjectDir
-        commandLine(venvPython, "-m", "isort", "--check", "mcp_server", "tests")
+        commandLine(venvExecutable("isort"), "--check", "mcp_server", "tests")
         isIgnoreExitValue = false
       }.exitValue
 
@@ -244,7 +257,7 @@ tasks {
 
       val blackExitCode = exec {
         workingDir = pythonProjectDir
-        commandLine(venvPython, "-m", "black", "--check", "mcp_server", "tests")
+        commandLine(venvExecutable("black"), "--check", "mcp_server", "tests")
         isIgnoreExitValue = false
       }.exitValue
 

--- a/mcp-server/build.gradle.kts
+++ b/mcp-server/build.gradle.kts
@@ -39,13 +39,6 @@ fun getUvExecutable(): String {
   }
 }
 
-val venvPython = when {
-  System.getProperty("os.name").contains("win", ignoreCase = true) ->
-    venvDir.resolve("Scripts/python.exe").absolutePath
-  else ->
-    venvDir.resolve("bin/python").absolutePath
-}
-
 // The formatters are invoked through their console scripts rather than `python -m <tool>`:
 // isort 9 no longer ships an `__main__` module, so `python -m isort` cannot be executed.
 fun venvExecutable(name: String): String = when {
@@ -54,6 +47,8 @@ fun venvExecutable(name: String): String = when {
   else ->
     venvDir.resolve("bin/$name").absolutePath
 }
+
+val venvPython = venvExecutable("python")
 
 // Pinned so that a new formatter release cannot change the outcome of the format check in CI.
 val blackRequirement = "black==26.5.1"

--- a/mcp-server/build.gradle.kts
+++ b/mcp-server/build.gradle.kts
@@ -248,7 +248,9 @@ tasks {
       val isortExitCode = exec {
         workingDir = pythonProjectDir
         commandLine(venvExecutable("isort"), "--check", "mcp_server", "tests")
-        isIgnoreExitValue = false
+        // Let the exit code reach the check below, so the failure is reported with the message
+        // that names the tool instead of a bare Gradle ExecException.
+        isIgnoreExitValue = true
       }.exitValue
 
       if (isortExitCode != 0) {
@@ -258,7 +260,9 @@ tasks {
       val blackExitCode = exec {
         workingDir = pythonProjectDir
         commandLine(venvExecutable("black"), "--check", "mcp_server", "tests")
-        isIgnoreExitValue = false
+        // Let the exit code reach the check below, so the failure is reported with the message
+        // that names the tool instead of a bare Gradle ExecException.
+        isIgnoreExitValue = true
       }.exitValue
 
       if (blackExitCode != 0) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `mcp-server/build.gradle.kts`:

1. Invoke the formatters through their venv console scripts (`.venv/bin/isort`, `.venv/bin/black`) instead of `python -m <tool>`, via a small `venvExecutable(name)` helper that mirrors the existing `venvPython` Windows/POSIX handling.
2. Pin the installed versions (`black==26.5.1`, `isort==9.0.0`) instead of installing them unconstrained.

### Why are the changes needed?

`isort` 9.0.0 no longer ships an `isort/__main__.py`, so `python -m isort` fails outright:

```
.venv/bin/python: No code object available for isort.__main__;
'isort' is a package and cannot be directly executed
> Task :mcp-server:formatCheckPython FAILED
```

`installFormatTools` installed `black` and `isort` without version constraints, so CI resolved the new release as soon as it was published and every job that runs `formatCheckPython` started failing — including the backend integration test jobs, which run the check before the tests. Pinning also keeps a future `black` release from silently changing the format check outcome.

Fix: #12660

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Locally on a clean venv:

- `./gradlew :mcp-server:formatCheckPython` — BUILD SUCCESSFUL (`80 files would be left unchanged`); fails on `main` with the error above.
- `./gradlew :mcp-server:formatApplyPython` — BUILD SUCCESSFUL, no files modified.
