### PR TITLE
[#12685] fix(core): Fix PolicyManager asymmetric set difference check for built-in policies

### DIFF
--- a/core/src/main/java/org/apache/gravitino/policy/PolicyManager.java
+++ b/core/src/main/java/org/apache/gravitino/policy/PolicyManager.java
@@ -500,12 +500,14 @@ public class PolicyManager implements PolicyDispatcher {
 
         if (policyType != Policy.BuiltInType.CUSTOM) {
           // cannot change the supported object types for built-in policies
+          Set<String> oldTypes = policyEntity.content().supportedObjectTypes();
+          Set<String> newTypes = updateContent.getContent().supportedObjectTypes();
           Preconditions.checkArgument(
-              Sets.difference(
-                      policyEntity.content().supportedObjectTypes(),
-                      updateContent.getContent().supportedObjectTypes())
-                  .isEmpty(),
-              "Policy content type mismatch: expected %s but got %s");
+              Sets.difference(oldTypes, newTypes).isEmpty()
+                  && Sets.difference(newTypes, oldTypes).isEmpty(),
+              "Policy supported object types cannot be changed for built-in policies: %s -> %s",
+              oldTypes,
+              newTypes);
         }
 
         newContent = updateContent.getContent();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the asymmetric set difference check in PolicyManager.updatePolicyEntity() that only blocks removing supportedObjectTypes from built-in policies, but silently allows adding new ones.

### Why are the changes needed?

The original check uses Sets.difference(old, new).isEmpty() which only verifies that old types are not removed - it does not detect when new types are added. This allows silently changing the supported object types of built-in policies.

Additionally, the error message format string was missing its format arguments.

### How was this patch tested?

Manual verification that symmetric Sets.difference checks in both directions now correctly prevent any modification to supported object types of built-in policies.

Fixes: #12685