### PR TITLE
[#12492] docs: document jdbc.options for PostgreSQL plan_cache_mode

### DIFF
--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -652,6 +652,18 @@ The `clients` property for example:
 `catalog-impl` has no effect.
 :::
 
+Unknown Iceberg catalog keys are passed through after the `gravitino.iceberg-rest.` prefix is stripped. For a PostgreSQL JDBC backend, a repeatedly executed prepared statement can switch to a generic plan after a few runs and make namespace/table existence checks much slower. Scope `plan_cache_mode=force_custom_plan` to Gravitino's connections with:
+
+```properties
+gravitino.iceberg-rest.jdbc.options = -c plan_cache_mode=force_custom_plan
+```
+
+That maps to Iceberg's `jdbc.options` JDBC connection property, so you do not need database-owner privileges.
+
+| Configuration item                    | Description                                                                                                                                                         | Default value | Required |
+|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
+| `gravitino.iceberg-rest.jdbc.options` | Extra JDBC connection options passed through to the Iceberg JDBC catalog. For PostgreSQL, `-c plan_cache_mode=force_custom_plan` keeps existence checks on custom plans. | (none)        | No       |
+
 #### Event Listeners
 
 Gravitino generates pre-event and post-event for table operations and provide a pluggable event listener to allow you to inject custom logic. For more details, refer to [Event listener configuration](gravitino-server-config.md#event-listener-configuration).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Documented `gravitino.iceberg-rest.jdbc.options` under Additional Iceberg Catalog Properties, with the PostgreSQL `plan_cache_mode=force_custom_plan` example.

### Why are the changes needed?

The key already passes through to Iceberg's JDBC catalog. On a large PostgreSQL backend it is easy to miss, and namespace/table existence checks then sit on generic plans.

Fix: #12492

### Does this PR introduce any user-facing change?

Docs only. No new property.

### How was this patch tested?

Checked that `IcebergConfig.getIcebergCatalogProperties()` keeps unknown keys, so `jdbc.options` reaches the Iceberg JDBC catalog.
