### PR TITLE
[#12652][#12653] improvement(core): add OCC for function and view writes

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaMapper.java
@@ -142,16 +142,35 @@ public interface FunctionMetaMapper {
   FunctionPO selectFunctionMetaBySchemaIdAndName(
       @Param("schemaId") Long schemaId, @Param("functionName") String functionName);
 
+  /**
+   * Selects and exclusively locks an active function metadata row.
+   *
+   * @param functionId the function ID
+   * @return the active function metadata, or {@code null} when it no longer exists
+   */
+  @SelectProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "selectFunctionMetaByIdForUpdate")
+  FunctionPO selectFunctionMetaByIdForUpdate(@Param("functionId") Long functionId);
+
   @SelectProvider(
       type = FunctionMetaSQLProviderFactory.class,
       method = "selectFunctionIdBySchemaIdAndFunctionName")
   Long selectFunctionIdBySchemaIdAndFunctionName(
       @Param("schemaId") Long schemaId, @Param("functionName") String functionName);
 
+  /**
+   * Soft-deletes a function only if its version has not changed since the caller read it.
+   *
+   * @param functionId the function ID
+   * @param currentVersion the version observed by the caller
+   * @return the number of deleted rows; zero means the function changed or disappeared
+   */
   @UpdateProvider(
       type = FunctionMetaSQLProviderFactory.class,
       method = "softDeleteFunctionMetaByFunctionId")
-  Integer softDeleteFunctionMetaByFunctionId(@Param("functionId") Long functionId);
+  Integer softDeleteFunctionMetaByFunctionId(
+      @Param("functionId") Long functionId, @Param("currentVersion") Integer currentVersion);
 
   @UpdateProvider(
       type = FunctionMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaSQLProviderFactory.java
@@ -90,13 +90,31 @@ public class FunctionMetaSQLProviderFactory {
     return getProvider().selectFunctionMetaBySchemaIdAndName(schemaId, functionName);
   }
 
+  /**
+   * Returns SQL that selects and exclusively locks an active function metadata row.
+   *
+   * @param functionId the function ID
+   * @return the locking select SQL
+   */
+  public static String selectFunctionMetaByIdForUpdate(@Param("functionId") Long functionId) {
+    return getProvider().selectFunctionMetaByIdForUpdate(functionId);
+  }
+
   public static String selectFunctionIdBySchemaIdAndFunctionName(
       @Param("schemaId") Long schemaId, @Param("functionName") String functionName) {
     return getProvider().selectFunctionIdBySchemaIdAndFunctionName(schemaId, functionName);
   }
 
-  public static String softDeleteFunctionMetaByFunctionId(@Param("functionId") Long functionId) {
-    return getProvider().softDeleteFunctionMetaByFunctionId(functionId);
+  /**
+   * Returns SQL that soft-deletes a function with a version check.
+   *
+   * @param functionId the function ID
+   * @param currentVersion the version observed by the caller
+   * @return the version-checked delete SQL
+   */
+  public static String softDeleteFunctionMetaByFunctionId(
+      @Param("functionId") Long functionId, @Param("currentVersion") Integer currentVersion) {
+    return getProvider().softDeleteFunctionMetaByFunctionId(functionId, currentVersion);
   }
 
   public static String softDeleteFunctionMetasByCatalogId(@Param("catalogId") Long catalogId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ViewMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ViewMetaMapper.java
@@ -107,6 +107,15 @@ public interface ViewMetaMapper {
   ViewPO selectViewMetaBySchemaIdAndName(
       @Param("schemaId") Long schemaId, @Param("viewName") String name);
 
+  /**
+   * Selects and exclusively locks an active view metadata row.
+   *
+   * @param viewId the view ID
+   * @return the active view metadata, or {@code null} when it no longer exists
+   */
+  @SelectProvider(type = ViewMetaSQLProviderFactory.class, method = "selectViewMetaByIdForUpdate")
+  ViewPO selectViewMetaByIdForUpdate(@Param("viewId") Long viewId);
+
   @ResultMap("viewPOResultMap")
   @SelectProvider(type = ViewMetaSQLProviderFactory.class, method = "selectViewByFullQualifiedName")
   ViewPO selectViewByFullQualifiedName(
@@ -127,8 +136,16 @@ public interface ViewMetaMapper {
   Integer updateViewMeta(
       @Param("newViewMeta") ViewPO newViewPO, @Param("oldViewMeta") ViewPO oldViewPO);
 
+  /**
+   * Soft-deletes a view only if its version has not changed since the caller read it.
+   *
+   * @param viewId the view ID
+   * @param currentVersion the version observed by the caller
+   * @return the number of deleted rows; zero means the view changed or disappeared
+   */
   @UpdateProvider(type = ViewMetaSQLProviderFactory.class, method = "softDeleteViewMetasByViewId")
-  Integer softDeleteViewMetasByViewId(@Param("viewId") Long viewId);
+  Integer softDeleteViewMetasByViewId(
+      @Param("viewId") Long viewId, @Param("currentVersion") Long currentVersion);
 
   @UpdateProvider(
       type = ViewMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ViewMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ViewMetaSQLProviderFactory.java
@@ -76,6 +76,16 @@ public class ViewMetaSQLProviderFactory {
     return getProvider().selectViewMetaBySchemaIdAndName(schemaId, name);
   }
 
+  /**
+   * Returns SQL that selects and exclusively locks an active view metadata row.
+   *
+   * @param viewId the view ID
+   * @return the locking select SQL
+   */
+  public static String selectViewMetaByIdForUpdate(@Param("viewId") Long viewId) {
+    return getProvider().selectViewMetaByIdForUpdate(viewId);
+  }
+
   public static String selectViewByFullQualifiedName(
       @Param("metalakeName") String metalakeName,
       @Param("catalogName") String catalogName,
@@ -98,8 +108,16 @@ public class ViewMetaSQLProviderFactory {
     return getProvider().updateViewMeta(newViewPO, oldViewPO);
   }
 
-  public static String softDeleteViewMetasByViewId(@Param("viewId") Long viewId) {
-    return getProvider().softDeleteViewMetasByViewId(viewId);
+  /**
+   * Returns SQL that soft-deletes a view with a version check.
+   *
+   * @param viewId the view ID
+   * @param currentVersion the version observed by the caller
+   * @return the version-checked delete SQL
+   */
+  public static String softDeleteViewMetasByViewId(
+      @Param("viewId") Long viewId, @Param("currentVersion") Long currentVersion) {
+    return getProvider().softDeleteViewMetasByViewId(viewId, currentVersion);
   }
 
   public static String softDeleteViewMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
@@ -120,8 +120,10 @@ public class FunctionMetaBaseSQLProvider {
         + " schema_id = #{functionMeta.schemaId},"
         + " function_type = #{functionMeta.functionType},"
         + " `deterministic` = #{functionMeta.deterministic},"
-        + " function_current_version = #{functionMeta.functionCurrentVersion},"
-        + " function_latest_version = #{functionMeta.functionLatestVersion},"
+        // Keep both version columns monotonic on overwrite. Assign latest first so MySQL computes
+        // both values from the stored current version rather than the newly assigned value.
+        + " function_latest_version = function_current_version + 1,"
+        + " function_current_version = function_current_version + 1,"
         + " audit_info = #{functionMeta.auditInfo},"
         + " deleted_at = #{functionMeta.deletedAt}";
   }
@@ -201,6 +203,26 @@ public class FunctionMetaBaseSQLProvider {
         + " WHERE fm.schema_id = #{schemaId} AND fm.deleted_at = 0 AND vi.deleted_at = 0";
   }
 
+  /**
+   * Returns the active function metadata row and holds it exclusively for the transaction.
+   *
+   * <p>The version table is deliberately not joined: PostgreSQL rejects locking the nullable side
+   * of an outer join, and conflict classification only needs the root row's identity and version.
+   *
+   * @param functionId the function ID
+   * @return the locking select SQL
+   */
+  public String selectFunctionMetaByIdForUpdate(@Param("functionId") Long functionId) {
+    return "SELECT function_id as functionId, function_name as functionName,"
+        + " metalake_id as metalakeId, catalog_id as catalogId, schema_id as schemaId,"
+        + " function_current_version as functionCurrentVersion,"
+        + " function_latest_version as functionLatestVersion,"
+        + " audit_info as auditInfo, deleted_at as deletedAt"
+        + " FROM "
+        + TABLE_NAME
+        + " WHERE function_id = #{functionId} AND deleted_at = 0 FOR UPDATE";
+  }
+
   public String listFunctionPOsByFunctionIds(@Param("functionIds") List<Long> functionIds) {
     return "<script>"
         + " SELECT function_id, function_name, schema_id"
@@ -227,11 +249,12 @@ public class FunctionMetaBaseSQLProvider {
         + " vi.audit_info as version_audit_info, vi.deleted_at as version_deleted_at"
         + " FROM "
         + TABLE_NAME
-        + " fm INNER JOIN "
+        + " fm LEFT JOIN "
         + VERSION_TABLE_NAME
         + " vi ON fm.function_id = vi.function_id AND fm.function_current_version = vi.version"
+        + " AND vi.deleted_at = 0"
         + " WHERE fm.schema_id = #{schemaId} AND fm.function_name = #{functionName}"
-        + " AND fm.deleted_at = 0 AND vi.deleted_at = 0";
+        + " AND fm.deleted_at = 0";
   }
 
   public String selectFunctionIdBySchemaIdAndFunctionName(
@@ -242,12 +265,21 @@ public class FunctionMetaBaseSQLProvider {
         + " WHERE schema_id = #{schemaId} AND function_name = #{functionName} AND deleted_at = 0";
   }
 
-  public String softDeleteFunctionMetaByFunctionId(@Param("functionId") Long functionId) {
+  /**
+   * Returns SQL that deletes only the function version observed by the caller.
+   *
+   * @param functionId the function ID
+   * @param currentVersion the version observed by the caller
+   * @return the version-checked delete SQL
+   */
+  public String softDeleteFunctionMetaByFunctionId(
+      @Param("functionId") Long functionId, @Param("currentVersion") Integer currentVersion) {
     return "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE function_id = #{functionId} AND deleted_at = 0";
+        + " WHERE function_id = #{functionId}"
+        + " AND function_current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   public String softDeleteFunctionMetasByCatalogId(@Param("catalogId") Long catalogId) {
@@ -287,6 +319,13 @@ public class FunctionMetaBaseSQLProvider {
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
 
+  /**
+   * Returns SQL that updates a function only while its OCC version is unchanged.
+   *
+   * @param newFunctionPO the function values to write
+   * @param oldFunctionPO the function values and OCC version read by the caller
+   * @return the version-checked update SQL
+   */
   public String updateFunctionMeta(
       @Param("newFunctionMeta") FunctionPO newFunctionPO,
       @Param("oldFunctionMeta") FunctionPO oldFunctionPO) {
@@ -303,14 +342,7 @@ public class FunctionMetaBaseSQLProvider {
         + " audit_info = #{newFunctionMeta.auditInfo},"
         + " deleted_at = #{newFunctionMeta.deletedAt}"
         + " WHERE function_id = #{oldFunctionMeta.functionId}"
-        + " AND function_name = #{oldFunctionMeta.functionName}"
-        + " AND metalake_id = #{oldFunctionMeta.metalakeId}"
-        + " AND catalog_id = #{oldFunctionMeta.catalogId}"
-        + " AND schema_id = #{oldFunctionMeta.schemaId}"
-        + " AND function_type = #{oldFunctionMeta.functionType}"
         + " AND function_current_version = #{oldFunctionMeta.functionCurrentVersion}"
-        + " AND function_latest_version = #{oldFunctionMeta.functionLatestVersion}"
-        + " AND audit_info = #{oldFunctionMeta.auditInfo}"
         + " AND deleted_at = 0";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ViewMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ViewMetaBaseSQLProvider.java
@@ -123,11 +123,31 @@ public class ViewMetaBaseSQLProvider {
         + " vi.audit_info as version_audit_info, vi.deleted_at as version_deleted_at"
         + " FROM "
         + TABLE_NAME
-        + " vm INNER JOIN "
+        + " vm LEFT JOIN "
         + VERSION_TABLE_NAME
         + " vi ON vm.view_id = vi.view_id AND vm.current_version = vi.version"
+        + " AND vi.deleted_at = 0"
         + " WHERE vm.schema_id = #{schemaId} AND vm.view_name = #{viewName}"
-        + " AND vm.deleted_at = 0 AND vi.deleted_at = 0";
+        + " AND vm.deleted_at = 0";
+  }
+
+  /**
+   * Returns the active view metadata row and holds it exclusively for the transaction.
+   *
+   * <p>The version table is deliberately not joined: PostgreSQL rejects locking the nullable side
+   * of an outer join, and conflict classification only needs the root row's identity and version.
+   *
+   * @param viewId the view ID
+   * @return the locking select SQL
+   */
+  public String selectViewMetaByIdForUpdate(@Param("viewId") Long viewId) {
+    return "SELECT view_id as viewId, view_name as viewName,"
+        + " metalake_id as metalakeId, catalog_id as catalogId, schema_id as schemaId,"
+        + " current_version as currentVersion, last_version as lastVersion,"
+        + " audit_info as auditInfo, deleted_at as deletedAt"
+        + " FROM "
+        + TABLE_NAME
+        + " WHERE view_id = #{viewId} AND deleted_at = 0 FOR UPDATE";
   }
 
   public String insertViewMeta(@Param("viewMeta") ViewPO viewPO) {
@@ -171,8 +191,10 @@ public class ViewMetaBaseSQLProvider {
         + " metalake_id = #{viewMeta.metalakeId},"
         + " catalog_id = #{viewMeta.catalogId},"
         + " schema_id = #{viewMeta.schemaId},"
-        + " current_version = #{viewMeta.currentVersion},"
-        + " last_version = #{viewMeta.lastVersion},"
+        // Keep both version columns monotonic on overwrite. Assign last first so MySQL computes
+        // both values from the stored current version rather than the newly assigned value.
+        + " last_version = current_version + 1,"
+        + " current_version = current_version + 1,"
         + " audit_info = #{viewMeta.auditInfo},"
         + " deleted_at = #{viewMeta.deletedAt}";
   }
@@ -214,12 +236,21 @@ public class ViewMetaBaseSQLProvider {
         + "</script>";
   }
 
-  public String softDeleteViewMetasByViewId(@Param("viewId") Long viewId) {
+  /**
+   * Returns SQL that deletes only the view version observed by the caller.
+   *
+   * @param viewId the view ID
+   * @param currentVersion the version observed by the caller
+   * @return the version-checked delete SQL
+   */
+  public String softDeleteViewMetasByViewId(
+      @Param("viewId") Long viewId, @Param("currentVersion") Long currentVersion) {
     return "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE view_id = #{viewId} AND deleted_at = 0";
+        + " WHERE view_id = #{viewId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   public String softDeleteViewMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
@@ -58,8 +58,12 @@ public class FunctionMetaPostgreSQLProvider extends FunctionMetaBaseSQLProvider 
         + " schema_id = #{functionMeta.schemaId},"
         + " function_type = #{functionMeta.functionType},"
         + " \"deterministic\" = #{functionMeta.deterministic},"
-        + " function_current_version = #{functionMeta.functionCurrentVersion},"
-        + " function_latest_version = #{functionMeta.functionLatestVersion},"
+        + " function_current_version = "
+        + FunctionMetaMapper.TABLE_NAME
+        + ".function_current_version + 1,"
+        + " function_latest_version = "
+        + FunctionMetaMapper.TABLE_NAME
+        + ".function_current_version + 1,"
         + " audit_info = #{functionMeta.auditInfo},"
         + " deleted_at = #{functionMeta.deletedAt}";
   }
@@ -93,19 +97,22 @@ public class FunctionMetaPostgreSQLProvider extends FunctionMetaBaseSQLProvider 
         + " vi.audit_info as version_audit_info, vi.deleted_at as version_deleted_at"
         + " FROM "
         + FunctionMetaMapper.TABLE_NAME
-        + " fm INNER JOIN "
+        + " fm LEFT JOIN "
         + FunctionMetaMapper.VERSION_TABLE_NAME
         + " vi ON fm.function_id = vi.function_id AND fm.function_current_version = vi.version"
+        + " AND vi.deleted_at = 0"
         + " WHERE fm.schema_id = #{schemaId} AND fm.function_name = #{functionName}"
-        + " AND fm.deleted_at = 0 AND vi.deleted_at = 0";
+        + " AND fm.deleted_at = 0";
   }
 
   @Override
-  public String softDeleteFunctionMetaByFunctionId(@Param("functionId") Long functionId) {
+  public String softDeleteFunctionMetaByFunctionId(
+      @Param("functionId") Long functionId, @Param("currentVersion") Integer currentVersion) {
     return "UPDATE "
         + FunctionMetaMapper.TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE function_id = #{functionId} AND deleted_at = 0";
+        + " WHERE function_id = #{functionId}"
+        + " AND function_current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   @Override
@@ -165,14 +172,7 @@ public class FunctionMetaPostgreSQLProvider extends FunctionMetaBaseSQLProvider 
         + " audit_info = #{newFunctionMeta.auditInfo},"
         + " deleted_at = #{newFunctionMeta.deletedAt}"
         + " WHERE function_id = #{oldFunctionMeta.functionId}"
-        + " AND function_name = #{oldFunctionMeta.functionName}"
-        + " AND metalake_id = #{oldFunctionMeta.metalakeId}"
-        + " AND catalog_id = #{oldFunctionMeta.catalogId}"
-        + " AND schema_id = #{oldFunctionMeta.schemaId}"
-        + " AND function_type = #{oldFunctionMeta.functionType}"
         + " AND function_current_version = #{oldFunctionMeta.functionCurrentVersion}"
-        + " AND function_latest_version = #{oldFunctionMeta.functionLatestVersion}"
-        + " AND audit_info = #{oldFunctionMeta.auditInfo}"
         + " AND deleted_at = 0";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ViewMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ViewMetaPostgreSQLProvider.java
@@ -51,8 +51,12 @@ public class ViewMetaPostgreSQLProvider extends ViewMetaBaseSQLProvider {
         + " metalake_id = #{viewMeta.metalakeId},"
         + " catalog_id = #{viewMeta.catalogId},"
         + " schema_id = #{viewMeta.schemaId},"
-        + " current_version = #{viewMeta.currentVersion},"
-        + " last_version = #{viewMeta.lastVersion},"
+        + " current_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
         + " audit_info = #{viewMeta.auditInfo},"
         + " deleted_at = #{viewMeta.deletedAt}";
   }
@@ -86,19 +90,22 @@ public class ViewMetaPostgreSQLProvider extends ViewMetaBaseSQLProvider {
         + " vi.audit_info as version_audit_info, vi.deleted_at as version_deleted_at"
         + " FROM "
         + TABLE_NAME
-        + " vm INNER JOIN "
+        + " vm LEFT JOIN "
         + VERSION_TABLE_NAME
         + " vi ON vm.view_id = vi.view_id AND vm.current_version = vi.version"
+        + " AND vi.deleted_at = 0"
         + " WHERE vm.schema_id = #{schemaId} AND vm.view_name = #{viewName}"
-        + " AND vm.deleted_at = 0 AND vi.deleted_at = 0";
+        + " AND vm.deleted_at = 0";
   }
 
   @Override
-  public String softDeleteViewMetasByViewId(@Param("viewId") Long viewId) {
+  public String softDeleteViewMetasByViewId(
+      @Param("viewId") Long viewId, @Param("currentVersion") Long currentVersion) {
     return "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE view_id = #{viewId} AND deleted_at = 0";
+        + " WHERE view_id = #{viewId}"
+        + " AND current_version = #{currentVersion} AND deleted_at = 0";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -48,6 +48,7 @@ import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.po.FunctionMaxVersionPO;
 import org.apache.gravitino.storage.relational.po.FunctionPO;
+import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -113,6 +114,7 @@ public class FunctionMetaService {
     try {
       fillFunctionPOBuilderParentEntityId(builder, functionEntity.namespace());
       FunctionPO po = initializeFunctionPO(functionEntity, builder);
+      AtomicReference<FunctionPO> persistedPO = new AtomicReference<>(po);
 
       SessionUtils.doMultipleWithCommit(
           // Hold the parent schema row until this transaction ends, so the function cannot be
@@ -126,13 +128,28 @@ public class FunctionMetaService {
                       po.metalakeId()),
           () ->
               SessionUtils.doWithoutCommit(
-                  FunctionMetaMapper.class, mapper -> ops.insertPO(mapper, po, overwrite)),
+                  FunctionMetaMapper.class,
+                  mapper -> {
+                    ops.insertPO(mapper, po, overwrite);
+                    if (overwrite) {
+                      FunctionPO storedPO =
+                          mapper.selectFunctionMetaBySchemaIdAndName(
+                              po.schemaId(), po.functionName());
+                      Preconditions.checkState(
+                          storedPO != null,
+                          "The overwritten function %s in schema %s does not exist",
+                          po.functionName(),
+                          po.schemaId());
+                      persistedPO.set(functionPOWithPersistedIdentityAndVersions(po, storedPO));
+                    }
+                  }),
           () ->
               SessionUtils.doWithoutCommit(
                   FunctionVersionMetaMapper.class,
                   mapper -> {
                     if (overwrite) {
-                      mapper.insertFunctionVersionMetaOnDuplicateKeyUpdate(po.functionVersionPO());
+                      mapper.insertFunctionVersionMetaOnDuplicateKeyUpdate(
+                          persistedPO.get().functionVersionPO());
                     } else {
                       mapper.insertFunctionVersionMeta(po.functionVersionPO());
                     }
@@ -149,42 +166,31 @@ public class FunctionMetaService {
       baseMetricName = "deleteFunction")
   public boolean deleteFunction(NameIdentifier ident) {
     FunctionPO functionPO = getFunctionPOByIdentifier(ident);
-    Long functionId = functionPO.functionId();
 
-    AtomicInteger functionDeletedCount = new AtomicInteger();
+    deleteFunctionWithVersion(ident, functionPO);
+    return true;
+  }
+
+  /**
+   * Deletes the observed function and its dependent rows in one transaction.
+   *
+   * <p>Package-private access lets concurrency tests submit a deliberately stale snapshot while
+   * exercising the same root-first ordering as the public delete path.
+   */
+  void deleteFunctionWithVersion(NameIdentifier identifier, FunctionPO observedFunctionPO) {
     SessionUtils.doMultipleWithCommit(
-        // delete function meta
+        // Check the root version before touching relationships. A stale drop stops here.
         () ->
-            functionDeletedCount.set(
-                SessionUtils.getWithoutCommit(
-                    FunctionMetaMapper.class,
-                    mapper -> mapper.softDeleteFunctionMetaByFunctionId(functionId))),
-
-        // delete function versions, owner rels, and securable object rels after meta deletion
-        () -> {
-          if (functionDeletedCount.get() > 0) {
-            SessionUtils.doWithoutCommit(
-                FunctionVersionMetaMapper.class,
-                mapper -> mapper.softDeleteFunctionVersionsByFunctionId(functionId));
-            SessionUtils.doWithoutCommit(
-                OwnerMetaMapper.class,
-                mapper ->
-                    mapper.softDeleteOwnerRelByMetadataObjectIdAndType(
-                        functionId, MetadataObject.Type.FUNCTION.name()));
-            SessionUtils.doWithoutCommit(
-                SecurableObjectMapper.class,
-                mapper ->
-                    mapper.softDeleteObjectRelsByMetadataObject(
-                        functionId, MetadataObject.Type.FUNCTION.name()));
-            SessionUtils.doWithoutCommit(
-                TagMetadataObjectRelMapper.class,
-                mapper ->
-                    mapper.softDeleteTagMetadataObjectRelsByMetadataObject(
-                        functionId, MetadataObject.Type.FUNCTION.name()));
-          }
-        });
-
-    return functionDeletedCount.get() > 0;
+            OccWriteSupport.deleteWithVersion(
+                () ->
+                    SessionUtils.getWithoutCommit(
+                        FunctionMetaMapper.class,
+                        mapper ->
+                            mapper.softDeleteFunctionMetaByFunctionId(
+                                observedFunctionPO.functionId(),
+                                observedFunctionPO.functionCurrentVersion())),
+                () -> functionWriteFailure(identifier, observedFunctionPO)),
+        () -> deleteFunctionDependents(observedFunctionPO.functionId()));
   }
 
   @Monitored(
@@ -268,36 +274,41 @@ public class FunctionMetaService {
         newEntity.id(),
         oldFunctionEntity.id());
 
+    boolean isSchemaChanged = !newEntity.namespace().equals(oldFunctionEntity.namespace());
+    Long newSchemaId =
+        isSchemaChanged
+            ? EntityIdService.getEntityId(
+                NameIdentifier.of(newEntity.namespace().levels()), Entity.EntityType.SCHEMA)
+            : oldFunctionPO.schemaId();
+
     try {
-      FunctionPO newFunctionPO = updateFunctionPO(oldFunctionPO, newEntity);
-      // Insert a new version and update function meta
+      FunctionPO newFunctionPO = updateFunctionPO(oldFunctionPO, newEntity, newSchemaId);
       SessionUtils.doMultipleWithCommit(
-          // The function was read before this transaction started. Lock its observed parent again
-          // before writing, so a schema drop cannot finish its function cleanup and then let this
-          // update add a new version below the deleted schema.
-          () ->
+          () -> {
+            if (isSchemaChanged) {
               SchemaMetaService.getInstance()
                   .lockSchemaForEntityWrite(
-                      identifier,
-                      oldFunctionPO.schemaId(),
+                      newEntity.nameIdentifier(),
+                      newSchemaId,
                       oldFunctionPO.catalogId(),
-                      oldFunctionPO.metalakeId()),
-          () ->
-              SessionUtils.doWithoutCommit(
-                  FunctionVersionMetaMapper.class,
-                  mapper -> mapper.insertFunctionVersionMeta(newFunctionPO.functionVersionPO())),
+                      oldFunctionPO.metalakeId());
+            }
+          },
           () -> {
+            // function_current_version is the sole OCC token. The root CAS is the transaction's
+            // decision point and must run before the unguarded version-row insert below.
             int updated =
                 SessionUtils.getWithoutCommit(
                     FunctionMetaMapper.class,
                     mapper -> ops.updatePO(mapper, newFunctionPO, oldFunctionPO));
             if (updated == 0) {
-              // The version row was inserted earlier in this transaction. Throwing here rolls the
-              // whole transaction back instead of leaving that version without an active function
-              // metadata row.
-              throw ExceptionUtils.concurrentModification(Entity.EntityType.FUNCTION, identifier);
+              throw functionWriteFailure(identifier, oldFunctionPO);
             }
-          });
+          },
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionVersionMetaMapper.class,
+                  mapper -> mapper.insertFunctionVersionMeta(newFunctionPO.functionVersionPO())));
 
       return newEntity;
     } catch (RuntimeException re) {
@@ -327,15 +338,85 @@ public class FunctionMetaService {
     builder.withSchemaId(namespacedEntityId.entityId());
   }
 
-  private FunctionPO updateFunctionPO(FunctionPO oldFunctionPO, FunctionEntity newFunction) {
+  private FunctionPO updateFunctionPO(
+      FunctionPO oldFunctionPO, FunctionEntity newFunction, Long newSchemaId) {
     Integer newVersion = oldFunctionPO.functionLatestVersion() + 1;
     FunctionPO.FunctionPOBuilder builder =
         FunctionPO.builder()
             .withMetalakeId(oldFunctionPO.metalakeId())
             .withCatalogId(oldFunctionPO.catalogId())
-            .withSchemaId(oldFunctionPO.schemaId())
+            .withSchemaId(newSchemaId)
             .withFunctionLatestVersion(newVersion)
             .withFunctionCurrentVersion(newVersion);
     return buildFunctionPO(newFunction, builder, newVersion);
+  }
+
+  private FunctionPO functionPOWithPersistedIdentityAndVersions(
+      FunctionPO incomingPO, FunctionPO persistedPO) {
+    FunctionVersionPO incomingVersionPO = incomingPO.functionVersionPO();
+    FunctionVersionPO persistedVersionPO =
+        FunctionVersionPO.builder()
+            .withFunctionId(persistedPO.functionId())
+            .withMetalakeId(incomingVersionPO.metalakeId())
+            .withCatalogId(incomingVersionPO.catalogId())
+            .withSchemaId(incomingVersionPO.schemaId())
+            .withFunctionVersion(persistedPO.functionCurrentVersion())
+            .withFunctionComment(incomingVersionPO.functionComment())
+            .withDefinitions(incomingVersionPO.definitions())
+            .withAuditInfo(incomingVersionPO.auditInfo())
+            .withDeletedAt(incomingVersionPO.deletedAt())
+            .build();
+    return FunctionPO.builder()
+        .withFunctionId(persistedPO.functionId())
+        .withFunctionName(incomingPO.functionName())
+        .withMetalakeId(incomingPO.metalakeId())
+        .withCatalogId(incomingPO.catalogId())
+        .withSchemaId(incomingPO.schemaId())
+        .withFunctionType(incomingPO.functionType())
+        .withDeterministic(incomingPO.deterministic())
+        .withFunctionLatestVersion(persistedPO.functionLatestVersion())
+        .withFunctionCurrentVersion(persistedPO.functionCurrentVersion())
+        .withAuditInfo(incomingPO.auditInfo())
+        .withDeletedAt(incomingPO.deletedAt())
+        .withFunctionVersionPO(persistedVersionPO)
+        .build();
+  }
+
+  private void deleteFunctionDependents(Long functionId) {
+    SessionUtils.doWithoutCommit(
+        FunctionVersionMetaMapper.class,
+        mapper -> mapper.softDeleteFunctionVersionsByFunctionId(functionId));
+    SessionUtils.doWithoutCommit(
+        OwnerMetaMapper.class,
+        mapper ->
+            mapper.softDeleteOwnerRelByMetadataObjectIdAndType(
+                functionId, MetadataObject.Type.FUNCTION.name()));
+    SessionUtils.doWithoutCommit(
+        SecurableObjectMapper.class,
+        mapper ->
+            mapper.softDeleteObjectRelsByMetadataObject(
+                functionId, MetadataObject.Type.FUNCTION.name()));
+    SessionUtils.doWithoutCommit(
+        TagMetadataObjectRelMapper.class,
+        mapper ->
+            mapper.softDeleteTagMetadataObjectRelsByMetadataObject(
+                functionId, MetadataObject.Type.FUNCTION.name()));
+  }
+
+  private RuntimeException functionWriteFailure(
+      NameIdentifier identifier, FunctionPO observedFunctionPO) {
+    return OccWriteSupport.writeFailure(
+        identifier,
+        Entity.EntityType.FUNCTION,
+        () ->
+            SessionUtils.getWithoutCommit(
+                FunctionMetaMapper.class,
+                mapper -> mapper.selectFunctionMetaByIdForUpdate(observedFunctionPO.functionId())),
+        null,
+        current ->
+            Objects.equals(current.functionName(), observedFunctionPO.functionName())
+                && Objects.equals(current.schemaId(), observedFunctionPO.schemaId())
+                && Objects.equals(current.catalogId(), observedFunctionPO.catalogId())
+                && Objects.equals(current.metalakeId(), observedFunctionPO.metalakeId()));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
@@ -27,7 +27,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -44,6 +44,7 @@ import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewVersionInfoMapper;
 import org.apache.gravitino.storage.relational.po.ViewPO;
+import org.apache.gravitino.storage.relational.po.ViewVersionInfoPO;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -104,6 +105,7 @@ public class ViewMetaService {
     ViewPO.ViewPOBuilder builder = ViewPO.builder();
     try {
       ViewPO po = initializeViewPO(viewEntity, builder);
+      AtomicReference<ViewPO> persistedPO = new AtomicReference<>(po);
 
       SessionUtils.doMultipleWithCommit(
           // Hold the parent schema row until this transaction ends, so the view cannot be
@@ -117,13 +119,28 @@ public class ViewMetaService {
                       po.getMetalakeId()),
           () ->
               SessionUtils.doWithoutCommit(
-                  ViewMetaMapper.class, mapper -> ops.insertPO(mapper, po, overwrite)),
+                  ViewMetaMapper.class,
+                  mapper -> {
+                    ops.insertPO(mapper, po, overwrite);
+                    if (overwrite) {
+                      ViewPO storedPO =
+                          mapper.selectViewMetaBySchemaIdAndName(
+                              po.getSchemaId(), po.getViewName());
+                      Preconditions.checkState(
+                          storedPO != null,
+                          "The overwritten view %s in schema %s does not exist",
+                          po.getViewName(),
+                          po.getSchemaId());
+                      persistedPO.set(viewPOWithPersistedIdentityAndVersions(po, storedPO));
+                    }
+                  }),
           () ->
               SessionUtils.doWithoutCommit(
                   ViewVersionInfoMapper.class,
                   mapper -> {
                     if (overwrite) {
-                      mapper.insertViewVersionInfoOnDuplicateKeyUpdate(po.getViewVersionInfoPO());
+                      mapper.insertViewVersionInfoOnDuplicateKeyUpdate(
+                          persistedPO.get().getViewVersionInfoPO());
                     } else {
                       mapper.insertViewVersionInfo(po.getViewVersionInfoPO());
                     }
@@ -149,27 +166,42 @@ public class ViewMetaService {
         newEntity.id(),
         oldViewEntity.id());
 
-    AtomicInteger updateResult = new AtomicInteger(0);
+    boolean isSchemaChanged = !newEntity.namespace().equals(oldViewEntity.namespace());
+    Long newSchemaId =
+        isSchemaChanged
+            ? EntityIdService.getEntityId(
+                NameIdentifier.of(newEntity.namespace().levels()), Entity.EntityType.SCHEMA)
+            : oldViewPO.getSchemaId();
+
     try {
-      ViewPO newViewPO = updateViewPO(oldViewPO, newEntity);
+      ViewPO newViewPO = updateViewPO(oldViewPO, newEntity, newSchemaId);
       SessionUtils.doMultipleWithCommit(
+          () -> {
+            if (isSchemaChanged) {
+              SchemaMetaService.getInstance()
+                  .lockSchemaForEntityWrite(
+                      newEntity.nameIdentifier(),
+                      newSchemaId,
+                      oldViewPO.getCatalogId(),
+                      oldViewPO.getMetalakeId());
+            }
+          },
+          () -> {
+            // current_version is the sole OCC token. The root CAS is the transaction's decision
+            // point and must run before the unguarded version-row insert below.
+            int updated =
+                SessionUtils.getWithoutCommit(
+                    ViewMetaMapper.class, mapper -> ops.updatePO(mapper, newViewPO, oldViewPO));
+            if (updated == 0) {
+              throw viewWriteFailure(ident, oldViewPO);
+            }
+          },
           () ->
               SessionUtils.doWithoutCommit(
                   ViewVersionInfoMapper.class,
-                  mapper -> mapper.insertViewVersionInfo(newViewPO.getViewVersionInfoPO())),
-          () -> {
-            updateResult.set(
-                SessionUtils.getWithoutCommit(
-                    ViewMetaMapper.class, mapper -> ops.updatePO(mapper, newViewPO, oldViewPO)));
-            if (updateResult.get() == 0) {
-              throw new RuntimeException("Failed to update the entity: " + ident);
-            }
-          });
+                  mapper -> mapper.insertViewVersionInfo(newViewPO.getViewVersionInfoPO())));
       return newEntity;
     } catch (RuntimeException re) {
-      if (updateResult.get() == 0) {
-        throw new IOException("Failed to update the entity: " + ident);
-      }
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.VIEW, newEntity.nameIdentifier().toString());
       throw re;
@@ -181,7 +213,30 @@ public class ViewMetaService {
       baseMetricName = "deleteViewByIdentifier")
   public boolean deleteView(NameIdentifier ident) {
     ViewPO viewPO = getViewPOByIdentifier(ident);
-    return deleteView(viewPO.getViewId());
+
+    deleteViewWithVersion(ident, viewPO);
+    return true;
+  }
+
+  /**
+   * Deletes the observed view and its dependent rows in one transaction.
+   *
+   * <p>Package-private access lets concurrency tests submit a deliberately stale snapshot while
+   * exercising the same root-first ordering as the public delete path.
+   */
+  void deleteViewWithVersion(NameIdentifier identifier, ViewPO observedViewPO) {
+    SessionUtils.doMultipleWithCommit(
+        // Check the root version before touching relationships. A stale drop stops here.
+        () ->
+            OccWriteSupport.deleteWithVersion(
+                () ->
+                    SessionUtils.getWithoutCommit(
+                        ViewMetaMapper.class,
+                        mapper ->
+                            mapper.softDeleteViewMetasByViewId(
+                                observedViewPO.getViewId(), observedViewPO.getCurrentVersion())),
+                () -> viewWriteFailure(identifier, observedViewPO)),
+        () -> deleteViewDependents(observedViewPO.getViewId()));
   }
 
   @Monitored(
@@ -205,51 +260,19 @@ public class ViewMetaService {
     return ops;
   }
 
-  private boolean deleteView(Long viewId) {
-    AtomicInteger deleteResult = new AtomicInteger(0);
-    SessionUtils.doMultipleWithCommit(
-        () ->
-            deleteResult.set(
-                SessionUtils.getWithoutCommit(
-                    ViewMetaMapper.class, mapper -> mapper.softDeleteViewMetasByViewId(viewId))),
-        () -> {
-          if (deleteResult.get() > 0) {
-            SessionUtils.doWithoutCommit(
-                ViewVersionInfoMapper.class,
-                mapper -> mapper.softDeleteViewVersionsByViewId(viewId));
-            SessionUtils.doWithoutCommit(
-                OwnerMetaMapper.class,
-                mapper ->
-                    mapper.softDeleteOwnerRelByMetadataObjectIdAndType(
-                        viewId, MetadataObject.Type.VIEW.name()));
-            SessionUtils.doWithoutCommit(
-                SecurableObjectMapper.class,
-                mapper ->
-                    mapper.softDeleteObjectRelsByMetadataObject(
-                        viewId, MetadataObject.Type.VIEW.name()));
-            SessionUtils.doWithoutCommit(
-                TagMetadataObjectRelMapper.class,
-                mapper ->
-                    mapper.softDeleteTagMetadataObjectRelsByMetadataObject(
-                        viewId, MetadataObject.Type.VIEW.name()));
-          }
-        });
-    return deleteResult.get() > 0;
-  }
-
-  private ViewPO updateViewPO(ViewPO oldViewPO, ViewEntity newEntity) {
+  private ViewPO updateViewPO(ViewPO oldViewPO, ViewEntity newEntity, Long newSchemaId) {
     Long newVersion = oldViewPO.getLastVersion() + 1;
     ViewPO.ViewPOBuilder builder =
         ViewPO.builder()
             .withMetalakeId(oldViewPO.getMetalakeId())
             .withCatalogId(oldViewPO.getCatalogId())
-            .withSchemaId(oldViewPO.getSchemaId())
+            .withSchemaId(newSchemaId)
             .withCurrentVersion(newVersion)
             .withLastVersion(newVersion);
     return buildViewPO(newEntity, builder, newVersion.intValue());
   }
 
-  private ViewPO getViewPOByIdentifier(NameIdentifier identifier) {
+  ViewPO getViewPOByIdentifier(NameIdentifier identifier) {
     NameIdentifierUtil.checkView(identifier);
     ViewPO viewPO =
         SessionUtils.getWithoutCommit(
@@ -269,5 +292,72 @@ public class ViewMetaService {
     return SessionUtils.getWithoutCommit(
         ViewMetaMapper.class,
         mapper -> POStorageReadRouting.listPOs(mapper, namespace, ops, Entity.EntityType.VIEW));
+  }
+
+  private ViewPO viewPOWithPersistedIdentityAndVersions(ViewPO incomingPO, ViewPO persistedPO) {
+    ViewVersionInfoPO incomingVersionPO = incomingPO.getViewVersionInfoPO();
+    ViewVersionInfoPO persistedVersionPO =
+        ViewVersionInfoPO.builder()
+            .withMetalakeId(incomingVersionPO.metalakeId())
+            .withCatalogId(incomingVersionPO.catalogId())
+            .withSchemaId(incomingVersionPO.schemaId())
+            .withViewId(persistedPO.getViewId())
+            .withVersion(persistedPO.getCurrentVersion().intValue())
+            .withViewComment(incomingVersionPO.viewComment())
+            .withColumns(incomingVersionPO.columns())
+            .withProperties(incomingVersionPO.properties())
+            .withDefaultCatalog(incomingVersionPO.defaultCatalog())
+            .withDefaultSchema(incomingVersionPO.defaultSchema())
+            .withRepresentations(incomingVersionPO.representations())
+            .withAuditInfo(incomingVersionPO.auditInfo())
+            .withDeletedAt(incomingVersionPO.deletedAt())
+            .build();
+    return ViewPO.builder()
+        .withViewId(persistedPO.getViewId())
+        .withViewName(incomingPO.getViewName())
+        .withMetalakeId(incomingPO.getMetalakeId())
+        .withCatalogId(incomingPO.getCatalogId())
+        .withSchemaId(incomingPO.getSchemaId())
+        .withAuditInfo(incomingPO.getAuditInfo())
+        .withCurrentVersion(persistedPO.getCurrentVersion())
+        .withLastVersion(persistedPO.getLastVersion())
+        .withDeletedAt(incomingPO.getDeletedAt())
+        .withViewVersionInfoPO(persistedVersionPO)
+        .build();
+  }
+
+  private void deleteViewDependents(Long viewId) {
+    SessionUtils.doWithoutCommit(
+        ViewVersionInfoMapper.class, mapper -> mapper.softDeleteViewVersionsByViewId(viewId));
+    SessionUtils.doWithoutCommit(
+        OwnerMetaMapper.class,
+        mapper ->
+            mapper.softDeleteOwnerRelByMetadataObjectIdAndType(
+                viewId, MetadataObject.Type.VIEW.name()));
+    SessionUtils.doWithoutCommit(
+        SecurableObjectMapper.class,
+        mapper ->
+            mapper.softDeleteObjectRelsByMetadataObject(viewId, MetadataObject.Type.VIEW.name()));
+    SessionUtils.doWithoutCommit(
+        TagMetadataObjectRelMapper.class,
+        mapper ->
+            mapper.softDeleteTagMetadataObjectRelsByMetadataObject(
+                viewId, MetadataObject.Type.VIEW.name()));
+  }
+
+  private RuntimeException viewWriteFailure(NameIdentifier identifier, ViewPO observedViewPO) {
+    return OccWriteSupport.writeFailure(
+        identifier,
+        Entity.EntityType.VIEW,
+        () ->
+            SessionUtils.getWithoutCommit(
+                ViewMetaMapper.class,
+                mapper -> mapper.selectViewMetaByIdForUpdate(observedViewPO.getViewId())),
+        null,
+        current ->
+            Objects.equals(current.getViewName(), observedViewPO.getViewName())
+                && Objects.equals(current.getSchemaId(), observedViewPO.getSchemaId())
+                && Objects.equals(current.getCatalogId(), observedViewPO.getCatalogId())
+                && Objects.equals(current.getMetalakeId(), observedViewPO.getMetalakeId()));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestFunctionMetaBaseSQLProvider.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestFunctionMetaBaseSQLProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestFunctionMetaBaseSQLProvider {
+
+  private static final FunctionMetaBaseSQLProvider PROVIDER = new FunctionMetaBaseSQLProvider();
+
+  @Test
+  void testOverwriteAdvancesStoredVersion() {
+    String sql = PROVIDER.insertFunctionMetaOnDuplicateKeyUpdate(null);
+    String updateClause = sql.substring(sql.indexOf(" ON DUPLICATE KEY UPDATE"));
+
+    Assertions.assertTrue(
+        updateClause.contains("function_latest_version = function_current_version + 1"));
+    Assertions.assertTrue(
+        updateClause.contains("function_current_version = function_current_version + 1"));
+    Assertions.assertFalse(
+        updateClause.contains("function_current_version = #{functionMeta.functionCurrentVersion}"));
+    Assertions.assertFalse(
+        updateClause.contains("function_latest_version = #{functionMeta.functionLatestVersion}"));
+  }
+
+  @Test
+  void testUpdateUsesOnlyIdVersionAndActiveStateForCas() {
+    String sql = PROVIDER.updateFunctionMeta(null, null);
+    String whereClause = sql.substring(sql.indexOf(" WHERE"));
+
+    Assertions.assertEquals(
+        " WHERE function_id = #{oldFunctionMeta.functionId}"
+            + " AND function_current_version = #{oldFunctionMeta.functionCurrentVersion}"
+            + " AND deleted_at = 0",
+        whereClause);
+  }
+
+  @Test
+  void testDirectDeleteUsesVersionCas() {
+    String sql = PROVIDER.softDeleteFunctionMetaByFunctionId(null, null);
+
+    Assertions.assertTrue(sql.contains("AND function_current_version = #{currentVersion}"));
+    Assertions.assertTrue(sql.endsWith("AND deleted_at = 0"));
+  }
+
+  @Test
+  void testConflictReadLocksActiveRow() {
+    String sql = PROVIDER.selectFunctionMetaByIdForUpdate(null);
+
+    Assertions.assertTrue(sql.contains("function_name as functionName"));
+    Assertions.assertTrue(sql.contains("function_current_version as functionCurrentVersion"));
+    Assertions.assertTrue(sql.contains("WHERE function_id = #{functionId} AND deleted_at = 0"));
+    Assertions.assertTrue(sql.endsWith("FOR UPDATE"));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestViewMetaBaseSQLProvider.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestViewMetaBaseSQLProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestViewMetaBaseSQLProvider {
+
+  private static final ViewMetaBaseSQLProvider PROVIDER = new ViewMetaBaseSQLProvider();
+
+  @Test
+  void testOverwriteAdvancesStoredVersion() {
+    String sql = PROVIDER.insertViewMetaOnDuplicateKeyUpdate(null);
+    String updateClause = sql.substring(sql.indexOf(" ON DUPLICATE KEY UPDATE"));
+
+    Assertions.assertTrue(updateClause.contains("last_version = current_version + 1"));
+    Assertions.assertTrue(updateClause.contains("current_version = current_version + 1"));
+    Assertions.assertFalse(updateClause.contains("current_version = #{viewMeta.currentVersion}"));
+    Assertions.assertFalse(updateClause.contains("last_version = #{viewMeta.lastVersion}"));
+  }
+
+  @Test
+  void testUpdateUsesVersionCas() {
+    String sql = PROVIDER.updateViewMeta(null, null);
+    String whereClause = sql.substring(sql.indexOf(" WHERE"));
+
+    Assertions.assertEquals(
+        " WHERE view_id = #{oldViewMeta.viewId} "
+            + " AND current_version = #{oldViewMeta.currentVersion} "
+            + " AND deleted_at = 0",
+        whereClause);
+  }
+
+  @Test
+  void testDirectDeleteUsesVersionCas() {
+    String sql = PROVIDER.softDeleteViewMetasByViewId(null, null);
+
+    Assertions.assertTrue(sql.contains("AND current_version = #{currentVersion}"));
+    Assertions.assertTrue(sql.endsWith("AND deleted_at = 0"));
+  }
+
+  @Test
+  void testConflictReadLocksActiveRow() {
+    String sql = PROVIDER.selectViewMetaByIdForUpdate(null);
+
+    Assertions.assertTrue(sql.contains("view_name as viewName"));
+    Assertions.assertTrue(sql.contains("current_version as currentVersion"));
+    Assertions.assertTrue(sql.contains("WHERE view_id = #{viewId} AND deleted_at = 0"));
+    Assertions.assertTrue(sql.endsWith("FOR UPDATE"));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TestFunctionMetaPostgreSQLProvider.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TestFunctionMetaPostgreSQLProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestFunctionMetaPostgreSQLProvider {
+
+  @Test
+  void testOverwriteAdvancesStoredVersion() {
+    String sql = new FunctionMetaPostgreSQLProvider().insertFunctionMetaOnDuplicateKeyUpdate(null);
+    String conflictClause = sql.substring(sql.indexOf(" ON CONFLICT"));
+
+    Assertions.assertTrue(
+        conflictClause.contains(
+            "function_current_version = "
+                + FunctionMetaMapper.TABLE_NAME
+                + ".function_current_version + 1"));
+    Assertions.assertTrue(
+        conflictClause.contains(
+            "function_latest_version = "
+                + FunctionMetaMapper.TABLE_NAME
+                + ".function_current_version + 1"));
+    Assertions.assertFalse(conflictClause.matches(".*[^.\\w]function_current_version\\s*\\+.*"));
+  }
+
+  @Test
+  void testDirectDeleteUsesVersionCas() {
+    String sql =
+        new FunctionMetaPostgreSQLProvider().softDeleteFunctionMetaByFunctionId(null, null);
+
+    Assertions.assertTrue(sql.contains("AND function_current_version = #{currentVersion}"));
+    Assertions.assertTrue(sql.endsWith("AND deleted_at = 0"));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TestViewMetaPostgreSQLProvider.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TestViewMetaPostgreSQLProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestViewMetaPostgreSQLProvider {
+
+  @Test
+  void testOverwriteAdvancesStoredVersion() {
+    String sql = new ViewMetaPostgreSQLProvider().insertViewMetaOnDuplicateKeyUpdate(null);
+    String conflictClause = sql.substring(sql.indexOf(" ON CONFLICT"));
+
+    Assertions.assertTrue(
+        conflictClause.contains(
+            "current_version = " + ViewMetaMapper.TABLE_NAME + ".current_version + 1"));
+    Assertions.assertTrue(
+        conflictClause.contains(
+            "last_version = " + ViewMetaMapper.TABLE_NAME + ".current_version + 1"));
+    Assertions.assertFalse(conflictClause.matches(".*[^.\\w]current_version\\s*\\+.*"));
+  }
+
+  @Test
+  void testDirectDeleteUsesVersionCas() {
+    String sql = new ViewMetaPostgreSQLProvider().softDeleteViewMetasByViewId(null, null);
+
+    Assertions.assertTrue(sql.contains("AND current_version = #{currentVersion}"));
+    Assertions.assertTrue(sql.endsWith("AND deleted_at = 0"));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
@@ -52,10 +52,14 @@ import org.apache.gravitino.meta.TagEntity;
 import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
+import org.apache.gravitino.storage.relational.po.FunctionPO;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 
@@ -276,7 +280,7 @@ public class TestFunctionMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
-  public void testUpdateFunctionRollsBackNewVersionAfterConcurrentDelete() throws IOException {
+  public void testUpdateFunctionReportsNoSuchAfterConcurrentDelete() throws IOException {
     String functionName = GravitinoITUtils.genRandomName("test_function");
     Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
     FunctionEntity function =
@@ -289,7 +293,7 @@ public class TestFunctionMetaService extends TestJDBCBackend {
     FunctionEntity updatedFunction = copyFunctionWithComment(function, "updated comment");
 
     assertThrows(
-        OptimisticLockException.class,
+        NoSuchEntityException.class,
         () ->
             FunctionMetaService.getInstance()
                 .updateFunction(
@@ -306,6 +310,236 @@ public class TestFunctionMetaService extends TestJDBCBackend {
     assertEquals(1, versions.size());
     assertVersionSoftDeleted(versions, 1);
     assertFalse(versions.containsKey(2));
+  }
+
+  @TestTemplate
+  public void testAlterReportsOptimisticLockConflictAndKeepsWinnerVersion() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("function_alter_conflict");
+    Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    assertThrows(
+        OptimisticLockException.class,
+        () ->
+            FunctionMetaService.getInstance()
+                .updateFunction(
+                    function.nameIdentifier(),
+                    entity -> {
+                      try {
+                        FunctionMetaService.getInstance()
+                            .updateFunction(
+                                function.nameIdentifier(),
+                                competing ->
+                                    copyFunctionWithComment(
+                                        (FunctionEntity) competing, "competing update"));
+                      } catch (IOException e) {
+                        throw new RuntimeException(e);
+                      }
+                      return copyFunctionWithComment((FunctionEntity) entity, "requested update");
+                    }));
+
+    FunctionEntity current =
+        FunctionMetaService.getInstance().getFunctionByIdentifier(function.nameIdentifier());
+    assertEquals("competing update", current.comment());
+    Map<Integer, Long> versions = listFunctionVersions(function.id());
+    assertEquals(2, versions.size());
+    assertTrue(versions.containsKey(2));
+  }
+
+  @TestTemplate
+  public void testAlterRollsBackRootCasWhenVersionInsertFails() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("function_version_insert_failure");
+    Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(function, false);
+    FunctionPO originalPO =
+        FunctionMetaService.getInstance().getFunctionPOByIdentifier(function.nameIdentifier());
+    FunctionEntity conflictingVersion = copyFunctionWithComment(function, "conflicting version");
+    FunctionPO conflictingPO =
+        FunctionPO.buildFunctionPO(
+            conflictingVersion,
+            FunctionPO.builder()
+                .withMetalakeId(originalPO.metalakeId())
+                .withCatalogId(originalPO.catalogId())
+                .withSchemaId(originalPO.schemaId())
+                .withFunctionLatestVersion(2)
+                .withFunctionCurrentVersion(2),
+            2);
+    SessionUtils.doWithCommit(
+        FunctionVersionMetaMapper.class,
+        mapper -> mapper.insertFunctionVersionMeta(conflictingPO.functionVersionPO()));
+
+    assertThrows(
+        EntityAlreadyExistsException.class,
+        () ->
+            FunctionMetaService.getInstance()
+                .updateFunction(
+                    function.nameIdentifier(),
+                    entity -> copyFunctionWithComment((FunctionEntity) entity, "must roll back")));
+
+    FunctionPO currentPO =
+        FunctionMetaService.getInstance().getFunctionPOByIdentifier(function.nameIdentifier());
+    assertEquals(1, currentPO.functionCurrentVersion());
+    assertEquals(1, currentPO.functionLatestVersion());
+    assertEquals(
+        function.comment(),
+        FunctionMetaService.getInstance()
+            .getFunctionByIdentifier(function.nameIdentifier())
+            .comment());
+  }
+
+  @TestTemplate
+  public void testAlterReportsNoSuchWhenRenamedConcurrently() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("function_alter_renamed");
+    Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(function, false);
+    NameIdentifier renamedIdentifier = NameIdentifier.of(namespace, functionName + "_winner");
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            FunctionMetaService.getInstance()
+                .updateFunction(
+                    function.nameIdentifier(),
+                    entity -> {
+                      try {
+                        FunctionMetaService.getInstance()
+                            .updateFunction(
+                                function.nameIdentifier(),
+                                competing ->
+                                    copyFunction(
+                                        (FunctionEntity) competing,
+                                        renamedIdentifier.name(),
+                                        namespace,
+                                        "renamed winner"));
+                      } catch (IOException e) {
+                        throw new RuntimeException(e);
+                      }
+                      return copyFunctionWithComment((FunctionEntity) entity, "stale update");
+                    }));
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> FunctionMetaService.getInstance().getFunctionByIdentifier(function.nameIdentifier()));
+    assertEquals(
+        "renamed winner",
+        FunctionMetaService.getInstance().getFunctionByIdentifier(renamedIdentifier).comment());
+  }
+
+  @TestTemplate
+  public void testAlterReportsNoSuchWhenMovedConcurrently() throws IOException {
+    String targetSchemaName = GravitinoITUtils.genRandomName("function_target_schema");
+    createAndInsertSchema(metalakeName, catalogName, targetSchemaName);
+    String functionName = GravitinoITUtils.genRandomName("function_alter_moved");
+    Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    Namespace movedNamespace =
+        NamespaceUtil.ofFunction(metalakeName, catalogName, targetSchemaName);
+    FunctionEntity function =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(function, false);
+    NameIdentifier movedIdentifier = NameIdentifier.of(movedNamespace, functionName);
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            FunctionMetaService.getInstance()
+                .updateFunction(
+                    function.nameIdentifier(),
+                    entity -> {
+                      try {
+                        FunctionMetaService.getInstance()
+                            .updateFunction(
+                                function.nameIdentifier(),
+                                competing ->
+                                    copyFunction(
+                                        (FunctionEntity) competing,
+                                        functionName,
+                                        movedNamespace,
+                                        "moved winner"));
+                      } catch (IOException e) {
+                        throw new RuntimeException(e);
+                      }
+                      return copyFunctionWithComment((FunctionEntity) entity, "stale update");
+                    }));
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> FunctionMetaService.getInstance().getFunctionByIdentifier(function.nameIdentifier()));
+    assertEquals(
+        "moved winner",
+        FunctionMetaService.getInstance().getFunctionByIdentifier(movedIdentifier).comment());
+  }
+
+  @TestTemplate
+  public void testDeleteRejectsStaleVersion() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("function_stale_delete");
+    Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(function, false);
+    TagEntity tag =
+        TagEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("function_occ_tag")
+            .withNamespace(NamespaceUtil.ofTag(metalakeName))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+    TagMetaService.getInstance().insertTag(tag, false);
+    TagMetaService.getInstance()
+        .associateTagsWithMetadataObject(
+            function.nameIdentifier(),
+            function.type(),
+            new NameIdentifier[] {tag.nameIdentifier()},
+            new NameIdentifier[0]);
+    FunctionPO stalePO =
+        FunctionMetaService.getInstance().getFunctionPOByIdentifier(function.nameIdentifier());
+
+    FunctionMetaService.getInstance()
+        .updateFunction(
+            function.nameIdentifier(),
+            entity -> copyFunctionWithComment((FunctionEntity) entity, "winning update"));
+
+    assertThrows(
+        OptimisticLockException.class,
+        () ->
+            FunctionMetaService.getInstance()
+                .deleteFunctionWithVersion(function.nameIdentifier(), stalePO));
+    assertEquals(
+        "winning update",
+        FunctionMetaService.getInstance()
+            .getFunctionByIdentifier(function.nameIdentifier())
+            .comment());
+    assertEquals(1, countActiveTagRelForMetadataObject(function.id(), "FUNCTION"));
+  }
+
+  @TestTemplate
+  public void testDeleteReportsNoSuchWhenDeletedConcurrently() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("function_delete_deleted");
+    Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(function, false);
+    FunctionPO stalePO =
+        FunctionMetaService.getInstance().getFunctionPOByIdentifier(function.nameIdentifier());
+
+    FunctionMetaService.getInstance().deleteFunction(function.nameIdentifier());
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            FunctionMetaService.getInstance()
+                .deleteFunctionWithVersion(function.nameIdentifier(), stalePO));
   }
 
   @TestTemplate
@@ -612,6 +846,43 @@ public class TestFunctionMetaService extends TestJDBCBackend {
         FunctionMetaService.getInstance().getFunctionByIdentifier(functionIdent);
     assertEquals("overwritten comment", loadedFunction.comment());
     assertTrue(loadedFunction.deterministic());
+    FunctionPO overwrittenPO =
+        FunctionMetaService.getInstance().getFunctionPOByIdentifier(functionIdent);
+    assertEquals(2, overwrittenPO.functionCurrentVersion());
+    assertEquals(2, overwrittenPO.functionLatestVersion());
+    assertEquals(2, listFunctionVersions(function.id()).size());
+  }
+
+  @TestTemplate
+  public void testNaturalKeyOverwriteUsesPersistedFunctionId() throws IOException {
+    // PostgreSQL's upsert targets function_id and rejects a different ID on the natural key before
+    // readback. This regression covers MySQL/H2 ON DUPLICATE KEY, which can choose either key.
+    Assumptions.assumeFalse("postgresql".equalsIgnoreCase(backendType));
+    String functionName = GravitinoITUtils.genRandomName("function_natural_key_overwrite");
+    Namespace namespace = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity original =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(original, false);
+    FunctionEntity replacement =
+        copyFunction(
+            createFunctionEntity(
+                RandomIdGenerator.INSTANCE.nextId(), namespace, functionName, AUDIT_INFO),
+            functionName,
+            namespace,
+            "replacement");
+
+    FunctionMetaService.getInstance().insertFunction(replacement, true);
+
+    FunctionEntity stored =
+        FunctionMetaService.getInstance().getFunctionByIdentifier(original.nameIdentifier());
+    FunctionPO storedPO =
+        FunctionMetaService.getInstance().getFunctionPOByIdentifier(original.nameIdentifier());
+    assertEquals(original.id(), stored.id());
+    assertEquals("replacement", stored.comment());
+    assertEquals(2, storedPO.functionCurrentVersion());
+    assertEquals(2, listFunctionVersions(original.id()).size());
+    assertTrue(listFunctionVersions(replacement.id()).isEmpty());
   }
 
   private int countActiveOwnerRelForMetadataObject(
@@ -698,10 +969,15 @@ public class TestFunctionMetaService extends TestJDBCBackend {
   }
 
   private FunctionEntity copyFunctionWithComment(FunctionEntity function, String comment) {
+    return copyFunction(function, function.name(), function.namespace(), comment);
+  }
+
+  private FunctionEntity copyFunction(
+      FunctionEntity function, String name, Namespace namespace, String comment) {
     return FunctionEntity.builder()
         .withId(function.id())
-        .withName(function.name())
-        .withNamespace(function.namespace())
+        .withName(name)
+        .withNamespace(namespace)
         .withComment(comment)
         .withFunctionType(function.functionType())
         .withDeterministic(function.deterministic())

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestViewMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestViewMetaService.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.OptimisticLockException;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TagEntity;
@@ -47,10 +48,14 @@ import org.apache.gravitino.rel.SQLRepresentation;
 import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.storage.relational.mapper.ViewVersionInfoMapper;
+import org.apache.gravitino.storage.relational.po.ViewPO;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 
@@ -162,7 +167,7 @@ public class TestViewMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
-  public void testUpdateViewRollbackWhenMetaUpdateAffectsZeroRows() throws IOException {
+  public void testUpdateViewReportsNoSuchAfterConcurrentDelete() throws IOException {
     String viewName = GravitinoITUtils.genRandomName("test_view");
     Namespace ns = NamespaceUtil.ofView(metalakeName, catalogName, schemaName);
     ViewEntity view =
@@ -185,7 +190,7 @@ public class TestViewMetaService extends TestJDBCBackend {
             .build();
 
     assertThrows(
-        IOException.class,
+        NoSuchEntityException.class,
         () ->
             ViewMetaService.getInstance()
                 .updateView(
@@ -199,6 +204,208 @@ public class TestViewMetaService extends TestJDBCBackend {
     assertEquals(1, versions.size());
     assertTrue(versions.containsKey(1));
     assertTrue(versions.get(1) > 0L);
+  }
+
+  @TestTemplate
+  public void testAlterReportsOptimisticLockConflictAndKeepsWinnerVersion() throws IOException {
+    String viewName = GravitinoITUtils.genRandomName("view_alter_conflict");
+    Namespace namespace = NamespaceUtil.ofView(metalakeName, catalogName, schemaName);
+    ViewEntity view =
+        createViewEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, viewName, AUDIT_INFO);
+    ViewMetaService.getInstance().insertView(view, false);
+
+    assertThrows(
+        OptimisticLockException.class,
+        () ->
+            ViewMetaService.getInstance()
+                .updateView(
+                    view.nameIdentifier(),
+                    entity -> {
+                      try {
+                        ViewMetaService.getInstance()
+                            .updateView(
+                                view.nameIdentifier(),
+                                competing ->
+                                    copyViewWithComment(
+                                        (ViewEntity) competing, "competing update"));
+                      } catch (IOException e) {
+                        throw new RuntimeException(e);
+                      }
+                      return copyViewWithComment((ViewEntity) entity, "requested update");
+                    }));
+
+    ViewEntity current = ViewMetaService.getInstance().getViewByIdentifier(view.nameIdentifier());
+    assertEquals("competing update", current.comment());
+    Map<Integer, Long> versions = listViewVersions(view.id());
+    assertEquals(2, versions.size());
+    assertTrue(versions.containsKey(2));
+  }
+
+  @TestTemplate
+  public void testAlterRollsBackRootCasWhenVersionInsertFails() throws IOException {
+    String viewName = GravitinoITUtils.genRandomName("view_version_insert_failure");
+    Namespace namespace = NamespaceUtil.ofView(metalakeName, catalogName, schemaName);
+    ViewEntity view =
+        createViewEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, viewName, AUDIT_INFO);
+    ViewMetaService.getInstance().insertView(view, false);
+    ViewEntity conflictingVersion = copyViewWithComment(view, "conflicting version");
+    ViewPO conflictingPO =
+        ViewPO.buildViewPO(
+            conflictingVersion, ViewPO.builder().withCurrentVersion(2L).withLastVersion(2L), 2);
+    SessionUtils.doWithCommit(
+        ViewVersionInfoMapper.class,
+        mapper -> mapper.insertViewVersionInfo(conflictingPO.getViewVersionInfoPO()));
+
+    assertThrows(
+        EntityAlreadyExistsException.class,
+        () ->
+            ViewMetaService.getInstance()
+                .updateView(
+                    view.nameIdentifier(),
+                    entity -> copyViewWithComment((ViewEntity) entity, "must roll back")));
+
+    ViewPO currentPO = ViewMetaService.getInstance().getViewPOByIdentifier(view.nameIdentifier());
+    assertEquals(1L, currentPO.getCurrentVersion());
+    assertEquals(1L, currentPO.getLastVersion());
+    assertEquals(
+        view.comment(),
+        ViewMetaService.getInstance().getViewByIdentifier(view.nameIdentifier()).comment());
+  }
+
+  @TestTemplate
+  public void testAlterReportsNoSuchWhenRenamedConcurrently() throws IOException {
+    String viewName = GravitinoITUtils.genRandomName("view_alter_renamed");
+    Namespace namespace = NamespaceUtil.ofView(metalakeName, catalogName, schemaName);
+    ViewEntity view =
+        createViewEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, viewName, AUDIT_INFO);
+    ViewMetaService.getInstance().insertView(view, false);
+    NameIdentifier renamedIdentifier = NameIdentifier.of(namespace, viewName + "_winner");
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            ViewMetaService.getInstance()
+                .updateView(
+                    view.nameIdentifier(),
+                    entity -> {
+                      try {
+                        ViewMetaService.getInstance()
+                            .updateView(
+                                view.nameIdentifier(),
+                                competing ->
+                                    copyView(
+                                        (ViewEntity) competing,
+                                        renamedIdentifier.name(),
+                                        namespace,
+                                        "renamed winner"));
+                      } catch (IOException e) {
+                        throw new RuntimeException(e);
+                      }
+                      return copyViewWithComment((ViewEntity) entity, "stale update");
+                    }));
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> ViewMetaService.getInstance().getViewByIdentifier(view.nameIdentifier()));
+    assertEquals(
+        "renamed winner",
+        ViewMetaService.getInstance().getViewByIdentifier(renamedIdentifier).comment());
+  }
+
+  @TestTemplate
+  public void testAlterReportsNoSuchWhenMovedConcurrently() throws IOException {
+    String targetSchemaName = GravitinoITUtils.genRandomName("view_target_schema");
+    createAndInsertSchema(metalakeName, catalogName, targetSchemaName);
+    String viewName = GravitinoITUtils.genRandomName("view_alter_moved");
+    Namespace namespace = NamespaceUtil.ofView(metalakeName, catalogName, schemaName);
+    Namespace movedNamespace = NamespaceUtil.ofView(metalakeName, catalogName, targetSchemaName);
+    ViewEntity view =
+        createViewEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, viewName, AUDIT_INFO);
+    ViewMetaService.getInstance().insertView(view, false);
+    NameIdentifier movedIdentifier = NameIdentifier.of(movedNamespace, viewName);
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            ViewMetaService.getInstance()
+                .updateView(
+                    view.nameIdentifier(),
+                    entity -> {
+                      try {
+                        ViewMetaService.getInstance()
+                            .updateView(
+                                view.nameIdentifier(),
+                                competing ->
+                                    copyView(
+                                        (ViewEntity) competing,
+                                        viewName,
+                                        movedNamespace,
+                                        "moved winner"));
+                      } catch (IOException e) {
+                        throw new RuntimeException(e);
+                      }
+                      return copyViewWithComment((ViewEntity) entity, "stale update");
+                    }));
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> ViewMetaService.getInstance().getViewByIdentifier(view.nameIdentifier()));
+    assertEquals(
+        "moved winner",
+        ViewMetaService.getInstance().getViewByIdentifier(movedIdentifier).comment());
+  }
+
+  @TestTemplate
+  public void testDeleteRejectsStaleVersion() throws IOException {
+    String viewName = GravitinoITUtils.genRandomName("view_stale_delete");
+    Namespace namespace = NamespaceUtil.ofView(metalakeName, catalogName, schemaName);
+    ViewEntity view =
+        createViewEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, viewName, AUDIT_INFO);
+    ViewMetaService.getInstance().insertView(view, false);
+    TagEntity tag =
+        TagEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("view_occ_tag")
+            .withNamespace(NamespaceUtil.ofTag(metalakeName))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+    TagMetaService.getInstance().insertTag(tag, false);
+    TagMetaService.getInstance()
+        .associateTagsWithMetadataObject(
+            view.nameIdentifier(),
+            view.type(),
+            new NameIdentifier[] {tag.nameIdentifier()},
+            new NameIdentifier[0]);
+    ViewPO stalePO = ViewMetaService.getInstance().getViewPOByIdentifier(view.nameIdentifier());
+
+    ViewMetaService.getInstance()
+        .updateView(
+            view.nameIdentifier(),
+            entity -> copyViewWithComment((ViewEntity) entity, "winning update"));
+
+    assertThrows(
+        OptimisticLockException.class,
+        () -> ViewMetaService.getInstance().deleteViewWithVersion(view.nameIdentifier(), stalePO));
+    assertEquals(
+        "winning update",
+        ViewMetaService.getInstance().getViewByIdentifier(view.nameIdentifier()).comment());
+    assertEquals(1, countActiveTagRelForMetadataObject(view.id(), "VIEW"));
+  }
+
+  @TestTemplate
+  public void testDeleteReportsNoSuchWhenDeletedConcurrently() throws IOException {
+    String viewName = GravitinoITUtils.genRandomName("view_delete_deleted");
+    Namespace namespace = NamespaceUtil.ofView(metalakeName, catalogName, schemaName);
+    ViewEntity view =
+        createViewEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, viewName, AUDIT_INFO);
+    ViewMetaService.getInstance().insertView(view, false);
+    ViewPO stalePO = ViewMetaService.getInstance().getViewPOByIdentifier(view.nameIdentifier());
+
+    ViewMetaService.getInstance().deleteView(view.nameIdentifier());
+
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> ViewMetaService.getInstance().deleteViewWithVersion(view.nameIdentifier(), stalePO));
   }
 
   @TestTemplate
@@ -273,6 +480,40 @@ public class TestViewMetaService extends TestJDBCBackend {
     NameIdentifier viewIdent = NameIdentifier.of(metalakeName, catalogName, schemaName, viewName);
     ViewEntity loaded = ViewMetaService.getInstance().getViewByIdentifier(viewIdent);
     assertEquals("overwritten comment", loaded.comment());
+    ViewPO overwrittenPO = ViewMetaService.getInstance().getViewPOByIdentifier(viewIdent);
+    assertEquals(2L, overwrittenPO.getCurrentVersion());
+    assertEquals(2L, overwrittenPO.getLastVersion());
+    assertEquals(2, listViewVersions(view.id()).size());
+  }
+
+  @TestTemplate
+  public void testNaturalKeyOverwriteUsesPersistedViewId() throws IOException {
+    // PostgreSQL's upsert targets view_id and rejects a different ID on the natural key before
+    // readback. This regression covers MySQL/H2 ON DUPLICATE KEY, which can choose either key.
+    Assumptions.assumeFalse("postgresql".equalsIgnoreCase(backendType));
+    String viewName = GravitinoITUtils.genRandomName("view_natural_key_overwrite");
+    Namespace namespace = NamespaceUtil.ofView(metalakeName, catalogName, schemaName);
+    ViewEntity original =
+        createViewEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, viewName, AUDIT_INFO);
+    ViewMetaService.getInstance().insertView(original, false);
+    ViewEntity replacement =
+        copyView(
+            createViewEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, viewName, AUDIT_INFO),
+            viewName,
+            namespace,
+            "replacement");
+
+    ViewMetaService.getInstance().insertView(replacement, true);
+
+    ViewEntity stored =
+        ViewMetaService.getInstance().getViewByIdentifier(original.nameIdentifier());
+    ViewPO storedPO =
+        ViewMetaService.getInstance().getViewPOByIdentifier(original.nameIdentifier());
+    assertEquals(original.id(), stored.id());
+    assertEquals("replacement", stored.comment());
+    assertEquals(2L, storedPO.getCurrentVersion());
+    assertEquals(2, listViewVersions(original.id()).size());
+    assertTrue(listViewVersions(replacement.id()).isEmpty());
   }
 
   @TestTemplate
@@ -331,6 +572,25 @@ public class TestViewMetaService extends TestJDBCBackend {
         .withDefaultSchema(null)
         .withProperties(ImmutableMap.of("k1", "v1"))
         .withAuditInfo(auditInfo)
+        .build();
+  }
+
+  private ViewEntity copyViewWithComment(ViewEntity view, String comment) {
+    return copyView(view, view.name(), view.namespace(), comment);
+  }
+
+  private ViewEntity copyView(ViewEntity view, String name, Namespace namespace, String comment) {
+    return ViewEntity.builder()
+        .withId(view.id())
+        .withName(name)
+        .withNamespace(namespace)
+        .withComment(comment)
+        .withColumns(view.columns())
+        .withRepresentations(view.representations())
+        .withDefaultCatalog(view.defaultCatalog())
+        .withDefaultSchema(view.defaultSchema())
+        .withProperties(view.properties())
+        .withAuditInfo(view.auditInfo())
         .build();
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add version-CAS updates and deletes for managed functions and views.
- Execute root metadata CAS before writing version and dependent rows.
- Classify stale-version conflicts and identity changes through stable-ID locking reads.
- Preserve monotonic versions during overwrite operations.
- Fence parent schemas during creation and target schemas during moves.
- Add SQL-provider and service coverage for H2, MySQL, and PostgreSQL.

### Why are the changes needed?

Concurrent writers could create competing version rows, stale deletes could remove relationships belonging to newer entities, and overwrite operations could reset OCC versions.

Fix: #12652
Fix: #12653

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. Concurrent function and view writes now report optimistic-lock or not-found errors consistently.

### How was this patch tested?

- Ran FunctionMetaService and ViewMetaService tests against H2, MySQL, and PostgreSQL.
- Ran base and PostgreSQL SQL-provider tests.
- Ran `./gradlew :core:spotlessApply`.
- Ran `./gradlew :core:compileTestJava`.
- Ran `./gradlew :core:javadoc`.