### PR TITLE
[#12740] fix(doris): Preserve default value on column type change

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisColumnDefaultValueConverter.java
@@ -26,21 +26,82 @@ import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.DO
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.FLOAT;
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.INT;
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.SMALLINT;
+import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.STRING;
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.TINYINT;
 import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
 import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import javax.annotation.Nullable;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.rel.expressions.Expression;
 import org.apache.gravitino.rel.expressions.UnparsedExpression;
+import org.apache.gravitino.rel.expressions.literals.Literal;
 import org.apache.gravitino.rel.expressions.literals.Literals;
 import org.apache.gravitino.rel.types.Decimal;
 import org.apache.gravitino.rel.types.Types;
 
 public class DorisColumnDefaultValueConverter extends JdbcColumnDefaultValueConverter {
+
+  /**
+   * Converts a Doris default value for a full column definition.
+   *
+   * <p>Doris expects string defaults in the quoted form for column modification. Unparsed values
+   * are already native Doris expressions returned by metadata and must be passed through without
+   * attempting to interpret them in Gravitino.
+   *
+   * @param defaultValue the loaded Gravitino default value
+   * @param doubleEscapeBackslashes whether Doris requires the additional backslash escaping layer
+   * @param tripleEscapeQuotes whether Doris 3.x MODIFY COLUMN requires three backslashes before
+   *     embedded double quotes
+   * @return the Doris SQL representation of the default value
+   */
+  @Nullable
+  public String fromGravitinoForColumnDefinition(
+      Expression defaultValue, boolean doubleEscapeBackslashes, boolean tripleEscapeQuotes) {
+    if (DEFAULT_VALUE_NOT_SET.equals(defaultValue)) {
+      return null;
+    }
+
+    if (defaultValue instanceof UnparsedExpression) {
+      return ((UnparsedExpression) defaultValue).unparsedExpression();
+    }
+
+    if (defaultValue instanceof Literal) {
+      Literal<?> literal = (Literal<?>) defaultValue;
+      if (literal.dataType() instanceof Types.StringType
+          || literal.dataType() instanceof Types.VarCharType
+          || literal.dataType() instanceof Types.FixedCharType) {
+        String value = String.valueOf(literal.value());
+        if (value.indexOf('\\') >= 0 || value.indexOf('\'') >= 0 || value.indexOf('"') >= 0) {
+          return quoteDorisLiteral(value, doubleEscapeBackslashes, tripleEscapeQuotes);
+        }
+      }
+    }
+
+    return super.fromGravitino(defaultValue);
+  }
+
+  /**
+   * Converts a default value for a CREATE TABLE column definition.
+   *
+   * <p>CREATE TABLE accepts the same Doris-compatible literal encoding, but unparsed expressions
+   * are not accepted from client-created table definitions. They are reserved for native
+   * expressions read from existing Doris metadata and replayed during MODIFY COLUMN.
+   *
+   * @param defaultValue the Gravitino default value
+   * @return the Doris SQL representation of the default value
+   */
+  @Nullable
+  public String fromGravitinoForCreateTableDefinition(Expression defaultValue) {
+    if (defaultValue instanceof UnparsedExpression) {
+      throw new IllegalArgumentException(
+          "Unparsed default expressions are not supported in CREATE TABLE definitions");
+    }
+    return fromGravitinoForColumnDefinition(defaultValue, false, false);
+  }
 
   @Override
   public Expression toGravitino(
@@ -90,13 +151,49 @@ public class DorisColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
             : Literals.timestampLiteral(
                 LocalDateTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case JdbcTypeConverter.VARCHAR:
-        return Literals.of(columnDefaultValue, Types.VarCharType.of(columnType.getColumnSize()));
+        return Literals.of(
+            unescapeDorisLiteral(columnDefaultValue),
+            Types.VarCharType.of(columnType.getColumnSize()));
       case CHAR:
-        return Literals.of(columnDefaultValue, Types.FixedCharType.of(columnType.getColumnSize()));
+        return Literals.of(
+            unescapeDorisLiteral(columnDefaultValue),
+            Types.FixedCharType.of(columnType.getColumnSize()));
+      case STRING:
       case JdbcTypeConverter.TEXT:
-        return Literals.stringLiteral(columnDefaultValue);
+        return Literals.stringLiteral(unescapeDorisLiteral(columnDefaultValue));
       default:
         return UnparsedExpression.of(columnDefaultValue);
     }
+  }
+
+  private static String quoteDorisLiteral(
+      String value, boolean doubleEscapeBackslashes, boolean tripleEscapeQuotes) {
+    String escapedBackslash = doubleEscapeBackslashes ? "\\".repeat(4) : "\\".repeat(2);
+    String escapedQuote = "\\".repeat(tripleEscapeQuotes ? 3 : 1) + "\"";
+    String escaped = value.replace("\\", escapedBackslash).replace("\"", escapedQuote);
+    return "\"" + escaped + "\"";
+  }
+
+  private static String unescapeDorisLiteral(String value) {
+    StringBuilder result = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char current = value.charAt(i);
+      if (current == '\\' && i + 1 < value.length()) {
+        char next = value.charAt(i + 1);
+        if (next == '\\' || next == '\'' || next == '\"') {
+          result.append(next);
+          i++;
+          continue;
+        }
+      } else if ((current == '\'' || current == '\"')
+          && i + 1 < value.length()
+          && value.charAt(i + 1) == current) {
+        result.append(current);
+        i++;
+        continue;
+      }
+      result.append(current);
+    }
+    return result.toString();
   }
 }

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -24,7 +24,6 @@ import static org.apache.gravitino.catalog.doris.DorisTablePropertiesMetadata.RE
 import static org.apache.gravitino.catalog.doris.DorisTablePropertiesMetadata.REPLICATION_FACTOR;
 import static org.apache.gravitino.catalog.doris.utils.DorisUtils.generatePartitionSqlFragment;
 import static org.apache.gravitino.catalog.jdbc.utils.JdbcConnectorUtils.escapeSqlLiteral;
-import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -971,7 +970,7 @@ public class DorisTableOperations extends JdbcTableOperations {
             .withName(col)
             .withType(updateColumnType.getNewDataType())
             .withComment(column.comment())
-            .withDefaultValue(DEFAULT_VALUE_NOT_SET)
+            .withDefaultValue(column.defaultValue())
             .withNullable(column.nullable())
             .withAutoIncrement(column.autoIncrement())
             .build();

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.catalog.doris.DorisTablePropertiesMetadata.RE
 import static org.apache.gravitino.catalog.doris.DorisTablePropertiesMetadata.REPLICATION_FACTOR;
 import static org.apache.gravitino.catalog.doris.utils.DorisUtils.generatePartitionSqlFragment;
 import static org.apache.gravitino.catalog.jdbc.utils.JdbcConnectorUtils.escapeSqlLiteral;
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -51,6 +52,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.catalog.doris.converter.DorisColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.doris.utils.DorisUtils;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
@@ -69,6 +71,7 @@ import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.rel.indexes.Indexes;
 import org.apache.gravitino.rel.partitions.ListPartition;
 import org.apache.gravitino.rel.partitions.RangePartition;
+import org.apache.gravitino.rel.types.Types;
 
 /** Table operations for Apache Doris. */
 public class DorisTableOperations extends JdbcTableOperations {
@@ -119,7 +122,7 @@ public class DorisTableOperations extends JdbcTableOperations {
                       .append(BACK_QUOTE)
                       .append(column.name())
                       .append(BACK_QUOTE);
-                  appendColumnDefinition(column, columnsSql);
+                  appendColumnDefinitionForDoris(column, columnsSql);
                   return columnsSql.toString();
                 })
             .collect(Collectors.joining(",\n")));
