### PR TITLE
[#12604] feat(core): Add Semantic Model create and load operations

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   implementation(libs.concurrent.trees)
   implementation(libs.guava)
   implementation(libs.h2db)
+  implementation(libs.jackson.databind)
   implementation(libs.jackson.jaxrs.json.provider) // This is required by lance
   implementation(libs.lance) {
     exclude(group = "com.fasterxml.jackson.core", module = "*") // provided by gravitino

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -902,7 +902,13 @@ public class GravitinoEnv {
     // TODO(#12594): Add Semantic Model ownership and privilege hooks.
     SemanticModelOperationDispatcher semanticModelOperationDispatcher =
         new SemanticModelOperationDispatcher(
-            catalogManager, schemaOperationDispatcher, entityStore, idGenerator, secretManager);
+            catalogManager,
+            schemaOperationDispatcher,
+            internalTableDispatcher,
+            internalViewDispatcher,
+            entityStore,
+            idGenerator,
+            secretManager);
     this.semanticModelDispatcher =
         new SemanticModelNormalizeDispatcher(semanticModelOperationDispatcher, catalogManager);
 

--- a/core/src/main/java/org/apache/gravitino/cache/BaseEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/BaseEntityCache.java
@@ -49,8 +49,8 @@ public abstract class BaseEntityCache implements EntityCache {
    * (an old comment, property, or job status), never a wrong pointer, and each can be invalidated
    * with a single one-to-one key drop. Every other type is read straight from the store.
    * User/group/role embed relation-derived data that a per-node cache cannot invalidate;
-   * model/model version and function carry a load-bearing pointer that would be silently wrong if
-   * served stale.
+   * model/model version, Semantic Model, and function carry load-bearing content that would be
+   * silently wrong if served stale.
    */
   private static final Set<Entity.EntityType> CACHEABLE_TYPES =
       Sets.immutableEnumSet(

--- a/core/src/main/java/org/apache/gravitino/cache/SupportsEntityStoreCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/SupportsEntityStoreCache.java
@@ -70,9 +70,9 @@ public interface SupportsEntityStoreCache {
    *
    * <p>Only self-contained entities are approved. User/group/role are deliberately excluded because
    * they contain relation-derived data whose source can change through another entity. Model/model
-   * version and function are also excluded because they carry load-bearing pointers that must not
-   * be served stale. Other unapproved and newly introduced entity types go straight to the store
-   * until their invalidation behavior has been validated.
+   * version, Semantic Model, and function are also excluded because they carry load-bearing content
+   * that must not be served stale. Other unapproved and newly introduced entity types go straight
+   * to the store until their invalidation behavior has been validated.
    *
    * <p>Implementations must also invoke {@link #invalidateOnKeyChange(Entity)} for every entity,
    * including non-cacheable ones, since a non-cacheable entity may still invalidate a cacheable

--- a/core/src/main/java/org/apache/gravitino/catalog/ManagedSemanticModelOperations.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ManagedSemanticModelOperations.java
@@ -18,58 +18,73 @@
  */
 package org.apache.gravitino.catalog;
 
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.time.Instant;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
 import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.SemanticModelEntity;
 import org.apache.gravitino.semantic.SemanticModel;
 import org.apache.gravitino.semantic.SemanticModelCatalog;
 import org.apache.gravitino.semantic.SemanticModelChange;
 import org.apache.gravitino.semantic.SemanticModelDefinition;
 import org.apache.gravitino.storage.IdGenerator;
+import org.apache.gravitino.utils.PrincipalUtils;
 
-/**
- * Provides storage-level Semantic Model operations backed by Gravitino's {@link EntityStore}.
- *
- * <p>The framework establishes the managed-operation boundary. Semantic Model entity persistence
- * and lifecycle implementations will be added in a follow-up change.
- */
+/** EntityStore-backed operations for Gravitino-managed Semantic Models. */
 public class ManagedSemanticModelOperations implements SemanticModelCatalog {
 
-  @SuppressWarnings("UnusedVariable")
   private final EntityStore store;
-
-  @SuppressWarnings("UnusedVariable")
   private final IdGenerator idGenerator;
+  private final BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator;
 
   /**
    * Creates managed Semantic Model operations.
    *
    * @param store The EntityStore used for persistence.
    * @param idGenerator The stable entity ID generator.
+   * @param writeValidator The complete definition and source validator for write operations.
    */
-  public ManagedSemanticModelOperations(EntityStore store, IdGenerator idGenerator) {
+  public ManagedSemanticModelOperations(
+      EntityStore store,
+      IdGenerator idGenerator,
+      BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator) {
+    Preconditions.checkArgument(store != null, "EntityStore must not be null");
+    Preconditions.checkArgument(idGenerator != null, "IdGenerator must not be null");
+    Preconditions.checkArgument(writeValidator != null, "Write validator must not be null");
     this.store = store;
     this.idGenerator = idGenerator;
+    this.writeValidator = writeValidator;
   }
 
   @Override
   public NameIdentifier[] listSemanticModels(Namespace namespace) throws NoSuchSchemaException {
-    // TODO: Implement when SemanticModelEntity is available.
+    // TODO: Implement in the Semantic Model list/alter/drop capability.
     throw new UnsupportedOperationException(
-        "listSemanticModels: SemanticModelEntity is not yet implemented");
+        "listSemanticModels: list/alter/drop capability is not implemented");
   }
 
   @Override
   public SemanticModel loadSemanticModel(NameIdentifier ident) throws NoSuchSemanticModelException {
-    // TODO: Implement when SemanticModelEntity is available.
-    throw new UnsupportedOperationException(
-        "loadSemanticModel: SemanticModelEntity is not yet implemented");
+    try {
+      return store.get(ident, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class);
+    } catch (NoSuchEntityException e) {
+      throw new NoSuchSemanticModelException(e, "Semantic Model %s does not exist", ident);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load Semantic Model " + ident, e);
+    }
   }
 
   @Override
@@ -80,24 +95,51 @@ public class ManagedSemanticModelOperations implements SemanticModelCatalog {
       Map<String, String> properties)
       throws NoSuchSchemaException, SemanticModelAlreadyExistsException,
           IllegalSemanticModelException {
-    // TODO: Implement when SemanticModelEntity is available.
-    throw new UnsupportedOperationException(
-        "createSemanticModel: SemanticModelEntity is not yet implemented");
+    Preconditions.checkArgument(properties != null, "Properties must not be null");
+
+    writeValidator.accept(ident, definition);
+
+    Instant now = Instant.now();
+    SemanticModelEntity entity =
+        SemanticModelEntity.builder()
+            .withId(idGenerator.nextId())
+            .withName(ident.name())
+            .withNamespace(ident.namespace())
+            .withComment(comment)
+            .withDefinition(definition)
+            .withProperties(properties)
+            .withAuditInfo(
+                AuditInfo.builder()
+                    .withCreator(PrincipalUtils.getCurrentUserName())
+                    .withCreateTime(now)
+                    .build())
+            .build();
+
+    try {
+      store.put(entity, false /* overwrite */);
+      return entity;
+    } catch (NoSuchEntityException e) {
+      throw new NoSuchSchemaException(e, "Schema %s does not exist", ident.namespace());
+    } catch (EntityAlreadyExistsException e) {
+      throw new SemanticModelAlreadyExistsException(e, "Semantic Model %s already exists", ident);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create Semantic Model " + ident, e);
+    }
   }
 
   @Override
   public SemanticModel alterSemanticModel(NameIdentifier ident, SemanticModelChange... changes)
       throws NoSuchSemanticModelException, SemanticModelAlreadyExistsException,
           IllegalSemanticModelException {
-    // TODO: Implement when SemanticModelEntity is available.
+    // TODO: Implement in the Semantic Model list/alter/drop capability.
     throw new UnsupportedOperationException(
-        "alterSemanticModel: SemanticModelEntity is not yet implemented");
+        "alterSemanticModel: list/alter/drop capability is not implemented");
   }
 
   @Override
   public boolean dropSemanticModel(NameIdentifier ident) {
-    // TODO: Implement when SemanticModelEntity is available.
+    // TODO: Implement in the Semantic Model list/alter/drop capability.
     throw new UnsupportedOperationException(
-        "dropSemanticModel: SemanticModelEntity is not yet implemented");
+        "dropSemanticModel: list/alter/drop capability is not implemented");
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/SemanticModelOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SemanticModelOperationDispatcher.java
@@ -48,6 +48,8 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
    *
    * @param catalogManager The catalog manager.
    * @param schemaDispatcher The schema operation dispatcher used for parent validation.
+   * @param tableDispatcher The internal table dispatcher used for source validation.
+   * @param viewDispatcher The internal view dispatcher used for source validation.
    * @param store The EntityStore used for Semantic Model persistence.
    * @param idGenerator The stable entity ID generator.
    * @param secretManager The secret manager required by the operation dispatcher base class.
@@ -55,13 +57,18 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
   public SemanticModelOperationDispatcher(
       CatalogManager catalogManager,
       SchemaDispatcher schemaDispatcher,
+      TableDispatcher tableDispatcher,
+      ViewDispatcher viewDispatcher,
       EntityStore store,
       IdGenerator idGenerator,
       SecretManager secretManager) {
     super(catalogManager, store, idGenerator, secretManager);
     this.catalogManager = catalogManager;
     this.schemaDispatcher = schemaDispatcher;
-    this.managedOperations = new ManagedSemanticModelOperations(store, idGenerator);
+    SemanticModelValidator validator =
+        new SemanticModelValidator(catalogManager, tableDispatcher, viewDispatcher);
+    this.managedOperations =
+        new ManagedSemanticModelOperations(store, idGenerator, validator::validateForWrite);
   }
 
   @Override
@@ -89,7 +96,6 @@ public class SemanticModelOperationDispatcher extends OperationDispatcher
       Map<String, String> properties)
       throws NoSuchSchemaException, SemanticModelAlreadyExistsException,
           IllegalSemanticModelException {
-    Preconditions.checkArgument(definition != null, "Definition must not be null");
     Preconditions.checkArgument(properties != null, "Properties must not be null");
     checkRelationalCatalog(ident.namespace());
     NameIdentifier schemaIdent = schemaIdentifier(ident);

--- a/core/src/main/java/org/apache/gravitino/catalog/SemanticModelValidator.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SemanticModelValidator.java
@@ -1,0 +1,492 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitiveOnName;
+import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.AIContextObject;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+
+/**
+ * Validates Semantic Model writes using Gravitino's Java value model and catalog metadata.
+ *
+ * <p>At implementation time, Apache Ossie commit {@code 88e0011148283302c9a04cd0287e00e0b9d87354},
+ * whose core specification version is {@code 0.2.0.dev0}, did not publish a reusable Java SDK or
+ * general-purpose Java validator artifact. The Java schema validation in that upstream tree was
+ * converter-specific. Gravitino therefore implements the applicable structural and model-local
+ * rules directly in Java. If a future Ossie release publishes a compatible Java SDK or validator,
+ * Gravitino should evaluate replacing this implementation with that upstream library.
+ *
+ * <p>{@code validateDefinition} is deterministic and performs no catalog I/O. {@code
+ * validateSources} resolves Table and logical View metadata and applies catalog capabilities,
+ * including column case sensitivity. {@code validateForWrite} composes both phases for create and
+ * definition-replacement writes. SQL expression semantics, transitive View semantics, and query
+ * engine compatibility are outside this validator's scope.
+ */
+final class SemanticModelValidator {
+
+  private final CatalogManager catalogManager;
+  private final TableDispatcher tableDispatcher;
+  private final ViewDispatcher viewDispatcher;
+
+  SemanticModelValidator(
+      CatalogManager catalogManager,
+      TableDispatcher tableDispatcher,
+      ViewDispatcher viewDispatcher) {
+    Preconditions.checkArgument(catalogManager != null, "Catalog manager must not be null");
+    Preconditions.checkArgument(tableDispatcher != null, "Table dispatcher must not be null");
+    Preconditions.checkArgument(viewDispatcher != null, "View dispatcher must not be null");
+    this.catalogManager = catalogManager;
+    this.tableDispatcher = tableDispatcher;
+    this.viewDispatcher = viewDispatcher;
+  }
+
+  static void validateDefinition(@Nullable SemanticModelDefinition definition) {
+    if (definition == null) {
+      throw invalid("$", "definition must not be null");
+    }
+
+    validateAIContext(definition.aiContext(), "aiContext");
+
+    Dataset[] datasets = definition.datasets();
+    if (datasets == null || datasets.length == 0) {
+      throw invalid("datasets", "must not be null or empty");
+    }
+
+    Map<String, String> datasetNames = new HashMap<>();
+    for (int index = 0; index < datasets.length; index++) {
+      validateDataset(datasets[index], "datasets[" + index + "]", datasetNames);
+    }
+
+    validateRelationships(definition.relationships(), datasetNames);
+    validateMetrics(definition.metrics());
+    validateCustomExtensions(definition.customExtensions(), "customExtensions");
+  }
+
+  void validateSources(String metalake, SemanticModelDefinition definition) {
+    Dataset[] datasets = definition.datasets();
+    Map<String, SourceColumns> columnsByDataset = new HashMap<>();
+
+    for (int datasetIndex = 0; datasetIndex < datasets.length; datasetIndex++) {
+      Dataset dataset = datasets[datasetIndex];
+      String datasetPath = "datasets[" + datasetIndex + "]";
+      NameIdentifier fullSource =
+          qualifySource(metalake, dataset.source(), datasetPath + ".source");
+      SourceColumns sourceColumns = loadSourceColumns(fullSource, datasetPath + ".source");
+      columnsByDataset.put(dataset.name(), sourceColumns);
+
+      validateSourceColumns(dataset.primaryKey(), datasetPath + ".primaryKey", sourceColumns);
+      String[][] uniqueKeys = dataset.uniqueKeys();
+      if (uniqueKeys != null) {
+        for (int keyIndex = 0; keyIndex < uniqueKeys.length; keyIndex++) {
+          validateSourceColumns(
+              uniqueKeys[keyIndex], datasetPath + ".uniqueKeys[" + keyIndex + "]", sourceColumns);
+        }
+      }
+    }
+
+    Relationship[] relationships = definition.relationships();
+    if (relationships == null) {
+      return;
+    }
+    for (int relationshipIndex = 0; relationshipIndex < relationships.length; relationshipIndex++) {
+      Relationship relationship = relationships[relationshipIndex];
+      String path = "relationships[" + relationshipIndex + "]";
+      SourceColumns fromColumns = columnsByDataset.get(relationship.from());
+      SourceColumns toColumns = columnsByDataset.get(relationship.to());
+      if (fromColumns == null || toColumns == null) {
+        throw invalid(
+            path, "relationship endpoints must reference datasets in the same Semantic Model");
+      }
+      validateSourceColumns(relationship.fromColumns(), path + ".fromColumns", fromColumns);
+      validateSourceColumns(relationship.toColumns(), path + ".toColumns", toColumns);
+    }
+  }
+
+  void validateForWrite(
+      NameIdentifier semanticModelIdent, @Nullable SemanticModelDefinition definition) {
+    if (semanticModelIdent == null || semanticModelIdent.namespace().length() != 3) {
+      throw invalid("$", "Semantic Model identifier must use metalake.catalog.schema.name");
+    }
+    validateDefinition(definition);
+    validateSources(semanticModelIdent.namespace().level(0), definition);
+  }
+
+  private static void validateDataset(
+      @Nullable Dataset dataset, String path, Map<String, String> datasetNames) {
+    if (dataset == null) {
+      throw invalid(path, "must not be null");
+    }
+
+    String namePath = path + ".name";
+    validateRequiredString(dataset.name(), namePath);
+    validateUniqueName(dataset.name(), namePath, "dataset", datasetNames);
+    validateSource(dataset.source(), path + ".source");
+    validateOptionalColumnNames(dataset.primaryKey(), path + ".primaryKey");
+    validateUniqueKeys(dataset.uniqueKeys(), path + ".uniqueKeys");
+    validateAIContext(dataset.aiContext(), path + ".aiContext");
+    validateFields(dataset.fields(), path + ".fields");
+    validateCustomExtensions(dataset.customExtensions(), path + ".customExtensions");
+  }
+
+  private static void validateSource(@Nullable NameIdentifier source, String path) {
+    if (source == null) {
+      throw invalid(path, "must not be null");
+    }
+    if (source.namespace().length() != 2) {
+      throw invalid(
+          path, "must contain exactly catalog.schema.name, but was '" + source.toString() + "'");
+    }
+  }
+
+  private static void validateUniqueKeys(@Nullable String[][] uniqueKeys, String path) {
+    if (uniqueKeys == null) {
+      return;
+    }
+
+    for (int index = 0; index < uniqueKeys.length; index++) {
+      String keyPath = path + "[" + index + "]";
+      String[] uniqueKey = uniqueKeys[index];
+      if (uniqueKey == null || uniqueKey.length == 0) {
+        throw invalid(keyPath, "must not be null or empty");
+      }
+      validateColumnNames(uniqueKey, keyPath, false);
+    }
+  }
+
+  private static void validateFields(@Nullable Field[] fields, String path) {
+    if (fields == null) {
+      return;
+    }
+
+    Map<String, String> fieldNames = new HashMap<>();
+    for (int index = 0; index < fields.length; index++) {
+      String fieldPath = path + "[" + index + "]";
+      Field field = fields[index];
+      if (field == null) {
+        throw invalid(fieldPath, "must not be null");
+      }
+
+      String namePath = fieldPath + ".name";
+      validateRequiredString(field.name(), namePath);
+      validateUniqueName(field.name(), namePath, "field", fieldNames);
+      validateExpression(field.expression(), fieldPath + ".expression");
+      validateAIContext(field.aiContext(), fieldPath + ".aiContext");
+      validateCustomExtensions(field.customExtensions(), fieldPath + ".customExtensions");
+    }
+  }
+
+  private static void validateRelationships(
+      @Nullable Relationship[] relationships, Map<String, String> datasetNames) {
+    if (relationships == null) {
+      return;
+    }
+
+    Map<String, String> relationshipNames = new HashMap<>();
+    for (int index = 0; index < relationships.length; index++) {
+      String path = "relationships[" + index + "]";
+      Relationship relationship = relationships[index];
+      if (relationship == null) {
+        throw invalid(path, "must not be null");
+      }
+
+      String namePath = path + ".name";
+      validateRequiredString(relationship.name(), namePath);
+      validateUniqueName(relationship.name(), namePath, "relationship", relationshipNames);
+      validateEndpoint(relationship.from(), path + ".from", datasetNames);
+      validateEndpoint(relationship.to(), path + ".to", datasetNames);
+
+      String[] fromColumns = relationship.fromColumns();
+      String[] toColumns = relationship.toColumns();
+      validateColumnNames(fromColumns, path + ".fromColumns", false);
+      validateColumnNames(toColumns, path + ".toColumns", false);
+      if (fromColumns.length != toColumns.length) {
+        throw invalid(
+            path + ".toColumns",
+            "must contain "
+                + fromColumns.length
+                + " columns to match "
+                + path
+                + ".fromColumns, but contained "
+                + toColumns.length);
+      }
+      validateAIContext(relationship.aiContext(), path + ".aiContext");
+      validateCustomExtensions(relationship.customExtensions(), path + ".customExtensions");
+    }
+  }
+
+  private static void validateEndpoint(
+      @Nullable String endpoint, String path, Map<String, String> datasetNames) {
+    validateRequiredString(endpoint, path);
+    if (!datasetNames.containsKey(endpoint)) {
+      throw invalid(
+          path,
+          "unknown dataset '"
+              + endpoint
+              + "'; relationship endpoints must reference datasets in the same model");
+    }
+  }
+
+  private static void validateMetrics(@Nullable Metric[] metrics) {
+    if (metrics == null) {
+      return;
+    }
+
+    Map<String, String> metricNames = new HashMap<>();
+    for (int index = 0; index < metrics.length; index++) {
+      String path = "metrics[" + index + "]";
+      Metric metric = metrics[index];
+      if (metric == null) {
+        throw invalid(path, "must not be null");
+      }
+
+      String namePath = path + ".name";
+      validateRequiredString(metric.name(), namePath);
+      validateUniqueName(metric.name(), namePath, "metric", metricNames);
+      validateExpression(metric.expression(), path + ".expression");
+      validateAIContext(metric.aiContext(), path + ".aiContext");
+      validateCustomExtensions(metric.customExtensions(), path + ".customExtensions");
+    }
+  }
+
+  private static void validateExpression(@Nullable Expression expression, String path) {
+    if (expression == null) {
+      throw invalid(path, "must not be null");
+    }
+
+    DialectExpression[] dialectExpressions = expression.dialects();
+    if (dialectExpressions == null || dialectExpressions.length == 0) {
+      throw invalid(path + ".dialects", "must not be null or empty");
+    }
+
+    Map<String, String> dialectPaths = new HashMap<>();
+    for (int index = 0; index < dialectExpressions.length; index++) {
+      String dialectExpressionPath = path + ".dialects[" + index + "]";
+      DialectExpression dialectExpression = dialectExpressions[index];
+      if (dialectExpression == null) {
+        throw invalid(dialectExpressionPath, "must not be null");
+      }
+
+      String dialect = dialectExpression.dialect();
+      String dialectPath = dialectExpressionPath + ".dialect";
+      validateRequiredString(dialect, dialectPath);
+      String firstPath = dialectPaths.putIfAbsent(dialect, dialectPath);
+      if (firstPath != null) {
+        throw invalid(
+            dialectPath, "duplicate dialect '" + dialect + "'; first declared at " + firstPath);
+      }
+      validateRequiredString(dialectExpression.expression(), dialectExpressionPath + ".expression");
+    }
+  }
+
+  private static void validateAIContext(@Nullable AIContext aiContext, String path) {
+    if (aiContext == null) {
+      return;
+    }
+
+    String text = aiContext.text();
+    AIContextObject object = aiContext.object();
+    if ((text == null) == (object == null)) {
+      throw invalid(path, "must contain exactly one string or object value");
+    }
+    if (object == null) {
+      return;
+    }
+
+    validateStringElements(object.synonyms(), path + ".synonyms");
+    validateStringElements(object.examples(), path + ".examples");
+    if (object.additionalProperties() == null) {
+      throw invalid(path + ".additionalProperties", "must not be null");
+    }
+    for (String name : object.additionalProperties().keySet()) {
+      if (name == null) {
+        throw invalid(path + ".additionalProperties", "property name must not be null");
+      }
+    }
+  }
+
+  private static void validateColumnNames(
+      @Nullable String[] columns, String path, boolean allowEmpty) {
+    if (columns == null || (!allowEmpty && columns.length == 0)) {
+      throw invalid(path, allowEmpty ? "must not be null" : "must not be null or empty");
+    }
+    for (int index = 0; index < columns.length; index++) {
+      validateRequiredString(columns[index], path + "[" + index + "]");
+    }
+  }
+
+  private static void validateOptionalColumnNames(@Nullable String[] columns, String path) {
+    if (columns == null) {
+      return;
+    }
+    for (int index = 0; index < columns.length; index++) {
+      validateRequiredString(columns[index], path + "[" + index + "]");
+    }
+  }
+
+  private static void validateStringElements(@Nullable String[] values, String path) {
+    if (values == null) {
+      return;
+    }
+    for (int index = 0; index < values.length; index++) {
+      if (values[index] == null) {
+        throw invalid(path + "[" + index + "]", "must not be null");
+      }
+    }
+  }
+
+  private static void validateCustomExtensions(
+      @Nullable CustomExtension[] customExtensions, String path) {
+    if (customExtensions == null) {
+      return;
+    }
+    for (int index = 0; index < customExtensions.length; index++) {
+      String extensionPath = path + "[" + index + "]";
+      CustomExtension extension = customExtensions[index];
+      if (extension == null) {
+        throw invalid(extensionPath, "must not be null");
+      }
+      if (extension.vendorName() == null) {
+        throw invalid(extensionPath + ".vendorName", "must not be null");
+      }
+      if (extension.data() == null) {
+        throw invalid(extensionPath + ".data", "must not be null");
+      }
+    }
+  }
+
+  private static void validateRequiredString(@Nullable String value, String path) {
+    if (value == null || value.isEmpty()) {
+      throw invalid(path, "must not be null or empty");
+    }
+  }
+
+  private static void validateUniqueName(
+      String name, String path, String memberType, Map<String, String> names) {
+    String firstPath = names.putIfAbsent(name, path);
+    if (firstPath != null) {
+      throw invalid(
+          path, "duplicate " + memberType + " name '" + name + "'; first declared at " + firstPath);
+    }
+  }
+
+  private static NameIdentifier qualifySource(
+      String metalake, NameIdentifier source, String sourcePath) {
+    if (source == null || source.namespace().length() != 2) {
+      throw invalid(sourcePath, "source must use catalog.schema.name");
+    }
+    return NameIdentifier.of(
+        Namespace.of(metalake, source.namespace().level(0), source.namespace().level(1)),
+        source.name());
+  }
+
+  private SourceColumns loadSourceColumns(NameIdentifier source, String sourcePath) {
+    try {
+      Table table = tableDispatcher.loadTable(source);
+      return sourceColumns(source, table == null ? null : table.columns());
+    } catch (NotFoundException | UnsupportedOperationException tableNotFound) {
+      try {
+        View view = viewDispatcher.loadView(source);
+        return sourceColumns(source, view == null ? null : view.columns());
+      } catch (NotFoundException | UnsupportedOperationException viewNotFound) {
+        throw new IllegalSemanticModelException(
+            viewNotFound,
+            "%s: source %s does not exist as a Table or logical View",
+            sourcePath,
+            source);
+      }
+    }
+  }
+
+  private SourceColumns sourceColumns(NameIdentifier source, Column[] columns) {
+    Capability capability = getCapability(source, catalogManager);
+    Function<String, String> normalizeColumn =
+        name -> applyCaseSensitiveOnName(Capability.Scope.COLUMN, name, capability);
+    Set<String> names =
+        columns == null
+            ? Collections.emptySet()
+            : Arrays.stream(columns)
+                .map(Column::name)
+                .map(normalizeColumn)
+                .collect(Collectors.toSet());
+    return new SourceColumns(source, names, normalizeColumn);
+  }
+
+  private static void validateSourceColumns(
+      @Nullable String[] columns, String path, SourceColumns sourceColumns) {
+    if (columns == null) {
+      return;
+    }
+    for (int columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+      String column = columns[columnIndex];
+      if (!sourceColumns.contains(column)) {
+        throw new IllegalSemanticModelException(
+            "%s[%s]: column '%s' does not exist in source %s",
+            path, columnIndex, column, sourceColumns.source);
+      }
+    }
+  }
+
+  private static IllegalSemanticModelException invalid(String path, String detail) {
+    return new IllegalSemanticModelException("%s: %s", path, detail);
+  }
+
+  private static final class SourceColumns {
+    private final NameIdentifier source;
+    private final Set<String> columns;
+    private final Function<String, String> normalizeColumn;
+
+    private SourceColumns(
+        NameIdentifier source, Set<String> columns, Function<String, String> normalizeColumn) {
+      this.source = source;
+      this.columns = columns;
+      this.normalizeColumn = normalizeColumn;
+    }
+
+    private boolean contains(String column) {
+      return columns.contains(normalizeColumn.apply(column));
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
@@ -64,6 +64,7 @@ import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.meta.PolicyEntity;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.SchemaEntity;
+import org.apache.gravitino.meta.SemanticModelEntity;
 import org.apache.gravitino.meta.StatisticEntity;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.meta.TagEntity;
@@ -89,6 +90,7 @@ import org.apache.gravitino.storage.relational.service.PolicyMetaService;
 import org.apache.gravitino.storage.relational.service.PolicyTagRelService;
 import org.apache.gravitino.storage.relational.service.RoleMetaService;
 import org.apache.gravitino.storage.relational.service.SchemaMetaService;
+import org.apache.gravitino.storage.relational.service.SemanticModelMetaService;
 import org.apache.gravitino.storage.relational.service.StatisticMetaService;
 import org.apache.gravitino.storage.relational.service.TableColumnMetaService;
 import org.apache.gravitino.storage.relational.service.TableMetaService;
@@ -282,6 +284,8 @@ public class JDBCBackend implements RelationalBackend, SupportsOrphanedRelationC
         return (E) JobMetaService.getInstance().getJobByIdentifier(ident);
       case VIEW:
         return (E) ViewMetaService.getInstance().getViewByIdentifier(ident);
+      case SEMANTIC_MODEL:
+        return (E) SemanticModelMetaService.getInstance().getSemanticModelByIdentifier(ident);
       default:
         throw new UnsupportedEntityTypeException(
             "Unsupported entity type: %s for get operation", entityType);
@@ -1083,6 +1087,9 @@ public class JDBCBackend implements RelationalBackend, SupportsOrphanedRelationC
       JobMetaService.getInstance().insertJob((JobEntity) e, overwritten);
     } else if (e instanceof ViewEntity) {
       ViewMetaService.getInstance().insertView((ViewEntity) e, overwritten);
+    } else if (e instanceof SemanticModelEntity) {
+      SemanticModelMetaService.getInstance()
+          .insertSemanticModel((SemanticModelEntity) e, overwritten);
     } else if (e instanceof GenericEntity) {
       GenericEntity genericEntity = (GenericEntity) e;
       throw new UnsupportedEntityTypeException(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStoreIdResolver.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStoreIdResolver.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.storage.relational.service.ModelMetaService;
 import org.apache.gravitino.storage.relational.service.PolicyMetaService;
 import org.apache.gravitino.storage.relational.service.RoleMetaService;
 import org.apache.gravitino.storage.relational.service.SchemaMetaService;
+import org.apache.gravitino.storage.relational.service.SemanticModelMetaService;
 import org.apache.gravitino.storage.relational.service.TableColumnMetaService;
 import org.apache.gravitino.storage.relational.service.TableMetaService;
 import org.apache.gravitino.storage.relational.service.TagMetaService;
@@ -69,7 +70,8 @@ public class RelationalEntityStoreIdResolver implements EntityIdResolver {
           Entity.EntityType.MODEL,
           Entity.EntityType.COLUMN,
           Entity.EntityType.FUNCTION,
-          Entity.EntityType.VIEW);
+          Entity.EntityType.VIEW,
+          Entity.EntityType.SEMANTIC_MODEL);
 
   @Override
   public NamespacedEntityId getEntityIds(NameIdentifier nameIdentifier, Entity.EntityType type) {
@@ -234,6 +236,17 @@ public class RelationalEntityStoreIdResolver implements EntityIdResolver {
                 .getViewIdBySchemaIdAndName(schemaIds.getSchemaId(), nameIdentifier.name());
         return new NamespacedEntityId(
             viewId, schemaIds.getMetalakeId(), schemaIds.getCatalogId(), schemaIds.getSchemaId());
+
+      case SEMANTIC_MODEL:
+        long semanticModelId =
+            SemanticModelMetaService.getInstance()
+                .getSemanticModelIdBySchemaIdAndName(
+                    schemaIds.getSchemaId(), nameIdentifier.name());
+        return new NamespacedEntityId(
+            semanticModelId,
+            schemaIds.getMetalakeId(),
+            schemaIds.getCatalogId(),
+            schemaIds.getSchemaId());
 
       case FUNCTION:
         long functionId =

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelMetaMapper.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.One;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.UpdateProvider;
+
+/** A MyBatis mapper for Semantic Model create and load operations. */
+public interface SemanticModelMetaMapper {
+
+  /** The Semantic Model identity table name. */
+  String TABLE_NAME = "semantic_model_meta";
+
+  /** The Semantic Model version snapshot table name. */
+  String VERSION_TABLE_NAME = "semantic_model_version_info";
+
+  /** Declares the nested result mapping for a Semantic Model version snapshot. */
+  @Results(
+      id = "mapToSemanticModelVersionInfoPO",
+      value = {
+        @Result(property = "id", column = "id", id = true),
+        @Result(property = "metalakeId", column = "version_metalake_id"),
+        @Result(property = "catalogId", column = "version_catalog_id"),
+        @Result(property = "schemaId", column = "version_schema_id"),
+        @Result(property = "semanticModelId", column = "version_semantic_model_id"),
+        @Result(property = "version", column = "version"),
+        @Result(property = "semanticModelName", column = "version_semantic_model_name"),
+        @Result(property = "semanticModelComment", column = "semantic_model_comment"),
+        @Result(property = "semanticModelDefinition", column = "semantic_model_definition"),
+        @Result(property = "properties", column = "properties"),
+        @Result(property = "auditInfo", column = "version_audit_info"),
+        @Result(property = "deletedAt", column = "version_deleted_at")
+      })
+  @Select("SELECT 1")
+  SemanticModelVersionInfoPO mapToSemanticModelVersionInfoPO();
+
+  /** Selects an active Semantic Model ID by schema ID and name. */
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelIdBySchemaIdAndName")
+  Long selectSemanticModelIdBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName);
+
+  /** Selects a current Semantic Model snapshot by schema ID and name. */
+  @Results(
+      id = "semanticModelPOResultMap",
+      value = {
+        @Result(property = "semanticModelId", column = "semantic_model_id", id = true),
+        @Result(property = "semanticModelName", column = "semantic_model_name"),
+        @Result(property = "metalakeId", column = "metalake_id"),
+        @Result(property = "catalogId", column = "catalog_id"),
+        @Result(property = "schemaId", column = "schema_id"),
+        @Result(property = "currentVersion", column = "current_version"),
+        @Result(property = "lastVersion", column = "last_version"),
+        @Result(property = "auditInfo", column = "audit_info"),
+        @Result(property = "deletedAt", column = "deleted_at"),
+        @Result(
+            property = "semanticModelVersionInfoPO",
+            javaType = SemanticModelVersionInfoPO.class,
+            column =
+                "{id,version_metalake_id,version_catalog_id,version_schema_id,"
+                    + "version_semantic_model_id,version,version_semantic_model_name,"
+                    + "semantic_model_comment,semantic_model_definition,properties,"
+                    + "version_audit_info,version_deleted_at}",
+            one = @One(resultMap = "mapToSemanticModelVersionInfoPO"))
+      })
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelMetaBySchemaIdAndName")
+  SemanticModelPO selectSemanticModelMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName);
+
+  /** Selects and locks an active Semantic Model identity by schema ID and name. */
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelMetaBySchemaIdAndNameForUpdate")
+  SemanticModelPO selectSemanticModelMetaBySchemaIdAndNameForUpdate(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName);
+
+  /** Selects a current Semantic Model snapshot by stable ID. */
+  @ResultMap("semanticModelPOResultMap")
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelMetaById")
+  SemanticModelPO selectSemanticModelMetaById(@Param("semanticModelId") Long semanticModelId);
+
+  /** Selects and locks a Semantic Model identity by stable ID. */
+  @ResultMap("semanticModelPOResultMap")
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelMetaByIdForUpdate")
+  SemanticModelPO selectSemanticModelMetaByIdForUpdate(
+      @Param("semanticModelId") Long semanticModelId);
+
+  /** Selects a current Semantic Model snapshot by fully qualified name. */
+  @ResultMap("semanticModelPOResultMap")
+  @SelectProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "selectSemanticModelByFullQualifiedName")
+  SemanticModelPO selectSemanticModelByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("semanticModelName") String semanticModelName);
+
+  /** Inserts a Semantic Model identity row. */
+  @InsertProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "insertSemanticModelMeta")
+  void insertSemanticModelMeta(@Param("semanticModelMeta") SemanticModelPO semanticModelPO);
+
+  /** Inserts or overwrites a Semantic Model identity row. */
+  @InsertProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "insertSemanticModelMetaOnDuplicateKeyUpdate")
+  void insertSemanticModelMetaOnDuplicateKeyUpdate(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO);
+
+  /** Updates a Semantic Model identity while its current version is unchanged. */
+  @UpdateProvider(
+      type = SemanticModelMetaSQLProviderFactory.class,
+      method = "updateSemanticModelMeta")
+  Integer updateSemanticModelMeta(
+      @Param("newSemanticModelMeta") SemanticModelPO newSemanticModelPO,
+      @Param("oldSemanticModelMeta") SemanticModelPO oldSemanticModelPO);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelMetaSQLProviderFactory.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.provider.base.SemanticModelMetaBaseSQLProvider;
+import org.apache.gravitino.storage.relational.mapper.provider.postgresql.SemanticModelMetaPostgreSQLProvider;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.annotations.Param;
+
+/** Selects database-specific SQL providers for Semantic Model create and load operations. */
+public class SemanticModelMetaSQLProviderFactory {
+
+  private static final Map<JDBCBackendType, SemanticModelMetaBaseSQLProvider>
+      SEMANTIC_MODEL_META_SQL_PROVIDER_MAP =
+          ImmutableMap.of(
+              JDBCBackendType.MYSQL, new SemanticModelMetaMySQLProvider(),
+              JDBCBackendType.H2, new SemanticModelMetaH2Provider(),
+              JDBCBackendType.POSTGRESQL, new SemanticModelMetaPostgreSQLProvider());
+
+  /** Returns the SQL provider for the configured relational backend. */
+  public static SemanticModelMetaBaseSQLProvider getProvider() {
+    String databaseId =
+        SqlSessionFactoryHelper.getInstance()
+            .getSqlSessionFactory()
+            .getConfiguration()
+            .getDatabaseId();
+    return SEMANTIC_MODEL_META_SQL_PROVIDER_MAP.get(JDBCBackendType.fromString(databaseId));
+  }
+
+  static class SemanticModelMetaMySQLProvider extends SemanticModelMetaBaseSQLProvider {}
+
+  static class SemanticModelMetaH2Provider extends SemanticModelMetaBaseSQLProvider {}
+
+  /** Provides SQL for selecting a Semantic Model ID by schema ID and name. */
+  public static String selectSemanticModelIdBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return getProvider().selectSemanticModelIdBySchemaIdAndName(schemaId, semanticModelName);
+  }
+
+  /** Provides SQL for selecting a Semantic Model by schema ID and name. */
+  public static String selectSemanticModelMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return getProvider().selectSemanticModelMetaBySchemaIdAndName(schemaId, semanticModelName);
+  }
+
+  /** Provides SQL for selecting and locking a Semantic Model identity by schema ID and name. */
+  public static String selectSemanticModelMetaBySchemaIdAndNameForUpdate(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return getProvider()
+        .selectSemanticModelMetaBySchemaIdAndNameForUpdate(schemaId, semanticModelName);
+  }
+
+  /** Provides SQL for selecting a Semantic Model by stable ID. */
+  public static String selectSemanticModelMetaById(@Param("semanticModelId") Long semanticModelId) {
+    return getProvider().selectSemanticModelMetaById(semanticModelId);
+  }
+
+  /** Provides SQL for selecting and locking a Semantic Model identity by stable ID. */
+  public static String selectSemanticModelMetaByIdForUpdate(
+      @Param("semanticModelId") Long semanticModelId) {
+    return getProvider().selectSemanticModelMetaByIdForUpdate(semanticModelId);
+  }
+
+  /** Provides SQL for selecting a Semantic Model by fully qualified name. */
+  public static String selectSemanticModelByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("semanticModelName") String semanticModelName) {
+    return getProvider()
+        .selectSemanticModelByFullQualifiedName(
+            metalakeName, catalogName, schemaName, semanticModelName);
+  }
+
+  /** Provides SQL for inserting a Semantic Model identity. */
+  public static String insertSemanticModelMeta(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return getProvider().insertSemanticModelMeta(semanticModelPO);
+  }
+
+  /** Provides SQL for inserting or overwriting a Semantic Model identity. */
+  public static String insertSemanticModelMetaOnDuplicateKeyUpdate(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return getProvider().insertSemanticModelMetaOnDuplicateKeyUpdate(semanticModelPO);
+  }
+
+  /** Provides SQL for updating a Semantic Model identity when its version is unchanged. */
+  public static String updateSemanticModelMeta(
+      @Param("newSemanticModelMeta") SemanticModelPO newSemanticModelPO,
+      @Param("oldSemanticModelMeta") SemanticModelPO oldSemanticModelPO) {
+    return getProvider().updateSemanticModelMeta(newSemanticModelPO, oldSemanticModelPO);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelVersionInfoMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelVersionInfoMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.Param;
+
+/** A MyBatis mapper for creating Semantic Model version snapshots. */
+public interface SemanticModelVersionInfoMapper {
+
+  /** The Semantic Model version snapshot table name. */
+  String TABLE_NAME = "semantic_model_version_info";
+
+  /** Inserts a Semantic Model version snapshot. */
+  @InsertProvider(
+      type = SemanticModelVersionInfoSQLProviderFactory.class,
+      method = "insertSemanticModelVersionInfo")
+  void insertSemanticModelVersionInfo(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO);
+
+  /** Inserts or overwrites a Semantic Model version snapshot. */
+  @InsertProvider(
+      type = SemanticModelVersionInfoSQLProviderFactory.class,
+      method = "insertSemanticModelVersionInfoOnDuplicateKeyUpdate")
+  void insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelVersionInfoSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SemanticModelVersionInfoSQLProviderFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.provider.base.SemanticModelVersionInfoBaseSQLProvider;
+import org.apache.gravitino.storage.relational.mapper.provider.postgresql.SemanticModelVersionInfoPostgreSQLProvider;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.annotations.Param;
+
+/** Selects database-specific SQL providers for Semantic Model snapshot creation. */
+public class SemanticModelVersionInfoSQLProviderFactory {
+
+  private static final Map<JDBCBackendType, SemanticModelVersionInfoBaseSQLProvider>
+      SEMANTIC_MODEL_VERSION_INFO_SQL_PROVIDER_MAP =
+          ImmutableMap.of(
+              JDBCBackendType.MYSQL, new SemanticModelVersionInfoMySQLProvider(),
+              JDBCBackendType.H2, new SemanticModelVersionInfoH2Provider(),
+              JDBCBackendType.POSTGRESQL, new SemanticModelVersionInfoPostgreSQLProvider());
+
+  /** Returns the SQL provider for the configured relational backend. */
+  public static SemanticModelVersionInfoBaseSQLProvider getProvider() {
+    String databaseId =
+        SqlSessionFactoryHelper.getInstance()
+            .getSqlSessionFactory()
+            .getConfiguration()
+            .getDatabaseId();
+    return SEMANTIC_MODEL_VERSION_INFO_SQL_PROVIDER_MAP.get(JDBCBackendType.fromString(databaseId));
+  }
+
+  static class SemanticModelVersionInfoMySQLProvider
+      extends SemanticModelVersionInfoBaseSQLProvider {}
+
+  static class SemanticModelVersionInfoH2Provider extends SemanticModelVersionInfoBaseSQLProvider {}
+
+  /** Provides SQL for inserting a Semantic Model version snapshot. */
+  public static String insertSemanticModelVersionInfo(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return getProvider().insertSemanticModelVersionInfo(versionInfoPO);
+  }
+
+  /** Provides SQL for inserting or overwriting a Semantic Model version snapshot. */
+  public static String insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return getProvider().insertSemanticModelVersionInfoOnDuplicateKeyUpdate(versionInfoPO);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
@@ -43,6 +43,8 @@ import org.apache.gravitino.storage.relational.mapper.PolicyVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelVersionInfoMapper;
 import org.apache.gravitino.storage.relational.mapper.StatisticMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.TableColumnMapper;
 import org.apache.gravitino.storage.relational.mapper.TableMetaMapper;
@@ -84,6 +86,8 @@ public class DefaultMapperPackageProvider implements MapperPackageProvider {
         RoleMetaMapper.class,
         SchemaMetaMapper.class,
         SecurableObjectMapper.class,
+        SemanticModelMetaMapper.class,
+        SemanticModelVersionInfoMapper.class,
         StatisticMetaMapper.class,
         TableColumnMapper.class,
         TableMetaMapper.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SemanticModelMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SemanticModelMetaBaseSQLProvider.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import static org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper.TABLE_NAME;
+import static org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper.VERSION_TABLE_NAME;
+
+import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.ibatis.annotations.Param;
+
+/** Provides MySQL-compatible SQL for Semantic Model create and load operations. */
+public class SemanticModelMetaBaseSQLProvider {
+
+  private static final String CURRENT_SNAPSHOT_COLUMNS =
+      " smm.semantic_model_id, smm.semantic_model_name, smm.metalake_id,"
+          + " smm.catalog_id, smm.schema_id, smm.current_version, smm.last_version,"
+          + " smm.audit_info, smm.deleted_at, smvi.id,"
+          + " smvi.metalake_id as version_metalake_id,"
+          + " smvi.catalog_id as version_catalog_id,"
+          + " smvi.schema_id as version_schema_id,"
+          + " smvi.semantic_model_id as version_semantic_model_id, smvi.version,"
+          + " smvi.semantic_model_name as version_semantic_model_name,"
+          + " smvi.semantic_model_comment, smvi.semantic_model_definition, smvi.properties,"
+          + " smvi.audit_info as version_audit_info,"
+          + " smvi.deleted_at as version_deleted_at";
+
+  /** Returns SQL for selecting an active Semantic Model ID by schema ID and name. */
+  public String selectSemanticModelIdBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return "SELECT semantic_model_id as semanticModelId FROM "
+        + TABLE_NAME
+        + " WHERE schema_id = #{schemaId}"
+        + " AND semantic_model_name = #{semanticModelName} AND deleted_at = 0";
+  }
+
+  /** Returns SQL for selecting a current Semantic Model snapshot by schema ID and name. */
+  public String selectSemanticModelMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return "SELECT"
+        + CURRENT_SNAPSHOT_COLUMNS
+        + " FROM "
+        + TABLE_NAME
+        + " smm INNER JOIN "
+        + VERSION_TABLE_NAME
+        + " smvi ON smm.semantic_model_id = smvi.semantic_model_id"
+        + " AND smm.current_version = smvi.version"
+        + " WHERE smm.schema_id = #{schemaId}"
+        + " AND smm.semantic_model_name = #{semanticModelName}"
+        + " AND smm.deleted_at = 0 AND smvi.deleted_at = 0";
+  }
+
+  /** Returns SQL for selecting and locking an active Semantic Model identity by natural key. */
+  public String selectSemanticModelMetaBySchemaIdAndNameForUpdate(
+      @Param("schemaId") Long schemaId, @Param("semanticModelName") String semanticModelName) {
+    return "SELECT semantic_model_id as semanticModelId,"
+        + " semantic_model_name as semanticModelName, metalake_id as metalakeId,"
+        + " catalog_id as catalogId, schema_id as schemaId,"
+        + " current_version as currentVersion, last_version as lastVersion,"
+        + " audit_info as auditInfo, deleted_at as deletedAt"
+        + " FROM "
+        + TABLE_NAME
+        + " WHERE schema_id = #{schemaId}"
+        + " AND semantic_model_name = #{semanticModelName}"
+        + " AND deleted_at = 0 FOR UPDATE";
+  }
+
+  /** Returns SQL for selecting a current Semantic Model snapshot by stable ID. */
+  public String selectSemanticModelMetaById(@Param("semanticModelId") Long semanticModelId) {
+    return "SELECT"
+        + CURRENT_SNAPSHOT_COLUMNS
+        + " FROM "
+        + TABLE_NAME
+        + " smm INNER JOIN "
+        + VERSION_TABLE_NAME
+        + " smvi ON smm.semantic_model_id = smvi.semantic_model_id"
+        + " AND smm.current_version = smvi.version"
+        + " WHERE smm.semantic_model_id = #{semanticModelId}"
+        + " AND smm.deleted_at = 0 AND smvi.deleted_at = 0";
+  }
+
+  /** Returns SQL for selecting and locking a Semantic Model identity by stable ID. */
+  public String selectSemanticModelMetaByIdForUpdate(
+      @Param("semanticModelId") Long semanticModelId) {
+    return "SELECT semantic_model_id, semantic_model_name, metalake_id, catalog_id, schema_id,"
+        + " current_version, last_version, audit_info, deleted_at FROM "
+        + TABLE_NAME
+        + " WHERE semantic_model_id = #{semanticModelId} AND deleted_at = 0 FOR UPDATE";
+  }
+
+  /** Returns SQL for selecting a current Semantic Model by fully qualified name. */
+  public String selectSemanticModelByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("semanticModelName") String semanticModelName) {
+    return """
+        SELECT
+            mm.metalake_id,
+            cm.catalog_id,
+            sm.schema_id,
+            smm.semantic_model_id,
+            smm.semantic_model_name,
+            smm.current_version,
+            smm.last_version,
+            smm.audit_info,
+            smm.deleted_at,
+            smvi.id,
+            smvi.metalake_id as version_metalake_id,
+            smvi.catalog_id as version_catalog_id,
+            smvi.schema_id as version_schema_id,
+            smvi.semantic_model_id as version_semantic_model_id,
+            smvi.version,
+            smvi.semantic_model_name as version_semantic_model_name,
+            smvi.semantic_model_comment,
+            smvi.semantic_model_definition,
+            smvi.properties,
+            smvi.audit_info as version_audit_info,
+            smvi.deleted_at as version_deleted_at
+        FROM
+            %s mm
+        INNER JOIN
+            %s cm ON mm.metalake_id = cm.metalake_id
+            AND cm.catalog_name = #{catalogName}
+            AND cm.deleted_at = 0
+        LEFT JOIN
+            %s sm ON cm.catalog_id = sm.catalog_id
+            AND sm.schema_name = #{schemaName}
+            AND sm.deleted_at = 0
+        LEFT JOIN
+            %s smm ON sm.schema_id = smm.schema_id
+            AND smm.semantic_model_name = #{semanticModelName}
+            AND smm.deleted_at = 0
+        LEFT JOIN
+            %s smvi ON smm.semantic_model_id = smvi.semantic_model_id
+            AND smm.current_version = smvi.version
+            AND smvi.deleted_at = 0
+        WHERE
+            mm.metalake_name = #{metalakeName}
+            AND mm.deleted_at = 0
+        """
+        .formatted(
+            MetalakeMetaMapper.TABLE_NAME,
+            CatalogMetaMapper.TABLE_NAME,
+            SchemaMetaMapper.TABLE_NAME,
+            TABLE_NAME,
+            VERSION_TABLE_NAME);
+  }
+
+  /** Returns SQL for inserting a Semantic Model identity row. */
+  public String insertSemanticModelMeta(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return "INSERT INTO "
+        + TABLE_NAME
+        + " (semantic_model_id, semantic_model_name, metalake_id, catalog_id, schema_id,"
+        + " current_version, last_version, audit_info, deleted_at)"
+        + " VALUES (#{semanticModelMeta.semanticModelId},"
+        + " #{semanticModelMeta.semanticModelName}, #{semanticModelMeta.metalakeId},"
+        + " #{semanticModelMeta.catalogId}, #{semanticModelMeta.schemaId},"
+        + " #{semanticModelMeta.currentVersion}, #{semanticModelMeta.lastVersion},"
+        + " #{semanticModelMeta.auditInfo}, #{semanticModelMeta.deletedAt})";
+  }
+
+  /** Returns SQL for inserting or overwriting a Semantic Model identity row. */
+  public String insertSemanticModelMetaOnDuplicateKeyUpdate(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return insertSemanticModelMeta(semanticModelPO)
+        + " ON DUPLICATE KEY UPDATE"
+        + " semantic_model_name = #{semanticModelMeta.semanticModelName},"
+        + " metalake_id = #{semanticModelMeta.metalakeId},"
+        + " catalog_id = #{semanticModelMeta.catalogId},"
+        + " schema_id = #{semanticModelMeta.schemaId},"
+        // Keep versions monotonic when an existing Semantic Model is overwritten. Assign
+        // last_version first so both columns advance from the stored current version.
+        + " last_version = current_version + 1,"
+        + " current_version = current_version + 1,"
+        + " audit_info = #{semanticModelMeta.auditInfo},"
+        + " deleted_at = #{semanticModelMeta.deletedAt}";
+  }
+
+  /** Returns SQL for updating a Semantic Model identity with a version check. */
+  public String updateSemanticModelMeta(
+      @Param("newSemanticModelMeta") SemanticModelPO newSemanticModelPO,
+      @Param("oldSemanticModelMeta") SemanticModelPO oldSemanticModelPO) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET semantic_model_name = #{newSemanticModelMeta.semanticModelName},"
+        + " metalake_id = #{newSemanticModelMeta.metalakeId},"
+        + " catalog_id = #{newSemanticModelMeta.catalogId},"
+        + " schema_id = #{newSemanticModelMeta.schemaId},"
+        + " current_version = #{newSemanticModelMeta.currentVersion},"
+        + " last_version = #{newSemanticModelMeta.lastVersion},"
+        + " audit_info = #{newSemanticModelMeta.auditInfo},"
+        + " deleted_at = #{newSemanticModelMeta.deletedAt}"
+        + " WHERE semantic_model_id = #{oldSemanticModelMeta.semanticModelId}"
+        + " AND current_version = #{oldSemanticModelMeta.currentVersion}"
+        + " AND deleted_at = 0"
+        + " AND NOT EXISTS (SELECT 1 FROM "
+        + VERSION_TABLE_NAME
+        + " smvi WHERE smvi.semantic_model_id = #{oldSemanticModelMeta.semanticModelId}"
+        + " AND smvi.version >= #{newSemanticModelMeta.currentVersion}"
+        + " AND smvi.deleted_at = 0)";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SemanticModelVersionInfoBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SemanticModelVersionInfoBaseSQLProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import org.apache.gravitino.storage.relational.mapper.SemanticModelVersionInfoMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.ibatis.annotations.Param;
+
+/** Provides MySQL-compatible SQL for creating Semantic Model version snapshots. */
+public class SemanticModelVersionInfoBaseSQLProvider {
+
+  /** Returns SQL for inserting a Semantic Model version snapshot. */
+  public String insertSemanticModelVersionInfo(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return "INSERT INTO "
+        + SemanticModelVersionInfoMapper.TABLE_NAME
+        + " (metalake_id, catalog_id, schema_id, semantic_model_id, version,"
+        + " semantic_model_name, semantic_model_comment, semantic_model_definition,"
+        + " properties, audit_info, deleted_at)"
+        + " VALUES (#{semanticModelVersionInfo.metalakeId},"
+        + " #{semanticModelVersionInfo.catalogId}, #{semanticModelVersionInfo.schemaId},"
+        + " #{semanticModelVersionInfo.semanticModelId}, #{semanticModelVersionInfo.version},"
+        + " #{semanticModelVersionInfo.semanticModelName},"
+        + " #{semanticModelVersionInfo.semanticModelComment},"
+        + " #{semanticModelVersionInfo.semanticModelDefinition},"
+        + " #{semanticModelVersionInfo.properties}, #{semanticModelVersionInfo.auditInfo},"
+        + " #{semanticModelVersionInfo.deletedAt})";
+  }
+
+  /** Returns SQL for inserting or overwriting a Semantic Model version snapshot. */
+  public String insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return insertSemanticModelVersionInfo(versionInfoPO)
+        + " ON DUPLICATE KEY UPDATE"
+        + " semantic_model_name = #{semanticModelVersionInfo.semanticModelName},"
+        + " semantic_model_comment = #{semanticModelVersionInfo.semanticModelComment},"
+        + " semantic_model_definition = #{semanticModelVersionInfo.semanticModelDefinition},"
+        + " properties = #{semanticModelVersionInfo.properties},"
+        + " audit_info = #{semanticModelVersionInfo.auditInfo},"
+        + " deleted_at = #{semanticModelVersionInfo.deletedAt}";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SemanticModelMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SemanticModelMetaPostgreSQLProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import static org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper.TABLE_NAME;
+
+import org.apache.gravitino.storage.relational.mapper.provider.base.SemanticModelMetaBaseSQLProvider;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.ibatis.annotations.Param;
+
+/** Provides PostgreSQL SQL for Semantic Model create and load operations. */
+public class SemanticModelMetaPostgreSQLProvider extends SemanticModelMetaBaseSQLProvider {
+
+  @Override
+  public String insertSemanticModelMetaOnDuplicateKeyUpdate(
+      @Param("semanticModelMeta") SemanticModelPO semanticModelPO) {
+    return insertSemanticModelMeta(semanticModelPO)
+        + " ON CONFLICT (semantic_model_id) DO UPDATE SET"
+        + " semantic_model_name = #{semanticModelMeta.semanticModelName},"
+        + " metalake_id = #{semanticModelMeta.metalakeId},"
+        + " catalog_id = #{semanticModelMeta.catalogId},"
+        + " schema_id = #{semanticModelMeta.schemaId},"
+        + " current_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
+        + " last_version = "
+        + TABLE_NAME
+        + ".current_version + 1,"
+        + " audit_info = #{semanticModelMeta.auditInfo},"
+        + " deleted_at = #{semanticModelMeta.deletedAt}";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SemanticModelVersionInfoPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SemanticModelVersionInfoPostgreSQLProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import org.apache.gravitino.storage.relational.mapper.provider.base.SemanticModelVersionInfoBaseSQLProvider;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.ibatis.annotations.Param;
+
+/** Provides PostgreSQL SQL for creating Semantic Model version snapshots. */
+public class SemanticModelVersionInfoPostgreSQLProvider
+    extends SemanticModelVersionInfoBaseSQLProvider {
+
+  @Override
+  public String insertSemanticModelVersionInfoOnDuplicateKeyUpdate(
+      @Param("semanticModelVersionInfo") SemanticModelVersionInfoPO versionInfoPO) {
+    return insertSemanticModelVersionInfo(versionInfoPO)
+        + " ON CONFLICT (semantic_model_id, version, deleted_at) DO UPDATE SET"
+        + " semantic_model_name = #{semanticModelVersionInfo.semanticModelName},"
+        + " semantic_model_comment = #{semanticModelVersionInfo.semanticModelComment},"
+        + " semantic_model_definition = #{semanticModelVersionInfo.semanticModelDefinition},"
+        + " properties = #{semanticModelVersionInfo.properties},"
+        + " audit_info = #{semanticModelVersionInfo.auditInfo},"
+        + " deleted_at = #{semanticModelVersionInfo.deletedAt}";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelPO.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import static org.apache.gravitino.storage.relational.utils.POConverters.DEFAULT_DELETED_AT;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.dto.semantic.SemanticModelDefinitionDTO;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.NamespacedEntityId;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.storage.relational.service.EntityIdService;
+
+/** The persistent object for Semantic Model identity metadata and its current version snapshot. */
+@Getter
+@EqualsAndHashCode(exclude = "semanticModelVersionInfoPO")
+@ToString
+public class SemanticModelPO {
+
+  /** The initial version allocated to a newly created Semantic Model. */
+  public static final Integer INITIAL_VERSION = 1;
+
+  private Long semanticModelId;
+  private String semanticModelName;
+  private Long metalakeId;
+  private Long catalogId;
+  private Long schemaId;
+  private String auditInfo;
+  private Integer currentVersion;
+  private Integer lastVersion;
+  private Long deletedAt;
+  private SemanticModelVersionInfoPO semanticModelVersionInfoPO;
+
+  /** Creates an empty persistent object for MyBatis. */
+  public SemanticModelPO() {}
+
+  /** A Lombok builder for {@link SemanticModelPO}. */
+  public static class SemanticModelPOBuilder {
+    // Lombok generates the builder methods.
+  }
+
+  @lombok.Builder(setterPrefix = "with")
+  private SemanticModelPO(
+      Long semanticModelId,
+      String semanticModelName,
+      Long metalakeId,
+      Long catalogId,
+      Long schemaId,
+      String auditInfo,
+      Integer currentVersion,
+      Integer lastVersion,
+      Long deletedAt,
+      SemanticModelVersionInfoPO semanticModelVersionInfoPO) {
+    Preconditions.checkArgument(semanticModelId != null, "Semantic Model id is required");
+    Preconditions.checkArgument(semanticModelName != null, "Semantic Model name is required");
+    Preconditions.checkArgument(metalakeId != null, "Metalake id is required");
+    Preconditions.checkArgument(catalogId != null, "Catalog id is required");
+    Preconditions.checkArgument(schemaId != null, "Schema id is required");
+    Preconditions.checkArgument(auditInfo != null, "Audit info is required");
+    Preconditions.checkArgument(currentVersion != null, "Current version is required");
+    Preconditions.checkArgument(lastVersion != null, "Last version is required");
+    Preconditions.checkArgument(deletedAt != null, "Deleted at is required");
+
+    this.semanticModelId = semanticModelId;
+    this.semanticModelName = semanticModelName;
+    this.metalakeId = metalakeId;
+    this.catalogId = catalogId;
+    this.schemaId = schemaId;
+    this.auditInfo = auditInfo;
+    this.currentVersion = currentVersion;
+    this.lastVersion = lastVersion;
+    this.deletedAt = deletedAt;
+    this.semanticModelVersionInfoPO = semanticModelVersionInfoPO;
+  }
+
+  /**
+   * Converts a persistent object and its current version snapshot to a Semantic Model entity.
+   *
+   * @param semanticModelPO The persistent object to convert.
+   * @param namespace The Semantic Model namespace.
+   * @return The converted Semantic Model entity.
+   */
+  public static SemanticModelEntity fromSemanticModelPO(
+      SemanticModelPO semanticModelPO, Namespace namespace) {
+    try {
+      SemanticModelVersionInfoPO versionPO = semanticModelPO.getSemanticModelVersionInfoPO();
+      SemanticModelDefinitionDTO definitionDTO =
+          JsonUtils.anyFieldMapper()
+              .readValue(versionPO.semanticModelDefinition(), SemanticModelDefinitionDTO.class);
+      Map<String, String> properties =
+          versionPO.properties() == null
+              ? Collections.emptyMap()
+              : JsonUtils.anyFieldMapper()
+                  .readValue(
+                      versionPO.properties(),
+                      JsonUtils.anyFieldMapper()
+                          .getTypeFactory()
+                          .constructMapType(Map.class, String.class, String.class));
+
+      return SemanticModelEntity.builder()
+          .withId(semanticModelPO.getSemanticModelId())
+          .withName(versionPO.semanticModelName())
+          .withNamespace(namespace)
+          .withComment(versionPO.semanticModelComment())
+          .withDefinition(definitionDTO.toDefinition())
+          .withProperties(properties)
+          .withAuditInfo(
+              JsonUtils.anyFieldMapper().readValue(semanticModelPO.getAuditInfo(), AuditInfo.class))
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to deserialize Semantic Model JSON", e);
+    }
+  }
+
+  /**
+   * Initializes a new Semantic Model identity and version-one snapshot.
+   *
+   * @param semanticModelEntity The Semantic Model entity.
+   * @param builder The identity persistent-object builder.
+   * @return The initialized persistent object.
+   */
+  public static SemanticModelPO initializeSemanticModelPO(
+      SemanticModelEntity semanticModelEntity, SemanticModelPOBuilder builder) {
+    return buildSemanticModelPO(semanticModelEntity, builder, INITIAL_VERSION);
+  }
+
+  /**
+   * Creates a complete version snapshot for a Semantic Model entity.
+   *
+   * @param semanticModelEntity The Semantic Model entity.
+   * @param namespacedEntityId The resolved schema and ancestor IDs.
+   * @param version The version to allocate.
+   * @return The version snapshot persistent object.
+   */
+  public static SemanticModelVersionInfoPO initializeSemanticModelVersionInfoPO(
+      SemanticModelEntity semanticModelEntity,
+      NamespacedEntityId namespacedEntityId,
+      Integer version) {
+    try {
+      String definitionJson =
+          JsonUtils.anyFieldMapper()
+              .writeValueAsString(
+                  SemanticModelDefinitionDTO.fromDefinition(semanticModelEntity.definition()));
+      String propertiesJson =
+          semanticModelEntity.properties().isEmpty()
+              ? null
+              : JsonUtils.anyFieldMapper().writeValueAsString(semanticModelEntity.properties());
+
+      return SemanticModelVersionInfoPO.builder()
+          .withSemanticModelId(semanticModelEntity.id())
+          .withMetalakeId(namespacedEntityId.namespaceIds()[0])
+          .withCatalogId(namespacedEntityId.namespaceIds()[1])
+          .withSchemaId(namespacedEntityId.entityId())
+          .withVersion(version)
+          .withSemanticModelName(semanticModelEntity.name())
+          .withSemanticModelComment(semanticModelEntity.comment())
+          .withSemanticModelDefinition(definitionJson)
+          .withProperties(propertiesJson)
+          .withAuditInfo(
+              JsonUtils.anyFieldMapper().writeValueAsString(semanticModelEntity.auditInfo()))
+          .withDeletedAt(DEFAULT_DELETED_AT)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize Semantic Model JSON", e);
+    }
+  }
+
+  /**
+   * Builds a Semantic Model identity persistent object and the requested complete snapshot.
+   *
+   * @param semanticModelEntity The Semantic Model entity.
+   * @param builder The identity persistent-object builder.
+   * @param version The version to allocate.
+   * @return The built persistent object.
+   */
+  public static SemanticModelPO buildSemanticModelPO(
+      SemanticModelEntity semanticModelEntity, SemanticModelPOBuilder builder, Integer version) {
+    try {
+      NamespacedEntityId namespacedEntityId =
+          EntityIdService.getEntityIds(
+              NameIdentifier.of(semanticModelEntity.namespace().levels()),
+              Entity.EntityType.SCHEMA);
+      SemanticModelVersionInfoPO versionPO =
+          initializeSemanticModelVersionInfoPO(semanticModelEntity, namespacedEntityId, version);
+      return builder
+          .withSemanticModelId(semanticModelEntity.id())
+          .withSemanticModelName(semanticModelEntity.name())
+          .withMetalakeId(namespacedEntityId.namespaceIds()[0])
+          .withCatalogId(namespacedEntityId.namespaceIds()[1])
+          .withSchemaId(namespacedEntityId.entityId())
+          .withAuditInfo(
+              JsonUtils.anyFieldMapper().writeValueAsString(semanticModelEntity.auditInfo()))
+          .withCurrentVersion(version)
+          .withLastVersion(version)
+          .withSemanticModelVersionInfoPO(versionPO)
+          .withDeletedAt(DEFAULT_DELETED_AT)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize Semantic Model audit info", e);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelVersionInfoPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/SemanticModelVersionInfoPO.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import com.google.common.base.Preconditions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.apache.commons.lang3.StringUtils;
+
+/** The persistent object for a complete Semantic Model version snapshot. */
+@EqualsAndHashCode
+@Getter
+@ToString
+@Accessors(fluent = true)
+public class SemanticModelVersionInfoPO {
+
+  private Long id;
+  private Long metalakeId;
+  private Long catalogId;
+  private Long schemaId;
+  private Long semanticModelId;
+  private Integer version;
+  private String semanticModelName;
+  private String semanticModelComment;
+  private String semanticModelDefinition;
+  private String properties;
+  private String auditInfo;
+  private Long deletedAt;
+
+  /** Creates an empty persistent object for MyBatis. */
+  public SemanticModelVersionInfoPO() {}
+
+  @lombok.Builder(setterPrefix = "with")
+  private SemanticModelVersionInfoPO(
+      Long id,
+      Long metalakeId,
+      Long catalogId,
+      Long schemaId,
+      Long semanticModelId,
+      Integer version,
+      String semanticModelName,
+      String semanticModelComment,
+      String semanticModelDefinition,
+      String properties,
+      String auditInfo,
+      Long deletedAt) {
+    Preconditions.checkArgument(metalakeId != null, "Metalake id is required");
+    Preconditions.checkArgument(catalogId != null, "Catalog id is required");
+    Preconditions.checkArgument(schemaId != null, "Schema id is required");
+    Preconditions.checkArgument(semanticModelId != null, "Semantic Model id is required");
+    Preconditions.checkArgument(version != null, "Semantic Model version is required");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(semanticModelName), "Semantic Model name cannot be empty");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(semanticModelDefinition),
+        "Semantic Model definition cannot be empty");
+    Preconditions.checkArgument(StringUtils.isNotBlank(auditInfo), "Audit info cannot be empty");
+    Preconditions.checkArgument(deletedAt != null, "Deleted at is required");
+
+    this.id = id;
+    this.metalakeId = metalakeId;
+    this.catalogId = catalogId;
+    this.schemaId = schemaId;
+    this.semanticModelId = semanticModelId;
+    this.version = version;
+    this.semanticModelName = semanticModelName;
+    this.semanticModelComment = semanticModelComment;
+    this.semanticModelDefinition = semanticModelDefinition;
+    this.properties = properties;
+    this.auditInfo = auditInfo;
+    this.deletedAt = deletedAt;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -502,10 +502,10 @@ public class SchemaMetaService {
   }
 
   /**
-   * Holds the parent schema row while a table, view, fileset, function, model, model version, or
-   * topic is written, so a child cannot be added below a schema that is going away. The lock is
-   * shared, so children of the same schema can still be written in parallel; dropping the schema
-   * takes the row exclusively and therefore waits for them.
+   * Holds the parent schema row while a table, view, fileset, function, model, model version,
+   * Semantic Model, or topic is written, so a child cannot be added below a schema that is going
+   * away. The lock is shared, so children of the same schema can still be written in parallel;
+   * dropping the schema takes the row exclusively and therefore waits for them.
    */
   void lockSchemaForEntityWrite(
       NameIdentifier entityIdentifier,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SemanticModelMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SemanticModelMetaService.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.service;
+
+import static org.apache.gravitino.metrics.source.MetricsSource.GRAVITINO_RELATIONAL_STORE_METRIC_NAME;
+import static org.apache.gravitino.storage.relational.po.SemanticModelPO.fromSemanticModelPO;
+import static org.apache.gravitino.storage.relational.po.SemanticModelPO.initializeSemanticModelPO;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.metrics.Monitored;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelVersionInfoMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.gravitino.storage.relational.po.SemanticModelVersionInfoPO;
+import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+
+/** Provides relational create and load operations for Semantic Model metadata. */
+public class SemanticModelMetaService {
+
+  private static final SemanticModelMetaService INSTANCE = new SemanticModelMetaService();
+
+  private final BasePOStorageOps<SemanticModelPO, SemanticModelMetaMapper> ops;
+
+  /** Returns the singleton Semantic Model metadata service. */
+  public static SemanticModelMetaService getInstance() {
+    return INSTANCE;
+  }
+
+  private SemanticModelMetaService() {
+    this.ops = new HierarchicalConversionPOStorageOps<>(new SemanticModelPOStorageOps());
+  }
+
+  /**
+   * Resolves a Semantic Model stable ID by schema ID and name.
+   *
+   * @param schemaId The parent schema ID.
+   * @param semanticModelName The Semantic Model name.
+   * @return The stable Semantic Model ID.
+   * @throws NoSuchEntityException If the Semantic Model does not exist.
+   */
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "getSemanticModelIdBySchemaIdAndName")
+  public Long getSemanticModelIdBySchemaIdAndName(long schemaId, String semanticModelName) {
+    Long semanticModelId =
+        SessionUtils.getWithoutCommit(
+            SemanticModelMetaMapper.class,
+            mapper -> mapper.selectSemanticModelIdBySchemaIdAndName(schemaId, semanticModelName));
+    if (semanticModelId == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.SEMANTIC_MODEL.name().toLowerCase(Locale.ROOT),
+          semanticModelName);
+    }
+    return semanticModelId;
+  }
+
+  /**
+   * Loads the current Semantic Model by identifier.
+   *
+   * @param identifier The Semantic Model identifier.
+   * @return The current Semantic Model entity.
+   * @throws NoSuchEntityException If the Semantic Model does not exist.
+   */
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "getSemanticModelByIdentifier")
+  public SemanticModelEntity getSemanticModelByIdentifier(NameIdentifier identifier) {
+    SemanticModelPO semanticModelPO = getSemanticModelPOByIdentifier(identifier);
+    return fromSemanticModelPO(semanticModelPO, identifier.namespace());
+  }
+
+  /**
+   * Inserts or overwrites a Semantic Model identity and its snapshot atomically.
+   *
+   * @param semanticModelEntity The Semantic Model entity.
+   * @param overwrite Whether to overwrite rows for the same stable ID or natural key.
+   * @throws IOException If relational persistence fails.
+   */
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "insertSemanticModel")
+  public void insertSemanticModel(SemanticModelEntity semanticModelEntity, boolean overwrite)
+      throws IOException {
+    NameIdentifierUtil.checkSemanticModel(semanticModelEntity.nameIdentifier());
+    try {
+      SemanticModelPO po =
+          initializeSemanticModelPO(semanticModelEntity, SemanticModelPO.builder());
+      AtomicReference<SemanticModelPO> persistedPO = new AtomicReference<>(po);
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              SchemaMetaService.getInstance()
+                  .lockSchemaForEntityWrite(
+                      semanticModelEntity.nameIdentifier(),
+                      po.getSchemaId(),
+                      po.getCatalogId(),
+                      po.getMetalakeId()),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  SemanticModelMetaMapper.class,
+                  mapper -> {
+                    SemanticModelPO storedPO =
+                        overwrite
+                            ? mapper.selectSemanticModelMetaBySchemaIdAndNameForUpdate(
+                                po.getSchemaId(), po.getSemanticModelName())
+                            : null;
+                    if (storedPO == null) {
+                      // Keep a missing-row import strict. Concurrent imports that both observed no
+                      // identity must not turn the losing insert into an overwrite with another ID.
+                      ops.insertPO(mapper, po, false);
+                      return;
+                    }
+
+                    SemanticModelPO replacementPO = semanticModelForOverwrite(po, storedPO);
+                    Integer updated = mapper.updateSemanticModelMeta(replacementPO, storedPO);
+                    Preconditions.checkState(
+                        updated != null && updated == 1,
+                        "The overwritten Semantic Model %s in schema %s changed while its row was held",
+                        po.getSemanticModelName(),
+                        po.getSchemaId());
+                    persistedPO.set(replacementPO);
+                  }),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  SemanticModelVersionInfoMapper.class,
+                  mapper ->
+                      mapper.insertSemanticModelVersionInfo(
+                          persistedPO.get().getSemanticModelVersionInfoPO())));
+    } catch (RuntimeException re) {
+      ExceptionUtils.checkSQLException(
+          re, Entity.EntityType.SEMANTIC_MODEL, semanticModelEntity.nameIdentifier().toString());
+      throw re;
+    }
+  }
+
+  /** Returns the persistent-object operations used by this service. */
+  public BasePOStorageOps<SemanticModelPO, SemanticModelMetaMapper> ops() {
+    return ops;
+  }
+
+  private static SemanticModelPO semanticModelForOverwrite(
+      SemanticModelPO source, SemanticModelPO persistedPO) {
+    int previousVersion = Math.max(persistedPO.getCurrentVersion(), persistedPO.getLastVersion());
+    Preconditions.checkState(
+        previousVersion < Integer.MAX_VALUE,
+        "Semantic Model %s has exhausted the version range",
+        persistedPO.getSemanticModelId());
+    int nextVersion = previousVersion + 1;
+    return SemanticModelPO.builder()
+        .withSemanticModelId(persistedPO.getSemanticModelId())
+        .withSemanticModelName(source.getSemanticModelName())
+        .withMetalakeId(persistedPO.getMetalakeId())
+        .withCatalogId(persistedPO.getCatalogId())
+        .withSchemaId(persistedPO.getSchemaId())
+        .withAuditInfo(source.getAuditInfo())
+        .withCurrentVersion(nextVersion)
+        .withLastVersion(nextVersion)
+        .withDeletedAt(source.getDeletedAt())
+        .withSemanticModelVersionInfoPO(
+            versionInfoForOverwrite(
+                source.getSemanticModelVersionInfoPO(), persistedPO, nextVersion))
+        .build();
+  }
+
+  private static SemanticModelVersionInfoPO versionInfoForOverwrite(
+      SemanticModelVersionInfoPO source, SemanticModelPO persistedPO, int nextVersion) {
+    return SemanticModelVersionInfoPO.builder()
+        .withMetalakeId(persistedPO.getMetalakeId())
+        .withCatalogId(persistedPO.getCatalogId())
+        .withSchemaId(persistedPO.getSchemaId())
+        .withSemanticModelId(persistedPO.getSemanticModelId())
+        .withVersion(nextVersion)
+        .withSemanticModelName(source.semanticModelName())
+        .withSemanticModelComment(source.semanticModelComment())
+        .withSemanticModelDefinition(source.semanticModelDefinition())
+        .withProperties(source.properties())
+        .withAuditInfo(source.auditInfo())
+        .withDeletedAt(source.deletedAt())
+        .build();
+  }
+
+  private SemanticModelPO getSemanticModelPOByIdentifier(NameIdentifier identifier) {
+    NameIdentifierUtil.checkSemanticModel(identifier);
+    SemanticModelPO semanticModelPO =
+        SessionUtils.getWithoutCommit(
+            SemanticModelMetaMapper.class,
+            mapper ->
+                POStorageReadRouting.getPO(
+                    mapper, identifier, ops, Entity.EntityType.SEMANTIC_MODEL));
+    if (semanticModelPO == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.SEMANTIC_MODEL.name().toLowerCase(Locale.ROOT),
+          identifier.name());
+    }
+    return semanticModelPO;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SemanticModelPOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SemanticModelPOStorageOps.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.service;
+
+import java.util.Locale;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+
+/** Provides relational persistent-object operations required to create and load Semantic Models. */
+public class SemanticModelPOStorageOps
+    extends BasePOStorageOps<SemanticModelPO, SemanticModelMetaMapper> {
+
+  /** Creates Semantic Model persistent-object operations. */
+  public SemanticModelPOStorageOps() {}
+
+  @Override
+  public void insertPO(
+      SemanticModelMetaMapper mapper, SemanticModelPO semanticModelPO, boolean overwrite) {
+    if (overwrite) {
+      mapper.insertSemanticModelMetaOnDuplicateKeyUpdate(semanticModelPO);
+    } else {
+      mapper.insertSemanticModelMeta(semanticModelPO);
+    }
+  }
+
+  @Override
+  public SemanticModelPO getPO(
+      SemanticModelMetaMapper mapper, Long parentId, String semanticModelName) {
+    return mapper.selectSemanticModelMetaBySchemaIdAndName(parentId, semanticModelName);
+  }
+
+  @Override
+  public SemanticModelPO getPOByFullName(
+      SemanticModelMetaMapper mapper, NameIdentifier identifier) {
+    Namespace namespace = identifier.namespace();
+    SemanticModelPO po =
+        mapper.selectSemanticModelByFullQualifiedName(
+            namespace.level(0), namespace.level(1), namespace.level(2), identifier.name());
+    if (po == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.CATALOG.name().toLowerCase(Locale.ROOT),
+          namespace.level(1));
+    }
+    if (po.getSchemaId() == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.SCHEMA.name().toLowerCase(Locale.ROOT),
+          namespace.level(2));
+    }
+    if (po.getSemanticModelId() == null) {
+      return null;
+    }
+    return po;
+  }
+
+  @Override
+  public boolean supportsParentIdRelationalRead() {
+    return true;
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperations.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperations.java
@@ -18,39 +18,210 @@
  */
 package org.apache.gravitino.catalog;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.SemanticModel;
 import org.apache.gravitino.semantic.SemanticModelChange;
 import org.apache.gravitino.semantic.SemanticModelDefinition;
 import org.apache.gravitino.storage.IdGenerator;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.memory.TestMemoryEntityStore.InMemoryEntityStore;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 public class TestManagedSemanticModelOperations {
 
   private static final Namespace NAMESPACE = Namespace.of("metalake", "catalog", "schema");
-  private static final NameIdentifier IDENT = NameIdentifier.of(NAMESPACE, "model");
-
-  private final ManagedSemanticModelOperations operations =
-      new ManagedSemanticModelOperations(mock(EntityStore.class), mock(IdGenerator.class));
+  private static final NameIdentifier IDENT = NameIdentifier.of(NAMESPACE, "sales_model");
 
   @Test
-  public void testOperationsRemainUnsupportedUntilEntityPersistenceIsAdded() {
-    SemanticModelDefinition definition = mock(SemanticModelDefinition.class);
+  public void testCreateThenLoadFromMemoryStore() {
+    InMemoryEntityStore store = new InMemoryEntityStore();
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(
+            store, new RandomIdGenerator(), (ident, definition) -> {});
+
+    SemanticModel created =
+        operations.createSemanticModel(
+            IDENT, "Sales model", definition("orders"), Map.of("domain", "sales"));
+    SemanticModel loaded = operations.loadSemanticModel(IDENT);
+
+    assertSame(created, loaded);
+    assertEquals("sales_model", loaded.name());
+    assertEquals("Sales model", loaded.comment());
+    assertEquals(definition("orders"), loaded.definition());
+    assertEquals(Map.of("domain", "sales"), loaded.properties());
+    assertNotNull(loaded.auditInfo().creator());
+    assertNotNull(loaded.auditInfo().createTime());
+  }
+
+  @Test
+  public void testValidationAndPersistenceOrder() throws IOException {
+    EntityStore store = mock(EntityStore.class);
+    IdGenerator idGenerator = mock(IdGenerator.class);
+    @SuppressWarnings("unchecked")
+    BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator = mock(BiConsumer.class);
+    when(idGenerator.nextId()).thenReturn(7L);
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(store, idGenerator, writeValidator);
+    SemanticModelDefinition definition = definition("orders");
+
+    SemanticModel created =
+        operations.createSemanticModel(IDENT, null, definition, Map.of("key", "value"));
+
+    InOrder order = inOrder(writeValidator, idGenerator, store);
+    order.verify(writeValidator).accept(IDENT, definition);
+    order.verify(idGenerator).nextId();
+    order.verify(store).put(any(SemanticModelEntity.class), eq(false));
+    assertEquals(7L, ((SemanticModelEntity) created).id());
+  }
+
+  @Test
+  public void testWriteValidationPrecedesEntityConstructionAndPersistence() {
+    @SuppressWarnings("unchecked")
+    BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator = mock(BiConsumer.class);
+    IllegalSemanticModelException failure =
+        new IllegalSemanticModelException("Semantic Model definition is invalid");
+    doThrow(failure).when(writeValidator).accept(eq(IDENT), any(SemanticModelDefinition.class));
+    EntityStore store = mock(EntityStore.class);
+    IdGenerator idGenerator = mock(IdGenerator.class);
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(store, idGenerator, writeValidator);
+
+    assertSame(
+        failure,
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () -> operations.createSemanticModel(IDENT, null, definition("orders"), Map.of())));
+    verifyNoInteractions(idGenerator, store);
+  }
+
+  @Test
+  public void testLoadDoesNotRunAnyValidation() throws IOException {
+    EntityStore store = mock(EntityStore.class);
+    @SuppressWarnings("unchecked")
+    BiConsumer<NameIdentifier, SemanticModelDefinition> writeValidator = mock(BiConsumer.class);
+    SemanticModelEntity entity = entity();
+    when(store.get(IDENT, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class))
+        .thenReturn(entity);
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(store, mock(IdGenerator.class), writeValidator);
+
+    assertSame(entity, operations.loadSemanticModel(IDENT));
+
+    verifyNoInteractions(writeValidator);
+  }
+
+  @Test
+  public void testCreateExceptionMapping() throws IOException {
+    assertCreateFailure(new NoSuchEntityException("Missing parent"), NoSuchSchemaException.class);
+    assertCreateFailure(
+        new EntityAlreadyExistsException("Already exists"),
+        SemanticModelAlreadyExistsException.class);
+
+    IOException ioFailure = new IOException("Write failed");
+    RuntimeException wrapped = assertCreateFailure(ioFailure, RuntimeException.class);
+    assertSame(ioFailure, wrapped.getCause());
+  }
+
+  @Test
+  public void testLoadExceptionMapping() throws IOException {
+    EntityStore store = mock(EntityStore.class);
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(
+            store, mock(IdGenerator.class), (ident, definition) -> {});
+
+    when(store.get(IDENT, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class))
+        .thenThrow(new NoSuchEntityException("Missing model"));
+    assertThrows(NoSuchSemanticModelException.class, () -> operations.loadSemanticModel(IDENT));
+
+    IOException ioFailure = new IOException("Read failed");
+    doThrow(ioFailure)
+        .when(store)
+        .get(IDENT, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class);
+    RuntimeException wrapped =
+        assertThrows(RuntimeException.class, () -> operations.loadSemanticModel(IDENT));
+    assertSame(ioFailure, wrapped.getCause());
+  }
+
+  @Test
+  public void testRemainingCapabilitiesAreExplicitlyUnsupported() {
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(
+            mock(EntityStore.class), mock(IdGenerator.class), (ident, definition) -> {});
 
     assertThrows(
         UnsupportedOperationException.class, () -> operations.listSemanticModels(NAMESPACE));
-    assertThrows(UnsupportedOperationException.class, () -> operations.loadSemanticModel(IDENT));
     assertThrows(
         UnsupportedOperationException.class,
-        () -> operations.createSemanticModel(IDENT, null, definition, Map.of()));
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> operations.alterSemanticModel(IDENT, SemanticModelChange.updateComment("updated")));
+        () ->
+            operations.alterSemanticModel(
+                IDENT, SemanticModelChange.updateComment("Not implemented")));
     assertThrows(UnsupportedOperationException.class, () -> operations.dropSemanticModel(IDENT));
+  }
+
+  private static RuntimeException assertCreateFailure(
+      Exception failure, Class<? extends RuntimeException> expectedType) throws IOException {
+    EntityStore store = mock(EntityStore.class);
+    doThrow(failure).when(store).put(any(SemanticModelEntity.class), eq(false));
+    ManagedSemanticModelOperations operations =
+        new ManagedSemanticModelOperations(store, () -> 1L, (ident, definition) -> {});
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class,
+            () -> operations.createSemanticModel(IDENT, null, definition("orders"), Map.of()));
+    assertInstanceOf(expectedType, thrown);
+    return thrown;
+  }
+
+  private static SemanticModelEntity entity() {
+    return SemanticModelEntity.builder()
+        .withId(1L)
+        .withName(IDENT.name())
+        .withNamespace(IDENT.namespace())
+        .withDefinition(definition("orders"))
+        .withAuditInfo(AuditInfo.EMPTY)
+        .build();
+  }
+
+  private static SemanticModelDefinition definition(String datasetName) {
+    return SemanticModelDefinition.builder()
+        .withDatasets(new Dataset[] {dataset(datasetName)})
+        .build();
+  }
+
+  private static Dataset dataset(String name) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .build();
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperationsJDBC.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestManagedSemanticModelOperationsJDBC.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.cache.NoOpsCache;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.relational.RelationalEntityStore;
+import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.utils.NamespaceUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/** Verifies managed create and load through a real relational persistence backend. */
+public class TestManagedSemanticModelOperationsJDBC extends TestJDBCBackend {
+
+  private final AtomicInteger writeValidationCount = new AtomicInteger();
+
+  private Config previousConfig;
+  private NameIdentifier modelIdent;
+  private ManagedSemanticModelOperations operations;
+
+  @BeforeAll
+  public void captureEnvironmentConfig() {
+    previousConfig = GravitinoEnv.getInstance().config();
+  }
+
+  @BeforeEach
+  public void prepareManagedOperations() throws IOException, IllegalAccessException {
+    writeValidationCount.set(0);
+    String metalake = "managed_semantic_model_metalake";
+    String catalog = "managed_semantic_model_catalog";
+    String schema = "managed_semantic_model_schema";
+    createAndInsertMakeLake(metalake);
+    createAndInsertCatalog(metalake, catalog);
+    createAndInsertSchema(metalake, catalog, schema);
+
+    Namespace namespace = NamespaceUtil.ofSemanticModel(metalake, catalog, schema);
+    modelIdent = NameIdentifier.of(namespace, "sales_model");
+
+    Config config = new Config(false) {};
+    config.set(Configs.CACHE_ENABLED, false);
+    RelationalEntityStore store = new RelationalEntityStore();
+    FieldUtils.writeField(store, "backend", backend, true);
+    FieldUtils.writeField(store, "cache", new NoOpsCache(config), true);
+    operations =
+        new ManagedSemanticModelOperations(
+            store,
+            RandomIdGenerator.INSTANCE,
+            (ident, definition) -> writeValidationCount.incrementAndGet());
+  }
+
+  @AfterEach
+  public void restoreEnvironmentConfig() throws IllegalAccessException {
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "config", previousConfig, true);
+  }
+
+  @TestTemplate
+  public void testCreateThenLoadRoundTrip() throws IOException {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("source_catalog", "source_schema", "orders"))
+            .withPrimaryKey(new String[0])
+            .withUniqueKeys(new String[0][])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {dataset})
+            .withRelationships(new Relationship[0])
+            .withMetrics((Metric[]) null)
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+
+    SemanticModel created =
+        operations.createSemanticModel(
+            modelIdent, "Persisted model", definition, Map.of("domain", "sales"));
+    SemanticModel loaded = operations.loadSemanticModel(modelIdent);
+
+    assertNotSame(created, loaded);
+    assertEquals(created, loaded);
+    assertEquals(definition, loaded.definition());
+    assertEquals(1, writeValidationCount.get());
+    assertTrue(backend.exists(modelIdent, Entity.EntityType.SEMANTIC_MODEL));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelOperationDispatcher.java
@@ -21,33 +21,46 @@ package org.apache.gravitino.catalog;
 import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
 import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
 import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Config;
-import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
+import org.apache.gravitino.exceptions.ConnectionFailedException;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
-import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
 import org.apache.gravitino.lock.LockManager;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.View;
 import org.apache.gravitino.secret.SecretManager;
 import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModel;
 import org.apache.gravitino.semantic.SemanticModelChange;
 import org.apache.gravitino.semantic.SemanticModelDefinition;
-import org.apache.gravitino.storage.IdGenerator;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.memory.TestMemoryEntityStore.InMemoryEntityStore;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,13 +68,23 @@ import org.junit.jupiter.api.Test;
 public class TestSemanticModelOperationDispatcher {
 
   private static final String METALAKE = "metalake";
-  private static final NameIdentifier CATALOG_IDENT = NameIdentifier.of(METALAKE, "catalog");
-  private static final Namespace NAMESPACE = Namespace.of(METALAKE, "catalog", "schema");
+  private static final NameIdentifier METADATA_CATALOG_IDENT =
+      NameIdentifier.of(METALAKE, "metadata_catalog");
+  private static final NameIdentifier SOURCE_CATALOG_IDENT = NameIdentifier.of(METALAKE, "sales");
+  private static final Namespace NAMESPACE =
+      Namespace.of(METALAKE, "metadata_catalog", "semantic_schema");
   private static final NameIdentifier SCHEMA_IDENT = NameIdentifier.of(NAMESPACE.levels());
   private static final NameIdentifier MODEL_IDENT = NameIdentifier.of(NAMESPACE, "sales_model");
+  private static final NameIdentifier ORDERS_SOURCE =
+      NameIdentifier.of(Namespace.of(METALAKE, "sales", "mart"), "orders");
+  private static final NameIdentifier CUSTOMERS_SOURCE =
+      NameIdentifier.of(Namespace.of(METALAKE, "sales", "mart"), "customers");
 
   private CatalogManager catalogManager;
   private SchemaDispatcher schemaDispatcher;
+  private TableDispatcher tableDispatcher;
+  private ViewDispatcher viewDispatcher;
+  private InMemoryEntityStore store;
   private SemanticModelOperationDispatcher dispatcher;
 
   @BeforeAll
@@ -77,10 +100,14 @@ public class TestSemanticModelOperationDispatcher {
   public void setUp() throws Exception {
     catalogManager = mock(CatalogManager.class);
     schemaDispatcher = mock(SchemaDispatcher.class);
+    tableDispatcher = mock(TableDispatcher.class);
+    viewDispatcher = mock(ViewDispatcher.class);
+    store = new InMemoryEntityStore();
 
+    useSourceCapability(Capability.DEFAULT);
     Catalog catalog = mock(Catalog.class);
     when(catalog.type()).thenReturn(Catalog.Type.RELATIONAL);
-    when(catalogManager.loadCatalog(CATALOG_IDENT)).thenReturn(catalog);
+    when(catalogManager.loadCatalog(METADATA_CATALOG_IDENT)).thenReturn(catalog);
     when(schemaDispatcher.loadSchema(SCHEMA_IDENT)).thenReturn(mock(Schema.class));
     when(schemaDispatcher.schemaExists(SCHEMA_IDENT)).thenReturn(true);
 
@@ -88,97 +115,270 @@ public class TestSemanticModelOperationDispatcher {
         new SemanticModelOperationDispatcher(
             catalogManager,
             schemaDispatcher,
-            mock(EntityStore.class),
-            mock(IdGenerator.class),
+            tableDispatcher,
+            viewDispatcher,
+            store,
+            new RandomIdGenerator(),
             mock(SecretManager.class));
   }
 
   @Test
-  public void testFrameworkValidatesParentAndDelegatesToManagedOperations() {
-    UnsupportedOperationException listFailure =
-        assertThrows(
-            UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
-    assertTrue(listFailure.getMessage().startsWith("listSemanticModels:"));
+  public void testCreateWithTableAndLogicalViewSourcesThenLoad() {
+    doReturn(tableWithColumns("order_id", "customer_id"))
+        .when(tableDispatcher)
+        .loadTable(ORDERS_SOURCE);
+    when(tableDispatcher.loadTable(CUSTOMERS_SOURCE))
+        .thenThrow(new NoSuchTableException("Table does not exist"));
+    doReturn(viewWithColumns("customer_id")).when(viewDispatcher).loadView(CUSTOMERS_SOURCE);
 
-    UnsupportedOperationException createFailure =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), Map.of()));
-    assertTrue(createFailure.getMessage().startsWith("createSemanticModel:"));
+    SemanticModel created =
+        dispatcher.createSemanticModel(MODEL_IDENT, "Sales", validDefinition(), Map.of());
 
-    UnsupportedOperationException loadFailure =
-        assertThrows(
-            UnsupportedOperationException.class, () -> dispatcher.loadSemanticModel(MODEL_IDENT));
-    assertTrue(loadFailure.getMessage().startsWith("loadSemanticModel:"));
-
-    UnsupportedOperationException alterFailure =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                dispatcher.alterSemanticModel(
-                    MODEL_IDENT, SemanticModelChange.updateComment("updated")));
-    assertTrue(alterFailure.getMessage().startsWith("alterSemanticModel:"));
-
-    UnsupportedOperationException dropFailure =
-        assertThrows(
-            UnsupportedOperationException.class, () -> dispatcher.dropSemanticModel(MODEL_IDENT));
-    assertTrue(dropFailure.getMessage().startsWith("dropSemanticModel:"));
-
-    verify(schemaDispatcher, times(2)).loadSchema(SCHEMA_IDENT);
-    verify(schemaDispatcher, times(3)).schemaExists(SCHEMA_IDENT);
+    assertEquals("sales_model", created.name());
+    assertEquals(2, created.definition().datasets().length);
+    assertSame(created, dispatcher.loadSemanticModel(MODEL_IDENT));
+    verify(tableDispatcher).loadTable(ORDERS_SOURCE);
+    verify(tableDispatcher).loadTable(CUSTOMERS_SOURCE);
+    verify(viewDispatcher).loadView(CUSTOMERS_SOURCE);
   }
 
   @Test
-  public void testMissingSchemaPreservesTypedResults() {
+  public void testLoadDoesNotRevalidatePersistedSources() {
+    doReturn(tableWithColumns("order_id", "customer_id"))
+        .when(tableDispatcher)
+        .loadTable(ORDERS_SOURCE);
+    when(tableDispatcher.loadTable(CUSTOMERS_SOURCE))
+        .thenThrow(new NoSuchTableException("Table does not exist"));
+    doReturn(viewWithColumns("customer_id")).when(viewDispatcher).loadView(CUSTOMERS_SOURCE);
+    SemanticModel created =
+        dispatcher.createSemanticModel(MODEL_IDENT, null, validDefinition(), Map.of());
+
+    when(tableDispatcher.loadTable(ORDERS_SOURCE))
+        .thenThrow(new ConnectionFailedException("Source is now unavailable"));
+    when(viewDispatcher.loadView(CUSTOMERS_SOURCE))
+        .thenThrow(new ConnectionFailedException("Source is now unavailable"));
+    clearInvocations(tableDispatcher, viewDispatcher);
+
+    assertSame(created, dispatcher.loadSemanticModel(MODEL_IDENT));
+    verifyNoInteractions(tableDispatcher, viewDispatcher);
+  }
+
+  @Test
+  public void testPrimaryUniqueAndRelationshipColumnsAreValidated() {
+    doReturn(tableWithColumns("order_id", "customer_id"))
+        .when(tableDispatcher)
+        .loadTable(ORDERS_SOURCE);
+    doReturn(tableWithColumns("customer_id")).when(tableDispatcher).loadTable(CUSTOMERS_SOURCE);
+
+    Dataset badPrimary =
+        dataset("orders", "orders", new String[] {"missing"}, new String[][] {{"customer_id"}});
+    assertSourceColumnFailure(definition(badPrimary), "primaryKey[0]");
+
+    Dataset badUnique =
+        dataset("orders", "orders", new String[] {"order_id"}, new String[][] {{"missing"}});
+    assertSourceColumnFailure(definition(badUnique), "uniqueKeys[0][0]");
+
+    Relationship badRelationship =
+        Relationship.builder()
+            .withName("orders_to_customers")
+            .withFrom("orders")
+            .withTo("customers")
+            .withFromColumns(new String[] {"missing"})
+            .withToColumns(new String[] {"customer_id"})
+            .build();
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withDatasets(
+                new Dataset[] {
+                  dataset("orders", "orders", null, null),
+                  dataset("customers", "customers", null, null)
+                })
+            .withRelationships(new Relationship[] {badRelationship})
+            .build();
+    assertSourceColumnFailure(definition, "relationships[0].fromColumns[0]");
+  }
+
+  @Test
+  public void testCatalogColumnCaseSensitivityIsHonored() throws Exception {
+    doReturn(tableWithColumns("ORDER_ID")).when(tableDispatcher).loadTable(ORDERS_SOURCE);
+    SemanticModelDefinition lowerCaseReference =
+        definition(dataset("orders", "orders", new String[] {"order_id"}, null));
+
+    IllegalSemanticModelException caseSensitiveFailure =
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () ->
+                dispatcher.createSemanticModel(
+                    MODEL_IDENT, null, lowerCaseReference, Map.of("mode", "sensitive")));
+    assertTrue(caseSensitiveFailure.getMessage().contains("primaryKey[0]"));
+
+    useSourceCapability(new CaseInsensitiveColumnsCapability());
+    SemanticModel created =
+        dispatcher.createSemanticModel(
+            MODEL_IDENT, null, lowerCaseReference, Map.of("mode", "insensitive"));
+    assertEquals("orders", created.definition().datasets()[0].name());
+  }
+
+  @Test
+  public void testMissingSourceIsRejectedBeforePersistence() {
+    NameIdentifier missingSource =
+        NameIdentifier.of(Namespace.of(METALAKE, "sales", "mart"), "missing");
+    when(tableDispatcher.loadTable(missingSource))
+        .thenThrow(new NoSuchTableException("Table does not exist"));
+    when(viewDispatcher.loadView(missingSource))
+        .thenThrow(new NoSuchViewException("View does not exist"));
+    SemanticModelDefinition definition =
+        definition(dataset("missing", "missing", null, new String[0][]));
+
+    IllegalSemanticModelException failure =
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition, Map.of()));
+
+    assertTrue(failure.getMessage().contains("does not exist as a Table or logical View"));
+    assertFalse(dispatcher.semanticModelExists(MODEL_IDENT));
+  }
+
+  @Test
+  public void testSchemaAndConnectionFailuresRemainTyped() {
     when(schemaDispatcher.loadSchema(SCHEMA_IDENT))
         .thenThrow(new NoSuchSchemaException("Schema does not exist"));
-    when(schemaDispatcher.schemaExists(SCHEMA_IDENT)).thenReturn(false);
-
-    assertThrows(NoSuchSchemaException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
     assertThrows(
         NoSuchSchemaException.class,
-        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), Map.of()));
-    assertThrows(
-        NoSuchSemanticModelException.class, () -> dispatcher.loadSemanticModel(MODEL_IDENT));
-    assertThrows(
-        NoSuchSemanticModelException.class,
-        () ->
-            dispatcher.alterSemanticModel(
-                MODEL_IDENT, SemanticModelChange.updateComment("updated")));
-    assertFalse(dispatcher.dropSemanticModel(MODEL_IDENT));
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, validDefinition(), Map.of()));
+
+    doReturn(mock(Schema.class)).when(schemaDispatcher).loadSchema(SCHEMA_IDENT);
+    ConnectionFailedException failure = new ConnectionFailedException("Catalog unavailable");
+    when(tableDispatcher.loadTable(ORDERS_SOURCE)).thenThrow(failure);
+    assertSame(
+        failure,
+        assertThrows(
+            ConnectionFailedException.class,
+            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, validDefinition(), Map.of())));
+    verify(viewDispatcher, never()).loadView(ORDERS_SOURCE);
+    assertFalse(dispatcher.semanticModelExists(MODEL_IDENT));
   }
 
   @Test
   public void testNonRelationalCatalogIsRejectedBeforeSchemaLookup() {
     Catalog catalog = mock(Catalog.class);
     when(catalog.type()).thenReturn(Catalog.Type.FILESET);
-    when(catalogManager.loadCatalog(CATALOG_IDENT)).thenReturn(catalog);
+    when(catalogManager.loadCatalog(METADATA_CATALOG_IDENT)).thenReturn(catalog);
 
-    UnsupportedOperationException failure =
-        assertThrows(
-            UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
-
-    assertTrue(failure.getMessage().contains("does not support Semantic Model operations"));
+    assertThrows(
+        UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
     verify(schemaDispatcher, never()).loadSchema(SCHEMA_IDENT);
   }
 
   @Test
-  public void testInvalidInputsAreRejectedBeforeCatalogLookup() {
+  public void testRemainingManagedCapabilitiesStayUnsupported() {
     assertThrows(
-        IllegalArgumentException.class,
-        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, null, Map.of()));
+        UnsupportedOperationException.class, () -> dispatcher.listSemanticModels(NAMESPACE));
     assertThrows(
-        IllegalArgumentException.class,
-        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition(), null));
-    verify(catalogManager, never()).loadCatalog(CATALOG_IDENT);
+        UnsupportedOperationException.class,
+        () ->
+            dispatcher.alterSemanticModel(
+                MODEL_IDENT, SemanticModelChange.updateComment("Not implemented")));
+    assertThrows(
+        UnsupportedOperationException.class, () -> dispatcher.dropSemanticModel(MODEL_IDENT));
   }
 
