### PR TITLE
[Cherry-pick to branch-1.3] [#12583] improvement(ci): Optimize build test execution (#12584)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ 17 ]
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -192,6 +192,7 @@ jobs:
 
           gradle_args=(
             build
+            --max-workers=2
             -PskipWeb=true
             -PskipITs
             -PskipDockerTests=false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ import com.github.jk1.license.render.ReportRenderer
 import com.github.vlsi.gradle.dsl.configureEach
 import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.attributes.java.TargetJvmVersion
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.internal.hash.ChecksumService
 import org.gradle.internal.os.OperatingSystem
@@ -33,6 +35,8 @@ import java.io.IOException
 import java.util.Locale
 
 Locale.setDefault(Locale.US)
+
+abstract class SharedTestEnvironmentLock : BuildService<BuildServiceParameters.None>
 
 plugins {
   `maven-publish`
@@ -59,6 +63,13 @@ plugins {
   alias(libs.plugins.dependencyLicenseReport)
   alias(libs.plugins.tasktree)
   alias(libs.plugins.errorprone)
+}
+
+val sharedTestEnvironmentLock = gradle.sharedServices.registerIfAbsent(
+  "sharedTestEnvironmentLock",
+  SharedTestEnvironmentLock::class
+) {
+  maxParallelUsages.set(1)
 }
 
 val snappyJavaVersion: String = libs.versions.snappy.java.get()
@@ -676,7 +687,11 @@ subprojects {
       showCauses = true
       showStackTraces = true
     }
-    reports.html.outputLocation.set(file("${rootProject.projectDir}/build/reports/"))
+    // Distinct outputs let Gradle execute independent test tasks in parallel.
+    val testReportPath = path.removePrefix(":").replace(':', '/')
+    reports.html.outputLocation.set(
+      rootProject.layout.buildDirectory.dir("reports/tests/$testReportPath")
+    )
     val skipTests = project.hasProperty("skipTests")
     if (!skipTests) {
       val extraArgs = project.property("extraJvmArgs") as List<String>
@@ -1251,6 +1266,22 @@ gradle.projectsEvaluated {
     subprojectJarOutputDirs.map { it.get().asFile.toPath().toAbsolutePath().normalize() }
 
   allprojects {
+    val runsIntegrationTestsOnly = rootProject.hasProperty("skipTests")
+    val hasDockerTests =
+      rootProject.extra["dockerTest"] == true && fileTree("src/test") {
+        include("**/*.java", "**/*.kt")
+      }.any { it.readText().contains("gravitino-docker-test") }
+
+    // Integration tests in different projects share the same Gravitino server, database,
+    // containers, and configuration files. Running them together lets one test stop or reset
+    // resources while another test is still using them. Normal builds keep independent unit tests
+    // parallel and serialize only projects that contain Docker-tagged tests.
+    if (runsIntegrationTestsOnly || hasDockerTests) {
+      tasks.withType<Test>().configureEach {
+        usesService(sharedTestEnvironmentLock)
+      }
+    }
+
     tasks.withType<Jar>().configureEach {
       mustRunAfter(cleanDistributionPackageTask)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport #12584 to `branch-1.3`.

- Write Gradle test reports to task-specific directories.
- Serialize tests sharing Docker resources.
- Limit the build job to two Gradle workers.
- Raise the build timeout from 90 to 120 minutes.

### Why are the changes needed?

Reduce the build critical path and avoid CI build timeouts on `branch-1.3`.

Fix: #12583

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew --no-daemon help --max-workers=2 -PskipWeb=true`
- `git diff --check`

### Cherry-pick information

- Original commit: `a80f6fd2e70c5d9e76ed98b3fbae706533687740`
- Target branch: `branch-1.3`
- Status: Clean cherry-pick
