### PR TITLE
[#12788] fix(server): reject null request body before validate() in create/register/add operations

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/BulkOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/BulkOperations.java
@@ -101,6 +101,14 @@ public class BulkOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       BulkUserAddRequest request) {
+    if (request == null) {
+      return ExceptionHandlers.handleUserException(
+          OperationType.ADD,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
     try {
       return Utils.doAs(
           httpRequest,
@@ -202,6 +210,14 @@ public class BulkOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       BulkGroupAddRequest request) {
+    if (request == null) {
+      return ExceptionHandlers.handleGroupException(
+          OperationType.ADD,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
     try {
       return Utils.doAs(
           httpRequest,

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -143,7 +143,16 @@ public class CatalogOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       CatalogCreateRequest request) {
-    String catalogName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received create catalog request with null request body");
+      return ExceptionHandlers.handleCatalogException(
+          OperationType.CREATE,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String catalogName = request.getName();
     LOG.info("Received create catalog request for metalake: {}", metalake);
     try {
       return Utils.doAs(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/FilesetOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/FilesetOperations.java
@@ -146,7 +146,16 @@ public class FilesetOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       FilesetCreateRequest request) {
-    String filesetName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received create fileset request with null request body");
+      return ExceptionHandlers.handleFilesetException(
+          OperationType.CREATE,
+          "",
+          schema,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String filesetName = request.getName();
     LOG.info(
         "Received create fileset request: {}.{}.{}.{}", metalake, catalog, schema, filesetName);
     try {

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/FunctionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/FunctionOperations.java
@@ -160,7 +160,16 @@ public class FunctionOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       FunctionRegisterRequest request) {
-    String functionName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received register function request with null request body");
+      return ExceptionHandlers.handleFunctionException(
+          OperationType.REGISTER,
+          "",
+          schema,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String functionName = request.getName();
     LOG.info(
         "Received register function request: {}.{}.{}.{}", metalake, catalog, schema, functionName);
     try {

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
@@ -113,7 +113,16 @@ public class GroupOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       GroupAddRequest request) {
-    String groupName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received add group request with null request body");
+      return ExceptionHandlers.handleGroupException(
+          OperationType.ADD,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String groupName = request.getName();
     try {
       return Utils.doAs(
           httpRequest,

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
@@ -158,8 +158,17 @@ public class JobOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       JobTemplateRegisterRequest request) {
+    if (request == null) {
+      LOG.warn("Received register job template request with null request body");
+      return ExceptionHandlers.handleJobTemplateException(
+          OperationType.REGISTER,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
     String jobTemplateName =
-        request == null || request.getJobTemplate() == null ? "" : request.getJobTemplate().name();
+        request.getJobTemplate() == null ? "" : request.getJobTemplate().name();
     LOG.info(
         "Received request to register job template {} in metalake: {}", jobTemplateName, metalake);
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ModelOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ModelOperations.java
@@ -172,7 +172,16 @@ public class ModelOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       ModelRegisterRequest request) {
-    String modelName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received register model request with null request body");
+      return ExceptionHandlers.handleModelException(
+          OperationType.REGISTER,
+          "",
+          schema,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String modelName = request.getName();
     LOG.info("Received register model request: {}.{}.{}.{}", metalake, catalog, schema, modelName);
 
     try {

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PolicyOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PolicyOperations.java
@@ -141,7 +141,16 @@ public class PolicyOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       PolicyCreateRequest request) {
-    String policyName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received create policy request with null request body");
+      return ExceptionHandlers.handlePolicyException(
+          OperationType.CREATE,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String policyName = request.getName();
     LOG.info("Received create policy request under metalake: {}", metalake);
 
     try {

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
@@ -140,7 +140,16 @@ public class RoleOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       RoleCreateRequest request) {
-    String roleName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received create role request with null request body");
+      return ExceptionHandlers.handleRoleException(
+          OperationType.CREATE,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String roleName = request.getName();
     try {
 
       return Utils.doAs(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
@@ -143,7 +143,16 @@ public class SchemaOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @AuthorizationRequest(type = AuthorizationRequest.RequestType.CREATE_SCHEMA)
           SchemaCreateRequest request) {
-    String schemaName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received create schema request with null request body");
+      return ExceptionHandlers.handleSchemaException(
+          OperationType.CREATE,
+          "",
+          catalog,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String schemaName = request.getName();
     LOG.info("Received create schema request: {}.{}.{}", metalake, catalog, schemaName);
     try {
       return Utils.doAs(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TableOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TableOperations.java
@@ -129,7 +129,16 @@ public class TableOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       TableCreateRequest request) {
-    String tableName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received create table request with null request body");
+      return ExceptionHandlers.handleTableException(
+          OperationType.CREATE,
+          "",
+          schema,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String tableName = request.getName();
     LOG.info("Received create table request: {}.{}.{}.{}", metalake, catalog, schema, tableName);
     try {
       return Utils.doAs(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TagOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TagOperations.java
@@ -151,7 +151,16 @@ public class TagOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       TagCreateRequest request) {
-    String tagName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received create tag request with null request body");
+      return ExceptionHandlers.handleTagException(
+          OperationType.CREATE,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String tagName = request.getName();
     LOG.info("Received create tag request under metalake: {}", metalake);
 
     try {

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TopicOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TopicOperations.java
@@ -124,7 +124,16 @@ public class TopicOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       TopicCreateRequest request) {
-    String topicName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received create topic request with null request body");
+      return ExceptionHandlers.handleTopicException(
+          OperationType.CREATE,
+          "",
+          schema,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String topicName = request.getName();
     LOG.info("Received create topic request: {}.{}.{}", metalake, catalog, schema);
     try {
       return Utils.doAs(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
@@ -155,7 +155,16 @@ public class UserOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       UserAddRequest request) {
-    String userName = request == null ? "" : request.getName();
+    if (request == null) {
+      LOG.warn("Received add user request with null request body");
+      return ExceptionHandlers.handleUserException(
+          OperationType.ADD,
+          "",
+          metalake,
+          new IllegalArgumentException("Request body cannot be null"));
+    }
+
+    String userName = request.getName();
     try {
       return Utils.doAs(
           httpRequest,

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestBulkOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestBulkOperations.java
@@ -160,6 +160,17 @@ public class TestBulkOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testBulkAddUsersWithNullRequest() {
+    Response resp =
+        target("/bulk/metalakes/metalake1/users/add")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testBulkAddUsersBestEffort() {
     User user1 = buildUser("user1");
     when(manager.addUsers(any(), any()))
@@ -222,6 +233,17 @@ public class TestBulkOperations extends BaseOperationsTest {
     Assertions.assertEquals(1, bulkResponse.getErrors().length);
     Assertions.assertEquals("ghost", bulkResponse.getErrors()[0].getName());
     Assertions.assertEquals(ErrorConstants.NOT_FOUND_CODE, bulkResponse.getErrors()[0].getCode());
+  }
+
+  @Test
+  public void testBulkAddGroupsWithNullRequest() {
+    Response resp =
+        target("/bulk/metalakes/metalake1/groups/add")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
   }
 
   @Test

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
@@ -222,6 +222,17 @@ public class TestCatalogOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreateCatalogWithNullRequest() {
+    Response resp =
+        target("/metalakes/metalake1/catalogs")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testCreateCatalog() {
     CatalogCreateRequest req =
         new CatalogCreateRequest(

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestFilesetOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestFilesetOperations.java
@@ -244,6 +244,17 @@ public class TestFilesetOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreateFilesetWithNullRequest() {
+    Response resp =
+        target(filesetPath(metalake, catalog, schema))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testCreateFileset() {
     Fileset fileset =
         mockFileset(

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestFunctionOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestFunctionOperations.java
@@ -267,6 +267,17 @@ public class TestFunctionOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testRegisterFunctionWithNullRequest() {
+    Response resp =
+        target(functionPath())
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testRegisterScalarFunction() {
     NameIdentifier funcId = NameIdentifierUtil.ofFunction(metalake, catalog, schema, "func1");
     Function mockFunction = mockFunction("func1", "test comment", FunctionType.SCALAR);

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestGroupOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestGroupOperations.java
@@ -123,6 +123,17 @@ public class TestGroupOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testAddGroupWithNullRequest() {
+    Response resp =
+        target("/metalakes/metalake1/groups")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testAddGroup() throws IOException {
     GroupAddRequest req = new GroupAddRequest("group1");
     Group group = buildGroup("group1");
@@ -221,9 +232,7 @@ public class TestGroupOperations extends BaseOperationsTest {
             .accept("application/vnd.gravitino.v1+json")
             .post(Entity.entity("null", MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), resp.getStatus());
-    ErrorResponse error = resp.readEntity(ErrorResponse.class);
-    Assertions.assertNotEquals(NullPointerException.class.getSimpleName(), error.getType());
+    assertNullRequestBodyRejected(resp);
   }
 
   @Test

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestJobOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestJobOperations.java
@@ -241,6 +241,22 @@ public class TestJobOperations extends JerseyTest {
   }
 
   @Test
+  public void testRegisterJobTemplateWithNullRequest() {
+    Response resp =
+        target(jobTemplatePath())
+            .request(APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Request body cannot be null"));
+  }
+
+  @Test
   public void testRegisterJobTemplate() {
     JobTemplateEntity template =
         newShellJobTemplateEntity("shell_template_1", "Test Shell Template 1");

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestModelOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestModelOperations.java
@@ -311,6 +311,17 @@ public class TestModelOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testRegisterModelWithNullRequest() {
+    Response resp =
+        target(modelPath())
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testRegisterModel() {
     NameIdentifier modelId = NameIdentifierUtil.ofModel(metalake, catalog, schema, "model1");
     Model mockModel = mockModel("model1", "comment1", 0);

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestPolicyOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestPolicyOperations.java
@@ -266,6 +266,17 @@ public class TestPolicyOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreatePolicyWithNullRequest() {
+    Response resp =
+        target(policyPath(metalake))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testCreatePolicy() {
     ImmutableMap<String, Object> contentFields = ImmutableMap.of("target_file_size_bytes", 1000);
     PolicyContent content =

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestRoleOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestRoleOperations.java
@@ -149,6 +149,17 @@ public class TestRoleOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreateRoleWithNullRequest() {
+    Response resp =
+        target("/metalakes/metalake1/roles")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testCreateRole() throws IllegalAccessException, NoSuchFieldException, IOException {
     SecurableObject securableObject =
         SecurableObjects.ofCatalog("catalog", Lists.newArrayList(Privileges.UseCatalog.allow()));

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestSchemaOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestSchemaOperations.java
@@ -219,6 +219,17 @@ public class TestSchemaOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreateSchemaWithNullRequest() {
+    Response resp =
+        target("/metalakes/" + metalake + "/catalogs/" + catalog + "/schemas")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testCreateSchema() {
     SchemaCreateRequest req =
         new SchemaCreateRequest("schema1", "comment", ImmutableMap.of("key", "value"));

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestTableOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestTableOperations.java
@@ -226,6 +226,17 @@ public class TestTableOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreateTableWithNullRequest() {
+    Response resp =
+        target(tablePath(metalake, catalog, schema))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testCreateTable() {
     Column[] columns =
         new Column[] {

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestTagOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestTagOperations.java
@@ -273,6 +273,17 @@ public class TestTagOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreateTagWithNullRequest() {
+    Response resp =
+        target(tagPath(metalake))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testCreateTag() {
     TagEntity tag1 =
         TagEntity.builder()

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestTopicOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestTopicOperations.java
@@ -227,6 +227,17 @@ public class TestTopicOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreateTopicWithNullRequest() {
+    Response resp =
+        target(topicPath(metalake, catalog, schema))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testCreateTopic() {
     Topic topic = mockTopic("topic1", "comment", ImmutableMap.of("key1", "value1"));
     when(dispatcher.createTopic(any(), any(), any(), any())).thenReturn(topic);

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestUserOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestUserOperations.java
@@ -119,6 +119,17 @@ public class TestUserOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testAddUserWithNullRequest() {
+    Response resp =
+        target("/metalakes/metalake1/users")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(new byte[0], MediaType.APPLICATION_JSON_TYPE));
+
+    assertNullRequestBodyRejected(resp);
+  }
+
+  @Test
   public void testAddUser() throws IOException {
     UserAddRequest req = new UserAddRequest("user1");
     User user = buildUser("user1");


### PR DESCRIPTION
### What changes were proposed in this pull request?

Several `create`/`register`/`add` REST operations called `request.validate()` without first checking for a null request body, so an empty or JSON `null` body dereferenced the request and returned HTTP 500 instead of a proper 400. Applied the existing `createMetalake` pattern (null-check first, then route an `IllegalArgumentException` through the corresponding exception handler) to:

- Catalog, Schema, Table, Fileset, Topic, Policy, and Tag creation
- Function, Model, and JobTemplate registration
- User, Group, and Role creation
- Bulk user and group creation

Also updated a pre-existing test in `TestGroupOperations` that had asserted the old 500 status as expected behavior, and added a `WithNullRequest` test for each fixed operation, matching the `assertNullRequestBodyRejected` pattern from #12770.

### Why are the changes needed?

A null request body currently returns HTTP 500 with an internal error response for these operations, instead of a structured 400. This is inconsistent with the already-fixed `alter`/`createView` operations (#12769, #12770) and with `createMetalake`, and it leaks an internal error to the caller for what is really a bad request.

Fix: #12788

### Does this PR introduce _any_ user-facing change?

Yes. A `create`/`register`/`add` request with a null or empty body now returns HTTP 400 with error code `1001`, error type `IllegalArgumentException`, and a message stating the request body cannot be null, instead of HTTP 500.

### How was this patch tested?

Added a `testXxxWithNullRequest()` test for each of the 14 fixed operations, verifying HTTP 400, error code `1001`, error type `IllegalArgumentException`, and the error message, using the shared `assertNullRequestBodyRejected` helper. Ran `:server:test` scoped to the 14 affected test classes: 176 tests, all passing.