@@ -257,6 +260,14 @@ public class DorisTableOperations extends JdbcTableOperations {
     if (!hasAutoIncrement) {
       return;
     }
+    String version = getDorisVersion("AUTO_INCREMENT compatibility check");
+    if (!isVersionAtLeast(version, 2, 1, 0)) {
+      throw new UnsupportedOperationException(
+          "AUTO_INCREMENT requires Doris 2.1.0 or later. Current server version: " + version);
+    }
+  }
+
+  private String getDorisVersion(String purpose) {
     Preconditions.checkState(dataSource != null, "dataSource is required for version validation");
     String version = null;
     // SELECT VERSION() returns the MySQL protocol version (e.g. "5.7.99"), not the Doris version.
@@ -283,21 +294,20 @@ public class DorisTableOperations extends JdbcTableOperations {
       }
     } catch (SQLException e) {
       throw new UnsupportedOperationException(
-          "Unable to determine Doris version for AUTO_INCREMENT compatibility check. "
-              + "Ensure the connection user has permission to execute SHOW FRONTENDS "
+          "Unable to determine Doris version for "
+              + purpose
+              + ". Ensure the connection user has permission to execute SHOW FRONTENDS "
               + "and the Doris FE is reachable.",
           e);
     }
     if (version == null) {
       throw new UnsupportedOperationException(
-          "Unable to determine Doris version for AUTO_INCREMENT compatibility check. "
-              + "Ensure the connection user has permission to execute SHOW FRONTENDS "
+          "Unable to determine Doris version for "
+              + purpose
+              + ". Ensure the connection user has permission to execute SHOW FRONTENDS "
               + "and the Doris FE is reachable.");
     }
-    if (!isVersionAtLeast(version, 2, 1, 0)) {
-      throw new UnsupportedOperationException(
-          "AUTO_INCREMENT requires Doris 2.1.0 or later. Current server version: " + version);
-    }
+    return version;
   }
 
   @VisibleForTesting