-  private static SemanticModelDefinition definition() {
-    Dataset dataset =
-        Dataset.builder()
-            .withName("orders")
-            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+  @Test
+  public void testNullDefinitionIsRejectedByValidator() {
+    assertThrows(
+        IllegalSemanticModelException.class,
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, null, Map.of()));
+    assertFalse(dispatcher.semanticModelExists(MODEL_IDENT));
+  }
+
+  @Test
+  public void testNullPropertiesAreRejectedBeforeCatalogLookup() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> dispatcher.createSemanticModel(MODEL_IDENT, null, validDefinition(), null));
+    verify(catalogManager, never()).loadCatalog(METADATA_CATALOG_IDENT);
+  }
+
+  private void useSourceCapability(Capability capability) throws Exception {
+    CatalogManager.CatalogWrapper wrapper = mock(CatalogManager.CatalogWrapper.class);
+    when(wrapper.capabilities()).thenReturn(capability);
+    when(catalogManager.loadCatalogAndWrap(SOURCE_CATALOG_IDENT)).thenReturn(wrapper);
+  }
+
+  private void assertSourceColumnFailure(
+      SemanticModelDefinition definition, String expectedMessageFragment) {
+    IllegalSemanticModelException failure =
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () -> dispatcher.createSemanticModel(MODEL_IDENT, null, definition, Map.of()));
+    assertTrue(failure.getMessage().contains(expectedMessageFragment));
+    assertFalse(dispatcher.semanticModelExists(MODEL_IDENT));
+  }
+
+  private static SemanticModelDefinition validDefinition() {
+    Dataset orders =
+        dataset("orders", "orders", new String[] {"order_id"}, new String[][] {{"customer_id"}});
+    Dataset customers =
+        dataset("customers", "customers", new String[] {"customer_id"}, new String[0][]);
+    Relationship relationship =
+        Relationship.builder()
+            .withName("orders_to_customers")
+            .withFrom("orders")
+            .withTo("customers")
+            .withFromColumns(new String[] {"customer_id"})
+            .withToColumns(new String[] {"customer_id"})
             .build();
+    return SemanticModelDefinition.builder()
+        .withDatasets(new Dataset[] {orders, customers})
+        .withRelationships(new Relationship[] {relationship})
+        .build();
+  }
+
+  private static SemanticModelDefinition definition(Dataset dataset) {
     return SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset}).build();
