### PR TITLE
[#12561] feat(lance): Add table creation authorization for Lance REST

### DIFF
--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceAuthorizationExpressions.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceAuthorizationExpressions.java
@@ -23,6 +23,8 @@ import static org.apache.gravitino.server.authorization.expression.Authorization
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_TABLE_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.PROBE_SCHEMA_AUTHORIZATION_EXPRESSION;
 
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
+
 /**
  * Authorization expressions for the Lance REST namespace surface.
  *
@@ -105,6 +107,27 @@ public final class LanceAuthorizationExpressions {
           + LOAD_TABLE_AUTHORIZATION_EXPRESSION
           + ") || (ANY_USE_CATALOG && ANY_USE_SCHEMA"
           + " && (ANY_PROBE_TABLE_LIKE || ANY_CREATE_TABLE)))";
+
+  /**
+   * Authorizes creating a table. The identifier must address a table, and the privilege is required
+   * on the schema that will hold it.
+   *
+   * <p>This expression covers the {@code create} and {@code exist_ok} modes only. The {@code
+   * overwrite} mode replaces an existing table, so it is authorized against {@link
+   * #MODIFY_TABLE_AUTHORIZATION_EXPRESSION} instead and CREATE_TABLE alone never grants it.
+   */
+  public static final String CREATE_TABLE_AUTHORIZATION_EXPRESSION =
+      """
+      entityType == 'TABLE' && (ANY(OWNER, METALAKE, CATALOG) ||
+      SCHEMA_OWNER_WITH_USE_CATALOG ||
+      ANY_USE_CATALOG && ANY_USE_SCHEMA && ANY_CREATE_TABLE)
+      """;
+
+  /** Authorizes altering an existing table, which requires MODIFY_TABLE or ownership. */
+  public static final String MODIFY_TABLE_AUTHORIZATION_EXPRESSION =
+      "entityType == 'TABLE' && ("
+          + AuthorizationExpressionConstants.MODIFY_TABLE_AUTHORIZATION_EXPRESSION
+          + ")";
 
   private LanceAuthorizationExpressions() {}
 }

