### PR TITLE
[#12795] improvement(infra): Enable automatic GitHub Copilot code review

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,8 +63,11 @@ github:
     - danhuawang
     - lasdf1234
     - nevzheng
-  # Automatic Copilot review on non-draft PRs targeting the default branch.
-  # See https://github.com/apache/infrastructure-asfyaml#copilot-code-review
+  # Copilot Code Review ruleset on the default branch (main).
+  # https://github.com/apache/infrastructure-asfyaml#copilot-code-review
+  # enabled:        true creates the ruleset; false or deleting this block removes it
+  # review_drafts:  false skips drafts; first auto-review when the PR is marked ready
+  # review_on_push: true re-reviews on later pushes (more comments and AI credits)
   copilot_code_review:
     enabled: true
     review_drafts: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,6 +63,12 @@ github:
     - danhuawang
     - lasdf1234
     - nevzheng
+  # Automatic Copilot review on non-draft PRs targeting the default branch.
+  # See https://github.com/apache/infrastructure-asfyaml#copilot-code-review
+  copilot_code_review:
+    enabled: true
+    review_drafts: false
+    review_on_push: true
 
 notifications:
   commits: commits@gravitino.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -67,11 +67,11 @@ github:
   # https://github.com/apache/infrastructure-asfyaml#copilot-code-review
   # enabled:        true creates the ruleset; false or deleting this block removes it
   # review_drafts:  false skips drafts; first auto-review when the PR is marked ready
-  # review_on_push: true re-reviews on later pushes (more comments and AI credits)
+  # review_on_push: false does not re-review on later pushes; add Copilot by hand
   copilot_code_review:
     enabled: true
     review_drafts: false
-    review_on_push: true
+    review_on_push: false
 
 notifications:
   commits: commits@gravitino.apache.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,7 @@ Reviewing and triaging helps maintain the project. You can:
 * Write clear commit messages and PR descriptions
 * Link to issues (e.g., `Fixes #123`)
 * Respond to reviewer feedback
+* GitHub Copilot may leave a first-pass review on non-draft PRs. Treat those comments as hints: implement the suggestion, or reply with why you are not taking it. Human reviewers remain responsible for the merge decision. Project-specific Copilot guidance lives in [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
 
 ## 💻 Setting Up Development Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,7 @@ Reviewing and triaging helps maintain the project. You can:
 * Add labels to categorize
 * Suggest improvements on PRs
 * Review code and give feedback
+* A Copilot first-pass review before human review is recommended, not required. Do not wait on Copilot if you are ready to review.
 
 ## 🔃 Creating Pull Requests
 
@@ -156,7 +157,7 @@ Reviewing and triaging helps maintain the project. You can:
 * Write clear commit messages and PR descriptions
 * Link to issues (e.g., `Fixes #123`)
 * Respond to reviewer feedback
-* GitHub Copilot may leave a first-pass review on non-draft PRs. Treat those comments as hints: implement the suggestion, or reply with why you are not taking it. Human reviewers remain responsible for the merge decision. Project-specific Copilot guidance lives in [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+* Letting Copilot finish a first-pass review before requesting human review is recommended, not required. Treat Copilot comments as hints: implement the suggestion, or reply with why you are not taking it. Human reviewers remain responsible for the merge decision. Project-specific Copilot guidance lives in [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
 
 ## 💻 Setting Up Development Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Reviewing and triaging helps maintain the project. You can:
 * Add labels to categorize
 * Suggest improvements on PRs
 * Review code and give feedback
-* A Copilot first-pass review before human review is recommended, not required. Do not wait on Copilot if you are ready to review.
+* Please add Copilot before you review. That is recommended, not required. Do not wait on Copilot if you are ready to review.
 
 ## 🔃 Creating Pull Requests
 
@@ -157,7 +157,7 @@ Reviewing and triaging helps maintain the project. You can:
 * Write clear commit messages and PR descriptions
 * Link to issues (e.g., `Fixes #123`)
 * Respond to reviewer feedback
-* Letting Copilot finish a first-pass review before requesting human review is recommended, not required. Treat Copilot comments as hints: implement the suggestion, or reply with why you are not taking it. Human reviewers remain responsible for the merge decision. Project-specific Copilot guidance lives in [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+* Please add Copilot on the PR. Automatic review runs once when the PR is marked ready; later pushes do not re-review, so add Copilot again after you push. Treat Copilot comments as hints: implement the suggestion, or reply with why you are not taking it. Human reviewers remain responsible for the merge decision. Project-specific Copilot guidance lives in [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
 
 ## 💻 Setting Up Development Environment
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable automatic GitHub Copilot review on non-draft pull requests targeting `main`, and document that people should add Copilot. That is recommended, not required.

`.asf.yaml` adds the ASF convenience block:

- `enabled: true` — create the `Copilot Code Review` ruleset on the default branch
- `review_drafts: false` — skip drafts; first auto-review when marked ready
- `review_on_push: false` — do not re-review on later pushes; add Copilot by hand after updates

`CONTRIBUTING.md` asks authors and reviewers to add Copilot, and to add it again after later pushes. Copilot is a first pass, not a gate. `.github/copilot-instructions.md` is unchanged.

The full contract (what this does and does not do, billing, capabilities, limitations) is in #12795.

### Why are the changes needed?

Copilot can already review when someone requests it. Automatic first-pass review needs the ASF `.asf.yaml` ruleset. Iceberg, Arrow, and other ASF projects already run this.

Fix: #12795

### Does this PR introduce _any_ user-facing change?

No runtime, API, or property-key change. After merge, authors with Copilot code-review access can get an automatic first pass when the PR is marked ready. Later pushes do not re-review unless someone adds Copilot. Waiting for Copilot is recommended, not required. Required human approval stays 1.

### How was this patch tested?

- Parsed `.asf.yaml` as YAML (`ruby -ryaml`)
- `git diff --check` passed
- Automatic Copilot review can only be confirmed after merge, when ASF Infra applies the ruleset

Nevin
Sent from my 🤖 (Cursor)