+  }
+
+  private static Dataset dataset(
+      String name, String source, String[] primaryKey, String[][] uniqueKeys) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", source))
+        .withPrimaryKey(primaryKey)
+        .withUniqueKeys(uniqueKeys)
+        .build();
+  }
+
+  private static Table tableWithColumns(String... names) {
+    Table table = mock(Table.class);
+    Column[] tableColumns = columns(names);
+    when(table.columns()).thenReturn(tableColumns);
+    return table;
+  }
+
+  private static View viewWithColumns(String... names) {
+    View view = mock(View.class);
+    Column[] viewColumns = columns(names);
+    when(view.columns()).thenReturn(viewColumns);
+    return view;
+  }
+
+  private static Column[] columns(String... names) {
+    Column[] columns = new Column[names.length];
+    for (int index = 0; index < names.length; index++) {
+      columns[index] = mock(Column.class);
+      when(columns[index].name()).thenReturn(names[index]);
+    }
+    return columns;
+  }
+
+  private static final class CaseInsensitiveColumnsCapability implements Capability {
+
+    @Override
+    public CapabilityResult caseSensitiveOnName(Scope scope) {
+      if (scope == Scope.COLUMN) {
+        return CapabilityResult.unsupported("Column names are case-insensitive");
+      }
+      return CapabilityResult.SUPPORTED;
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelValidator.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSemanticModelValidator.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.AIContextObject;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dialects;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestSemanticModelValidator {
+
+  @Test
+  public void testValidCompleteDefinitionWithoutExternalResolution() {
+    CustomExtension extension = extension();
+    Dataset orders =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("missing_catalog", "missing_schema", "orders"))
+            .withPrimaryKey(new String[] {"order_id"})
+            .withUniqueKeys(new String[][] {{"order_id"}, {"external_id", "source"}})
+            .withFields(
+                new Field[] {
+                  field("id", expression("order_id")), field("amount", expression("amount"))
+                })
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+    Dataset customers =
+        Dataset.builder()
+            .withName("customers")
+            .withSource(NameIdentifier.of("missing_catalog", "missing_schema", "customers"))
+            .withFields(new Field[] {field("id", expression("customer_id"))})
+            .build();
+    Relationship relationship =
+        relationship(
+            "orders_to_customers",
+            "orders",
+            "customers",
+            new String[] {"customer_id", "tenant_id"},
+            new String[] {"id", "tenant_id"});
+    Metric metric =
+        Metric.builder()
+            .withName("total_revenue")
+            .withExpression(
+                multiDialectExpression(
+                    "SUM(orders.amount) /* text is intentionally uninterpreted */",
+                    "SUM(orders.amount)"))
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {orders, customers})
+            .withRelationships(new Relationship[] {relationship})
+            .withMetrics(new Metric[] {metric})
+            .withCustomExtensions(new CustomExtension[] {extension})
+            .build();
+
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(definition));
+  }
+
+  @ParameterizedTest
+  @MethodSource("validAIContexts")
+  public void testAIContextAcceptsTextAndObjectVariants(AIContext aiContext) {
+    SemanticModelDefinition definition =
+        SemanticModelDefinition.builder()
+            .withAIContext(aiContext)
+            .withDatasets(new Dataset[] {dataset("orders")})
+            .build();
+
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(definition));
+  }
+
+  @Test
+  public void testDefinitionValidationAcceptsCustomDialectsWithoutParsingSql() {
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withFields(
+                new Field[] {
+                  field(
+                      "order_id",
+                      Expression.builder()
+                          .withDialects(
+                              new DialectExpression[] {
+                                dialect("TRINO", "not parsed by metadata validation"),
+                                dialect("trino", "also preserved exactly")
+                              })
+                          .build())
+                })
+            .build();
+
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(definition(dataset)));
+  }
+
+  @Test
+  public void testValidateForWriteComposesDefinitionAndSourceValidation() throws Exception {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    TableDispatcher tableDispatcher = mock(TableDispatcher.class);
+    ViewDispatcher viewDispatcher = mock(ViewDispatcher.class);
+    CatalogManager.CatalogWrapper wrapper = mock(CatalogManager.CatalogWrapper.class);
+    when(wrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    when(catalogManager.loadCatalogAndWrap(NameIdentifier.of("metalake", "sales")))
+        .thenReturn(wrapper);
+
+    Column column = mock(Column.class);
+    when(column.name()).thenReturn("order_id");
+    Table table = mock(Table.class);
+    when(table.columns()).thenReturn(new Column[] {column});
+    NameIdentifier source = NameIdentifier.of(Namespace.of("metalake", "sales", "mart"), "orders");
+    when(tableDispatcher.loadTable(source)).thenReturn(table);
+
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withPrimaryKey(new String[] {"order_id"})
+            .build();
+    NameIdentifier model =
+        NameIdentifier.of(Namespace.of("metalake", "metadata", "models"), "sales_model");
+    SemanticModelValidator validator =
+        new SemanticModelValidator(catalogManager, tableDispatcher, viewDispatcher);
+
+    assertDoesNotThrow(() -> validator.validateForWrite(model, definition(dataset)));
+    verify(tableDispatcher).loadTable(source);
+    verifyNoInteractions(viewDispatcher);
+  }
+
+  @Test
+  public void testDefinitionFailurePreventsSourceResolution() {
+    CatalogManager catalogManager = mock(CatalogManager.class);
+    TableDispatcher tableDispatcher = mock(TableDispatcher.class);
+    ViewDispatcher viewDispatcher = mock(ViewDispatcher.class);
+    SemanticModelValidator validator =
+        new SemanticModelValidator(catalogManager, tableDispatcher, viewDispatcher);
+    NameIdentifier model =
+        NameIdentifier.of(Namespace.of("metalake", "metadata", "models"), "sales_model");
+
+    assertThrows(
+        IllegalSemanticModelException.class,
+        () -> validator.validateForWrite(model, definition(dataset("orders"), dataset("orders"))));
+    verifyNoInteractions(catalogManager, tableDispatcher, viewDispatcher);
+  }
+
+  @Test
+  public void testOptionalArraysDistinguishAbsentAndExplicitEmpty() {
+    SemanticModelDefinition absent =
+        SemanticModelDefinition.builder().withDatasets(new Dataset[] {dataset("orders")}).build();
+    Dataset explicitEmptyDataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withPrimaryKey(new String[0])
+            .withUniqueKeys(new String[0][])
+            .withFields(new Field[0])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+    SemanticModelDefinition explicitEmpty =
+        SemanticModelDefinition.builder()
+            .withDatasets(new Dataset[] {explicitEmptyDataset})
+            .withRelationships(new Relationship[0])
+            .withMetrics(new Metric[0])
+            .withCustomExtensions(new CustomExtension[0])
+            .build();
+
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(absent));
+    assertDoesNotThrow(() -> SemanticModelValidator.validateDefinition(explicitEmpty));
+  }
+
+  @Test
+  public void testDefinitionAndDatasetStructure() {
+    assertInvalid(null, "$: definition must not be null");
+
+    SemanticModelDefinition nullDataset = mock(SemanticModelDefinition.class);
+    when(nullDataset.datasets()).thenReturn(new Dataset[] {null});
+    assertInvalid(nullDataset, "datasets[0]: must not be null");
+
+    assertInvalid(
+        definition(dataset("orders"), dataset("orders")),
+        "datasets[1].name: duplicate dataset name 'orders'; first declared at datasets[0].name");
+
+    Dataset shortSource =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "orders"))
+            .build();
+    assertInvalid(
+        definition(shortSource),
+        "datasets[0].source: must contain exactly catalog.schema.name, but was 'sales.orders'");
+  }
+
+  @Test
+  public void testAIContextMustContainExactlyOneTypedVariant() {
+    AIContext invalidContext = mock(AIContext.class);
+    when(invalidContext.text()).thenReturn(null);
+    when(invalidContext.object()).thenReturn(null);
+    SemanticModelDefinition invalidDefinition = mock(SemanticModelDefinition.class);
+    when(invalidDefinition.aiContext()).thenReturn(invalidContext);
+    when(invalidDefinition.datasets()).thenReturn(new Dataset[] {dataset("orders")});
+
+    assertInvalid(invalidDefinition, "aiContext: must contain exactly one string or object value");
+
+    AIContext bothVariants = mock(AIContext.class);
+    when(bothVariants.text()).thenReturn("Use certified definitions");
+    when(bothVariants.object()).thenReturn(AIContextObject.builder().build());
+    when(invalidDefinition.aiContext()).thenReturn(bothVariants);
+    assertInvalid(invalidDefinition, "aiContext: must contain exactly one string or object value");
+  }
+
+  @Test
+  public void testFieldNamesAreUniquePerDataset() {
+    Dataset duplicateFields =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withFields(
+                new Field[] {field("id", expression("id")), field("id", expression("order_id"))})
+            .build();
+
+    assertInvalid(
+        definition(duplicateFields),
+        "datasets[0].fields[1].name: duplicate field name 'id'; first declared at "
+            + "datasets[0].fields[0].name");
+
+    assertDoesNotThrow(
+        () ->
+            SemanticModelValidator.validateDefinition(
+                definition(datasetWithField("orders", "id"), datasetWithField("customers", "id"))));
+  }
+
+  @Test
+  public void testDatasetKeyShapesAreDefensivelyValidated() {
+    Dataset invalidPrimary = mockDataset("orders");
+    when(invalidPrimary.primaryKey()).thenReturn(new String[] {null});
+    assertInvalid(
+        definition(invalidPrimary), "datasets[0].primaryKey[0]: must not be null or empty");
+
+    Dataset invalidUnique = mockDataset("orders");
+    when(invalidUnique.uniqueKeys()).thenReturn(new String[][] {new String[0]});
+    assertInvalid(
+        definition(invalidUnique), "datasets[0].uniqueKeys[0]: must not be null or empty");
+  }
+
+  @Test
+  public void testRelationshipNamesEndpointsAndColumns() {
+    Dataset orders = dataset("orders");
+    Dataset customers = dataset("customers");
+    Relationship relationship = relationship("by_customer", "orders", "customers");
+
+    assertInvalid(
+        definition(
+            new Dataset[] {orders, customers},
+            new Relationship[] {relationship, relationship},
+            null),
+        "relationships[1].name: duplicate relationship name 'by_customer'; first declared at "
+            + "relationships[0].name");
+    assertInvalid(
+        definition(
+            new Dataset[] {orders},
+            new Relationship[] {relationship("missing", "orders", "customers")},
+            null),
+        "relationships[0].to: unknown dataset 'customers'; relationship endpoints must reference "
+            + "datasets in the same model");
+
+    Relationship mismatched = mock(Relationship.class);
+    when(mismatched.name()).thenReturn("mismatched");
+    when(mismatched.from()).thenReturn("orders");
+    when(mismatched.to()).thenReturn("customers");
+    when(mismatched.fromColumns()).thenReturn(new String[] {"customer_id", "tenant_id"});
+    when(mismatched.toColumns()).thenReturn(new String[] {"id"});
+    assertInvalid(
+        definition(new Dataset[] {orders, customers}, new Relationship[] {mismatched}, null),
+        "relationships[0].toColumns: must contain 2 columns to match "
+            + "relationships[0].fromColumns, but contained 1");
+  }
+
+  @Test
+  public void testMetricNamesAndExpressions() {
+    Metric revenue = metric("revenue", expression("SUM(amount)"));
+    assertInvalid(
+        definition(new Dataset[] {dataset("orders")}, null, new Metric[] {revenue, revenue}),
+        "metrics[1].name: duplicate metric name 'revenue'; first declared at metrics[0].name");
+
+    DialectExpression ansi = dialect(Dialects.ANSI_SQL, "SUM(amount)");
+    Expression duplicateDialect = mock(Expression.class);
+    when(duplicateDialect.dialects()).thenReturn(new DialectExpression[] {ansi, ansi});
+    assertInvalid(
+        definition(
+            new Dataset[] {dataset("orders")},
+            null,
+            new Metric[] {metric("revenue", duplicateDialect)}),
+        "metrics[0].expression.dialects[1].dialect: duplicate dialect 'ANSI_SQL'; first declared "
+            + "at metrics[0].expression.dialects[0].dialect");
+  }
+
+  @Test
+  public void testNullNestedMembersAreDefensivelyValidated() {
+    Dataset nullField = mockDataset("orders");
+    when(nullField.fields()).thenReturn(new Field[] {null});
+    assertInvalid(definition(nullField), "datasets[0].fields[0]: must not be null");
+
+    SemanticModelDefinition nullRelationship = mock(SemanticModelDefinition.class);
+    when(nullRelationship.datasets()).thenReturn(new Dataset[] {dataset("orders")});
+    when(nullRelationship.relationships()).thenReturn(new Relationship[] {null});
+    assertInvalid(nullRelationship, "relationships[0]: must not be null");
+
+    SemanticModelDefinition nullMetric = mock(SemanticModelDefinition.class);
+    when(nullMetric.datasets()).thenReturn(new Dataset[] {dataset("orders")});
+    when(nullMetric.metrics()).thenReturn(new Metric[] {null});
+    assertInvalid(nullMetric, "metrics[0]: must not be null");
+  }
+
+  private static void assertInvalid(
+      @Nullable SemanticModelDefinition definition, String expectedMessage) {
+    IllegalSemanticModelException exception =
+        assertThrows(
+            IllegalSemanticModelException.class,
+            () -> SemanticModelValidator.validateDefinition(definition));
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+
+  private static Stream<AIContext> validAIContexts() {
+    return Stream.of(
+        AIContext.of("Use certified definitions"),
+        AIContext.of(
+            AIContextObject.builder()
+                .withInstructions("Use certified definitions")
+                .withSynonyms(new String[] {"sales", "bookings"})
+                .withExamples(new String[] {"Revenue by day"})
+                .build()));
+  }
+
+  private static SemanticModelDefinition definition(Dataset... datasets) {
+    return SemanticModelDefinition.builder().withDatasets(datasets).build();
+  }
+
+  private static SemanticModelDefinition definition(
+      Dataset[] datasets, @Nullable Relationship[] relationships, @Nullable Metric[] metrics) {
+    return SemanticModelDefinition.builder()
+        .withDatasets(datasets)
+        .withRelationships(relationships)
+        .withMetrics(metrics)
+        .build();
+  }
+
+  private static Dataset dataset(String name) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .build();
+  }
+
+  private static Dataset datasetWithField(String name, String fieldName) {
+    return Dataset.builder()
+        .withName(name)
+        .withSource(NameIdentifier.of("sales", "mart", name))
+        .withFields(new Field[] {field(fieldName, expression(fieldName))})
+        .build();
+  }
+
+  private static Dataset mockDataset(String name) {
+    Dataset dataset = mock(Dataset.class);
+    when(dataset.name()).thenReturn(name);
+    when(dataset.source()).thenReturn(NameIdentifier.of("sales", "mart", name));
+    return dataset;
+  }
+
+  private static Field field(String name, Expression expression) {
+    return Field.builder().withName(name).withExpression(expression).build();
+  }
+
+  private static Metric metric(String name, Expression expression) {
+    return Metric.builder().withName(name).withExpression(expression).build();
+  }
+
+  private static Relationship relationship(String name, String from, String to) {
+    return relationship(name, from, to, new String[] {"customer_id"}, new String[] {"id"});
+  }
+
+  private static Relationship relationship(
+      String name, String from, String to, String[] fromColumns, String[] toColumns) {
+    return Relationship.builder()
+        .withName(name)
+        .withFrom(from)
+        .withTo(to)
+        .withFromColumns(fromColumns)
+        .withToColumns(toColumns)
+        .build();
+  }
+
+  private static Expression expression(String value) {
+    return Expression.builder()
+        .withDialects(new DialectExpression[] {dialect(Dialects.ANSI_SQL, value)})
+        .build();
+  }
+
+  private static Expression multiDialectExpression(String ansi, String bigQuery) {
+    return Expression.builder()
+        .withDialects(
+            new DialectExpression[] {
+              dialect(Dialects.ANSI_SQL, ansi), dialect(Dialects.BIGQUERY, bigQuery)
+            })
+        .build();
+  }
+
+  private static DialectExpression dialect(String dialect, String expression) {
+    return DialectExpression.builder().withDialect(dialect).withExpression(expression).build();
+  }
+
+  private static CustomExtension extension() {
+    return CustomExtension.builder().withVendorName("example").withData("{}").build();
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestSemanticModelJDBCBackend.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestSemanticModelJDBCBackend.java
@@ -1,0 +1,551 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.meta.NamespacedEntityId;
+import org.apache.gravitino.meta.SemanticModelEntity;
+import org.apache.gravitino.semantic.AIContext;
+import org.apache.gravitino.semantic.AIContextObject;
+import org.apache.gravitino.semantic.CustomExtension;
+import org.apache.gravitino.semantic.DataType;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.DialectExpression;
+import org.apache.gravitino.semantic.Dimension;
+import org.apache.gravitino.semantic.Expression;
+import org.apache.gravitino.semantic.Field;
+import org.apache.gravitino.semantic.Metric;
+import org.apache.gravitino.semantic.Relationship;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SemanticModelVersionInfoMapper;
+import org.apache.gravitino.storage.relational.po.SemanticModelPO;
+import org.apache.gravitino.storage.relational.service.POStorageReadRouting;
+import org.apache.gravitino.storage.relational.service.SemanticModelMetaService;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
+import org.apache.gravitino.utils.NamespaceUtil;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.TestTemplate;
+
+/** Tests Semantic Model create and load persistence through {@link JDBCBackend}. */
+public class TestSemanticModelJDBCBackend extends TestJDBCBackend {
+
+  @TestTemplate
+  public void testCreateAndLoadRoundTrip() throws IOException {
+    Namespace namespace = createParents("round_trip");
+    SemanticModelEntity absent =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "absent_optional_model",
+            false,
+            ImmutableMap.of("domain", "sales"));
+    SemanticModelEntity empty =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "empty_optional_model",
+            true,
+            ImmutableMap.of());
+
+    backend.insert(absent, false);
+    backend.insert(empty, false);
+
+    SemanticModelEntity loadedAbsent =
+        backend.get(absent.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL);
+    SemanticModelEntity loadedEmpty =
+        backend.get(empty.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL);
+
+    assertEquals(absent, loadedAbsent);
+    assertEquals(empty, loadedEmpty);
+    assertNull(loadedAbsent.definition().relationships());
+    assertNull(loadedAbsent.definition().metrics());
+    assertEquals(0, loadedEmpty.definition().relationships().length);
+    assertEquals(0, loadedEmpty.definition().metrics().length);
+    assertTrue(loadedEmpty.properties().isEmpty());
+    assertEquals(
+        new BigDecimal("1.50"),
+        loadedAbsent.definition().aiContext().object().additionalProperties().get("threshold"));
+    assertNull(loadedAbsent.definition().aiContext().object().examples());
+    assertEquals(0, loadedAbsent.definition().aiContext().object().synonyms().length);
+  }
+
+  @TestTemplate
+  public void testDuplicateAndMissingEntities() throws IOException {
+    Namespace namespace = createParents("duplicate");
+    SemanticModelEntity original =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "sales_model",
+            false,
+            ImmutableMap.of("owner", "analytics"));
+    backend.insert(original, false);
+
+    SemanticModelEntity duplicate =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            original.name(),
+            true,
+            ImmutableMap.of());
+    assertThrows(EntityAlreadyExistsException.class, () -> backend.insert(duplicate, false));
+    assertEquals(
+        original, backend.get(original.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL));
+
+    NameIdentifier missingModel = NameIdentifier.of(namespace, "missing_model");
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> backend.get(missingModel, Entity.EntityType.SEMANTIC_MODEL));
+
+    String suffix = Long.toUnsignedString(RandomIdGenerator.INSTANCE.nextId());
+    String metalakeName = "missing_parent_metalake_" + suffix;
+    String catalogName = "missing_parent_catalog_" + suffix;
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+    Namespace missingParentNamespace =
+        NamespaceUtil.ofSemanticModel(metalakeName, catalogName, "missing_schema");
+    SemanticModelEntity missingParent =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            missingParentNamespace,
+            "orphan_model",
+            false,
+            ImmutableMap.of());
+
+    assertThrows(NoSuchEntityException.class, () -> backend.insert(missingParent, false));
+    assertEquals(0, countRows(SemanticModelMetaMapper.TABLE_NAME, missingParent.id()));
+    assertEquals(0, countRows(SemanticModelVersionInfoMapper.TABLE_NAME, missingParent.id()));
+  }
+
+  @TestTemplate
+  public void testCreateRollsBackIdentityWhenSnapshotInsertFails() throws IOException {
+    Namespace namespace = createParents("transaction");
+    SemanticModelEntity semanticModel =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "transaction_model",
+            false,
+            ImmutableMap.of("domain", "finance"));
+    SemanticModelPO po =
+        SemanticModelPO.initializeSemanticModelPO(semanticModel, SemanticModelPO.builder());
+    SessionUtils.doWithCommit(
+        SemanticModelVersionInfoMapper.class,
+        mapper -> mapper.insertSemanticModelVersionInfo(po.getSemanticModelVersionInfoPO()));
+
+    assertThrows(EntityAlreadyExistsException.class, () -> backend.insert(semanticModel, false));
+    assertEquals(0, countRows(SemanticModelMetaMapper.TABLE_NAME, semanticModel.id()));
+    assertEquals(1, countRows(SemanticModelVersionInfoMapper.TABLE_NAME, semanticModel.id()));
+    assertEquals(0, countEntityChanges());
+  }
+
+  @TestTemplate
+  public void testOverwriteAdvancesVersionAndRetainsPreviousSnapshot() throws IOException {
+    Namespace namespace = createParents("overwrite_version");
+    SemanticModelEntity original =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "versioned_model",
+            false,
+            ImmutableMap.of("revision", "one"));
+    SemanticModelEntity replacement =
+        semanticModel(
+            original.id(), namespace, original.name(), true, ImmutableMap.of("revision", "two"));
+
+    backend.insert(original, false);
+    backend.insert(replacement, true);
+
+    assertEquals(
+        replacement, backend.get(original.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL));
+    SemanticModelPO persisted = getSemanticModelPO(original.id());
+    assertEquals(2, persisted.getCurrentVersion());
+    assertEquals(2, persisted.getLastVersion());
+    assertEquals(List.of(1, 2), activeSnapshotVersions(original.id()));
+    assertEquals(0, countEntityChanges());
+  }
+
+  @TestTemplate
+  public void testNaturalKeyOverwriteUsesPersistedSemanticModelId() throws IOException {
+    Namespace namespace = createParents("natural_key_overwrite");
+    SemanticModelEntity original =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "natural_key_model",
+            false,
+            ImmutableMap.of("revision", "one"));
+    SemanticModelEntity replacement =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            original.name(),
+            true,
+            ImmutableMap.of("revision", "two"));
+    SemanticModelEntity expected =
+        semanticModel(
+            original.id(), namespace, original.name(), true, ImmutableMap.of("revision", "two"));
+
+    backend.insert(original, false);
+    backend.insert(replacement, true);
+
+    assertEquals(
+        expected, backend.get(original.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL));
+    SemanticModelPO persisted = getSemanticModelPO(original.id());
+    assertEquals(2, persisted.getCurrentVersion());
+    assertEquals(2, persisted.getLastVersion());
+    assertEquals(List.of(1, 2), activeSnapshotVersions(original.id()));
+    assertEquals(0, countRows(SemanticModelMetaMapper.TABLE_NAME, replacement.id()));
+    assertEquals(0, countRows(SemanticModelVersionInfoMapper.TABLE_NAME, replacement.id()));
+  }
+
+  @TestTemplate
+  public void testOverwriteInsertCreatesMissingSemanticModel() throws IOException {
+    Namespace namespace = createParents("overwrite_insert");
+    SemanticModelEntity imported =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "imported_model",
+            false,
+            ImmutableMap.of("source", "external"));
+
+    backend.insert(imported, true);
+
+    assertEquals(
+        imported, backend.get(imported.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL));
+    assertEquals(1, countRows(SemanticModelMetaMapper.TABLE_NAME, imported.id()));
+    assertEquals(1, countRows(SemanticModelVersionInfoMapper.TABLE_NAME, imported.id()));
+    assertEquals(List.of(1), activeSnapshotVersions(imported.id()));
+  }
+
+  @TestTemplate
+  public void testSemanticModelReadRoutesAndEntityIdResolver() throws IOException {
+    Namespace namespace = createParents("read_routes");
+    SemanticModelEntity semanticModel =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "routed_model",
+            false,
+            ImmutableMap.of("domain", "sales"));
+    backend.insert(semanticModel, false);
+
+    SemanticModelPO byParentId = readSemanticModelPO(semanticModel.nameIdentifier(), true);
+    SemanticModelPO byFullName = readSemanticModelPO(semanticModel.nameIdentifier(), false);
+    assertEquals(semanticModel.id(), byParentId.getSemanticModelId());
+    assertEquals(semanticModel.id(), byFullName.getSemanticModelId());
+
+    RelationalEntityStoreIdResolver resolver = new RelationalEntityStoreIdResolver();
+    NamespacedEntityId resolved =
+        resolver.getEntityIds(semanticModel.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL);
+    assertEquals(semanticModel.id().longValue(), resolved.entityId());
+
+    String metalake = namespace.level(0);
+    String catalog = namespace.level(1);
+    String schema = namespace.level(2);
+    List<NameIdentifier> missingParents =
+        List.of(
+            NameIdentifier.of(
+                NamespaceUtil.ofSemanticModel("missing_metalake", catalog, schema),
+                semanticModel.name()),
+            NameIdentifier.of(
+                NamespaceUtil.ofSemanticModel(metalake, "missing_catalog", schema),
+                semanticModel.name()),
+            NameIdentifier.of(
+                NamespaceUtil.ofSemanticModel(metalake, catalog, "missing_schema"),
+                semanticModel.name()));
+    for (NameIdentifier missing : missingParents) {
+      assertThrows(NoSuchEntityException.class, () -> readSemanticModelPO(missing, true));
+      assertThrows(NoSuchEntityException.class, () -> readSemanticModelPO(missing, false));
+      assertThrows(
+          NoSuchEntityException.class,
+          () -> resolver.getEntityIds(missing, Entity.EntityType.SEMANTIC_MODEL));
+    }
+
+    NameIdentifier missingModel = NameIdentifier.of(namespace, "missing_model");
+    assertNull(readSemanticModelPO(missingModel, true));
+    assertNull(readSemanticModelPO(missingModel, false));
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> resolver.getEntityIds(missingModel, Entity.EntityType.SEMANTIC_MODEL));
+  }
+
+  @TestTemplate
+  public void testConcurrentCreatesAndOverwriteRacesRemainAtomic() throws Exception {
+    Namespace namespace = createParents("concurrent");
+    SemanticModelEntity first =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            "concurrent_model",
+            false,
+            ImmutableMap.of("candidate", "first"));
+    SemanticModelEntity second =
+        semanticModel(
+            RandomIdGenerator.INSTANCE.nextId(),
+            namespace,
+            first.name(),
+            true,
+            ImmutableMap.of("candidate", "second"));
+
+    List<Throwable> createResults = insertConcurrently(first, false, second, false);
+    assertEquals(1, createResults.stream().filter(Objects::isNull).count());
+    Throwable createFailure =
+        createResults.stream().filter(Objects::nonNull).findFirst().orElseThrow();
+    assertTrue(createFailure instanceof EntityAlreadyExistsException);
+    assertEquals(
+        1,
+        countRows(SemanticModelMetaMapper.TABLE_NAME, first.id())
+            + countRows(SemanticModelMetaMapper.TABLE_NAME, second.id()));
+    assertEquals(
+        1,
+        countRows(SemanticModelVersionInfoMapper.TABLE_NAME, first.id())
+            + countRows(SemanticModelVersionInfoMapper.TABLE_NAME, second.id()));
+
+    SemanticModelEntity created =
+        backend.get(first.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL);
+    SemanticModelEntity overwriteOne =
+        semanticModel(
+            created.id(), namespace, created.name(), false, ImmutableMap.of("winner", "one"));
+    SemanticModelEntity overwriteTwo =
+        semanticModel(
+            created.id(), namespace, created.name(), true, ImmutableMap.of("winner", "two"));
+
+    List<Throwable> overwriteResults = insertConcurrently(overwriteOne, true, overwriteTwo, true);
+    assertTrue(overwriteResults.stream().allMatch(Objects::isNull));
+
+    SemanticModelPO persisted = getSemanticModelPO(created.id());
+    assertEquals(3, persisted.getCurrentVersion());
+    assertEquals(3, persisted.getLastVersion());
+    assertEquals(List.of(1, 2, 3), activeSnapshotVersions(created.id()));
+    SemanticModelEntity winner =
+        backend.get(created.nameIdentifier(), Entity.EntityType.SEMANTIC_MODEL);
+    assertTrue(winner.equals(overwriteOne) || winner.equals(overwriteTwo));
+    assertEquals(0, countEntityChanges());
+  }
+
+  private Namespace createParents(String prefix) throws IOException {
+    String suffix = Long.toUnsignedString(RandomIdGenerator.INSTANCE.nextId());
+    String metalakeName = prefix + "_metalake_" + suffix;
+    String catalogName = prefix + "_catalog_" + suffix;
+    String schemaName = prefix + "_schema_" + suffix;
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+    createAndInsertSchema(metalakeName, catalogName, schemaName);
+    return NamespaceUtil.ofSemanticModel(metalakeName, catalogName, schemaName);
+  }
+
+  private SemanticModelEntity semanticModel(
+      Long id,
+      Namespace namespace,
+      String name,
+      boolean explicitEmpty,
+      Map<String, String> properties) {
+    AIContextObject context =
+        AIContextObject.builder()
+            .withInstructions("Use certified sales definitions")
+            .withSynonyms(new String[0])
+            .withAdditionalProperties(
+                Map.of("threshold", new BigDecimal("1.50"), "nested", List.of(new BigInteger("3"))))
+            .build();
+    Field field =
+        Field.builder()
+            .withName("ordered_at")
+            .withExpression(
+                Expression.builder()
+                    .withDialects(
+                        new DialectExpression[] {
+                          DialectExpression.builder()
+                              .withDialect("ansi")
+                              .withExpression("ordered_at")
+                              .build()
+                        })
+                    .build())
+            .withDimension(Dimension.builder().withIsTime(true).build())
+            .withDatatype(DataType.DATE_TIME_TZ)
+            .build();
+    Dataset dataset =
+        Dataset.builder()
+            .withName("orders")
+            .withSource(NameIdentifier.of("sales", "mart", "orders"))
+            .withPrimaryKey(new String[0])
+            .withFields(new Field[] {field})
+            .build();
+    SemanticModelDefinition.Builder definitionBuilder =
+        SemanticModelDefinition.builder()
+            .withAIContext(AIContext.of(context))
+            .withDatasets(new Dataset[] {dataset});
+    if (explicitEmpty) {
+      definitionBuilder
+          .withRelationships(new Relationship[0])
+          .withMetrics(new Metric[0])
+          .withCustomExtensions(new CustomExtension[0]);
+    }
+
+    return SemanticModelEntity.builder()
+        .withId(id)
+        .withName(name)
+        .withNamespace(namespace)
+        .withComment(explicitEmpty ? null : "Governed sales definitions")
+        .withDefinition(definitionBuilder.build())
+        .withProperties(properties)
+        .withAuditInfo(AUDIT_INFO)
+        .build();
+  }
+
+  private int countRows(String tableName, Long semanticModelId) {
+    if (!SemanticModelMetaMapper.TABLE_NAME.equals(tableName)
+        && !SemanticModelVersionInfoMapper.TABLE_NAME.equals(tableName)) {
+      throw new IllegalArgumentException("Unsupported Semantic Model table: " + tableName);
+    }
+    String sql = String.format("SELECT count(*) FROM %s WHERE semantic_model_id = ?", tableName);
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        PreparedStatement statement = connection.prepareStatement(sql)) {
+      statement.setLong(1, semanticModelId);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        return resultSet.getInt(1);
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Failed to count Semantic Model rows", e);
+    }
+  }
+
+  private SemanticModelPO getSemanticModelPO(Long semanticModelId) {
+    SemanticModelPO po =
+        SessionUtils.getWithoutCommit(
+            SemanticModelMetaMapper.class,
+            mapper -> mapper.selectSemanticModelMetaById(semanticModelId));
+    assertNotNull(po);
+    return po;
+  }
+
+  private SemanticModelPO readSemanticModelPO(NameIdentifier identifier, boolean cacheEnabled) {
+    return SessionUtils.getWithoutCommit(
+        SemanticModelMetaMapper.class,
+        mapper ->
+            POStorageReadRouting.getPO(
+                mapper,
+                identifier,
+                SemanticModelMetaService.getInstance().ops(),
+                Entity.EntityType.SEMANTIC_MODEL,
+                cacheEnabled));
+  }
+
+  private List<Integer> activeSnapshotVersions(Long semanticModelId) {
+    String sql =
+        String.format(
+            "SELECT version FROM %s WHERE semantic_model_id = ? AND deleted_at = 0 ORDER BY version",
+            SemanticModelVersionInfoMapper.TABLE_NAME);
+    List<Integer> versions = new ArrayList<>();
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        PreparedStatement statement = connection.prepareStatement(sql)) {
+      statement.setLong(1, semanticModelId);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        while (resultSet.next()) {
+          versions.add(resultSet.getInt(1));
+        }
+      }
+      return versions;
+    } catch (SQLException e) {
+      throw new RuntimeException("Failed to list Semantic Model versions", e);
+    }
+  }
+
+  private int countEntityChanges() {
+    return SessionUtils.getWithoutCommit(
+        EntityChangeLogMapper.class,
+        mapper ->
+            Math.toIntExact(
+                mapper.selectEntityChanges(0, 100).stream()
+                    .filter(
+                        record ->
+                            Entity.EntityType.SEMANTIC_MODEL.name().equals(record.getEntityType()))
+                    .count()));
+  }
+
+  private List<Throwable> insertConcurrently(
+      SemanticModelEntity first,
+      boolean overwriteFirst,
+      SemanticModelEntity second,
+      boolean overwriteSecond)
+      throws Exception {
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<Throwable> firstResult =
+          executor.submit(() -> insertAfterStart(first, overwriteFirst, start));
+      Future<Throwable> secondResult =
+          executor.submit(() -> insertAfterStart(second, overwriteSecond, start));
+      start.countDown();
+      return Arrays.asList(
+          firstResult.get(30, TimeUnit.SECONDS), secondResult.get(30, TimeUnit.SECONDS));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private Throwable insertAfterStart(
+      SemanticModelEntity semanticModel, boolean overwrite, CountDownLatch start) {
+    try {
+      assertTrue(start.await(30, TimeUnit.SECONDS));
+      backend.insert(semanticModel, overwrite);
+      return null;
+    } catch (Throwable throwable) {
+      return throwable;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
@@ -53,11 +53,14 @@ import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.meta.FunctionEntity;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.SchemaEntity;
+import org.apache.gravitino.meta.SemanticModelEntity;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.meta.TagEntity;
 import org.apache.gravitino.meta.TopicEntity;
 import org.apache.gravitino.meta.ViewEntity;
 import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.semantic.Dataset;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
@@ -177,6 +180,25 @@ public class TestSchemaMetaService extends TestJDBCBackend {
                         0,
                         Collections.emptyMap(),
                         AUDIT_INFO),
+                    false),
+            namespace ->
+                backend.insert(
+                    SemanticModelEntity.builder()
+                        .withId(RandomIdGenerator.INSTANCE.nextId())
+                        .withName("child_semantic_model")
+                        .withNamespace(namespace)
+                        .withDefinition(
+                            SemanticModelDefinition.builder()
+                                .withDatasets(
+                                    new Dataset[] {
+                                      Dataset.builder()
+                                          .withName("child_dataset")
+                                          .withSource(NameIdentifier.of("source_table"))
+                                          .build()
+                                    })
+                                .build())
+                        .withAuditInfo(AUDIT_INFO)
+                        .build(),
                     false),
             namespace ->
                 backend.insert(

--- a/design-docs/gravitino-entity-cache-multinode-design.md
+++ b/design-docs/gravitino-entity-cache-multinode-design.md
@@ -274,7 +274,7 @@ The danger depends on where the real data comes from.
 
 **Group 1 — the data comes from the connector: table, view, topic, and schemas in external catalogs.** For these, Gravitino does not read the metadata from its own cache. On every load it asks the underlying system (Hive, Iceberg, JDBC, Kafka) for the current object, and uses the cached entity only for Gravitino's own id and audit fields. All nodes ask the same underlying system, so they all see the same thing. If the object was dropped or renamed, the connector call fails right away with a "not found" error. **This whole group is safe — nothing to do.**
 
-**Group 2 — the data comes from Gravitino's own store: metalake, catalog, managed schema, fileset, model, model version, function.** Here the cached entity *is* the answer, so a stale read really can return an old value. We looked at each alter in this group.
+**Group 2 — the data comes from Gravitino's own store: metalake, catalog, managed schema, fileset, model, model version, Semantic Model, function.** Here the cached entity *is* the answer, so a stale read really can return an old value. We looked at each alter in this group.
 
 (Views follow the same rule as tables: their definition is read through the connector on every load, so they sit in Group 1 and are safe.)
 
@@ -291,22 +291,23 @@ Most alters are safe:
 | drop                                               | for Group 1 the connector call fails; for a fileset the file path is gone and access fails                                                            | yes   |
 | catalog changes                                    | already handled today by a separate cross-node signal (`CatalogChangeLogListener`), not by this cache                                                 | yes   |
 
-Five cases are **not** safe — a stale read gives a wrong answer with no error. They are in the model area, functions, or the metalake on/off flag:
+Six cases are **not** safe — a stale read gives a wrong answer with no error. They are in the model area, Semantic Models, functions, or the metalake on/off flag:
 
 | Change                                                                | Why a stale read is wrong, with no error                                                                                                                                                            |
 | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | model version — update / add / remove URI                             | the URI points to the model files. An old URI silently loads the **wrong model files**.                                                                                                             |
 | model version — update aliases                                        | an alias silently points to the **wrong version**.                                                                                                                                                  |
 | model — latest version (after a new version is added on another node) | "get the latest version" silently returns an **old version**.                                                                                                                                       |
+| Semantic Model — overwrite definition                                | the current version selects the definition used for semantic queries. An old version silently uses the **wrong definition**.                                                                        |
 | function — add / update / remove implementation or definition         | the implementation is the code the function runs. An old copy silently runs the **wrong function code**.                                                                                            |
 | metalake — disable                                                    | a node with a stale copy still thinks the metalake is on and **lets operations run** on a metalake that was turned off. (Turning it back on is safe: a stale node only throws "in use" by mistake.) |
 
 #### What we do about it
 
-A stale read is only a problem for a **per-node** cache, and only for the load-bearing pointers listed above. A **shared** cache (redis) keeps one copy for the whole cluster, so it has no window at all and can safely cache everything. So the handling depends on the cache kind (`coherence()`):
+A stale read is only a problem for a **per-node** cache, and only for the load-bearing content listed above. A **shared** cache (redis) keeps one copy for the whole cluster, so it has no window at all and can safely cache everything. So the handling depends on the cache kind (`coherence()`):
 
-- **Shared cache (redis, `SHARED`): cache everything.** There is no per-node window, so model, model version, and function are cached like any other entity, with no extra work. The writing node clears the one shared copy, and every node sees it at once.
-- **Per-node cache (caffeine, `LOCAL_PER_NODE`): do not cache model, model version, or function.** Each holds a load-bearing pointer (a version URI, the latest version, or the function implementation) that would be silently wrong on another node during the poll window. They are read rarely, so reading them from the DB every time costs little, and it keeps the rule simple — an entity type is either in or out, with no special per-read handling. If they ever get hot, we can revisit.
+- **Shared cache (redis, `SHARED`): cache everything.** There is no per-node window, so model, model version, Semantic Model, and function are cached like any other entity, with no extra work. The writing node clears the one shared copy, and every node sees it at once.
+- **Per-node cache (caffeine, `LOCAL_PER_NODE`): do not cache model, model version, Semantic Model, or function.** Each holds load-bearing content (a version URI, the latest version, a Semantic Model definition, or a function implementation) that would be silently wrong on another node during the poll window. They are read rarely, so reading them from the DB every time costs little, and it keeps the rule simple — an entity type is either in or out, with no special per-read handling. If they ever get hot, we can revisit.
 - **Metalake on/off flag — cached like the rest of the metalake.** Disabling or deleting a metalake is a rare, tenant-level admin action, so we accept the small window instead of adding special handling: the metalake is cached and invalidated across nodes through the change log like any other entity, so after a disable, another node stops allowing operations within one poll interval.
 
 We do **not** need a per-entity version check on the cache: for a point read, checking the DB version costs the same query as just reading the row, so it would buy nothing.
@@ -322,10 +323,11 @@ We do **not** need a per-entity version check on the cache: for a point read, ch
 | tag, policy          | self-contained; a stale read is only cosmetic (old comment/property)                              | cache + change-log invalidation                                        | cache            |
 | job                  | self-contained operational entity; a stale read is only an old job status                         | cache + change-log invalidation                                        | cache            |
 | model, model version | carries a load-bearing pointer (a version's URI, the latest version) that would be wrong if stale | **not cached — read from the DB** (revisit if it gets hot)             | cache            |
+| Semantic Model       | its current version selects the definition used for semantic queries                              | **not cached — read from the DB** (revisit if it gets hot)             | cache            |
 | function             | the cached value *is* the code that runs, so a stale copy would run the wrong code                | **not cached — read from the DB** (revisit if it gets hot)             | cache            |
 | user, group, role    | derived fields (`roleNames`, `securableObjects`) need a reverse lookup                            | not cached                                                             | not cached       |
 
-After this, everything a per-node cache serves is safe or bounded: connector-backed entities are safe by construction; self-contained store entities are only ever cosmetically stale (and a rare metalake disable self-corrects within one poll interval); model / model version / function are read from the DB. A shared cache is safe throughout because it has no window.
+After this, everything a per-node cache serves is safe or bounded: connector-backed entities are safe by construction; self-contained store entities are only ever cosmetically stale (and a rare metalake disable self-corrects within one poll interval); model / model version / Semantic Model / function are read from the DB. A shared cache is safe throughout because it has no window.
 
 #### The staleness promise (SLA)
 

--- a/design-docs/gravitino-semantic-model-design.md
+++ b/design-docs/gravitino-semantic-model-design.md
@@ -269,10 +269,10 @@ DataType = "String" | "Integer" | "Decimal" | "Float" | "Boolean"
 Create and alter validate the complete candidate object before persistence. Validation is atomic:
 if any check fails, no change is persisted.
 
-1. **Contract validation.** Check required fields, collection cardinality, enum values, string
-   constraints, and the pinned Ossie structure.
-2. **Model-local validation.** Check name uniqueness, relationship endpoints, referenced fields,
-   key shapes, and dialect uniqueness without consulting a catalog.
+1. **Contract validation.** Check required fields, collection cardinality, typed alternatives, string
+   constraints, and the Java contract derived from the pinned Ossie structure.
+2. **Model-local validation.** Check name uniqueness, relationship endpoints, key shapes, and dialect
+   uniqueness without consulting a catalog.
 3. **Catalog validation.** Resolve every Dataset source and validate explicitly named source
    columns. Validation uses the caller's authorization context so it does not disclose metadata the
    caller cannot access.
@@ -293,33 +293,23 @@ engine and remain outside the metadata write path.
 
 #### Ossie Compatibility
 
-The public API is a Gravitino contract derived from Ossie, not a stored YAML or JSON document. For
-compatibility validation, the server projects a candidate object into an in-memory Ossie document:
+The public API is a Gravitino contract derived from Ossie, not a stored YAML or JSON document. The
+runtime write path validates the Java object model directly; it does not project a candidate into an
+Ossie document or invoke JSON Schema validation. At implementation time, Apache Ossie commit
+`88e0011148283302c9a04cd0287e00e0b9d87354` did not publish a reusable Java SDK or general-purpose
+Java validator; its Java schema validation was converter-specific. Gravitino therefore implements
+the applicable structural and model-local rules directly in Java, followed by catalog-backed source
+checks. SQL expression validation is not carried into the metadata write path because execution
+semantics and engine compatibility are outside its scope.
 
-```yaml
-version: 0.2.0.dev0
-semantic_model:
-  - name: sales_model
-    description: Governed sales definitions
-    datasets:
-      - name: orders
-        source: sales.mart.orders
-```
-
-The projection maps the entity name to `SemanticModel.name`, `comment` to `description`, and encodes
-each source `NameIdentifier` using the reversible source grammar above. The request path supplies the
-metalake and is not serialized into Ossie.
-
-The request path does not invoke the upstream Python validator or create an intermediate YAML
-string. The implementation validates the in-memory projection against a Gravitino profile derived
-from the bundled copy of the pinned JSON Schema, then runs Gravitino-specific model-local and
-catalog checks. The profile preserves the pinned structural constraints while treating dialect
-identifiers as open non-empty strings. Upstream validation tools are used only in compatibility
-fixtures that contain Ossie-defined dialects.
+Core contract tests validate the Java value model directly, including both `AIContext` variants,
+name uniqueness, relationship references and column cardinality, and absent versus explicitly empty
+arrays. Gravitino's runtime contract deliberately accepts any non-empty custom dialect identifier and
+preserves it exactly, even when the dialect is outside the pinned upstream schema.
 
 The entity carries no per-model Ossie specification version. Each Gravitino release pins one exact
 upstream schema commit and defines the supported read and write contract. Updating that schema
-requires a Gravitino code change, compatibility fixtures, and storage read tests. If a future
+requires a Gravitino code change, native validator tests, and storage read tests. If a future
 incompatible Ossie contract must coexist with the current one, explicit per-entity versioning
 requires a separate design; it should not be inferred from `custom_extensions`.
 
@@ -353,6 +343,11 @@ Supported `SemanticModelChange` operations are:
 - `setProperty` and `removeProperty`: Update Gravitino-specific properties.
 - `replaceDefinition`: Atomically replaces AI context, datasets, relationships, metrics, and custom
   extensions.
+
+Create and `replaceDefinition` run complete Java definition and catalog-backed source validation
+before persistence. A properties-only alter does not revalidate the definition or visit sources.
+Rename and comment changes also do not visit sources; rename continues through the existing
+identifier normalization contract. List, load, and drop do not run write validation.
 
 Each alter request applies all changes atomically to the current Semantic Model. Rename retains the
 stable entity ID. Owner, tag, and policy changes use their existing governance stores and remain


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add managed Core operations for creating and loading Semantic Models:

- Validate Semantic Model definitions and sources with Java-native validation.
- Build Semantic Model entity and audit metadata and persist them through the entity store.
- Return persisted Semantic Models on load without revalidating external sources.
- Add focused unit and JDBC tests.

This Draft PR currently includes a squashed snapshot of #12602 at `a764ab2835fb429df6882589b3d67c5d5b206d03`. The dependency commit will be dropped after #12602 is merged.

### Why are the changes needed?

Gravitino Core needs managed create and load behavior for Semantic Models, including validation, metadata construction, persistence, and dispatcher integration.

Fix: #12604

### Does this PR introduce _any_ user-facing change?

Yes. It implements the existing Semantic Model create and load operations in Gravitino Core. No new public API, REST, OpenAPI, or client surface is introduced.

### How was this patch tested?

- `./gradlew :core:spotlessCheck`
- `./gradlew :core:test -PskipITs` — 2,001 tests, 0 failures, 0 errors, 2 skipped
- `git diff --check origin/main..HEAD`