--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceMetadataAuthorizationMethodInterceptor.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceMetadataAuthorizationMethodInterceptor.java
@@ -143,9 +143,11 @@ public class LanceMetadataAuthorizationMethodInterceptor
    * @return the maximum number of levels the operation's identifier may carry
    */
   private static int maxIdentifierLevels(Method method) {
-    return LanceTableOperations.class.isAssignableFrom(method.getDeclaringClass())
-        ? TABLE_IDENTIFIER_LEVELS
-        : SCHEMA_NAMESPACE_LEVELS;
+    return isTableOperation(method) ? TABLE_IDENTIFIER_LEVELS : SCHEMA_NAMESPACE_LEVELS;
+  }
+
+  private static boolean isTableOperation(Method method) {
+    return LanceTableOperations.class.isAssignableFrom(method.getDeclaringClass());
   }
 
   /**
@@ -161,7 +163,12 @@ public class LanceMetadataAuthorizationMethodInterceptor
   @Override
   protected Optional<AuthorizationHandler> createAuthorizationHandler(
       Method method, Parameter[] parameters, Object[] args) {
-    return createMode(parameters, args).map(OverwriteAuthzHandler::new);
+    String overwriteExpression =
+        isTableOperation(method)
+            ? LanceAuthorizationExpressions.MODIFY_TABLE_AUTHORIZATION_EXPRESSION
+            : LanceAuthorizationExpressions.MODIFY_NAMESPACE_AUTHORIZATION_EXPRESSION;
+    return createMode(parameters, args)
+        .map(mode -> new OverwriteAuthzHandler(mode, overwriteExpression));
   }
 
   @Override
@@ -196,8 +203,8 @@ public class LanceMetadataAuthorizationMethodInterceptor
    * Authorizes a create request whose mode overwrites an object that already exists.
    *
    * <p>An overwrite replaces an existing namespace or table, so it is a modification rather than a
-   * creation and is authorized against the ownership expression for the addressed entity instead of
-   * the create expression on the method. Without this, CREATE_CATALOG, CREATE_SCHEMA, or
+   * creation and is authorized against the modification expression for the invoked resource instead
+   * of the create expression on the method. Without this, CREATE_CATALOG, CREATE_SCHEMA, or
    * CREATE_TABLE would escalate into permission to replace an object the caller does not own.
    *
    * <p>The mode alone decides this, without probing whether the object exists: an existence probe
@@ -209,14 +216,16 @@ public class LanceMetadataAuthorizationMethodInterceptor
     private static final String OVERWRITE_MODE = "OVERWRITE";
 
     private final boolean overwrite;
+    private final String authorizationExpression;
 
-    private OverwriteAuthzHandler(String mode) {
+    private OverwriteAuthzHandler(String mode, String authorizationExpression) {
       // Read the mode through the same normalization the create operation applies, so a token the
       // operation will act on as an overwrite cannot be authorized as a plain create. Comparing the
       // raw string here would leave a gap: " overwrite " reaches the operation as OVERWRITE but
       // would not match, and a caller holding only a create privilege could replace an object owned
       // by somebody else.
       this.overwrite = OVERWRITE_MODE.equals(CommonUtil.normalizeToken(mode));
+      this.authorizationExpression = authorizationExpression;
     }
 
     @Override
@@ -226,12 +235,8 @@ public class LanceMetadataAuthorizationMethodInterceptor
       }
 
       Entity.EntityType entityType = deepestEntityType(nameIdentifierMap);
-      String expression =
-          entityType == Entity.EntityType.TABLE
-              ? LanceAuthorizationExpressions.MODIFY_TABLE_AUTHORIZATION_EXPRESSION
-              : LanceAuthorizationExpressions.MODIFY_NAMESPACE_AUTHORIZATION_EXPRESSION;
       boolean authorized =
-          new AuthorizationExpressionEvaluator(expression)
+          new AuthorizationExpressionEvaluator(authorizationExpression)
               .evaluate(
                   nameIdentifierMap,
                   new HashMap<>(),

--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceMetadataAuthorizationMethodInterceptor.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceMetadataAuthorizationMethodInterceptor.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.ws.rs.PathParam;
@@ -49,6 +50,7 @@ import org.lance.namespace.errors.InvalidInputException;
 import org.lance.namespace.errors.LanceNamespaceException;
 import org.lance.namespace.errors.PermissionDeniedException;
 import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.RegisterTableRequest;
 
 /** Resolves Lance namespace IDs and maps shared authorization failures to Lance REST responses. */
 public class LanceMetadataAuthorizationMethodInterceptor
@@ -147,24 +149,19 @@ public class LanceMetadataAuthorizationMethodInterceptor
   }
 
   /**
-   * Returns the handler that authorizes an overwrite of an existing namespace. Overwrite is the
-   * only Lance namespace write whose required privileges are carried in the request body rather
-   * than in the request path, so it cannot be expressed by the method annotation alone.
+   * Returns the handler that authorizes an overwrite of an existing object. The mode of a Lance
+   * create request travels in the request body or in a query parameter rather than in the request
+   * path, so which privileges a create needs cannot be expressed by the method annotation alone.
    *
    * @param method invoked protocol method
    * @param parameters invoked method parameters
    * @param args invoked method arguments
-   * @return the overwrite handler when the request carries a create-namespace body
+   * @return the overwrite handler for a create request, empty for every other operation
    */
   @Override
   protected Optional<AuthorizationHandler> createAuthorizationHandler(
       Method method, Parameter[] parameters, Object[] args) {
-    for (Object arg : args) {
-      if (arg instanceof CreateNamespaceRequest) {
-        return Optional.of(new CreateNamespaceAuthzHandler((CreateNamespaceRequest) arg));
-      }
-    }
-    return Optional.empty();
+    return createMode(parameters, args).map(OverwriteAuthzHandler::new);
   }
 
   @Override
