### PR TITLE
[MINOR] docs: document gravitino.secret provider configuration

### DIFF
--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -526,6 +526,53 @@ That configuration builds three clients: two instances of one custom AWS factory
 Azure factory. Further `gravitino.kms.provider.<name>.*` keys are factory properties, not a closed
 schema; each factory documents the keys it accepts.
 
+### Entity Secrets
+
+Entity secrets keep connection secrets such as `jdbc-password` or cloud static keys out of plaintext
+entity property storage. The server registers named `SecretProvider` instances from
+`gravitino.conf`. Create and alter requests reference those names through `secretBindings` and
+`secretReferences` (and the matching alter `@type`s). The entity store keeps a URN string for each
+secret property. This is separate from [Key Management](#key-management), which configures KMS
+clients for key operations rather than entity property secrets.
+
+The list is empty by default, and then the server has no secrets providers. Create or alter calls
+that need a provider fail until you name at least one. Naming a provider without a `className`, or
+with a class the server cannot construct as a `SecretProvider`, fails startup. Apache Gravitino
+ships an in-memory provider for tests and local use. It is not durable and is not for production.
+
+| Configuration Item                            | Description                                                                                                                                                             | Default Value |
+|-----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `gravitino.secret.providers`                  | Comma-separated secrets-provider instance names. Each name must match `[A-Za-z0-9][A-Za-z0-9_-]*`. Duplicates fail startup.                                            | (empty)       |
+| `gravitino.secret.provider.<name>.className`  | Required `SecretProvider` implementation class for that instance. The class must have a no-arg constructor.                                                             | (none)        |
+| `gravitino.secret.provider.<name>.uri`        | Optional non-secret endpoint advertised by `GET /configs/secrets/providers`. Not used by the in-memory provider.                                                        | (none)        |
+| `gravitino.secret.provider.<name>.<key>`      | Any other property under that name is passed to `SecretProvider.initialize` (except `className`). Nested dots in `<key>` are allowed.                                   | (none)        |
+
+Every name in `providers` needs a matching `.className`. Bindings and references on catalog,
+schema, and fileset APIs use the instance name from this list as their `provider` field, not the
+implementation class name.
+
+```text
+# conf/gravitino.conf
+gravitino.secret.providers = memory
+
+gravitino.secret.provider.memory.className = org.apache.gravitino.secret.memory.InMemorySecretsProvider
+```
+
+That configuration registers one provider named `memory` of type `memory`. List configured
+providers (name, type, and optional `uri` only) with:
+
+```shell
+curl http://localhost:8090/configs/secrets/providers
+```
+
+With a provider registered, create a catalog, schema, or fileset with `secretBindings` (write the
+plaintext through the provider and store a URN) or `secretReferences` (store a locator URN without
+writing material). Alter supports `setSecretBinding` and `setSecretReference`. GET and list omit
+secret property keys. Resolve plaintext for connectors with the object's secrets API, documented in
+the OpenAPI under `/metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectFullName}/secrets`.
+[Credential Vending](security/credential-vending.md) resolves secret URNs when initializing
+credential providers so vended static credentials are plaintext rather than URNs.
+
 ## Catalog Properties
 
 Catalog properties configure one catalog rather than the server. They come from two places: a
@@ -701,6 +748,8 @@ in `conf/gravitino-env.sh`.
   into the underlying systems through Apache Ranger or a native permission model
 - [Credential Vending](security/credential-vending.md), for issuing temporary storage credentials to
   engines instead of distributing long-lived keys
+- [Entity Secrets](#entity-secrets), for `gravitino.secret.*` providers that store connection secrets
+  as URNs on catalog, schema, and fileset properties
 - [HTTPS](security/how-to-use-https.md), for the `gravitino.server.webserver.*` key store, trust
   store, and client certificate properties
 - [CORS](security/how-to-use-cors.md), for letting browser clients served from another origin call

--- a/docs/index.md
+++ b/docs/index.md
@@ -215,6 +215,9 @@ Gravitino provides security configurations for Gravitino, including HTTPS, authe
 * [Local users and groups](./security/local-users-and-groups.md): operator guide for the local user store behind HTTP Basic authentication, including service admin setup and `/api/idp` management APIs.
 * [Access Control](./security/access-control.md): provides access control configurations.
 * [CORS](./security/how-to-use-cors.md): provides CORS configurations.
+* [Entity secrets](./gravitino-server-config.md#entity-secrets): configures `gravitino.secret.*`
+  providers so catalog, schema, and fileset connection secrets are stored as URNs rather than
+  plaintext.
 
 ### Gravitino MCP Server
 

--- a/docs/security/credential-vending.md
+++ b/docs/security/credential-vending.md
@@ -449,6 +449,14 @@ The Gravitino Spark and Flink connectors call this for you and inject the return
 
 Over the IRC, a credential is vended for writing when the caller is entitled to modify the table, and for reading otherwise. Narrowing the caller's roles with the `X-Gravitino-Active-Roles` header narrows this as well, so a caller whose active roles no longer carry `MODIFY_TABLE` is vended a read-only credential. See [Narrowing Access with Active Roles](access-control.md#narrowing-access-with-active-roles).
 
+## Entity Secrets
+
+Catalog properties used by credential providers, such as `jdbc-password` or static cloud keys, can
+be stored as entity secret URNs instead of plaintext. Configure secrets providers with
+`gravitino.secret.*` as described in
+[Entity Secrets](../gravitino-server-config.md#entity-secrets). When credential vending initializes
+providers, the server resolves those URNs to plaintext so clients receive usable credentials.
+
 ## Custom Credentials
 
 Gravitino supports custom credentials. You can implement the `org.apache.gravitino.credential.CredentialProvider` interface to support custom credentials, and place the corresponding jar in the classpath of the IRC or the Fileset catalog.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Document how to configure entity secrets providers (`gravitino.secret.*`) in the server configuration guide, next to the existing Key Management section.

- Add an **Entity Secrets** section to `docs/gravitino-server-config.md` (providers table, in-memory example, discovery endpoint, brief create/alter / omit / getSecrets / credential-vending notes).
- Cross-link from `docs/security/credential-vending.md` and `docs/index.md`.

### Why are the changes needed?

Entity secrets (SecretManager / SecretProvider) are available on `main`, but user-facing docs did not describe how to enable providers. Configuration only appeared in the design doc.

### Does this PR introduce _any_ user-facing change?

Docs only. No code or API behavior change.

### How was this patch tested?

- `check_links.py` on the touched Markdown files
- Manual review against `SecretProviderRegistry` config keys and the in-memory provider class name


Made with [Cursor](https://cursor.com)