### PR TITLE
fix(#12682): Add hadoop-aws dependency to Paimon catalog for S3 warehouse support

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-paimon/build.gradle.kts
@@ -133,6 +133,13 @@ dependencies {
   implementation(libs.hadoop3.mapreduce.client.core) {
     exclude("*")
   }
+  implementation(libs.hadoop3.aws) {
+    exclude("com.sun.jersey")
+    exclude("javax.servlet")
+    exclude("org.apache.zookeeper")
+    exclude("org.mortbay.jetty")
+    exclude("org.eclipse.jetty")
+  }
 
   // Required by Paimon HiveCatalog#createView, which calls hive ql metadata Table APIs.
   runtimeOnly(libs.hive2.exec) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `hadoop-aws` (3.3.6) as an implementation dependency to `catalog-lakehouse-paimon`.

### Why are the changes needed?

Fix: #12682

Paimon catalog fails to access `s3a://` warehouse because the `org.apache.hadoop.fs.s3a.S3AFileSystem` class is unavailable at runtime. When Paimon falls back to `HadoopFileIO` for S3A schemes, it requires `hadoop-aws` on the classpath.

### Does this PR introduce any user-facing change?

No. Users who use S3A warehouses with Paimon catalog will now be able to access them without manually adding the hadoop-aws jar.

### How was this patch tested?

Verified that `org.apache.hadoop.fs.s3a.S3AFileSystem` class is present in the hadoop-aws-3.3.6.jar artifact.