@@ -196,43 +193,45 @@ public class LanceMetadataAuthorizationMethodInterceptor
   }
 
   /**
-   * Authorizes a create-namespace request whose mode overwrites an existing namespace.
+   * Authorizes a create request whose mode overwrites an object that already exists.
    *
-   * <p>An overwrite replaces the properties of a namespace that already exists, so it is a
-   * modification rather than a creation and is authorized against {@link
-   * LanceAuthorizationExpressions#MODIFY_NAMESPACE_AUTHORIZATION_EXPRESSION}. The mode alone
-   * decides this, without probing whether the namespace exists: an existence probe at authorization
-   * time would race with the create that follows it, and the resulting privilege requirement would
-   * depend on that race.
+   * <p>An overwrite replaces an existing namespace or table, so it is a modification rather than a
+   * creation and is authorized against the ownership expression for the addressed entity instead of
+   * the create expression on the method. Without this, CREATE_CATALOG, CREATE_SCHEMA, or
+   * CREATE_TABLE would escalate into permission to replace an object the caller does not own.
+   *
+   * <p>The mode alone decides this, without probing whether the object exists: an existence probe
+   * at authorization time would race with the create that follows it, and the required privilege
+   * would then depend on that race.
    */
-  private static final class CreateNamespaceAuthzHandler implements AuthorizationHandler {
+  private static final class OverwriteAuthzHandler implements AuthorizationHandler {
 
     private static final String OVERWRITE_MODE = "OVERWRITE";
 
-    private final CreateNamespaceRequest request;
-    private boolean overwriteAuthorized;
+    private final boolean overwrite;
 
-    private CreateNamespaceAuthzHandler(CreateNamespaceRequest request) {
-      this.request = request;
+    private OverwriteAuthzHandler(String mode) {
+      // Read the mode through the same normalization the create operation applies, so a token the
+      // operation will act on as an overwrite cannot be authorized as a plain create. Comparing the
+      // raw string here would leave a gap: " overwrite " reaches the operation as OVERWRITE but
+      // would not match, and a caller holding only a create privilege could replace an object owned
+      // by somebody else.
+      this.overwrite = OVERWRITE_MODE.equals(CommonUtil.normalizeToken(mode));
     }
 
     @Override
     public void process(Map<Entity.EntityType, NameIdentifier> nameIdentifierMap) {
-      if (!isOverwrite()) {
+      if (!overwrite) {
         return;
       }
 
-      // A namespace that is being overwritten already exists, so the create expression on the
-      // method must not be evaluated: it would let CREATE_CATALOG or CREATE_SCHEMA replace an
-      // object the caller does not own.
-      overwriteAuthorized = true;
-      Entity.EntityType entityType =
-          nameIdentifierMap.containsKey(Entity.EntityType.SCHEMA)
-              ? Entity.EntityType.SCHEMA
-              : Entity.EntityType.CATALOG;
+      Entity.EntityType entityType = deepestEntityType(nameIdentifierMap);
+      String expression =
+          entityType == Entity.EntityType.TABLE
+              ? LanceAuthorizationExpressions.MODIFY_TABLE_AUTHORIZATION_EXPRESSION
+              : LanceAuthorizationExpressions.MODIFY_NAMESPACE_AUTHORIZATION_EXPRESSION;
       boolean authorized =
-          new AuthorizationExpressionEvaluator(
-                  LanceAuthorizationExpressions.MODIFY_NAMESPACE_AUTHORIZATION_EXPRESSION)
+          new AuthorizationExpressionEvaluator(expression)
               .evaluate(
                   nameIdentifierMap,
                   new HashMap<>(),
@@ -240,23 +239,26 @@ public class LanceMetadataAuthorizationMethodInterceptor
                   Optional.of(entityType.name()));
       if (!authorized) {
         throw new ForbiddenException(
-            "User '%s' is not authorized to overwrite the namespace '%s'",
+            "User '%s' is not authorized to overwrite '%s'",
             PrincipalUtils.getCurrentUserName(), nameIdentifierMap.get(entityType));
       }
     }
 
     @Override
     public boolean authorizationCompleted() {
-      return overwriteAuthorized;
+      // An overwrite is fully authorized here, so the create expression on the method must not be
+      // evaluated afterwards. A create that does not overwrite falls through to it unchanged.
+      return overwrite;
     }
 
-    private boolean isOverwrite() {
-      // Read the mode through the same normalization the create operation applies, so a token the
-      // operation will act on as an overwrite cannot be authorized as a plain create. Comparing the
-      // raw string here would leave a gap: " overwrite " reaches the operation as OVERWRITE but
-      // would not match, and a caller holding only a create privilege could replace a namespace
-      // owned by somebody else.
-      return OVERWRITE_MODE.equals(CommonUtil.normalizeToken(request.getMode()));
+    private static Entity.EntityType deepestEntityType(
+        Map<Entity.EntityType, NameIdentifier> nameIdentifierMap) {
+      if (nameIdentifierMap.containsKey(Entity.EntityType.TABLE)) {
+        return Entity.EntityType.TABLE;
+      }
+      return nameIdentifierMap.containsKey(Entity.EntityType.SCHEMA)
+          ? Entity.EntityType.SCHEMA
+          : Entity.EntityType.CATALOG;
     }
   }
 
@@ -269,6 +271,23 @@ public class LanceMetadataAuthorizationMethodInterceptor
   private InvalidInputException unsupportedIdentifier(String namespaceId) {
     return new InvalidInputException(
         "Unsupported Lance namespace identifier: " + namespaceId, "", namespaceId);
+  }
+
+  /**
+   * Returns the requested create mode, or empty when the invoked operation does not create an
+   * object. Lance carries the mode in the create-namespace body, in the register-table body, or in
+   * the {@code mode} query parameter of create-table.
+   */
+  private static Optional<String> createMode(Parameter[] parameters, Object[] args) {
+    for (Object arg : args) {
+      if (arg instanceof CreateNamespaceRequest) {
+        return Optional.of(Objects.toString(((CreateNamespaceRequest) arg).getMode(), ""));
+      }
+      if (arg instanceof RegisterTableRequest) {
+        return Optional.of(Objects.toString(((RegisterTableRequest) arg).getMode(), ""));
+      }
+    }
+    return queryArgument(parameters, args, "mode");
   }
 
   private static Optional<String> pathArgument(Parameter[] parameters, Object[] args, String name) {

--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceTableOperations.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceTableOperations.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.lance.common.ops.NamespaceWrapper.NAMESPACE_D
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_LOCATION;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_LOCATION_HEADER;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_PROPERTIES_PREFIX_HEADER;
+import static org.apache.gravitino.lance.service.authorization.LanceAuthorizationExpressions.CREATE_TABLE_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.lance.service.authorization.LanceAuthorizationExpressions.PROBE_TABLE_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.lance.service.authorization.LanceAuthorizationExpressions.READ_TABLE_AUTHORIZATION_EXPRESSION;
 
@@ -121,6 +122,7 @@ public class LanceTableOperations {
   @Produces("application/json")
   @Timed(name = "create-table." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "create-table", absolute = true)
+  @AuthorizationExpression(expression = CREATE_TABLE_AUTHORIZATION_EXPRESSION)
   public Response createTable(
       @PathParam("id") String tableId,
       @QueryParam("mode") @DefaultValue("create") String mode, // create, exist_ok, overwrite
@@ -160,6 +162,7 @@ public class LanceTableOperations {
   @Produces("application/json")
   @Timed(name = "declare-table." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "declare-table", absolute = true)
+  @AuthorizationExpression(expression = CREATE_TABLE_AUTHORIZATION_EXPRESSION)
   public Response declareTable(
       @PathParam("id") String tableId,
       @QueryParam("delimiter") @DefaultValue(NAMESPACE_DELIMITER_DEFAULT) String delimiter,
@@ -188,6 +191,7 @@ public class LanceTableOperations {
   @Path("/register")
   @Timed(name = "register-table." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "register-table", absolute = true)
+  @AuthorizationExpression(expression = CREATE_TABLE_AUTHORIZATION_EXPRESSION)
   public Response registerTable(
       @PathParam("id") String tableId,
       @QueryParam("delimiter") @DefaultValue("$") String delimiter,

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceTableAuthorizationIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceTableAuthorizationIT.java
@@ -42,6 +42,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
 import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 
@@ -53,12 +55,16 @@ public class LanceTableAuthorizationIT extends BaseIT {
   private static final String PROBER = "lance_table_authz_prober";
   private static final String CATALOG = "lance_table_authz_catalog";
   private static final String SCHEMA = "lance_table_authz_schema";
+  // Tables created by the write tests live in their own schema, so the listing tests keep asserting
+  // the exact contents of the read schema whatever order the tests run in.
+  private static final String WRITE_SCHEMA = "lance_table_authz_write_schema";
 
   // The hidden table sorts first so that a listing filtered after pagination rather than before it
   // would return an empty first page instead of the visible table.
   private static final String HIDDEN_TABLE = "a_hidden_table";
   private static final String VISIBLE_TABLE = "b_visible_table";
   private static final String MISSING_TABLE = "c_missing_table";
+  private static final String PROBER_TABLE = "d_prober_table";
   private static final String DELIMITER = ".";
 
   @TempDir private static Path tempDir;
@@ -82,6 +88,7 @@ public class LanceTableAuthorizationIT extends BaseIT {
 
     createNamespace(CATALOG);
     createNamespace(id(CATALOG, SCHEMA));
+    createNamespace(id(CATALOG, WRITE_SCHEMA));
     registerTable(VISIBLE_TABLE);
     registerTable(HIDDEN_TABLE);
 
@@ -115,6 +122,11 @@ public class LanceTableAuthorizationIT extends BaseIT {
             SecurableObjects.ofSchema(
                 catalogScope,
                 SCHEMA,
+                new ArrayList<>(
+                    List.of(Privileges.UseSchema.allow(), Privileges.CreateTable.allow()))),
+            SecurableObjects.ofSchema(
+                catalogScope,
+                WRITE_SCHEMA,
                 new ArrayList<>(
                     List.of(Privileges.UseSchema.allow(), Privileges.CreateTable.allow())))));
   }
@@ -169,6 +181,27 @@ public class LanceTableAuthorizationIT extends BaseIT {
     Assertions.assertEquals(List.of(HIDDEN_TABLE, VISIBLE_TABLE), listTables(ADMIN, 10));
   }
 
+  @Test
+  public void testTableCreationRequiresCreateTablePrivilege() throws Exception {
+    // Selecting a table is not creating one.
+    assertStatus(403, register(READER, SCHEMA, "reader_table", null, location("reader_table")));
+    assertStatus(403, declare(READER, SCHEMA, "reader_table"));
+
+    assertStatus(200, register(PROBER, WRITE_SCHEMA, PROBER_TABLE, null, location(PROBER_TABLE)));
+    // Creating assigns ownership, so the creator can read back what it created even though it
+    // holds no SELECT_TABLE privilege.
+    assertStatus(200, table(PROBER, WRITE_SCHEMA, PROBER_TABLE, "describe"));
+  }
+
+  @Test
+  public void testCreateTablePrivilegeCannotOverwriteAnotherOwnersTable() throws Exception {
+    String replacement = location(HIDDEN_TABLE) + "overwritten/";
+    assertStatus(403, register(PROBER, SCHEMA, HIDDEN_TABLE, "overwrite", replacement));
+
+    // A denied overwrite must not have reached the metadata store.
+    Assertions.assertEquals(location(HIDDEN_TABLE), describedLocation(ADMIN, HIDDEN_TABLE));
+  }
+
   private List<String> listTables(String user, int limit) throws Exception {
     HttpRequest request =
         request(user, "/v1/namespace/" + id(CATALOG, SCHEMA) + "/table/list", "&limit=" + limit)
@@ -208,17 +241,43 @@ public class LanceTableAuthorizationIT extends BaseIT {
   }
 
   private void registerTable(String tableName) throws Exception {
+    assertStatus(200, register(ADMIN, SCHEMA, tableName, null, location(tableName)));
+  }
+
+  private HttpResponse<String> register(
+      String user, String schema, String tableName, String mode, String location) throws Exception {
     RegisterTableRequest body = new RegisterTableRequest();
-    body.setId(List.of(CATALOG, SCHEMA, tableName));
+    body.setId(List.of(CATALOG, schema, tableName));
+    body.setLocation(location);
+    body.setMode(mode);
+    return send(user, "/v1/table/" + id(CATALOG, schema, tableName) + "/register", body);
+  }
+
+  private HttpResponse<String> declare(String user, String schema, String tableName)
+      throws Exception {
+    DeclareTableRequest body = new DeclareTableRequest();
+    body.setId(List.of(CATALOG, schema, tableName));
     body.setLocation(location(tableName));
-    assertStatus(
-        200, send(ADMIN, "/v1/table/" + id(CATALOG, SCHEMA, tableName) + "/register", body));
+    return send(user, "/v1/table/" + id(CATALOG, schema, tableName) + "/declare", body);
+  }
+
+  private String describedLocation(String user, String tableName) throws Exception {
+    HttpResponse<String> response = table(user, tableName, "describe");
+    assertStatus(200, response);
+    return ObjectMapperProvider.objectMapper()
+        .readValue(response.body(), DescribeTableResponse.class)
+        .getLocation();
   }
 
   private HttpResponse<String> table(String user, String tableName, String operation)
       throws Exception {
+    return table(user, SCHEMA, tableName, operation);
+  }
+
+  private HttpResponse<String> table(String user, String schema, String tableName, String operation)
+      throws Exception {
     HttpRequest request =
-        request(user, "/v1/table/" + id(CATALOG, SCHEMA, tableName) + "/" + operation, "")
+        request(user, "/v1/table/" + id(CATALOG, schema, tableName) + "/" + operation, "")
             .POST(HttpRequest.BodyPublishers.ofString("{}"))
             .build();
     return httpClient.send(request, HttpResponse.BodyHandlers.ofString());

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/authorization/TestLanceMetadataAuthorizationMethodInterceptor.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/authorization/TestLanceMetadataAuthorizationMethodInterceptor.java
@@ -351,6 +351,26 @@ class TestLanceMetadataAuthorizationMethodInterceptor {
   }
 
   @Test
+  void testTableOverwriteRejectsIdentifiersOfTheWrongDepth() throws Throwable {
+    when(authorizer.isOwner(any(), any(), any(), any())).thenReturn(true);
+    allow(Privilege.Name.values());
+
+    // Overwrite authorization must retain the table operation's target type. Deriving the
+    // expression from the identifier depth would authorize these as catalog or schema overwrites.
+    assertErrorResponse(
+        interceptor.invoke(createTableInvocation(CATALOG, "overwrite")), Response.Status.FORBIDDEN);
+    assertErrorResponse(
+        interceptor.invoke(createTableInvocation(CATALOG + "$" + SCHEMA, "overwrite")),
+        Response.Status.FORBIDDEN);
+    assertErrorResponse(
+        interceptor.invoke(registerTableInvocation(CATALOG, "overwrite")),
+        Response.Status.FORBIDDEN);
+    assertErrorResponse(
+        interceptor.invoke(registerTableInvocation(CATALOG + "$" + SCHEMA, "overwrite")),
+        Response.Status.FORBIDDEN);
+  }
+
+  @Test
   void testModifyTablePrivilegeAndOwnershipAuthorizeOverwrite() throws Throwable {
     allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.MODIFY_TABLE);
     assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "overwrite")));

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/authorization/TestLanceMetadataAuthorizationMethodInterceptor.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/authorization/TestLanceMetadataAuthorizationMethodInterceptor.java
@@ -49,9 +49,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.DeclareTableRequest;
 import org.lance.namespace.model.DescribeTableRequest;
 import org.lance.namespace.model.DropNamespaceRequest;
 import org.lance.namespace.model.ErrorResponse;
+import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.TableExistsRequest;
 import org.mockito.MockedStatic;
 
@@ -314,6 +316,87 @@ class TestLanceMetadataAuthorizationMethodInterceptor {
         interceptor.invoke(listTablesInvocation(tableId())), Response.Status.BAD_REQUEST);
 
     assertEquals(PROCEEDED, interceptor.invoke(listTablesInvocation(CATALOG + "$" + SCHEMA)));
+  }
+
+  @Test
+  void testTableCreationRequiresCreateTablePrivilege() throws Throwable {
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.CREATE_TABLE);
+    assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "create")));
+    assertEquals(PROCEEDED, interceptor.invoke(declareTableInvocation(tableId())));
+    assertEquals(PROCEEDED, interceptor.invoke(registerTableInvocation(tableId(), "create")));
+
+    // Reading a table is not creating one.
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.SELECT_TABLE);
+    MethodInvocation create = createTableInvocation(tableId(), "create");
+    assertErrorResponse(interceptor.invoke(create), Response.Status.FORBIDDEN);
+    verify(create, never()).proceed();
+    assertErrorResponse(
+        interceptor.invoke(declareTableInvocation(tableId())), Response.Status.FORBIDDEN);
+    assertErrorResponse(
+        interceptor.invoke(registerTableInvocation(tableId(), "create")),
+        Response.Status.FORBIDDEN);
+  }
+
+  @Test
+  void testCreateTablePrivilegeCannotOverwriteAnExistingTable() throws Throwable {
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.CREATE_TABLE);
+
+    assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "exist_ok")));
+    MethodInvocation overwrite = createTableInvocation(tableId(), "overwrite");
+    assertErrorResponse(interceptor.invoke(overwrite), Response.Status.FORBIDDEN);
+    verify(overwrite, never()).proceed();
+    assertErrorResponse(
+        interceptor.invoke(registerTableInvocation(tableId(), "OVERWRITE")),
+        Response.Status.FORBIDDEN);
+  }
+
+  @Test
+  void testModifyTablePrivilegeAndOwnershipAuthorizeOverwrite() throws Throwable {
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.MODIFY_TABLE);
+    assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "overwrite")));
+    assertEquals(PROCEEDED, interceptor.invoke(registerTableInvocation(tableId(), "overwrite")));
+
+    when(authorizer.isOwner(any(), any(), any(), any())).thenReturn(true);
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA);
+    assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "overwrite")));
+  }
+
+  private MethodInvocation createTableInvocation(String tableId, String mode) throws Throwable {
+    Method method =
+        LanceTableOperations.class.getMethod(
+            "createTable",
+            String.class,
+            String.class,
+            String.class,
+            String.class,
+            String.class,
+            HttpHeaders.class,
+            byte[].class);
+    return invocation(method, tableId, mode, "$", null, null, null, new byte[0]);
+  }
+
+  private MethodInvocation declareTableInvocation(String tableId) throws Throwable {
+    Method method =
+        LanceTableOperations.class.getMethod(
+            "declareTable",
+            String.class,
+            String.class,
+            DeclareTableRequest.class,
+            HttpHeaders.class);
+    return invocation(method, tableId, "$", new DeclareTableRequest(), null);
+  }
+
+  private MethodInvocation registerTableInvocation(String tableId, String mode) throws Throwable {
+    Method method =
+        LanceTableOperations.class.getMethod(
+            "registerTable",
+            String.class,
+            String.class,
+            HttpHeaders.class,
+            RegisterTableRequest.class);
+    RegisterTableRequest request = new RegisterTableRequest();
+    request.setMode(mode);
+    return invocation(method, tableId, "$", null, request);
   }
 
   private String tableId() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Authorizes the Lance REST table creation operations.