@@ -739,6 +749,7 @@ public class DorisTableOperations extends JdbcTableOperations {
     TableChange.UpdateComment updateComment = null;
     List<TableChange.SetProperty> setProperties = new ArrayList<>();
     List<String> alterSql = new ArrayList<>();
+    Optional<String> modifyDorisVersion = Optional.empty();
     for (int i = 0; i < changes.length; i++) {
       TableChange change = changes[i];
       if (change instanceof TableChange.UpdateComment) {
@@ -758,7 +769,16 @@ public class DorisTableOperations extends JdbcTableOperations {
       } else if (change instanceof TableChange.UpdateColumnType) {
         lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
         TableChange.UpdateColumnType updateColumnType = (TableChange.UpdateColumnType) change;
-        alterSql.add(updateColumnTypeFieldDefinition(updateColumnType, lazyLoadTable));
+        if (updateColumnType.fieldName().length == 1 && modifyDorisVersion.isEmpty()) {
+          JdbcColumn currentColumn =
+              getJdbcColumnFromTable(lazyLoadTable, updateColumnType.fieldName()[0]);
+          if (requiresVersionAwareModifyEscaping(currentColumn)) {
+            modifyDorisVersion =
+                Optional.of(getDorisVersion("MODIFY COLUMN default literal compatibility check"));
+          }
+        }
+        alterSql.add(
+            updateColumnTypeFieldDefinition(updateColumnType, lazyLoadTable, modifyDorisVersion));
       } else if (change instanceof TableChange.UpdateColumnComment) {
         TableChange.UpdateColumnComment updateColumnComment =
             (TableChange.UpdateColumnComment) change;
@@ -958,7 +978,9 @@ public class DorisTableOperations extends JdbcTableOperations {
   }
 
   private String updateColumnTypeFieldDefinition(
-      TableChange.UpdateColumnType updateColumnType, JdbcTable jdbcTable) {
+      TableChange.UpdateColumnType updateColumnType,
+      JdbcTable jdbcTable,
+      Optional<String> dorisVersion) {
     if (updateColumnType.fieldName().length > 1) {
       throw new UnsupportedOperationException("Doris does not support nested column names.");
     }
@@ -974,33 +996,84 @@ public class DorisTableOperations extends JdbcTableOperations {
             .withNullable(column.nullable())
             .withAutoIncrement(column.autoIncrement())
             .build();
-    return appendColumnDefinition(newColumn, sqlBuilder).toString();
+    return appendColumnDefinitionForModify(newColumn, sqlBuilder, dorisVersion).toString();
   }
 
-  private StringBuilder appendColumnDefinition(JdbcColumn column, StringBuilder sqlBuilder) {
-    // Add data type
+  private StringBuilder appendColumnDefinitionForModify(
+      JdbcColumn column, StringBuilder sqlBuilder, Optional<String> dorisVersion) {
+    return appendColumnDefinition(column, sqlBuilder, true, dorisVersion, true);
+  }
+
+  private StringBuilder appendColumnDefinitionForDoris(
+      JdbcColumn column, StringBuilder sqlBuilder) {
+    return appendColumnDefinition(column, sqlBuilder, true, Optional.empty(), false);
+  }
+
+  private StringBuilder appendColumnDefinition(
+      JdbcColumn column,
+      StringBuilder sqlBuilder,
+      boolean includeDefaultValue,
+      Optional<String> dorisVersion,
+      boolean useModifyDefaultSerializer) {
     sqlBuilder.append(SPACE).append(typeConverter.fromGravitino(column.dataType())).append(SPACE);
 
-    // Add NOT NULL if the column is marked as such
     if (column.nullable()) {
       sqlBuilder.append("NULL ");
     } else {
       sqlBuilder.append("NOT NULL ");
     }
 
-    // Add DEFAULT value if specified
-    appendDefaultValue(column, sqlBuilder);
+    if (includeDefaultValue && !DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
+      Preconditions.checkState(
+          columnDefaultValueConverter instanceof DorisColumnDefaultValueConverter,
+          "DorisColumnDefaultValueConverter is required for Doris column default serialization");
+      DorisColumnDefaultValueConverter converter =
+          (DorisColumnDefaultValueConverter) columnDefaultValueConverter;
+      boolean isDoris3x =
+          dorisVersion
+              .map(
+                  version ->
+                      isVersionAtLeast(version, 3, 0, 0) && !isVersionAtLeast(version, 4, 0, 0))
+              .orElse(false);
+      sqlBuilder
+          .append("DEFAULT ")
+          .append(
+              useModifyDefaultSerializer
+                  ? converter.fromGravitinoForColumnDefinition(
+                      column.defaultValue(), isDoris3x, isDoris3x)
+                  : converter.fromGravitinoForCreateTableDefinition(column.defaultValue()))
+          .append(SPACE);
+    } else if (!includeDefaultValue) {
+      appendDefaultValue(column, sqlBuilder);
+    }
 
-    // Add column auto_increment if specified
     if (column.autoIncrement()) {
       sqlBuilder.append(DORIS_AUTO_INCREMENT).append(" ");
     }
 
-    // Add column comment if specified
     if (StringUtils.isNotEmpty(column.comment())) {
       sqlBuilder.append("COMMENT '").append(escapeSqlLiteral(column.comment(), '\'')).append("' ");
     }
     return sqlBuilder;
+  }
+
+  private static boolean requiresVersionAwareModifyEscaping(Column column) {
+    if (!(column.defaultValue() instanceof Literal)) {
+      return false;
+    }
+
+    Literal<?> literal = (Literal<?>) column.defaultValue();
+    if (!(literal.dataType() instanceof Types.StringType
+        || literal.dataType() instanceof Types.VarCharType
+        || literal.dataType() instanceof Types.FixedCharType)) {
+      return false;
+    }
+    String value = literal.value() == null ? null : String.valueOf(literal.value());
+    return value != null && (value.contains("\\") || value.contains("\""));
+  }
+
+  private StringBuilder appendColumnDefinition(JdbcColumn column, StringBuilder sqlBuilder) {
+    return appendColumnDefinition(column, sqlBuilder, false, Optional.empty(), false);
   }
 
   static String addIndexDefinition(TableChange.AddIndex addIndex) {

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/converter/TestDorisColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/converter/TestDorisColumnDefaultValueConverter.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.doris.converter;
+
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
+
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.rel.expressions.Expression;
+import org.apache.gravitino.rel.expressions.UnparsedExpression;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link DorisColumnDefaultValueConverter}. */
+public class TestDorisColumnDefaultValueConverter {
+
+  private static final DorisColumnDefaultValueConverter CONVERTER =
+      new DorisColumnDefaultValueConverter();
+
+  @Test
+  public void testFromGravitinoForColumnDefinitionPreservesSupportedDefaults() {
+    Assertions.assertNull(
+        CONVERTER.fromGravitinoForColumnDefinition(DEFAULT_VALUE_NOT_SET, false, false));
+    Assertions.assertEquals(
+        "NULL", CONVERTER.fromGravitinoForColumnDefinition(Literals.NULL, false, false));
+    Assertions.assertEquals(
+        "7", CONVERTER.fromGravitinoForColumnDefinition(Literals.integerLiteral(7), false, false));
+    Assertions.assertEquals(
+        "CURRENT_TIMESTAMP",
+        CONVERTER.fromGravitinoForColumnDefinition(
+            DEFAULT_VALUE_OF_CURRENT_TIMESTAMP, false, false));
+    Assertions.assertEquals(
+        "CURRENT_DATE",
+        CONVERTER.fromGravitinoForColumnDefinition(
+            UnparsedExpression.of("CURRENT_DATE"), false, false));
+  }
+
+  @Test
+  public void testCreateTableDefinitionRejectsUnparsedDefaults() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CONVERTER.fromGravitinoForCreateTableDefinition(UnparsedExpression.of("CURRENT_DATE")));
+  }
+
+  @Test
+  public void testFromGravitinoForColumnDefinitionEscapesStringDefaultsByDorisVersion() {
+    Expression defaultValue = Literals.stringLiteral("owner's\\value");
+
+    Assertions.assertEquals(
+        "\"owner's\\\\value\"",
+        CONVERTER.fromGravitinoForColumnDefinition(defaultValue, false, false));
+    Assertions.assertEquals(
+        "\"owner's\\\\\\\\value\"",
+        CONVERTER.fromGravitinoForColumnDefinition(defaultValue, true, false));
+  }
+
+  @Test
+  public void testFromGravitinoForColumnDefinitionEscapesQuoteDelimiter() {
+    Expression defaultValue = Literals.stringLiteral("owner's \"value\"\\path");
+
+    Assertions.assertEquals(
+        "\"" + "owner's \\\"value\\\"\\\\path" + "\"",
+        CONVERTER.fromGravitinoForColumnDefinition(defaultValue, false, false));
+    Assertions.assertEquals(
+        "\"" + "owner's \\\"value\\\"\\\\\\\\path" + "\"",
+        CONVERTER.fromGravitinoForColumnDefinition(defaultValue, true, false));
+    Assertions.assertEquals(
+        "\""
+            + "owner's "
+            + "\\".repeat(3)
+            + "\""
+            + "value"
+            + "\\".repeat(3)
+            + "\""
+            + "\\".repeat(2)
+            + "path\"",
+        CONVERTER.fromGravitinoForColumnDefinition(defaultValue, false, true));
+    Assertions.assertEquals(
+        "\""
+            + "owner's "
+            + "\\".repeat(3)
+            + "\""
+            + "value"
+            + "\\".repeat(3)
+            + "\""
+            + "\\".repeat(4)
+            + "path\"",
+        CONVERTER.fromGravitinoForColumnDefinition(defaultValue, true, true));
+  }
+
+  @Test
+  public void testFromGravitinoForColumnDefinitionEscapesAdjacentBackslashAndQuote() {
+    Expression defaultValue = Literals.stringLiteral("prefix" + "\\" + "\"" + "suffix");
+
+    Assertions.assertEquals(
+        "\"prefix" + "\\".repeat(7) + "\"suffix\"",
+        CONVERTER.fromGravitinoForColumnDefinition(defaultValue, true, true));
+  }
+
+  @Test
+  public void testToGravitinoUnescapesStringDefaults() {
+    JdbcTypeConverter.JdbcTypeBean typeBean = new JdbcTypeConverter.JdbcTypeBean("varchar");
+    typeBean.setColumnSize(32);
+
+    Assertions.assertEquals(
+        Literals.of("owner's\\value", Types.VarCharType.of(32)),
+        CONVERTER.toGravitino(typeBean, "owner''s\\\\value", false, false));
+
+    Assertions.assertEquals(
+        Literals.stringLiteral("owner's\\value"),
+        CONVERTER.toGravitino(
+            new JdbcTypeConverter.JdbcTypeBean("string"), "owner''s\\\\value", false, false));
+  }
+}

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDoris3xIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDoris3xIT.java
@@ -30,6 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Maps;
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -95,6 +99,7 @@ public class CatalogDoris3xIT extends BaseIT {
 
   private GravitinoMetalake metalake;
   private Catalog catalog;
+  private String jdbcUrl;
 
   @BeforeAll
   public void startup() throws IOException {
@@ -125,7 +130,7 @@ public class CatalogDoris3xIT extends BaseIT {
 
   private void createCatalog() {
     DorisContainer dorisContainer = containerSuite.getDorisContainer(DorisImageName.VERSION_3_0);
-    String jdbcUrl =
+    jdbcUrl =
         String.format(
             "jdbc:mysql://%s:%d/",
             dorisContainer.getContainerIpAddress(), dorisContainer.getFeMysqlPort());
@@ -218,6 +223,53 @@ public class CatalogDoris3xIT extends BaseIT {
         .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
         .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
         .untilAsserted(() -> assertEquals(0, tc.loadTable(tid).index().length));
+  }
+
+  @Test
+  void testAlterColumnTypePreservesDefaultValue() throws SQLException {
+    TableCatalog tc = catalog.asTableCatalog();
+    String tableName = GravitinoITUtils.genRandomName("t_alter_type_preserves_default");
+    NameIdentifier tid = NameIdentifier.of(schemaName, tableName);
+    String distributionColumnName = "dist_key";
+    String valueColumnName = "agg_value";
+    String createSql =
+        String.format(
+            "CREATE TABLE `%s` ("
+                + "`%s` INT NOT NULL DEFAULT \"7\", "
+                + "`%s` BIGINT NOT NULL, "
+                + "`%s` BIGINT SUM DEFAULT \"0\""
+                + ") AGGREGATE KEY(`%s`, `%s`) "
+                + "DISTRIBUTED BY HASH(`%s`) BUCKETS 1 "
+                + "PROPERTIES (\"replication_num\" = \"1\")",
+            tableName,
+            colName1,
+            distributionColumnName,
+            valueColumnName,
+            colName1,
+            distributionColumnName,
+            distributionColumnName);
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(createSql);
+    }
+
+    Column originalColumn = findColumn(tc.loadTable(tid), colName1);
+    assertEquals(Types.IntegerType.get(), originalColumn.dataType());
+    assertEquals(Literals.integerLiteral(7), originalColumn.defaultValue());
+
+    tc.alterTable(tid, TableChange.updateColumnType(new String[] {colName1}, Types.LongType.get()));
+
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Column updatedColumn = findColumn(tc.loadTable(tid), colName1);
+              assertEquals(Types.LongType.get(), updatedColumn.dataType());
+              assertEquals(Literals.longLiteral(7L), updatedColumn.defaultValue());
+            });
   }
 
   @Test

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDoris3xIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDoris3xIT.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
@@ -270,6 +271,258 @@ public class CatalogDoris3xIT extends BaseIT {
               assertEquals(Types.LongType.get(), updatedColumn.dataType());
               assertEquals(Literals.longLiteral(7L), updatedColumn.defaultValue());
             });
+  }
+
+  @Test
+  void testAlterColumnTypePreservesQuotedAndBackslashDefaultValue() throws SQLException {
+    TableCatalog tc = catalog.asTableCatalog();
+    String tableName = GravitinoITUtils.genRandomName("t_alter_type_special_default");
+    NameIdentifier tid = NameIdentifier.of(schemaName, tableName);
+    String logicalDefault = "owner's \"value\"\\\\path";
+    String sqlDefault = "owner's \\\"value\\\"" + "\\\\\\\\" + "path";
+    String createSql =
+        String.format(
+            "CREATE TABLE %s ("
+                + "col_pk BIGINT NOT NULL, "
+                + "col_data VARCHAR(32) NOT NULL DEFAULT \"%s\") "
+                + "DUPLICATE KEY(col_pk) "
+                + "DISTRIBUTED BY HASH(col_pk) BUCKETS 1 "
+                + "PROPERTIES (\"replication_num\" = \"1\")",
+            tableName, sqlDefault);
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(createSql);
+    }
+
+    Column originalColumn = findColumn(tc.loadTable(tid), colName2);
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(32)), originalColumn.defaultValue());
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(String.format("INSERT INTO %s (col_pk) VALUES (0)", tableName));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 0", tableName))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+
+    tc.alterTable(
+        tid, TableChange.updateColumnType(new String[] {colName2}, Types.VarCharType.of(64)));
+
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Column updatedColumn = findColumn(tc.loadTable(tid), colName2);
+              assertEquals(Types.VarCharType.of(64), updatedColumn.dataType());
+              assertEquals(
+                  Literals.of(logicalDefault, Types.VarCharType.of(64)),
+                  updatedColumn.defaultValue());
+            });
+
+    Table alteredTable = tc.loadTable(tid);
+    NameIdentifier recreatedTid =
+        NameIdentifier.of(
+            schemaName, GravitinoITUtils.genRandomName("t_recreated_special_default"));
+    tc.createTable(
+        recreatedTid,
+        alteredTable.columns(),
+        alteredTable.comment(),
+        alteredTable.properties(),
+        alteredTable.partitioning(),
+        alteredTable.distribution(),
+        alteredTable.sortOrder(),
+        alteredTable.index());
+    Column recreatedColumn = findColumn(tc.loadTable(recreatedTid), colName2);
+    assertEquals(Types.VarCharType.of(64), recreatedColumn.dataType());
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(64)), recreatedColumn.defaultValue());
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(String.format("INSERT INTO %s (col_pk) VALUES (1)", tableName));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 1", tableName))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(
+          String.format("INSERT INTO %s (col_pk) VALUES (2)", recreatedTid.name()));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 2", recreatedTid.name()))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+  }
+
+  @Test
+  void testAlterColumnTypePreservesBackslashOnlyDefaultValue() throws SQLException {
+    TableCatalog tc = catalog.asTableCatalog();
+    String tableName = GravitinoITUtils.genRandomName("t_alter_type_backslash_default");
+    NameIdentifier tid = NameIdentifier.of(schemaName, tableName);
+    String logicalDefault = "owner's\\value";
+    String sqlDefault = quotedDefaultExpression(logicalDefault, 1, 2);
+    String createSql =
+        String.format(
+            "CREATE TABLE %s ("
+                + "col_pk BIGINT NOT NULL, "
+                + "col_data VARCHAR(32) NOT NULL DEFAULT %s) "
+                + "DUPLICATE KEY(col_pk) "
+                + "DISTRIBUTED BY HASH(col_pk) BUCKETS 1 "
+                + "PROPERTIES (\"replication_num\" = \"1\")",
+            tableName, sqlDefault);
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(createSql);
+    }
+
+    Column originalColumn = findColumn(tc.loadTable(tid), colName2);
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(32)), originalColumn.defaultValue());
+
+    tc.alterTable(
+        tid, TableChange.updateColumnType(new String[] {colName2}, Types.VarCharType.of(64)));
+
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Column updatedColumn = findColumn(tc.loadTable(tid), colName2);
+              assertEquals(Types.VarCharType.of(64), updatedColumn.dataType());
+              assertEquals(
+                  Literals.of(logicalDefault, Types.VarCharType.of(64)),
+                  updatedColumn.defaultValue());
+            });
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(String.format("INSERT INTO %s (col_pk) VALUES (1)", tableName));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 1", tableName))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+  }
+
+  @Test
+  void testAlterColumnTypePreservesAdjacentBackslashQuoteDefaultValue() throws SQLException {
+    TableCatalog tc = catalog.asTableCatalog();
+    String tableName = GravitinoITUtils.genRandomName("t_alter_type_adjacent_default");
+    NameIdentifier tid = NameIdentifier.of(schemaName, tableName);
+    String logicalDefault = "prefix" + "\\" + "\"" + "suffix";
+    String sqlDefault = quotedDefaultExpression(logicalDefault, 1, 2);
+    String createSql =
+        String.format(
+            "CREATE TABLE %s ("
+                + "col_pk BIGINT NOT NULL, "
+                + "col_data VARCHAR(32) NOT NULL DEFAULT %s) "
+                + "DUPLICATE KEY(col_pk) "
+                + "DISTRIBUTED BY HASH(col_pk) BUCKETS 1 "
+                + "PROPERTIES (\"replication_num\" = \"1\")",
+            tableName, sqlDefault);
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(createSql);
+    }
+
+    Column originalColumn = findColumn(tc.loadTable(tid), colName2);
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(32)), originalColumn.defaultValue());
+
+    tc.alterTable(
+        tid, TableChange.updateColumnType(new String[] {colName2}, Types.VarCharType.of(64)));
+
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Column updatedColumn = findColumn(tc.loadTable(tid), colName2);
+              assertEquals(Types.VarCharType.of(64), updatedColumn.dataType());
+              assertEquals(
+                  Literals.of(logicalDefault, Types.VarCharType.of(64)),
+                  updatedColumn.defaultValue());
+            });
+
+    Table alteredTable = tc.loadTable(tid);
+    NameIdentifier recreatedTid =
+        NameIdentifier.of(
+            schemaName, GravitinoITUtils.genRandomName("t_recreated_adjacent_default"));
+    tc.createTable(
+        recreatedTid,
+        alteredTable.columns(),
+        alteredTable.comment(),
+        alteredTable.properties(),
+        alteredTable.partitioning(),
+        alteredTable.distribution(),
+        alteredTable.sortOrder(),
+        alteredTable.index());
+    Column recreatedColumn = findColumn(tc.loadTable(recreatedTid), colName2);
+    assertEquals(Types.VarCharType.of(64), recreatedColumn.dataType());
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(64)), recreatedColumn.defaultValue());
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(String.format("INSERT INTO %s (col_pk) VALUES (1)", tableName));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 1", tableName))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(
+          String.format("INSERT INTO %s (col_pk) VALUES (2)", recreatedTid.name()));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 2", recreatedTid.name()))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+  }
+
+  private static String quotedDefaultExpression(
+      String value, int quoteBackslashCount, int valueBackslashCount) {
+    String escaped = value.replace("\\", "\\".repeat(valueBackslashCount));
+    escaped = escaped.replace("\"", "\\".repeat(quoteBackslashCount) + "\"");
+    return "\"" + escaped + "\"";
   }
 
   @Test

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDoris4xIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDoris4xIT.java
@@ -26,6 +26,7 @@ import static org.apache.gravitino.integration.test.util.ITUtils.assertPartition
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Maps;
@@ -219,6 +220,92 @@ public class CatalogDoris4xIT extends BaseIT {
         .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
         .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
         .untilAsserted(() -> assertEquals(0, tc.loadTable(tid).index().length));
+  }
+
+  @Test
+  void testAlterColumnTypePreservesDefaultValue() {
+    TableCatalog tc = catalog.asTableCatalog();
+    NameIdentifier tid =
+        NameIdentifier.of(
+            schemaName, GravitinoITUtils.genRandomName("t_alter_type_preserves_default"));
+    Column defaultedColumn =
+        Column.of(
+            colName2,
+            Types.VarCharType.of(10),
+            "defaulted column",
+            false,
+            false,
+            Literals.of("seed", Types.VarCharType.of(10)));
+
+    tc.createTable(
+        tid,
+        new Column[] {
+          Column.of(colName1, Types.LongType.get(), "pk", false, false, null), defaultedColumn
+        },
+        tableComment,
+        Collections.emptyMap(),
+        Transforms.EMPTY_TRANSFORM,
+        hashDist(),
+        null,
+        null);
+
+    tc.alterTable(
+        tid, TableChange.updateColumnType(new String[] {colName2}, Types.VarCharType.of(20)));
+
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Column updatedColumn = findColumn(tc.loadTable(tid), colName2);
+              assertEquals(Types.VarCharType.of(20), updatedColumn.dataType());
+              assertEquals(
+                  Literals.of("seed", Types.VarCharType.of(20)), updatedColumn.defaultValue());
+            });
+  }
+
+  @Test
+  void testAlterColumnTypeRejectsInvalidConversionWithDefaultValue() {
+    TableCatalog tc = catalog.asTableCatalog();
+    NameIdentifier tid =
+        NameIdentifier.of(
+            schemaName, GravitinoITUtils.genRandomName("t_alter_type_rejects_invalid"));
+    Column defaultedColumn =
+        Column.of(
+            colName2,
+            Types.VarCharType.of(10),
+            "defaulted column",
+            false,
+            false,
+            Literals.of("true", Types.VarCharType.of(10)));
+
+    tc.createTable(
+        tid,
+        new Column[] {
+          Column.of(colName1, Types.LongType.get(), "pk", false, false, null), defaultedColumn
+        },
+        tableComment,
+        Collections.emptyMap(),
+        Transforms.EMPTY_TRANSFORM,
+        hashDist(),
+        null,
+        null);
+
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                tc.alterTable(
+                    tid,
+                    TableChange.updateColumnType(
+                        new String[] {colName2}, Types.BooleanType.get())));
+
+    assertTrue(
+        exception.getMessage().contains("Can not change VARCHAR to BOOLEAN"),
+        exception.getMessage());
+    Column unchangedColumn = findColumn(tc.loadTable(tid), colName2);
+    assertEquals(Types.VarCharType.of(10), unchangedColumn.dataType());
+    assertEquals(Literals.of("true", Types.VarCharType.of(10)), unchangedColumn.defaultValue());
   }
 
   @Test

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDoris4xIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDoris4xIT.java
@@ -31,6 +31,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Maps;
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -97,6 +102,7 @@ public class CatalogDoris4xIT extends BaseIT {
 
   private GravitinoMetalake metalake;
   private Catalog catalog;
+  private String jdbcUrl;
 
   @BeforeAll
   public void startup() throws IOException {
@@ -127,7 +133,7 @@ public class CatalogDoris4xIT extends BaseIT {
 
   private void createCatalog() {
     DorisContainer dorisContainer = containerSuite.getDorisContainer(DorisImageName.VERSION_4_0);
-    String jdbcUrl =
+    jdbcUrl =
         String.format(
             "jdbc:mysql://%s:%d/",
             dorisContainer.getContainerIpAddress(), dorisContainer.getFeMysqlPort());
@@ -262,6 +268,182 @@ public class CatalogDoris4xIT extends BaseIT {
               assertEquals(
                   Literals.of("seed", Types.VarCharType.of(20)), updatedColumn.defaultValue());
             });
+  }
+
+  @Test
+  void testAlterColumnTypePreservesQuotedAndBackslashDefaultValue() throws SQLException {
+    TableCatalog tc = catalog.asTableCatalog();
+    String tableName = GravitinoITUtils.genRandomName("t_alter_type_special_default");
+    NameIdentifier tid = NameIdentifier.of(schemaName, tableName);
+    String logicalDefault = "owner's \"value\"\\path";
+    String sqlDefault = "owner's \\\"value\\\"" + "\\\\" + "path";
+    String createSql =
+        String.format(
+            "CREATE TABLE %s ("
+                + "col_pk BIGINT NOT NULL, "
+                + "col_data VARCHAR(32) NOT NULL DEFAULT \"%s\") "
+                + "DUPLICATE KEY(col_pk) "
+                + "DISTRIBUTED BY HASH(col_pk) BUCKETS 1 "
+                + "PROPERTIES (\"replication_num\" = \"1\")",
+            tableName, sqlDefault);
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(createSql);
+    }
+
+    Column originalColumn = findColumn(tc.loadTable(tid), colName2);
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(32)), originalColumn.defaultValue());
+
+    tc.alterTable(
+        tid, TableChange.updateColumnType(new String[] {colName2}, Types.VarCharType.of(64)));
+
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Column updatedColumn = findColumn(tc.loadTable(tid), colName2);
+              assertEquals(Types.VarCharType.of(64), updatedColumn.dataType());
+              assertEquals(
+                  Literals.of(logicalDefault, Types.VarCharType.of(64)),
+                  updatedColumn.defaultValue());
+            });
+
+    Table alteredTable = tc.loadTable(tid);
+    NameIdentifier recreatedTid =
+        NameIdentifier.of(
+            schemaName, GravitinoITUtils.genRandomName("t_recreated_special_default"));
+    tc.createTable(
+        recreatedTid,
+        alteredTable.columns(),
+        alteredTable.comment(),
+        alteredTable.properties(),
+        alteredTable.partitioning(),
+        alteredTable.distribution(),
+        alteredTable.sortOrder(),
+        alteredTable.index());
+    Column recreatedColumn = findColumn(tc.loadTable(recreatedTid), colName2);
+    assertEquals(Types.VarCharType.of(64), recreatedColumn.dataType());
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(64)), recreatedColumn.defaultValue());
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(String.format("INSERT INTO %s (col_pk) VALUES (1)", tableName));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 1", tableName))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(
+          String.format("INSERT INTO %s (col_pk) VALUES (2)", recreatedTid.name()));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 2", recreatedTid.name()))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+  }
+
+  @Test
+  void testAlterColumnTypePreservesAdjacentBackslashQuoteDefaultValue() throws SQLException {
+    TableCatalog tc = catalog.asTableCatalog();
+    String tableName = GravitinoITUtils.genRandomName("t_alter_type_adjacent_default");
+    NameIdentifier tid = NameIdentifier.of(schemaName, tableName);
+    String logicalDefault = "prefix" + "\\" + "\"" + "suffix";
+    String sqlDefault = quotedDefaultExpression(logicalDefault, 1, 2);
+    String createSql =
+        String.format(
+            "CREATE TABLE %s ("
+                + "col_pk BIGINT NOT NULL, "
+                + "col_data VARCHAR(32) NOT NULL DEFAULT %s) "
+                + "DUPLICATE KEY(col_pk) "
+                + "DISTRIBUTED BY HASH(col_pk) BUCKETS 1 "
+                + "PROPERTIES (\"replication_num\" = \"1\")",
+            tableName, sqlDefault);
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(createSql);
+    }
+
+    Column originalColumn = findColumn(tc.loadTable(tid), colName2);
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(32)), originalColumn.defaultValue());
+
+    tc.alterTable(
+        tid, TableChange.updateColumnType(new String[] {colName2}, Types.VarCharType.of(64)));
+
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Column updatedColumn = findColumn(tc.loadTable(tid), colName2);
+              assertEquals(Types.VarCharType.of(64), updatedColumn.dataType());
+              assertEquals(
+                  Literals.of(logicalDefault, Types.VarCharType.of(64)),
+                  updatedColumn.defaultValue());
+            });
+
+    Table alteredTable = tc.loadTable(tid);
+    NameIdentifier recreatedTid =
+        NameIdentifier.of(
+            schemaName, GravitinoITUtils.genRandomName("t_recreated_adjacent_default"));
+    tc.createTable(
+        recreatedTid,
+        alteredTable.columns(),
+        alteredTable.comment(),
+        alteredTable.properties(),
+        alteredTable.partitioning(),
+        alteredTable.distribution(),
+        alteredTable.sortOrder(),
+        alteredTable.index());
+    Column recreatedColumn = findColumn(tc.loadTable(recreatedTid), colName2);
+    assertEquals(Types.VarCharType.of(64), recreatedColumn.dataType());
+    assertEquals(
+        Literals.of(logicalDefault, Types.VarCharType.of(64)), recreatedColumn.defaultValue());
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(String.format("INSERT INTO %s (col_pk) VALUES (1)", tableName));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 1", tableName))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                jdbcUrl + schemaName, DorisContainer.USER_NAME, DorisContainer.PASSWORD);
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(
+          String.format("INSERT INTO %s (col_pk) VALUES (2)", recreatedTid.name()));
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              String.format("SELECT col_data FROM %s WHERE col_pk = 2", recreatedTid.name()))) {
+        assertTrue(resultSet.next());
+        assertEquals(logicalDefault, resultSet.getString(1));
+      }
+    }
   }
 
   @Test
