### PR TITLE
[Cherry-pick to branch-1.3] [#12734] resolve the conflict

### DIFF
--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -33,14 +33,11 @@ import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedCatalogView;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
-<<<<<<< HEAD
-=======
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
->>>>>>> 4b529ce4d ([#12734] fix(flink-connector): skip no-op table alter to avoid updates must not be empty (#12735))
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -52,6 +49,7 @@ import org.apache.gravitino.flink.connector.utils.DefaultCatalogCompat;
 import org.apache.gravitino.rel.Dialects;
 import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.TableCatalog;
 import org.apache.gravitino.rel.ViewCatalog;
 import org.apache.gravitino.rel.ViewChange;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/hive/TestGravitinoHiveCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/hive/TestGravitinoHiveCatalog.java
@@ -29,36 +29,17 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.gravitino.Catalog;
-import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.flink.connector.PartitionConverter;
 import org.apache.gravitino.flink.connector.SchemaAndTablePropertiesConverter;
 import org.apache.gravitino.flink.connector.utils.DefaultCatalogCompat;
 import org.apache.gravitino.rel.Table;
 import org.apache.gravitino.rel.TableCatalog;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestGravitinoHiveCatalog {
-
-  @Test
-  public void testGetTableThrowsCatalogExceptionWhenForbidden() throws Exception {
-    Catalog gravitinoCatalog = Mockito.mock(Catalog.class);
-    TableCatalog tableCatalog = Mockito.mock(TableCatalog.class);
-    ForbiddenException forbiddenException = new ForbiddenException("denied");
-    Mockito.when(gravitinoCatalog.asTableCatalog()).thenReturn(tableCatalog);
-    Mockito.when(tableCatalog.loadTable(Mockito.any())).thenThrow(forbiddenException);
-    TestableGravitinoHiveCatalog catalog = new TestableGravitinoHiveCatalog(gravitinoCatalog);
-
-    CatalogException catalogException =
-        Assertions.assertThrows(
-            CatalogException.class, () -> catalog.getTable(new ObjectPath("db", "tbl")));
-
-    Assertions.assertSame(forbiddenException, catalogException.getCause());
-  }
 
   @Test
   public void testGenericTableAlterSkipsCallWhenNoChanges() throws Exception {


### PR DESCRIPTION

### What changes were proposed in this pull request?

This is the branch-1.3 backport of #12735 (cherry-pick of commit 4b529ce). It resolves the cherry-pick conflicts introduced because branch-1.3 differs from main:

- `TestBaseCatalog.java`: added the imports that exist on main but are missing on branch-1.3 (`ObjectPath`, `TableNotExistException`, `TableCatalog`) and dropped the conflicting `CatalogException` import that is unused here.
- `TestGravitinoHiveCatalog.java`: removed `testGetTableThrowsCatalogExceptionWhenForbidden` (and its now-unused imports). That test is not part of this fix and depends on the `ForbiddenException` -> `CatalogException` conversion in `getTable`, which does not exist on branch-1.3.

The core fix is unchanged from #12735: skip forwarding an empty `TableChange` list to Gravitino when a table alter results in no actual change.


### Why are the changes needed?

A no-op `ALTER TABLE` produced an empty update list, which the server rejects with `IllegalArgumentException: updates must not be empty`, failing the Flink job. This backports the fix to branch-1.3.

Fix: #12734 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

`./gradlew :flink-connector:flink-common:check -PskipITs` passes on branch-1.3.