### PR TITLE
[#12785] fix(server): Skip existence probe after MODIFY_TABLE denial

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/filter/authorization/LoadTableAuthorizationExecutor.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/authorization/LoadTableAuthorizationExecutor.java
@@ -45,6 +45,7 @@ import org.apache.gravitino.server.web.filter.ParameterUtil;
  */
 public class LoadTableAuthorizationExecutor extends CommonAuthorizerExecutor {
   private final AuthorizationExpressionEvaluator allowCheckExistenceEvaluator;
+  private final boolean requiresModifyTablePrivilege;
 
   public LoadTableAuthorizationExecutor(
       Parameter[] parameters,
@@ -62,12 +63,15 @@ public class LoadTableAuthorizationExecutor extends CommonAuthorizerExecutor {
             ? null
             : new AuthorizationExpressionEvaluator(allowCheckExistenceExpression);
 
-    if (!shouldCheckModifyTablePrivilege(secondaryExpression, secondaryExpressionCondition)) {
-      return;
-    }
-
-    String privileges = (String) ParameterUtil.extractFromParameters(parameters, args);
-    if (containsModifyTablePrivilege(privileges)) {
+    boolean supportsModifyTablePrivilege =
+        shouldCheckModifyTablePrivilege(secondaryExpression, secondaryExpressionCondition);
+    String privileges =
+        supportsModifyTablePrivilege
+            ? (String) ParameterUtil.extractFromParameters(parameters, args)
+            : null;
+    this.requiresModifyTablePrivilege =
+        supportsModifyTablePrivilege && containsModifyTablePrivilege(privileges);
+    if (requiresModifyTablePrivilege) {
       this.expression = secondaryExpression;
       this.authorizationExpressionEvaluator =
           new AuthorizationExpressionEvaluator(secondaryExpression);
@@ -78,6 +82,10 @@ public class LoadTableAuthorizationExecutor extends CommonAuthorizerExecutor {
   public boolean execute(AuthorizationRequestContext authorizationRequestContext) throws Exception {
     if (super.execute(authorizationRequestContext)) {
       return true;
+    }
+
+    if (requiresModifyTablePrivilege) {
+      return false;
     }
 
     if (allowCheckExistenceEvaluator == null

--- a/server/src/test/java/org/apache/gravitino/server/web/filter/TestGravitinoInterceptionService.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/filter/TestGravitinoInterceptionService.java
@@ -19,6 +19,7 @@ package org.apache.gravitino.server.web.filter;
 
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.CAN_ACCESS_METADATA_AND_TAG;
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_TABLE_AUTHORIZATION_EXPRESSION;
+import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.MODIFY_TABLE_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.PROBE_TABLE_LIKE_AUTHORIZATION_EXPRESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -65,6 +66,7 @@ import org.apache.gravitino.server.authorization.annotations.AuthorizationFullNa
 import org.apache.gravitino.server.authorization.annotations.AuthorizationMetadata;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationObjectType;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationRequest;
+import org.apache.gravitino.server.authorization.annotations.ExpressionCondition;
 import org.apache.gravitino.server.web.Utils;
 import org.apache.gravitino.server.web.rest.MetadataObjectTagOperations;
 import org.apache.gravitino.tag.TagDispatcher;
@@ -643,6 +645,106 @@ public class TestGravitinoInterceptionService {
     }
   }
 
+  @Test
+  public void testLoadTableModifyAuthorizationDenialSkipsExistenceProbe() throws Throwable {
+    try (MockedStatic<PrincipalUtils> principalUtilsMocked = mockStatic(PrincipalUtils.class);
+        MockedStatic<GravitinoAuthorizerProvider> authorizerMocked =
+            mockStatic(GravitinoAuthorizerProvider.class);
+        MockedStatic<AuthorizationUtils> authUtilsMocked = mockStatic(AuthorizationUtils.class);
+        MockedStatic<GravitinoEnv> envMocked = mockStatic(GravitinoEnv.class)) {
+      principalUtilsMocked
+          .when(PrincipalUtils::getCurrentPrincipal)
+          .thenReturn(new UserPrincipal("tester"));
+      principalUtilsMocked.when(PrincipalUtils::getCurrentUserName).thenReturn("tester");
+
+      authUtilsMocked
+          .when(
+              () ->
+                  AuthorizationUtils.checkCurrentUser(
+                      ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
+          .thenAnswer(invocation -> null);
+
+      GravitinoAuthorizerProvider mockedProvider = mock(GravitinoAuthorizerProvider.class);
+      GravitinoAuthorizer authorizer = tableProbeAuthorizer();
+      authorizerMocked.when(GravitinoAuthorizerProvider::getInstance).thenReturn(mockedProvider);
+      when(mockedProvider.getGravitinoAuthorizer()).thenReturn(authorizer);
+
+      GravitinoEnv mockEnv = mock(GravitinoEnv.class);
+      TableDispatcher tableDispatcher = mock(TableDispatcher.class);
+      EventBus mockEventBus = spy(new EventBus(Collections.emptyList()));
+      envMocked.when(GravitinoEnv::getInstance).thenReturn(mockEnv);
+      when(mockEnv.tableDispatcher()).thenReturn(tableDispatcher);
+      when(mockEnv.eventBus()).thenReturn(mockEventBus);
+
+      MethodInterceptor interceptor = tableLoadInterceptor();
+      MethodInvocation invocation = tableLoadInvocation("MODIFY_TABLE");
+
+      Response response = (Response) interceptor.invoke(invocation);
+
+      assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+      verify(tableDispatcher, never()).tableExists(ArgumentMatchers.any());
+      verify(invocation, never()).proceed();
+      verify(authorizer, never())
+          .authorize(
+              ArgumentMatchers.any(),
+              ArgumentMatchers.anyString(),
+              ArgumentMatchers.any(),
+              ArgumentMatchers.eq(Privilege.Name.PROBE_TABLE_LIKE),
+              ArgumentMatchers.any());
+      verify(mockEventBus)
+          .dispatchEvent(ArgumentMatchers.any(AuthorizationDenialFailureEvent.class));
+      Assertions.assertTrue(RequestContext.isOperationFailureFired());
+    }
+  }
+
+  @Test
+  public void testNeverSecondaryConditionKeepsExistenceProbeForModifyText() throws Throwable {
+    try (MockedStatic<PrincipalUtils> principalUtilsMocked = mockStatic(PrincipalUtils.class);
+        MockedStatic<GravitinoAuthorizerProvider> authorizerMocked =
+            mockStatic(GravitinoAuthorizerProvider.class);
+        MockedStatic<AuthorizationUtils> authUtilsMocked = mockStatic(AuthorizationUtils.class);
+        MockedStatic<GravitinoEnv> envMocked = mockStatic(GravitinoEnv.class)) {
+      principalUtilsMocked
+          .when(PrincipalUtils::getCurrentPrincipal)
+          .thenReturn(new UserPrincipal("tester"));
+      principalUtilsMocked.when(PrincipalUtils::getCurrentUserName).thenReturn("tester");
+
+      authUtilsMocked
+          .when(
+              () ->
+                  AuthorizationUtils.checkCurrentUser(
+                      ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
+          .thenAnswer(invocation -> null);
+
+      GravitinoAuthorizerProvider mockedProvider = mock(GravitinoAuthorizerProvider.class);
+      GravitinoAuthorizer authorizer = tableProbeAuthorizer();
+      authorizerMocked.when(GravitinoAuthorizerProvider::getInstance).thenReturn(mockedProvider);
+      when(mockedProvider.getGravitinoAuthorizer()).thenReturn(authorizer);
+
+      GravitinoEnv mockEnv = mock(GravitinoEnv.class);
+      TableDispatcher tableDispatcher = mock(TableDispatcher.class);
+      EventBus mockEventBus = mock(EventBus.class);
+      envMocked.when(GravitinoEnv::getInstance).thenReturn(mockEnv);
+      when(mockEnv.tableDispatcher()).thenReturn(tableDispatcher);
+      when(mockEnv.eventBus()).thenReturn(mockEventBus);
+      when(tableDispatcher.tableExists(ArgumentMatchers.any())).thenReturn(false);
+
+      MethodInterceptor interceptor =
+          tableLoadInterceptor(TestTableLoadOperationsWithNeverSecondary.class);
+      MethodInvocation invocation =
+          tableLoadInvocation(TestTableLoadOperationsWithNeverSecondary.class, "MODIFY_TABLE");
+      Response notFound = Utils.notFound("NoSuchTableException", "Table does not exist");
+      when(invocation.proceed()).thenReturn(notFound);
+
+      Response response = (Response) interceptor.invoke(invocation);
+
+      assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+      verify(tableDispatcher).tableExists(ArgumentMatchers.any());
+      verify(invocation).proceed();
+      verify(mockEventBus, never()).dispatchEvent(ArgumentMatchers.any());
+    }
+  }
+
   /**
    * When {@code checkCurrentUser} throws {@link NoSuchMetalakeException}, the 403 is a
    * resource-not-found masquerading as forbidden — no {@link AuthorizationDenialFailureEvent} is
@@ -715,6 +817,27 @@ public class TestGravitinoInterceptionService {
     @AuthorizationExpression(
         expression = LOAD_TABLE_AUTHORIZATION_EXPRESSION,
         allowCheckExistence = PROBE_TABLE_LIKE_AUTHORIZATION_EXPRESSION,
+        secondaryExpression = MODIFY_TABLE_AUTHORIZATION_EXPRESSION,
+        secondaryExpressionCondition = ExpressionCondition.REQUIRED_MODIFY_PRIVILEGES,
+        accessMetadataType = MetadataObject.Type.TABLE)
+    public Response loadTable(
+        @AuthorizationMetadata(type = Entity.EntityType.METALAKE) String metalake,
+        @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
+        @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
+        @AuthorizationMetadata(type = Entity.EntityType.TABLE) String table,
+        @AuthorizationRequest(type = AuthorizationRequest.RequestType.LOAD_TABLE)
+            String requiredPrivileges) {
+      return Utils.ok("unused");
+    }
+  }
+
+  public static class TestTableLoadOperationsWithNeverSecondary {
+
+    @AuthorizationExpression(
+        expression = LOAD_TABLE_AUTHORIZATION_EXPRESSION,
+        allowCheckExistence = PROBE_TABLE_LIKE_AUTHORIZATION_EXPRESSION,
+        secondaryExpression = MODIFY_TABLE_AUTHORIZATION_EXPRESSION,
+        secondaryExpressionCondition = ExpressionCondition.NEVER,
         accessMetadataType = MetadataObject.Type.TABLE)
     public Response loadTable(
         @AuthorizationMetadata(type = Entity.EntityType.METALAKE) String metalake,
@@ -748,21 +871,38 @@ public class TestGravitinoInterceptionService {
   }
 
   private MethodInterceptor tableLoadInterceptor() throws NoSuchMethodException {
+    return tableLoadInterceptor(TestTableLoadOperations.class);
+  }
+
+  private MethodInterceptor tableLoadInterceptor(Class<?> operationsClass)
+      throws NoSuchMethodException {
     Method method =
-        TestTableLoadOperations.class.getMethod(
+        operationsClass.getMethod(
             "loadTable", String.class, String.class, String.class, String.class, String.class);
     return new GravitinoInterceptionService().getMethodInterceptors(method).get(0);
   }
 
   private MethodInvocation tableLoadInvocation() throws NoSuchMethodException {
+    return tableLoadInvocation(TestTableLoadOperations.class, null);
+  }
+
+  private MethodInvocation tableLoadInvocation(String requiredPrivileges)
+      throws NoSuchMethodException {
+    return tableLoadInvocation(TestTableLoadOperations.class, requiredPrivileges);
+  }
+
+  private MethodInvocation tableLoadInvocation(Class<?> operationsClass, String requiredPrivileges)
+      throws NoSuchMethodException {
     Method method =
-        TestTableLoadOperations.class.getMethod(
+        operationsClass.getMethod(
             "loadTable", String.class, String.class, String.class, String.class, String.class);
     MethodInvocation invocation = mock(MethodInvocation.class);
     when(invocation.getMethod()).thenReturn(method);
     when(invocation.getArguments())
         .thenReturn(
-            new Object[] {"testMetalake", "testCatalog", "testSchema", "missingTable", null});
+            new Object[] {
+              "testMetalake", "testCatalog", "testSchema", "missingTable", requiredPrivileges
+            });
     return invocation;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR prevents `LoadTableAuthorizationExecutor` from running the table-like existence probe after an explicit `MODIFY_TABLE` authorization request is denied. The executor records whether the request selected the secondary modify-table expression and returns the denial before evaluating the probe expression or calling `tableDispatcher().tableExists()`. Ordinary load-table denials retain their existing existence-probe behavior.

The regression coverage uses the load-table authorization annotation shape and verifies the denial response, denial event, request failure state, REST invocation, dispatcher interaction, and probe authorization interaction. A separate `NEVER` condition fixture verifies that raw `MODIFY_TABLE` text does not suppress ordinary probing when the secondary expression is not active.

This PR is intentionally prepared to be opened as a Draft PR.

### Why are the changes needed?

When a write-aware client requests `MODIFY_TABLE`, the current Server path can fail that authorization and then call `tableExists()` to distinguish a missing table from an existing forbidden table. External JDBC catalogs perform metadata I/O during that existence check; `jdbc-doris` opens a MySQL-protocol connection before checking the table. A denied write can therefore contact the external catalog, incur connection and latency costs, and return an internal error if the catalog is unavailable instead of a deterministic authorization denial.

This fixes Apache Gravitino Issue #12785. The change is generic Server authorization logic and does not add Doris, Spark, JDBC, public API, or catalog-specific behavior.

Fix: #12785

### Does this PR introduce _any_ user-facing change?

Yes. An explicitly denied `MODIFY_TABLE` request now returns `403 Forbidden` without an existence probe, including when the requested table does not exist. Such a request previously could probe the external catalog and return `404 Not Found` when the probe was allowed. Ordinary load/read denial behavior remains unchanged, and no configuration or public API is added.

### How was this patch tested?

- `./gradlew :server:test --tests 'org.apache.gravitino.server.web.filter.authorization.TestLoadTableAuthorizationExecutor' --tests 'org.apache.gravitino.server.web.filter.TestGravitinoInterceptionService' -PskipITs -PskipDockerTests=true --console=plain --no-daemon`
- `./gradlew :server:test -PskipITs -PskipDockerTests=true --console=plain --no-daemon`
- `./gradlew :server:spotlessCheck`
- `./gradlew rat`
- `./gradlew :server:build -x test`
- `git diff --check`

The final Server suite completed with 344 tests across 50 suites, with zero skipped tests, failures, or errors. No Docker test is required for this Server-only change; the downstream Doris/Spark zero-I/O integration test remains tracked in the Doris governed read/write worktree and will run after this fix is merged and that worktree is rebased.