@@ -648,5 +830,12 @@ public class CatalogDoris4xIT extends BaseIT {
         .filter(c -> c.name().equals(columnName))
         .findFirst()
         .orElseThrow(() -> new AssertionError("Column not found: " + columnName));
+  }
+
+  private static String quotedDefaultExpression(
+      String value, int quoteBackslashCount, int valueBackslashCount) {
+    String escaped = value.replace("\\", "\\".repeat(valueBackslashCount));
+    escaped = escaped.replace("\"", "\\".repeat(quoteBackslashCount) + "\"");
+    return "\"" + escaped + "\"";
   }
 }

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperationsSqlGeneration.java
@@ -26,6 +26,7 @@ import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.expressions.NamedReference;
+import org.apache.gravitino.rel.expressions.UnparsedExpression;
 import org.apache.gravitino.rel.expressions.distributions.Distribution;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;
 import org.apache.gravitino.rel.expressions.literals.Literals;
@@ -54,6 +56,7 @@ public class TestDorisTableOperationsSqlGeneration {
 
   private static class TestableDorisTableOperations extends DorisTableOperations {
     private JdbcTable loadedTable = JdbcTable.builder().withName("test_table").build();
+    private Statement versionStatement;
 
     public TestableDorisTableOperations() {
       super.exceptionMapper = new JdbcExceptionConverter();
@@ -64,12 +67,12 @@ public class TestDorisTableOperationsSqlGeneration {
         // Uses SHOW FRONTENDS to get the actual Doris version (not MySQL protocol version)
         DataSource mockDataSource = Mockito.mock(DataSource.class);
         Connection mockConnection = Mockito.mock(Connection.class);
-        Statement mockStatement = Mockito.mock(Statement.class);
+        versionStatement = Mockito.mock(Statement.class);
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
         ResultSetMetaData mockMetaData = Mockito.mock(ResultSetMetaData.class);
         Mockito.when(mockDataSource.getConnection()).thenReturn(mockConnection);
-        Mockito.when(mockConnection.createStatement()).thenReturn(mockStatement);
-        Mockito.when(mockStatement.executeQuery("SHOW FRONTENDS")).thenReturn(mockResultSet);
+        Mockito.when(mockConnection.createStatement()).thenReturn(versionStatement);
+        Mockito.when(versionStatement.executeQuery("SHOW FRONTENDS")).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.getMetaData()).thenReturn(mockMetaData);
         Mockito.when(mockMetaData.getColumnCount()).thenReturn(1);
         Mockito.when(mockMetaData.getColumnLabel(1)).thenReturn("Version");
@@ -111,6 +114,19 @@ public class TestDorisTableOperationsSqlGeneration {
           JdbcTable.builder().withName("test_table").withColumns(new JdbcColumn[] {column}).build();
       return alterTableSql(
           "test_table", TableChange.updateColumnType(new String[] {column.name()}, newType));
+    }
+
+    public String updateColumnTypesSql(JdbcColumn[] columns, Type[] newTypes) {
+      loadedTable = JdbcTable.builder().withName("test_table").withColumns(columns).build();
+      TableChange[] changes = new TableChange[columns.length];
+      for (int i = 0; i < columns.length; i++) {
+        changes[i] = TableChange.updateColumnType(new String[] {columns[i].name()}, newTypes[i]);
+      }
+      return alterTableSql("test_table", changes);
+    }
+
+    public Statement versionStatement() {
+      return versionStatement;
     }
 
     @Override
@@ -185,6 +201,141 @@ public class TestDorisTableOperationsSqlGeneration {
     Assertions.assertEquals(
         "ALTER TABLE `test_table`\n"
             + "MODIFY COLUMN `col1` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP ;",
+        sql);
+  }
+
+  @Test
+  public void testUpdateColumnTypeEscapesQuotedAndBackslashDefault() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(32))
+            .withNullable(false)
+            .withDefaultValue(Literals.stringLiteral("owner's\\value"))
+            .build();
+
+    String sql = ops.updateColumnTypeSql(column, Types.VarCharType.of(64));
+
+    Assertions.assertEquals(
+        "ALTER TABLE `test_table`\n"
+            + "MODIFY COLUMN `col1` varchar(64) NOT NULL DEFAULT \"owner's\\\\\\\\value\" ;",
+        sql);
+  }
+
+  @Test
+  public void testUpdateColumnTypeEscapesDoubleQuoteDefaultForDoris3x() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(32))
+            .withNullable(false)
+            .withDefaultValue(Literals.stringLiteral("owner's \"value\""))
+            .build();
+
+    String sql = ops.updateColumnTypeSql(column, Types.VarCharType.of(64));
+    String expectedDefault =
+        "\"owner's " + "\\".repeat(3) + "\"" + "value" + "\\".repeat(3) + "\"\"";
+
+    Assertions.assertEquals(
+        "ALTER TABLE `test_table`\n"
+            + "MODIFY COLUMN `col1` varchar(64) NOT NULL DEFAULT "
+            + expectedDefault
+            + " ;",
+        sql);
+  }
+
+  @Test
+  public void testUpdateColumnTypeQueriesDorisVersionOncePerAlterRequest() throws SQLException {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn firstColumn =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(32))
+            .withNullable(false)
+            .withDefaultValue(Literals.stringLiteral("owner's \"first\""))
+            .build();
+    JdbcColumn secondColumn =
+        JdbcColumn.builder()
+            .withName("col2")
+            .withType(Types.VarCharType.of(32))
+            .withNullable(false)
+            .withDefaultValue(Literals.stringLiteral("owner's \"second\""))
+            .build();
+
+    String sql =
+        ops.updateColumnTypesSql(
+            new JdbcColumn[] {firstColumn, secondColumn},
+            new Type[] {Types.VarCharType.of(64), Types.VarCharType.of(64)});
+
+    Mockito.verify(ops.versionStatement(), Mockito.times(1)).executeQuery("SHOW FRONTENDS");
+    Assertions.assertTrue(sql.contains("`col1` varchar(64)"), sql);
+    Assertions.assertTrue(sql.contains("`col2` varchar(64)"), sql);
+  }
+
+  @Test
+  public void testCreateTableEscapesQuotedAndBackslashDefault() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(32))
+            .withNullable(false)
+            .withDefaultValue(Literals.stringLiteral("owner's \"value\"\\path"))
+            .build();
+
+    TestableDorisTableOperations mockOps = Mockito.spy(ops);
+    Mockito.doAnswer(a -> a.getArgument(0))
+        .when(mockOps)
+        .appendNecessaryProperties(Mockito.anyMap());
+
+    String sql =
+        mockOps.createTableSql(
+            "test_table",
+            new JdbcColumn[] {column},
+            Distributions.hash(1, NamedReference.field("col1")));
+    String expectedDefault = "\"owner's \\\"value\\\"\\\\path\"";
+
+    Assertions.assertTrue(
+        sql.contains("`col1` varchar(32) NOT NULL DEFAULT " + expectedDefault), sql);
+  }
+
+  @Test
+  public void testCreateTableRejectsUnparsedDefaultExpression() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.DateType.get())
+            .withNullable(false)
+            .withDefaultValue(UnparsedExpression.of("CURRENT_DATE"))
+            .build();
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ops.createTableSql(
+                "test_table",
+                new JdbcColumn[] {column},
+                Distributions.hash(1, NamedReference.field("col1"))));
+  }
+
+  @Test
+  public void testUpdateColumnTypePassesThroughUnparsedDefaultExpression() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.DateType.get())
+            .withNullable(false)
+            .withDefaultValue(UnparsedExpression.of("CURRENT_DATE"))
+            .build();
+
+    String sql = ops.updateColumnTypeSql(column, Types.DateType.get());
+
+    Assertions.assertEquals(
+        "ALTER TABLE `test_table`\nMODIFY COLUMN `col1` datev2 NOT NULL DEFAULT CURRENT_DATE ;",
         sql);
   }
 

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperationsSqlGeneration.java
@@ -20,6 +20,8 @@ package org.apache.gravitino.catalog.doris.operation;
 
 import static org.apache.gravitino.catalog.doris.DorisTablePropertiesMetadata.REPLICATION_ALLOCATION;
 import static org.apache.gravitino.catalog.doris.DorisTablePropertiesMetadata.REPLICATION_FACTOR;
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -29,10 +31,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
+import org.apache.gravitino.catalog.doris.converter.DorisColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.doris.converter.DorisTypeConverter;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
-import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.expressions.NamedReference;
@@ -42,6 +44,7 @@ import org.apache.gravitino.rel.expressions.literals.Literals;
 import org.apache.gravitino.rel.expressions.transforms.Transforms;
 import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -50,10 +53,12 @@ import org.mockito.Mockito;
 public class TestDorisTableOperationsSqlGeneration {
 
   private static class TestableDorisTableOperations extends DorisTableOperations {
+    private JdbcTable loadedTable = JdbcTable.builder().withName("test_table").build();
+
     public TestableDorisTableOperations() {
       super.exceptionMapper = new JdbcExceptionConverter();
       super.typeConverter = new DorisTypeConverter();
-      super.columnDefaultValueConverter = new JdbcColumnDefaultValueConverter();
+      super.columnDefaultValueConverter = new DorisColumnDefaultValueConverter();
       try {
         // Set up a mock DataSource for validateAutoIncrementVersion
         // Uses SHOW FRONTENDS to get the actual Doris version (not MySQL protocol version)
@@ -101,10 +106,17 @@ public class TestDorisTableOperationsSqlGeneration {
       return generateAlterTableSql("database", tableName, changes);
     }
 
+    public String updateColumnTypeSql(JdbcColumn column, Type newType) {
+      loadedTable =
+          JdbcTable.builder().withName("test_table").withColumns(new JdbcColumn[] {column}).build();
+      return alterTableSql(
+          "test_table", TableChange.updateColumnType(new String[] {column.name()}, newType));
+    }
+
     @Override
     protected JdbcTable getOrCreateTable(
         String databaseName, String tableName, JdbcTable lazyLoadCreateTable) {
-      return JdbcTable.builder().withName(tableName).build();
+      return loadedTable;
     }
 
     public String createTableSqlWithIndexes(
@@ -118,6 +130,106 @@ public class TestDorisTableOperationsSqlGeneration {
           distribution,
           indexes);
     }
+  }
+
+  @Test
+  public void testUpdateColumnTypePreservesStringDefaultAndColumnAttributes() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(10))
+            .withComment("comment")
+            .withNullable(true)
+            .withDefaultValue(Literals.of("seed", Types.VarCharType.of(10)))
+            .build();
+
+    String sql = ops.updateColumnTypeSql(column, Types.VarCharType.of(20));
+
+    Assertions.assertEquals(
+        "ALTER TABLE `test_table`\n"
+            + "MODIFY COLUMN `col1` varchar(20) NULL DEFAULT 'seed' COMMENT 'comment' ;",
+        sql);
+  }
+
+  @Test
+  public void testUpdateColumnTypePreservesNumericDefault() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.IntegerType.get())
+            .withNullable(false)
+            .withDefaultValue(Literals.integerLiteral(7))
+            .build();
+
+    String sql = ops.updateColumnTypeSql(column, Types.LongType.get());
+
+    Assertions.assertEquals(
+        "ALTER TABLE `test_table`\nMODIFY COLUMN `col1` bigint NOT NULL DEFAULT 7 ;", sql);
+  }
+
+  @Test
+  public void testUpdateColumnTypePreservesCurrentTimestampDefault() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn column =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.TimestampType.withoutTimeZone())
+            .withNullable(false)
+            .withDefaultValue(DEFAULT_VALUE_OF_CURRENT_TIMESTAMP)
+            .build();
+
+    String sql = ops.updateColumnTypeSql(column, Types.TimestampType.withoutTimeZone(6));
+
+    Assertions.assertEquals(
+        "ALTER TABLE `test_table`\n"
+            + "MODIFY COLUMN `col1` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP ;",
+        sql);
+  }
+
+  @Test
+  public void testUpdateColumnTypePreservesNullAndUnsetDefaultDistinction() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    JdbcColumn nullDefaultColumn =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.IntegerType.get())
+            .withNullable(true)
+            .withDefaultValue(Literals.NULL)
+            .build();
+    JdbcColumn unsetDefaultColumn =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.IntegerType.get())
+            .withNullable(true)
+            .withDefaultValue(DEFAULT_VALUE_NOT_SET)
+            .build();
+
+    String nullDefaultSql = ops.updateColumnTypeSql(nullDefaultColumn, Types.LongType.get());
+    String unsetDefaultSql = ops.updateColumnTypeSql(unsetDefaultColumn, Types.LongType.get());
+
+    Assertions.assertEquals(
+        "ALTER TABLE `test_table`\nMODIFY COLUMN `col1` bigint NULL DEFAULT NULL ;",
+        nullDefaultSql);
+    Assertions.assertEquals(
+        "ALTER TABLE `test_table`\nMODIFY COLUMN `col1` bigint NULL ;", unsetDefaultSql);
+  }
+
+  @Test
+  public void testUpdateColumnTypeRejectsNestedColumnName() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+
+    UnsupportedOperationException exception =
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                ops.alterTableSql(
+                    "test_table",
+                    TableChange.updateColumnType(
+                        new String[] {"parent", "child"}, Types.LongType.get())));
+
+    Assertions.assertEquals("Doris does not support nested column names.", exception.getMessage());
   }
 
   @Test
