### PR TITLE
Fix servlets outside /api/* receiving no authentication

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/web/HealthCheckPathMatcher.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/HealthCheckPathMatcher.java
@@ -37,10 +37,9 @@ public class HealthCheckPathMatcher {
    * Returns {@code true} if {@code path} targets a Gravitino health check endpoint.
    *
    * <p>Covers the canonical API path ({@code /api/health} and {@code /api/health/*}) and the
-   * root-level aliases ({@code /health}, {@code /health/*}, {@code /health.html}) that forward to
-   * the canonical paths. During a {@link javax.servlet.RequestDispatcher} forward, {@code
-   * getRequestURI()} returns the original URI rather than the target, so these aliases must be
-   * included here.
+   * root-level health aliases ({@code /health}, {@code /health/*}, {@code /health.html}) that
+   * forward to the canonical paths. Also covers the web UI root ({@code /}) and static resource
+   * paths ({@code /ui/*}) so the login page is reachable without authentication.
    *
    * <p>Subclasses should override this method and call {@code super.isHealthCheckPath(path)} first
    * to preserve the base paths.
@@ -56,6 +55,8 @@ public class HealthCheckPathMatcher {
         || path.startsWith("/health/")
         || path.equals("/health.html")
         || path.equals("/api/health")
-        || path.startsWith("/api/health/");
+        || path.startsWith("/api/health/")
+        || path.equals("/")
+        || path.startsWith("/ui/");
   }
 }

--- a/server/src/main/java/org/apache/gravitino/server/GravitinoServer.java
+++ b/server/src/main/java/org/apache/gravitino/server/GravitinoServer.java
@@ -196,12 +196,12 @@ public class GravitinoServer extends ResourceConfig {
     server.addServlet(new HealthAliasServlet(), "/health/*");
     server.addServlet(new HealthAliasServlet(), "/health.html");
 
-    server.addFilter(new RequestContextFilter(), API_ANY_PATH);
+    server.addFilter(new RequestContextFilter(), "/*");
     server.addFilter(
-        new HttpAuditFilter(gravitinoEnv.eventBus(), EventSource.GRAVITINO_SERVER), API_ANY_PATH);
-    server.addCustomFilters(API_ANY_PATH);
-    server.addFilter(new VersioningFilter(), API_ANY_PATH);
-    server.addSystemFilters(API_ANY_PATH);
+        new HttpAuditFilter(gravitinoEnv.eventBus(), EventSource.GRAVITINO_SERVER), "/*");
+    server.addCustomFilters("/*");
+    server.addFilter(new VersioningFilter(), "/*");
+    server.addSystemFilters("/*");
     if (server.isWebUiEnabled()) {
       server.addFilter(new WebUIFilter(), "/"); // Redirect to the /ui/index html page.
       server.addFilter(new WebUIFilter(), "/ui/*"); // Redirect to the static html file.

--- a/server/src/main/java/org/apache/gravitino/server/GravitinoServer.java
+++ b/server/src/main/java/org/apache/gravitino/server/GravitinoServer.java
@@ -82,6 +82,8 @@ public class GravitinoServer extends ResourceConfig {
 
   private static final String API_ANY_PATH = "/api/*";
 
+  private static final String ROOT_PATH = "/*";
+
   public static final String CONF_FILE = "gravitino.conf";
 
   public static final String WEBSERVER_CONF_PREFIX = "gravitino.server.webserver.";
@@ -196,12 +198,12 @@ public class GravitinoServer extends ResourceConfig {
     server.addServlet(new HealthAliasServlet(), "/health/*");
     server.addServlet(new HealthAliasServlet(), "/health.html");
 
-    server.addFilter(new RequestContextFilter(), "/*");
+    server.addFilter(new RequestContextFilter(), ROOT_PATH);
     server.addFilter(
-        new HttpAuditFilter(gravitinoEnv.eventBus(), EventSource.GRAVITINO_SERVER), "/*");
-    server.addCustomFilters("/*");
-    server.addFilter(new VersioningFilter(), "/*");
-    server.addSystemFilters("/*");
+        new HttpAuditFilter(gravitinoEnv.eventBus(), EventSource.GRAVITINO_SERVER), ROOT_PATH);
+    server.addCustomFilters(ROOT_PATH);
+    server.addFilter(new VersioningFilter(), ROOT_PATH);
+    server.addSystemFilters(ROOT_PATH);
     if (server.isWebUiEnabled()) {
       server.addFilter(new WebUIFilter(), "/"); // Redirect to the /ui/index html page.
       server.addFilter(new WebUIFilter(), "/ui/*"); // Redirect to the static html file.


### PR DESCRIPTION
Fixes #12760: Servlets registered outside the /api/* pathspec (such as /configs, /health/*) receive no authentication, audit, or versioning filters.

### Changes

- Widen filter pathspec from /api/* to /* so all servlets are covered
- Add / and /ui/* to HealthCheckPathMatcher to maintain Web UI accessibility without authentication

### Security Impact

Previously, endpoints like /configs and /configs/secrets/providers were accessible without any authentication. This fix ensures all servlets go through the authentication filter chain.