### PR TITLE
[Cherry-pick to branch-1.3] [#11795] fix(docker): Upgrade bundled PostgreSQL JDBC driver (#11796)

### DIFF
--- a/dev/docker/gravitino/gravitino-dependency.sh
+++ b/dev/docker/gravitino/gravitino-dependency.sh
@@ -74,7 +74,7 @@ mkdir -p "${jdbc_driver_dir}"
 mysql_driver="mysql-connector-java-8.0.27.jar"
 wget "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/$mysql_driver" -O "${jdbc_driver_dir}/${mysql_driver}"
 
-pg_driver="postgresql-42.7.0.jar"
+pg_driver="postgresql-42.7.11.jar"
 wget "https://jdbc.postgresql.org/download/${pg_driver}" -O "${jdbc_driver_dir}/${pg_driver}"
 
 echo "Finish downloading"

--- a/dev/docker/trino/Dockerfile
+++ b/dev/docker/trino/Dockerfile
@@ -23,7 +23,7 @@ USER root
 
 COPY --chown=trino:trino packages/trino/conf /etc/trino
 COPY --chown=trino:trino packages/gravitino-trino-connector/mysql-connector-java-8.0.27.jar /usr/lib/trino/plugin/iceberg/
-COPY --chown=trino:trino packages/gravitino-trino-connector/postgresql-42.7.0.jar /usr/lib/trino/plugin/iceberg/
+COPY --chown=trino:trino packages/gravitino-trino-connector/postgresql-42.7.11.jar /usr/lib/trino/plugin/iceberg/
 
 RUN mkdir /tmp/gravitino
 COPY --chown=trino:trino packages/gravitino-trino-connector /tmp/gravitino

--- a/dev/docker/trino/trino-dependency.sh
+++ b/dev/docker/trino/trino-dependency.sh
@@ -32,7 +32,7 @@ ${gravitino_home}/gradlew :trino-connector:trino-connector-473-478:assembleTrino
 cp -r "${gravitino_home}/distribution/gravitino-trino-connector-473-478" "${trino_dir}/packages/gravitino-trino-connector"
 
 MYSQL_VERSION="8.0.27"
-PG_VERSION="42.7.0"
+PG_VERSION="42.7.11"
 MYSQL_JAVA_CONNECTOR_URL="https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_VERSION}/mysql-connector-java-${MYSQL_VERSION}.jar"
 PG_JAVA_CONNECTOR_URL="https://jdbc.postgresql.org/download/postgresql-${PG_VERSION}.jar"
 
@@ -42,7 +42,7 @@ if [ ! -f "${trino_dir}/packages/gravitino-trino-connector/mysql-connector-java-
 fi
 
 # Download PostgreSQL jdbc driver if it does not exist.
-if [ ! -f "${trino_dir}/packages/gravitino-trino-connector/postgresql-{PG_VERSION}.jar" ]; then
+if [ ! -f "${trino_dir}/packages/gravitino-trino-connector/postgresql-${PG_VERSION}.jar" ]; then
   cd "${trino_dir}/packages/gravitino-trino-connector/" && curl -O "$PG_JAVA_CONNECTOR_URL" && cd -
 fi
 

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/BaseIT.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/BaseIT.java
@@ -114,7 +114,7 @@ public class BaseIT {
       "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.26/mysql-connector-java-8.0.26.jar";
 
   public static final String DOWNLOAD_POSTGRESQL_JDBC_DRIVER_URL =
-      "https://jdbc.postgresql.org/download/postgresql-42.7.0.jar";
+      "https://jdbc.postgresql.org/download/postgresql-42.7.11.jar";
 
   public static final String DOWNLOAD_CLICKHOUSE_JDBC_DRIVER_URL =
       "https://repo1.maven.org/maven2/com/clickhouse/clickhouse-jdbc/0.7.1/clickhouse-jdbc-0.7.1-all.jar";

--- a/trino-connector/integration-test/trino-test-tools/download_jar.sh
+++ b/trino-connector/integration-test/trino-test-tools/download_jar.sh
@@ -54,10 +54,10 @@ download_mysql_jar() {
 }
 
 download_postgresql_jar() {
-  download_jar "postgresql-42.7.0.jar" \
-  "https://jdbc.postgresql.org/download/postgresql-42.7.0.jar" \
+  download_jar "postgresql-42.7.11.jar" \
+  "https://jdbc.postgresql.org/download/postgresql-42.7.11.jar" \
   "$GRAVITINO_SERVER_DIR/catalogs/jdbc-postgresql/libs"
-  cp -rp $GRAVITINO_SERVER_DIR/catalogs/jdbc-postgresql/libs/postgresql-42.7.0.jar $GRAVITINO_SERVER_DIR/catalogs/lakehouse-iceberg/libs
+  cp -rp $GRAVITINO_SERVER_DIR/catalogs/jdbc-postgresql/libs/postgresql-42.7.11.jar $GRAVITINO_SERVER_DIR/catalogs/lakehouse-iceberg/libs
 }
 
 download_iceberg_aws_bundle() {
@@ -84,4 +84,3 @@ download_trino-cascading-connector() {
       exit 1
   fi
 }
-


### PR DESCRIPTION
**Cherry-pick Information:**
- Original commit: 95c07c75de132e256277eb870b2f7e62897e6680
- Target branch: `branch-1.3`
- Status: ⚠️ Cherry-pick with conflict resolution — kept branch-1.3's rewritten docs/how-to-use-relational-backend-storage.md wording (already recommends latest driver version) instead of the incoming pinned-version text; all code/script changes applied cleanly.