@@ -140,7 +252,7 @@ public class TestDorisTableOperationsSqlGeneration {
         .appendNecessaryProperties(Mockito.anyMap());
 
     String sql = mockOps.createTableSql(tableName, new JdbcColumn[] {col1}, distribution);
-    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    DorisColumnDefaultValueConverter converter = new DorisColumnDefaultValueConverter();
     Assertions.assertTrue(
         sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
         "Should contain DEFAULT '' but was: " + sql);
@@ -166,7 +278,7 @@ public class TestDorisTableOperationsSqlGeneration {
         .appendNecessaryProperties(Mockito.anyMap());
 
     String sql = mockOps.createTableSql(tableName, new JdbcColumn[] {col1}, distribution);
-    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    DorisColumnDefaultValueConverter converter = new DorisColumnDefaultValueConverter();
     Assertions.assertTrue(
         sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
         "Should contain DEFAULT value but was: " + sql);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request preserves the loaded Doris column default when `TableChange.UpdateColumnType` builds the replacement column definition. It also adds focused SQL-generation coverage for string, numeric, `CURRENT_TIMESTAMP`, explicit `DEFAULT NULL`, unset defaults, preserved column attributes, and nested-column rejection.

The integration coverage verifies successful default-preserving type changes on Doris 3.0.6.2 and 4.0.6, and verifies on Doris 4.0.6 that an unsupported `VARCHAR` to `BOOLEAN` conversion is still rejected without changing the column type or default.

This pull request is opened as a draft so it can be reviewed in parallel with a related Doris default-literal converter change. Before this draft is marked ready, it will be rebased onto that change, its string and numeric SQL expectations will be aligned with the merged Doris quoting rules, and an exact quote/backslash default-value case will be added and verified.

### Why are the changes needed?

The Doris catalog currently replaces the existing default with `DEFAULT_VALUE_NOT_SET` when generating a `MODIFY COLUMN` statement for `UpdateColumnType`. Doris treats `MODIFY COLUMN` as a complete column definition and rejects the operation with `Can not change default value` when the submitted definition omits an existing default.

Preserving the loaded default makes the generated definition faithful to the unchanged column attributes while leaving type and default compatibility validation to Doris.

Fix: #12740

### Does this PR introduce _any_ user-facing change?

Yes. A supported Doris column type change can now preserve an existing default value instead of failing because the generated `MODIFY COLUMN` definition omits that default. This pull request does not change any public API or property key.

### How was this patch tested?

- `./gradlew :catalogs:catalog-jdbc-doris:spotlessCheck --console=plain --no-daemon`
- `./gradlew rat --console=plain --no-daemon`
- `./gradlew :catalogs:catalog-jdbc-doris:test -PskipITs --console=plain --no-daemon`
- `./gradlew :catalogs:catalog-jdbc-doris:build -x test --console=plain --no-daemon`
- Local static precheck covering negative-test consistency, string-slice safety, switch-case coverage, stale-comment references, orphan-test detection, commit-message validation, regex validation, cross-module impact, and unintended-file detection: all checks passed.
- Doris 3.0.6.2: `./gradlew :catalogs:catalog-jdbc-doris:test --tests 'org.apache.gravitino.catalog.doris.integration.test.CatalogDoris3xIT.testAlterColumnTypePreservesDefaultValue' -PskipDockerTests=false -PdorisMultiVersionTest --console=plain --no-daemon`
- Doris 4.0.6: `./gradlew :catalogs:catalog-jdbc-doris:test --tests 'org.apache.gravitino.catalog.doris.integration.test.CatalogDoris4xIT.testAlterColumnTypePreservesDefaultValue' -PskipDockerTests=false -PdorisMultiVersionTest --console=plain --no-daemon`
- Doris 4.0.6: `./gradlew :catalogs:catalog-jdbc-doris:test --tests 'org.apache.gravitino.catalog.doris.integration.test.CatalogDoris4xIT.testAlterColumnTypeRejectsInvalidConversionWithDefaultValue' -PskipDockerTests=false -PdorisMultiVersionTest --console=plain --no-daemon`

All listed checks and focused tests passed. The post-commit static precheck completed all nine checks successfully.
