### PR TITLE
[#12269] fix(authz): Allow catalog owners to grant schema privileges

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -585,9 +585,10 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
 
     MetadataObject metadataObject = MetadataObjects.parse(fullName, metadataType);
     do {
-      if (isOwner(currentPrincipal, metalake, metadataObject, requestContext)) {
-        return hasParentUsagePermission(
-            currentPrincipal, metalake, metadataObject, metalakeObject, requestContext);
+      if (isOwner(currentPrincipal, metalake, metadataObject, requestContext)
+          && hasParentUsagePermission(
+              currentPrincipal, metalake, metadataObject, metalakeObject, requestContext)) {
+        return true;
       }
     } while ((metadataObject = MetadataObjects.parent(metadataObject)) != null);
     return false;

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -2429,6 +2429,30 @@ public class TestJcasbinAuthorizer {
   }
 
   @Test
+  public void testHasSetOwnerPermissionAllowsSchemaAndCatalogOwner() throws Exception {
+    MetadataObject metalakeObject =
+        MetadataObjects.of(ImmutableList.of(METALAKE), MetadataObject.Type.METALAKE);
+    metadataIdConverterMockedStatic
+        .when(() -> MetadataIdConverter.getID(eq(metalakeObject), eq(METALAKE)))
+        .thenReturn(Optional.of(USER_METALAKE_ID));
+    when(ownerMetaMapper.selectOwnerByMetadataObjectIdAndType(eq(CATALOG_ID), eq("SCHEMA")))
+        .thenReturn(new OwnerInfo(USER_ID, "USER"));
+    when(ownerMetaMapper.selectOwnerByMetadataObjectIdAndType(eq(CATALOG_ID), eq("CATALOG")))
+        .thenReturn(new OwnerInfo(USER_ID, "USER"));
+    getOwnerRelCache(jcasbinAuthorizer).invalidateAll();
+
+    try {
+      assertTrue(
+          jcasbinAuthorizer.hasSetOwnerPermission(
+              METALAKE, "SCHEMA", "testCatalog.testSchema", new AuthorizationRequestContext()));
+    } finally {
+      metadataIdConverterMockedStatic
+          .when(() -> MetadataIdConverter.getID(eq(metalakeObject), eq(METALAKE)))
+          .thenReturn(Optional.of(CATALOG_ID));
+    }
+  }
+
+  @Test
   public void testHasSetOwnerPermissionRejectsDenyUseCatalogForTableOwner() throws Exception {
     makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

A user who owns a catalog and one of its schemas can currently get `403 Forbidden` when granting schema privileges unless they also have an explicit `USE_CATALOG` grant. This change allows the catalog owner to perform the operation and adds a regression for that case.

The authorizer now continues checking ancestors when ownership of the current object does not satisfy its parent usage requirement.

### Why are the changes needed?

The schema ownership check returned its failed `USE_CATALOG` result immediately, so the authorizer never reached the catalog ownership check. A user who owned both objects received `403 Forbidden: "Current user can not grant privilege to role."`, while owning only the catalog allowed the same operation.

Fix: #12269

### Does this PR introduce _any_ user-facing change?

Yes. A catalog owner who also owns a child schema can grant privileges on that schema without a redundant `USE_CATALOG` grant.

### How was this patch tested?

```shell
./gradlew :server-common:test --tests 'org.apache.gravitino.server.authorization.jcasbin.TestJcasbinAuthorizer'
```

<details>
<summary>Raw logs</summary>

```text
Before, on upstream main:
TestJcasbinAuthorizer.testHasSetOwnerPermissionAllowsSchemaAndCatalogOwner FAILED
expected: <true> but was: <false>
Tests: 1, failures: 1

After:
Tests: 59, skipped: 0, failures: 0, errors: 0
BUILD SUCCESSFUL
```

</details>
