### PR TITLE
[#12724] fix(core): resolve secret URNs in catalog credential vending

### DIFF
--- a/clients/client-python/tests/integration/integration_test_env.py
+++ b/clients/client-python/tests/integration/integration_test_env.py
@@ -47,9 +47,16 @@ def get_gravitino_server_version(**kwargs):
         return False
 
 
-def check_gravitino_server_status(**kwargs) -> bool:
+def check_gravitino_server_status(max_attempts: int = 30, interval_secs: float = 1.0, **kwargs) -> bool:
+    """Poll until the Gravitino server answers /api/version, or give up.
+
+    ``gravitino.sh restart`` returns as soon as the JVM process is up; Jetty can
+    still take several seconds before port 8090 accepts connections. Five
+    one-second polls are not enough under CI load (PythonIT has timed out when
+    Jetty became ready milliseconds after the last attempt).
+    """
     gravitino_server_running = False
-    for i in range(5):
+    for i in range(max_attempts):
         logger.info("Monitoring Gravitino server status. Attempt %s", i + 1)
         if get_gravitino_server_version(**kwargs):
             logger.debug("Gravitino Server is running")
@@ -57,7 +64,7 @@ def check_gravitino_server_status(**kwargs) -> bool:
             break
         else:
             logger.debug("Gravitino Server is not running")
-            time.sleep(1)
+            time.sleep(interval_secs)
     return gravitino_server_running
 
 
@@ -153,9 +160,10 @@ class IntegrationTestEnv(unittest.TestCase):
             logger.info("stderr: %s", result.stderr)
 
         gravitino_server_running = True
-        for i in range(5):
+        for i in range(30):
             logger.debug("Monitoring Gravitino server status. Attempt %s", i + 1)
-            if check_gravitino_server_status():
+            # Single probe: the nested startup poll must not run here.
+            if get_gravitino_server_version():
                 logger.debug("Gravitino server still running")
                 time.sleep(1)
             else:

--- a/clients/client-python/tests/integration/integration_test_env.py
+++ b/clients/client-python/tests/integration/integration_test_env.py
@@ -47,7 +47,9 @@ def get_gravitino_server_version(**kwargs):
         return False
 
 
-def check_gravitino_server_status(max_attempts: int = 30, interval_secs: float = 1.0, **kwargs) -> bool:
+def check_gravitino_server_status(
+    max_attempts: int = 30, interval_secs: float = 1.0, **kwargs
+) -> bool:
     """Poll until the Gravitino server answers /api/version, or give up.
 
     ``gravitino.sh restart`` returns as soon as the JVM process is up; Jetty can

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1437,8 +1437,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     // Resolve secret URNs to plaintext for connector init only; entity storage keeps URNs.
     catalog
         .withCatalogConf(secretManager.toPlaintextProperties(entity.getProperties()))
-        .withCatalogEntity(entity)
-        .withSecretManager(secretManager);
+        .withCatalogEntity(entity);
     catalog.initAuthorizationPluginInstance(classLoader, metalakeEntity.id());
     return catalog;
   }

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1437,7 +1437,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     // Resolve secret URNs to plaintext for connector init only; entity storage keeps URNs.
     catalog
         .withCatalogConf(secretManager.toPlaintextProperties(entity.getProperties()))
-        .withCatalogEntity(entity);
+        .withCatalogEntity(entity)
+        .withSecretManager(secretManager);
     catalog.initAuthorizationPluginInstance(classLoader, metalakeEntity.id());
     return catalog;
   }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -88,6 +88,8 @@ public abstract class BaseCatalog<T extends BaseCatalog>
 
   private Map<String, String> conf;
 
+  private SecretManager secretManager;
+
   private volatile CatalogOperations ops;
 
   private volatile Capability capability;
@@ -376,10 +378,10 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     if (catalogCredentialManager == null) {
       synchronized (this) {
         if (catalogCredentialManager == null) {
+          Preconditions.checkState(secretManager != null, "secretManager is not set");
           // Entity storage keeps secret URNs; credential vending must return plaintext so
           // getCredentials / JdbcCredential (and other static-key providers) are usable by clients.
           Map<String, String> props = propertiesWithCredentialProviders();
-          SecretManager secretManager = GravitinoEnv.getInstance().secretManager();
           this.catalogCredentialManager =
               new CatalogCredentialManager(name(), secretManager.toPlaintextProperties(props));
         }
@@ -432,12 +434,32 @@ public abstract class BaseCatalog<T extends BaseCatalog>
   }
 
   /**
+   * Sets the {@link SecretManager} used to resolve secret URNs for this catalog.
+   *
+   * @param secretManager The SecretManager instance.
+   * @return The instance of the concrete subclass of BaseCatalog.
+   */
+  public T withSecretManager(SecretManager secretManager) {
+    this.secretManager = secretManager;
+    return (T) this;
+  }
+
+  /**
    * Retrieves the CatalogEntity associated with this catalog.
    *
    * @return The CatalogEntity instance.
    */
   public CatalogEntity entity() {
     return entity;
+  }
+
+  /**
+   * Retrieves the {@link SecretManager} associated with this catalog.
+   *
+   * @return The SecretManager instance.
+   */
+  public SecretManager secretManager() {
+    return secretManager;
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -378,12 +378,13 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     if (catalogCredentialManager == null) {
       synchronized (this) {
         if (catalogCredentialManager == null) {
-          Preconditions.checkState(secretManager != null, "secretManager is not set");
-          // Entity storage keeps secret URNs; credential vending must return plaintext so
-          // getCredentials / JdbcCredential (and other static-key providers) are usable by clients.
+          // Entity storage may keep secret URNs; resolve them when SecretManager is available so
+          // getCredentials / JdbcCredential (and other static-key providers) return plaintext.
           Map<String, String> props = propertiesWithCredentialProviders();
-          this.catalogCredentialManager =
-              new CatalogCredentialManager(name(), secretManager.toPlaintextProperties(props));
+          if (secretManager != null) {
+            props = secretManager.toPlaintextProperties(props);
+          }
+          this.catalogCredentialManager = new CatalogCredentialManager(name(), props);
         }
       }
     }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -497,8 +497,7 @@ public abstract class BaseCatalog<T extends BaseCatalog>
   public Map<String, String> propertiesWithCredentialProviders() {
     // Prefer conf: createBaseCatalog sets it via SecretManager.toPlaintextProperties so credential
     // vending receives plaintext. Fall back to entity props when conf is unset (e.g. unit tests).
-    Map<String, String> props =
-        Maps.newHashMap(conf != null ? conf : entity().getProperties());
+    Map<String, String> props = Maps.newHashMap(conf != null ? conf : entity().getProperties());
     if (StringUtils.isNotBlank(props.get(CredentialConstants.CREDENTIAL_PROVIDERS))) {
       return props;
     }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -48,6 +48,7 @@ import org.apache.gravitino.credential.S3SecretKeyCredential;
 import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.AzureProperties;
 import org.apache.gravitino.storage.GCSProperties;
 import org.apache.gravitino.storage.OSSProperties;
@@ -86,6 +87,8 @@ public abstract class BaseCatalog<T extends BaseCatalog>
   private CatalogEntity entity;
 
   private Map<String, String> conf;
+
+  private SecretManager secretManager;
 
   private volatile CatalogOperations ops;
 
@@ -427,6 +430,17 @@ public abstract class BaseCatalog<T extends BaseCatalog>
   }
 
   /**
+   * Sets the {@link SecretManager} used to resolve secret URNs for this catalog.
+   *
+   * @param secretManager The SecretManager instance; may be null when secrets are not configured.
+   * @return The instance of the concrete subclass of BaseCatalog.
+   */
+  public T withSecretManager(SecretManager secretManager) {
+    this.secretManager = secretManager;
+    return (T) this;
+  }
+
+  /**
    * Retrieves the CatalogEntity associated with this catalog.
    *
    * @return The CatalogEntity instance.
@@ -487,17 +501,20 @@ public abstract class BaseCatalog<T extends BaseCatalog>
 
   /**
    * Retrieves the properties of the catalog including credential providers. Detects storage and
-   * catalog-specific credential providers from catalog conf when set (CatalogManager resolves
-   * secret URNs into conf while entity storage keeps URNs), otherwise from raw entity properties,
-   * and injects them before {@link CatalogCredentialManager} is initialized. Subclasses may
-   * override {@link #addCatalogSpecificCredentialProviders} to add additional providers.
+   * catalog-specific credential providers from the raw entity properties (including hidden ones)
+   * and injects them before {@link CatalogCredentialManager} is initialized. When a {@link
+   * SecretManager} is set, secret URN values are resolved to plaintext so credential vending can
+   * use them. Subclasses may override {@link #addCatalogSpecificCredentialProviders} to add
+   * additional providers.
    *
    * @return A map of properties with credential providers set.
    */
   public Map<String, String> propertiesWithCredentialProviders() {
-    // Prefer conf: createBaseCatalog sets it via SecretManager.toPlaintextProperties so credential
-    // vending receives plaintext. Fall back to entity props when conf is unset (e.g. unit tests).
-    Map<String, String> props = Maps.newHashMap(conf != null ? conf : entity().getProperties());
+    // Entity storage keeps secret URNs; resolve to plaintext when SecretManager is available.
+    Map<String, String> props = Maps.newHashMap(entity().getProperties());
+    if (secretManager != null) {
+      props = Maps.newHashMap(secretManager.toPlaintextProperties(props));
+    }
     if (StringUtils.isNotBlank(props.get(CredentialConstants.CREDENTIAL_PROVIDERS))) {
       return props;
     }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -48,7 +48,6 @@ import org.apache.gravitino.credential.S3SecretKeyCredential;
 import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.meta.CatalogEntity;
-import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.AzureProperties;
 import org.apache.gravitino.storage.GCSProperties;
 import org.apache.gravitino.storage.OSSProperties;
@@ -87,8 +86,6 @@ public abstract class BaseCatalog<T extends BaseCatalog>
   private CatalogEntity entity;
 
   private Map<String, String> conf;
-
-  private SecretManager secretManager;
 
   private volatile CatalogOperations ops;
 
@@ -378,13 +375,8 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     if (catalogCredentialManager == null) {
       synchronized (this) {
         if (catalogCredentialManager == null) {
-          // Entity storage may keep secret URNs; resolve them when SecretManager is available so
-          // getCredentials / JdbcCredential (and other static-key providers) return plaintext.
-          Map<String, String> props = propertiesWithCredentialProviders();
-          if (secretManager != null) {
-            props = secretManager.toPlaintextProperties(props);
-          }
-          this.catalogCredentialManager = new CatalogCredentialManager(name(), props);
+          this.catalogCredentialManager =
+              new CatalogCredentialManager(name(), propertiesWithCredentialProviders());
         }
       }
     }
@@ -435,32 +427,12 @@ public abstract class BaseCatalog<T extends BaseCatalog>
   }
 
   /**
-   * Sets the {@link SecretManager} used to resolve secret URNs for this catalog.
-   *
-   * @param secretManager The SecretManager instance.
-   * @return The instance of the concrete subclass of BaseCatalog.
-   */
-  public T withSecretManager(SecretManager secretManager) {
-    this.secretManager = secretManager;
-    return (T) this;
-  }
-
-  /**
    * Retrieves the CatalogEntity associated with this catalog.
    *
    * @return The CatalogEntity instance.
    */
   public CatalogEntity entity() {
     return entity;
-  }
-
-  /**
-   * Retrieves the {@link SecretManager} associated with this catalog.
-   *
-   * @return The SecretManager instance.
-   */
-  public SecretManager secretManager() {
-    return secretManager;
   }
 
   @Override
@@ -515,14 +487,18 @@ public abstract class BaseCatalog<T extends BaseCatalog>
 
   /**
    * Retrieves the properties of the catalog including credential providers. Detects storage and
-   * catalog-specific credential providers from the raw entity properties (including hidden ones)
+   * catalog-specific credential providers from catalog conf when set (CatalogManager resolves
+   * secret URNs into conf while entity storage keeps URNs), otherwise from raw entity properties,
    * and injects them before {@link CatalogCredentialManager} is initialized. Subclasses may
    * override {@link #addCatalogSpecificCredentialProviders} to add additional providers.
    *
-   * @return A map of raw properties with credential providers set.
+   * @return A map of properties with credential providers set.
    */
   public Map<String, String> propertiesWithCredentialProviders() {
-    Map<String, String> props = Maps.newHashMap(entity().getProperties());
+    // Prefer conf: createBaseCatalog sets it via SecretManager.toPlaintextProperties so credential
+    // vending receives plaintext. Fall back to entity props when conf is unset (e.g. unit tests).
+    Map<String, String> props =
+        Maps.newHashMap(conf != null ? conf : entity().getProperties());
     if (StringUtils.isNotBlank(props.get(CredentialConstants.CREDENTIAL_PROVIDERS))) {
       return props;
     }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -48,6 +48,7 @@ import org.apache.gravitino.credential.S3SecretKeyCredential;
 import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.storage.AzureProperties;
 import org.apache.gravitino.storage.GCSProperties;
 import org.apache.gravitino.storage.OSSProperties;
@@ -375,8 +376,12 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     if (catalogCredentialManager == null) {
       synchronized (this) {
         if (catalogCredentialManager == null) {
+          // Entity storage keeps secret URNs; credential vending must return plaintext so
+          // getCredentials / JdbcCredential (and other static-key providers) are usable by clients.
+          Map<String, String> props = propertiesWithCredentialProviders();
+          SecretManager secretManager = GravitinoEnv.getInstance().secretManager();
           this.catalogCredentialManager =
-              new CatalogCredentialManager(name(), propertiesWithCredentialProviders());
+              new CatalogCredentialManager(name(), secretManager.toPlaintextProperties(props));
         }
       }
     }

--- a/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
@@ -19,34 +19,100 @@
 package org.apache.gravitino.credential;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import org.apache.gravitino.Catalog;
+import org.apache.gravitino.Config;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestCatalog;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.secret.SecretConstants;
+import org.apache.gravitino.secret.SecretManager;
+import org.apache.gravitino.secret.SecretMaterial;
+import org.apache.gravitino.secret.SecretProviderRegistry;
+import org.apache.gravitino.secret.SecretUrn;
+import org.apache.gravitino.secret.memory.InMemorySecretsProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies that catalog credential vending uses catalog conf (plaintext) rather than raw entity
- * properties that may still store secret URNs.
+ * Verifies that {@code propertiesWithCredentialProviders} resolves entity secret URNs to plaintext
+ * via the catalog's {@link SecretManager}.
  */
 public class TestBaseCatalogCredentialSecrets {
 
   @Test
-  void testCatalogCredentialManagerUsesPlaintextConfOverEntityUrn() {
-    String urn = "urn:gravitino-secret:memory:catalog:1:jdbc-password";
-    Map<String, String> entityProps = new HashMap<>();
-    entityProps.put(CredentialConstants.CREDENTIAL_PROVIDERS, JdbcCredential.JDBC_CREDENTIAL_TYPE);
-    entityProps.put(JdbcCredential.GRAVITINO_JDBC_USER, "iceberg");
-    entityProps.put(JdbcCredential.GRAVITINO_JDBC_PASSWORD, urn);
+  void testPropertiesWithCredentialProvidersResolvesEntityUrn() throws Exception {
+    try (SecretManager secretManager = memorySecretManager()) {
+      SecretUrn urn =
+          SecretUrn.buildWriteThrough(
+              "memory",
+              Map.of(
+                  SecretConstants.ATTR_ENTITY_TYPE,
+                  "catalog",
+                  SecretConstants.ATTR_ENTITY_ID,
+                  "1",
+                  SecretConstants.ATTR_PROPERTY_KEY,
+                  "jdbc-password"));
+      secretManager.writeSecrets(java.util.List.of(new SecretMaterial(urn, "plain-jdbc-pass")));
 
-    // CatalogManager sets conf via SecretManager.toPlaintextProperties(entity props).
-    Map<String, String> confProps = new HashMap<>(entityProps);
-    confProps.put(JdbcCredential.GRAVITINO_JDBC_PASSWORD, "plain-jdbc-pass");
+      Map<String, String> entityProps =
+          Map.of(
+              CredentialConstants.CREDENTIAL_PROVIDERS,
+              JdbcCredential.JDBC_CREDENTIAL_TYPE,
+              JdbcCredential.GRAVITINO_JDBC_USER,
+              "iceberg",
+              JdbcCredential.GRAVITINO_JDBC_PASSWORD,
+              urn.toString());
+
+      CatalogEntity entity =
+          CatalogEntity.builder()
+              .withId(1L)
+              .withName("jdbc-secret-catalog")
+              .withNamespace(Namespace.of("metalake"))
+              .withType(Catalog.Type.RELATIONAL)
+              .withProvider("test")
+              .withProperties(entityProps)
+              .withAuditInfo(
+                  AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
+              .build();
+
+      TestCatalog catalog =
+          new TestCatalog()
+              .withCatalogEntity(entity)
+              .withCatalogConf(entityProps)
+              .withSecretManager(secretManager);
+
+      Assertions.assertEquals(
+          "plain-jdbc-pass",
+          catalog.propertiesWithCredentialProviders().get(JdbcCredential.GRAVITINO_JDBC_PASSWORD));
+
+      Optional<Credential> credential =
+          catalog
+              .catalogCredentialManager()
+              .getCredential(
+                  JdbcCredential.JDBC_CREDENTIAL_TYPE, new CatalogCredentialContext("user"));
+
+      Assertions.assertTrue(credential.isPresent());
+      JdbcCredential jdbc = (JdbcCredential) credential.get();
+      Assertions.assertEquals("iceberg", jdbc.jdbcUser());
+      Assertions.assertEquals("plain-jdbc-pass", jdbc.jdbcPassword());
+    }
+  }
+
+  @Test
+  void testPropertiesWithCredentialProvidersWithoutSecretManagerKeepsUrn() {
+    String urn = "urn:gravitino-secret:memory:catalog:1:jdbc-password";
+    Map<String, String> entityProps =
+        Map.of(
+            CredentialConstants.CREDENTIAL_PROVIDERS,
+            JdbcCredential.JDBC_CREDENTIAL_TYPE,
+            JdbcCredential.GRAVITINO_JDBC_USER,
+            "iceberg",
+            JdbcCredential.GRAVITINO_JDBC_PASSWORD,
+            urn);
 
     CatalogEntity entity =
         CatalogEntity.builder()
@@ -60,22 +126,23 @@ public class TestBaseCatalogCredentialSecrets {
                 AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
             .build();
 
-    TestCatalog catalog = new TestCatalog().withCatalogEntity(entity).withCatalogConf(confProps);
+    TestCatalog catalog = new TestCatalog().withCatalogEntity(entity).withCatalogConf(entityProps);
 
     Assertions.assertEquals(
-        "plain-jdbc-pass",
+        urn,
         catalog.propertiesWithCredentialProviders().get(JdbcCredential.GRAVITINO_JDBC_PASSWORD));
+  }
 
-    Optional<Credential> credential =
-        catalog
-            .catalogCredentialManager()
-            .getCredential(
-                JdbcCredential.JDBC_CREDENTIAL_TYPE, new CatalogCredentialContext("user"));
-
-    Assertions.assertTrue(credential.isPresent());
-    Assertions.assertInstanceOf(JdbcCredential.class, credential.get());
-    JdbcCredential jdbc = (JdbcCredential) credential.get();
-    Assertions.assertEquals("iceberg", jdbc.jdbcUser());
-    Assertions.assertEquals("plain-jdbc-pass", jdbc.jdbcPassword());
+  private static SecretManager memorySecretManager() {
+    Config config = new Config(false) {};
+    Properties properties = new Properties();
+    properties.setProperty(SecretProviderRegistry.GRAVITINO_SECRET_PROVIDERS, "memory");
+    properties.setProperty(
+        SecretProviderRegistry.GRAVITINO_SECRET_PROVIDER_PREFIX
+            + "memory."
+            + SecretProviderRegistry.CLASS_NAME,
+        InMemorySecretsProvider.class.getName());
+    config.loadFromProperties(properties);
+    return new SecretManager(config);
   }
 }

--- a/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
@@ -19,97 +19,64 @@
 package org.apache.gravitino.credential;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import org.apache.gravitino.Catalog;
-import org.apache.gravitino.Config;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestCatalog;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.CatalogEntity;
-import org.apache.gravitino.secret.SecretConstants;
-import org.apache.gravitino.secret.SecretManager;
-import org.apache.gravitino.secret.SecretMaterial;
-import org.apache.gravitino.secret.SecretProviderRegistry;
-import org.apache.gravitino.secret.SecretUrn;
-import org.apache.gravitino.secret.memory.InMemorySecretsProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies that catalog credential vending resolves secret URNs to plaintext so {@code
- * getCredentials} / {@link JdbcCredential} return usable passwords.
+ * Verifies that catalog credential vending uses catalog conf (plaintext) rather than raw entity
+ * properties that may still store secret URNs.
  */
 public class TestBaseCatalogCredentialSecrets {
 
   @Test
-  void testCatalogCredentialManagerResolvesJdbcPasswordUrn() throws Exception {
-    try (SecretManager secretManager = memorySecretManager()) {
-      SecretUrn urn =
-          SecretUrn.buildWriteThrough(
-              "memory",
-              Map.of(
-                  SecretConstants.ATTR_ENTITY_TYPE,
-                  "catalog",
-                  SecretConstants.ATTR_ENTITY_ID,
-                  "1",
-                  SecretConstants.ATTR_PROPERTY_KEY,
-                  "jdbc-password"));
-      secretManager.writeSecrets(java.util.List.of(new SecretMaterial(urn, "plain-jdbc-pass")));
+  void testCatalogCredentialManagerUsesPlaintextConfOverEntityUrn() {
+    String urn = "urn:gravitino-secret:memory:catalog:1:jdbc-password";
+    Map<String, String> entityProps = new HashMap<>();
+    entityProps.put(CredentialConstants.CREDENTIAL_PROVIDERS, JdbcCredential.JDBC_CREDENTIAL_TYPE);
+    entityProps.put(JdbcCredential.GRAVITINO_JDBC_USER, "iceberg");
+    entityProps.put(JdbcCredential.GRAVITINO_JDBC_PASSWORD, urn);
 
-      Map<String, String> props =
-          Map.of(
-              CredentialConstants.CREDENTIAL_PROVIDERS,
-              JdbcCredential.JDBC_CREDENTIAL_TYPE,
-              JdbcCredential.GRAVITINO_JDBC_USER,
-              "iceberg",
-              JdbcCredential.GRAVITINO_JDBC_PASSWORD,
-              urn.toString());
+    // CatalogManager sets conf via SecretManager.toPlaintextProperties(entity props).
+    Map<String, String> confProps = new HashMap<>(entityProps);
+    confProps.put(JdbcCredential.GRAVITINO_JDBC_PASSWORD, "plain-jdbc-pass");
 
-      CatalogEntity entity =
-          CatalogEntity.builder()
-              .withId(1L)
-              .withName("jdbc-secret-catalog")
-              .withNamespace(Namespace.of("metalake"))
-              .withType(Catalog.Type.RELATIONAL)
-              .withProvider("test")
-              .withProperties(props)
-              .withAuditInfo(
-                  AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
-              .build();
+    CatalogEntity entity =
+        CatalogEntity.builder()
+            .withId(1L)
+            .withName("jdbc-secret-catalog")
+            .withNamespace(Namespace.of("metalake"))
+            .withType(Catalog.Type.RELATIONAL)
+            .withProvider("test")
+            .withProperties(entityProps)
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
+            .build();
 
-      TestCatalog catalog =
-          new TestCatalog()
-              .withCatalogEntity(entity)
-              .withCatalogConf(props)
-              .withSecretManager(secretManager);
+    TestCatalog catalog =
+        new TestCatalog().withCatalogEntity(entity).withCatalogConf(confProps);
 
-      Optional<Credential> credential =
-          catalog
-              .catalogCredentialManager()
-              .getCredential(
-                  JdbcCredential.JDBC_CREDENTIAL_TYPE, new CatalogCredentialContext("user"));
+    Assertions.assertEquals(
+        "plain-jdbc-pass",
+        catalog.propertiesWithCredentialProviders().get(JdbcCredential.GRAVITINO_JDBC_PASSWORD));
 
-      Assertions.assertTrue(credential.isPresent());
-      Assertions.assertInstanceOf(JdbcCredential.class, credential.get());
-      JdbcCredential jdbc = (JdbcCredential) credential.get();
-      Assertions.assertEquals("iceberg", jdbc.jdbcUser());
-      Assertions.assertEquals("plain-jdbc-pass", jdbc.jdbcPassword());
-      Assertions.assertFalse(jdbc.jdbcPassword().startsWith("urn:gravitino-secret:"));
-    }
-  }
+    Optional<Credential> credential =
+        catalog
+            .catalogCredentialManager()
+            .getCredential(
+                JdbcCredential.JDBC_CREDENTIAL_TYPE, new CatalogCredentialContext("user"));
 
-  private static SecretManager memorySecretManager() {
-    Config config = new Config(false) {};
-    Properties properties = new Properties();
-    properties.setProperty(SecretProviderRegistry.GRAVITINO_SECRET_PROVIDERS, "memory");
-    properties.setProperty(
-        SecretProviderRegistry.GRAVITINO_SECRET_PROVIDER_PREFIX
-            + "memory."
-            + SecretProviderRegistry.CLASS_NAME,
-        InMemorySecretsProvider.class.getName());
-    config.loadFromProperties(properties);
-    return new SecretManager(config);
+    Assertions.assertTrue(credential.isPresent());
+    Assertions.assertInstanceOf(JdbcCredential.class, credential.get());
+    JdbcCredential jdbc = (JdbcCredential) credential.get();
+    Assertions.assertEquals("iceberg", jdbc.jdbcUser());
+    Assertions.assertEquals("plain-jdbc-pass", jdbc.jdbcPassword());
   }
 }

--- a/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.credential;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.TestCatalog;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.secret.SecretConstants;
+import org.apache.gravitino.secret.SecretManager;
+import org.apache.gravitino.secret.SecretMaterial;
+import org.apache.gravitino.secret.SecretProviderRegistry;
+import org.apache.gravitino.secret.SecretUrn;
+import org.apache.gravitino.secret.memory.InMemorySecretsProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that catalog credential vending resolves secret URNs to plaintext so {@code
+ * getCredentials} / {@link JdbcCredential} return usable passwords.
+ */
+public class TestBaseCatalogCredentialSecrets {
+
+  @AfterEach
+  public void tearDown() throws IllegalAccessException {
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "secretManager", null, true);
+  }
+
+  @Test
+  void testCatalogCredentialManagerResolvesJdbcPasswordUrn() throws Exception {
+    try (SecretManager secretManager = memorySecretManager()) {
+      FieldUtils.writeField(GravitinoEnv.getInstance(), "secretManager", secretManager, true);
+
+      SecretUrn urn =
+          SecretUrn.buildWriteThrough(
+              "memory",
+              Map.of(
+                  SecretConstants.ATTR_ENTITY_TYPE,
+                  "catalog",
+                  SecretConstants.ATTR_ENTITY_ID,
+                  "1",
+                  SecretConstants.ATTR_PROPERTY_KEY,
+                  "jdbc-password"));
+      secretManager.writeSecrets(java.util.List.of(new SecretMaterial(urn, "plain-jdbc-pass")));
+
+      Map<String, String> props =
+          Map.of(
+              CredentialConstants.CREDENTIAL_PROVIDERS,
+              JdbcCredential.JDBC_CREDENTIAL_TYPE,
+              JdbcCredential.GRAVITINO_JDBC_USER,
+              "iceberg",
+              JdbcCredential.GRAVITINO_JDBC_PASSWORD,
+              urn.toString());
+
+      CatalogEntity entity =
+          CatalogEntity.builder()
+              .withId(1L)
+              .withName("jdbc-secret-catalog")
+              .withNamespace(Namespace.of("metalake"))
+              .withType(Catalog.Type.RELATIONAL)
+              .withProvider("test")
+              .withProperties(props)
+              .withAuditInfo(
+                  AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
+              .build();
+
+      TestCatalog catalog = new TestCatalog().withCatalogEntity(entity).withCatalogConf(props);
+
+      Optional<Credential> credential =
+          catalog
+              .catalogCredentialManager()
+              .getCredential(
+                  JdbcCredential.JDBC_CREDENTIAL_TYPE, new CatalogCredentialContext("user"));
+
+      Assertions.assertTrue(credential.isPresent());
+      Assertions.assertInstanceOf(JdbcCredential.class, credential.get());
+      JdbcCredential jdbc = (JdbcCredential) credential.get();
+      Assertions.assertEquals("iceberg", jdbc.jdbcUser());
+      Assertions.assertEquals("plain-jdbc-pass", jdbc.jdbcPassword());
+      Assertions.assertFalse(jdbc.jdbcPassword().startsWith("urn:gravitino-secret:"));
+    }
+  }
+
+  private static SecretManager memorySecretManager() {
+    Config config = new Config(false) {};
+    Properties properties = new Properties();
+    properties.setProperty(SecretProviderRegistry.GRAVITINO_SECRET_PROVIDERS, "memory");
+    properties.setProperty(
+        SecretProviderRegistry.GRAVITINO_SECRET_PROVIDER_PREFIX
+            + "memory."
+            + SecretProviderRegistry.CLASS_NAME,
+        InMemorySecretsProvider.class.getName());
+    config.loadFromProperties(properties);
+    return new SecretManager(config);
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
@@ -60,8 +60,7 @@ public class TestBaseCatalogCredentialSecrets {
                 AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
             .build();
 
-    TestCatalog catalog =
-        new TestCatalog().withCatalogEntity(entity).withCatalogConf(confProps);
+    TestCatalog catalog = new TestCatalog().withCatalogEntity(entity).withCatalogConf(confProps);
 
     Assertions.assertEquals(
         "plain-jdbc-pass",

--- a/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestBaseCatalogCredentialSecrets.java
@@ -22,10 +22,8 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Config;
-import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestCatalog;
 import org.apache.gravitino.meta.AuditInfo;
@@ -36,7 +34,6 @@ import org.apache.gravitino.secret.SecretMaterial;
 import org.apache.gravitino.secret.SecretProviderRegistry;
 import org.apache.gravitino.secret.SecretUrn;
 import org.apache.gravitino.secret.memory.InMemorySecretsProvider;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -46,16 +43,9 @@ import org.junit.jupiter.api.Test;
  */
 public class TestBaseCatalogCredentialSecrets {
 
-  @AfterEach
-  public void tearDown() throws IllegalAccessException {
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "secretManager", null, true);
-  }
-
   @Test
   void testCatalogCredentialManagerResolvesJdbcPasswordUrn() throws Exception {
     try (SecretManager secretManager = memorySecretManager()) {
-      FieldUtils.writeField(GravitinoEnv.getInstance(), "secretManager", secretManager, true);
-
       SecretUrn urn =
           SecretUrn.buildWriteThrough(
               "memory",
@@ -89,7 +79,11 @@ public class TestBaseCatalogCredentialSecrets {
                   AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
               .build();
 
-      TestCatalog catalog = new TestCatalog().withCatalogEntity(entity).withCatalogConf(props);
+      TestCatalog catalog =
+          new TestCatalog()
+              .withCatalogEntity(entity)
+              .withCatalogConf(props)
+              .withSecretManager(secretManager);
 
       Optional<Credential> credential =
           catalog


### PR DESCRIPTION
### What changes were proposed in this pull request?

Resolve secret URNs to plaintext when initializing `CatalogCredentialManager` in
`BaseCatalog.catalogCredentialManager()`, so `getCredentials` / `JdbcCredential`
(and other static-key providers) return usable plaintext instead of storage URNs.
Add a unit test covering JDBC password URN resolution.

### Why are the changes needed?

Entity storage keeps secret-backed properties as URNs. `getSecrets` already
resolves them, but credential vending initialized providers from raw entity
props, so clients received URNs and standalone Iceberg REST JDBC auth failed.

Fix: #12724

### Does this PR introduce _any_ user-facing change?

Yes. `getCredentials` for secret-backed static credentials (e.g. `jdbc-password`,
S3 secret keys) now returns plaintext instead of secret URNs. Storage / getCatalog
masking (`******`) is unchanged.

### How was this patch tested?

- Unit: `TestBaseCatalogCredentialSecrets`
- Manual E2E: Vault KV entity secrets with Iceberg REST (aux + standalone) and
  Lance REST (aux + standalone); credentials API returns plaintext; IRC/Lance OK

Made with [Cursor](https://cursor.com)