- `create-table`, `declare-table`, and `register-table` all require `USE_CATALOG`, `USE_SCHEMA`, and `CREATE_TABLE` on the target schema, so the three ways of introducing a table cannot diverge.
- A create whose mode overwrites an existing table is a modification, so it is authorized against `MODIFY_TABLE` or ownership instead. The overwrite handler introduced for namespaces in #12559 now covers tables as well and picks the expression from the addressed entity, which keeps `CREATE_TABLE` from escalating into permission to replace a table the caller does not own. The mode travels in a query parameter for `create-table` and in the request body for `register-table`, so neither can be expressed by the method annotation alone.

Assigning the caller as owner after a successful create needs no new code: Lance runs its writes through the Gravitino table dispatcher, whose hook already sets the owner. The integration test verifies this by having the creator read back a table it holds no `SELECT_TABLE` on.

Credential vending stays out of scope.

Fix: #12561

### Does this PR introduce _any_ user-facing change?

Yes. With authorization enabled, create, declare, and register are authorized and denied requests return 403 without creating metadata. As for namespaces, `mode=overwrite` always requires ownership or `MODIFY_TABLE`, whether or not the table exists: deciding this from the mode alone avoids an existence probe that would race with the write that follows it.

### How was this patch tested?

- `TestLanceMetadataAuthorizationMethodInterceptor`: new tests covering the `CREATE_TABLE` requirement across all three entry points, the overwrite escalation guard, and overwrite authorized by `MODIFY_TABLE` or ownership.
- `LanceTableAuthorizationIT`: two new tests covering creation denial and success with ownership assigned, and a denied overwrite leaving the registered location untouched. The successful create writes into a schema of its own, so the listing tests keep asserting the exact contents of the read schema whatever order the tests run in.
- `./gradlew :lance:lance-rest-server:build` — all tests passing.

https://claude.ai/code/session_011A4FqHJarzs2xvs7WbusMT
