### PR TITLE
[#12730] improvement(docker-image): Update kerberos-hive to 0.1.7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -212,7 +212,7 @@ allprojects {
 
       // Gravitino CI Docker image
       param.environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "apache/gravitino-ci:hive-0.1.20")
-      param.environment("GRAVITINO_CI_KERBEROS_HIVE_DOCKER_IMAGE", "apache/gravitino-ci:kerberos-hive-0.1.6")
+      param.environment("GRAVITINO_CI_KERBEROS_HIVE_DOCKER_IMAGE", "apache/gravitino-ci:kerberos-hive-0.1.7")
       param.environment("GRAVITINO_CI_DORIS_DOCKER_IMAGE", "apache/gravitino-ci:doris-0.1.5")
       param.environment("GRAVITINO_CI_DORIS_FE_IMAGE", System.getenv("GRAVITINO_CI_DORIS_FE_IMAGE") ?: "")
       param.environment("GRAVITINO_CI_DORIS_BE_IMAGE", System.getenv("GRAVITINO_CI_DORIS_BE_IMAGE") ?: "")

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -284,6 +284,10 @@ Use this kind of image to test the catalog of Apache Hive with kerberos enable
 
 Changelog
 
+- apache/gravitino-ci:kerberos-hive-0.1.7
+  - Exclude the installation archives from the final image layers to reduce the image size.
+    For more information, see [PR](https://github.com/apache/gravitino/pull/12731)
+
 - apache/gravitino-ci:kerberos-hive-0.1.6
   - Change username from `datastrato` to `gravitino`.
     For more information, see [PR](https://github.com/apache/gravitino/pull/7040)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the default Kerberos-enabled Hive integration test image from `kerberos-hive-0.1.6` to `kerberos-hive-0.1.7`.

Also add the new image version to the Docker image changelog.

### Why are the changes needed?

#12731 reduced the image size by excluding the installation archives from the final image layers. The corresponding `kerberos-hive-0.1.7` image has now been published, so the project should use the updated image.

Related to #12730.
Follow-up to #12731.

### Does this PR introduce _any_ user-facing change?

No. This only changes the default Docker image used by Kerberos-enabled Hive integration tests.

### How was this patch tested?

- Ran `./gradlew spotlessCheck`.
- Verified that `apache/gravitino-ci:kerberos-hive-0.1.7` is active on Docker Hub for both `linux/amd64` and `linux/arm64`.