### PR TITLE
[#12524] feat(iceberg-rest): Add catalog discovery endpoint

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -190,6 +190,7 @@ public class RESTService implements GravitinoAuxiliaryService {
                   .to(InterceptionService.class)
                   .in(Singleton.class);
             }
+            bind(configProvider).to(IcebergConfigProvider.class).ranked(1);
             bind(icebergCatalogWrapperManager).to(IcebergCatalogWrapperManager.class).ranked(1);
             bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(1);
             cleanupManager.ifPresent(

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/DynamicIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/DynamicIcebergConfigProvider.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
 import org.apache.gravitino.auth.AuthProperties;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
@@ -56,6 +57,8 @@ import org.apache.gravitino.utils.NameIdentifierUtil;
  * <p>The catalogName is iceberg_catalog
  */
 public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
+
+  private static final String ICEBERG_CATALOG_PROVIDER = "lakehouse-iceberg";
 
   private String gravitinoMetalake;
   private Optional<String> defaultDynamicCatalogName;
@@ -108,6 +111,16 @@ public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
     // Auxiliary: BaseCatalog + SecretManager plaintext. Standalone: properties + getSecrets,
     // then JdbcCredential overlays so credentials win.
     return Optional.of(getIcebergConfigFromCatalogProperties(resolveProps(catalog)));
+  }
+
+  @Override
+  public String[] listCatalogs() {
+    return Arrays.stream(getCatalogFetcher().listCatalogsInfo())
+        .filter(catalog -> ICEBERG_CATALOG_PROVIDER.equals(catalog.provider()))
+        .map(Catalog::name)
+        .distinct()
+        .sorted()
+        .toArray(String[]::new);
   }
 
   private static Map<String, String> resolveProps(Catalog catalog) {
@@ -275,6 +288,8 @@ public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
   interface CatalogFetcher extends Closeable {
     Catalog loadCatalog(String catalogName) throws NoSuchCatalogException;
 
+    Catalog[] listCatalogsInfo();
+
     @Override
     default void close() {}
   }
@@ -306,6 +321,11 @@ public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
       NameIdentifier catalogIdent = NameIdentifierUtil.ofCatalog(metalake, catalogName);
       return catalogDispatcher.loadCatalog(catalogIdent);
     }
+
+    @Override
+    public Catalog[] listCatalogsInfo() {
+      return catalogDispatcher.listCatalogsInfo(Namespace.of(metalake));
+    }
   }
 
   /**
@@ -327,6 +347,11 @@ public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
     @Override
     public Catalog loadCatalog(String catalogName) throws NoSuchCatalogException {
       return getGravitinoClient().loadCatalog(catalogName);
+    }
+
+    @Override
+    public Catalog[] listCatalogsInfo() {
+      return getGravitinoClient().listCatalogsInfo();
     }
 
     @Override

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/IcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/IcebergConfigProvider.java
@@ -47,6 +47,18 @@ public interface IcebergConfigProvider extends Closeable {
   Optional<IcebergConfig> getIcebergCatalogConfig(String catalogName);
 
   /**
+   * List Iceberg catalogs served by this provider.
+   *
+   * <p>The default implementation advertises only the provider's default catalog to preserve
+   * compatibility with custom providers that predate catalog discovery.
+   *
+   * @return the names accepted by the Iceberg REST server's {@code warehouse} parameter
+   */
+  default String[] listCatalogs() {
+    return new String[] {getDefaultCatalogName()};
+  }
+
+  /**
    * Get metalake name.
    *
    * @return the name of metalake.

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/StaticIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/StaticIcebergConfigProvider.java
@@ -68,6 +68,11 @@ public class StaticIcebergConfigProvider implements IcebergConfigProvider {
   }
 
   @Override
+  public String[] listCatalogs() {
+    return catalogConfigs.keySet().stream().sorted().toArray(String[]::new);
+  }
+
+  @Override
   public void close() {}
 
   private Optional<String> getCatalogName(String catalogConfigKey) {

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergCatalogListResponse.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergCatalogListResponse.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+/** Response for the Gravitino Iceberg REST catalog discovery endpoint. */
+public class IcebergCatalogListResponse {
+
+  private final CatalogInfo[] catalogs;
+
+  /**
+   * Creates a catalog list response.
+   *
+   * @param catalogs catalogs served by the Iceberg REST server
+   */
+  @JsonCreator
+  public IcebergCatalogListResponse(@JsonProperty("catalogs") CatalogInfo[] catalogs) {
+    this.catalogs = Preconditions.checkNotNull(catalogs, "catalogs must not be null");
+  }
+
+  /**
+   * Returns the catalogs served by the Iceberg REST server.
+   *
+   * @return catalog information
+   */
+  public CatalogInfo[] catalogs() {
+    return catalogs;
+  }
+
+  /** Catalog information advertised by the Iceberg REST server. */
+  public static class CatalogInfo {
+
+    private final String name;
+
+    /**
+     * Creates catalog information.
+     *
+     * @param name catalog name accepted as an Iceberg REST {@code warehouse}
+     */
+    @JsonCreator
+    public CatalogInfo(@JsonProperty("name") String name) {
+      this.name = Preconditions.checkNotNull(name, "name must not be null");
+    }
+
+    /**
+     * Returns the advertised catalog name.
+     *
+     * @return catalog name
+     */
+    public String name() {
+      return name;
+    }
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergCatalogOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergCatalogOperations.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+import org.apache.gravitino.iceberg.service.provider.IcebergConfigProvider;
+import org.apache.gravitino.iceberg.service.rest.IcebergCatalogListResponse.CatalogInfo;
+import org.apache.gravitino.metrics.MetricNames;
+
+/** Gravitino-private management operations for Iceberg REST catalogs. */
+@Path("/gravitino/v1/management/catalogs")
+@Produces(MediaType.APPLICATION_JSON)
+public class IcebergCatalogOperations {
+
+  private final IcebergConfigProvider configProvider;
+
+  /**
+   * Creates Iceberg catalog management operations.
+   *
+   * @param configProvider provider used to discover catalogs served by this REST server
+   */
+  @Inject
+  public IcebergCatalogOperations(IcebergConfigProvider configProvider) {
+    this.configProvider = configProvider;
+  }
+
+  /**
+   * Lists catalogs served by this Iceberg REST server.
+   *
+   * @return catalog names accepted by the server's {@code warehouse} parameter
+   */
+  @GET
+  @Timed(name = "list-rest-catalog." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "list-rest-catalog", absolute = true)
+  public Response listCatalogs() {
+    String[] catalogNames =
+        Preconditions.checkNotNull(configProvider.listCatalogs(), "catalogs must not be null");
+    CatalogInfo[] catalogs =
+        Arrays.stream(catalogNames)
+            .map(name -> Preconditions.checkNotNull(name, "catalog name must not be null"))
+            .distinct()
+            .sorted()
+            .map(CatalogInfo::new)
+            .toArray(CatalogInfo[]::new);
+    return IcebergRESTUtils.ok(new IcebergCatalogListResponse(catalogs));
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergAuthenticationFilter.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergAuthenticationFilter.java
@@ -74,6 +74,7 @@ public class TestIcebergAuthenticationFilter {
       strings = {
         "/iceberg/v1/namespaces",
         "/iceberg/v1/config",
+        "/iceberg/gravitino/v1/management/catalogs",
         "/iceberg/healthcheck",
         "/api/metalakes"
       })

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestDynamicIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestDynamicIcebergConfigProvider.java
@@ -35,6 +35,7 @@ import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.connector.BaseCatalog;
@@ -116,6 +117,11 @@ public class TestDynamicIcebergConfigProvider {
               throw new NoSuchCatalogException("Catalog not found: %s", catalogName);
             }
             return catalog;
+          }
+
+          @Override
+          public Catalog[] listCatalogsInfo() {
+            return catalogMap.values().toArray(Catalog[]::new);
           }
         };
     provider.setCatalogFetcher(mockFetcher);
@@ -209,6 +215,29 @@ public class TestDynamicIcebergConfigProvider {
         IllegalArgumentException.class, () -> provider.getIcebergCatalogConfig(invalidCatalogName));
     Assertions.assertThrowsExactly(
         IllegalArgumentException.class, () -> provider.getIcebergCatalogConfig(""));
+  }
+
+  @Test
+  public void testListCatalogs() {
+    Catalog alphaCatalog = Mockito.mock(Catalog.class);
+    Mockito.when(alphaCatalog.name()).thenReturn("alpha");
+    Mockito.when(alphaCatalog.provider()).thenReturn("lakehouse-iceberg");
+    Catalog zetaCatalog = Mockito.mock(Catalog.class);
+    Mockito.when(zetaCatalog.name()).thenReturn("zeta");
+    Mockito.when(zetaCatalog.provider()).thenReturn("lakehouse-iceberg");
+    Catalog nonIcebergCatalog = Mockito.mock(Catalog.class);
+    Mockito.when(nonIcebergCatalog.name()).thenReturn("hive");
+    Mockito.when(nonIcebergCatalog.provider()).thenReturn("hive");
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put(IcebergConstants.GRAVITINO_METALAKE, "test_metalake");
+    properties.put(IcebergConstants.ICEBERG_REST_DEFAULT_DYNAMIC_CATALOG_NAME, "alpha");
+    DynamicIcebergConfigProvider provider = new DynamicIcebergConfigProvider();
+    provider.initialize(properties);
+    setMockCatalogFetcher(
+        provider, Map.of("zeta", zetaCatalog, "hive", nonIcebergCatalog, "alpha", alphaCatalog));
+
+    Assertions.assertArrayEquals(new String[] {"alpha", "zeta"}, provider.listCatalogs());
   }
 
   @Test
@@ -306,6 +335,8 @@ public class TestDynamicIcebergConfigProvider {
 
     NameIdentifier catalogIdent = NameIdentifierUtil.ofCatalog(metalakeName, catalogName);
     Mockito.when(mockInternalCatalogDispatcher.loadCatalog(catalogIdent)).thenReturn(mockCatalog);
+    Mockito.when(mockInternalCatalogDispatcher.listCatalogsInfo(Namespace.of(metalakeName)))
+        .thenReturn(new Catalog[] {mockCatalog});
     Map<String, String> catalogProperties =
         new HashMap<String, String>() {
           {
@@ -314,6 +345,7 @@ public class TestDynamicIcebergConfigProvider {
           }
         };
     Mockito.when(mockCatalog.provider()).thenReturn("lakehouse-iceberg");
+    Mockito.when(mockCatalog.name()).thenReturn(catalogName);
     Mockito.when(mockCatalog.properties()).thenReturn(catalogProperties);
 
     // Set the mock CatalogDispatchers to GravitinoEnv
@@ -336,7 +368,9 @@ public class TestDynamicIcebergConfigProvider {
     Optional<IcebergConfig> icebergConfig = provider.getIcebergCatalogConfig(catalogName);
 
     Assertions.assertTrue(icebergConfig.isPresent());
+    Assertions.assertArrayEquals(new String[] {catalogName}, provider.listCatalogs());
     Mockito.verify(mockInternalCatalogDispatcher).loadCatalog(catalogIdent);
+    Mockito.verify(mockInternalCatalogDispatcher).listCatalogsInfo(Namespace.of(metalakeName));
     Mockito.verify(mockCatalogDispatcher, Mockito.never()).loadCatalog(catalogIdent);
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestStaticIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestStaticIcebergConfigProvider.java
@@ -101,6 +101,33 @@ public class TestStaticIcebergConfigProvider {
     Assertions.assertTrue(hiveOps.getCatalog() instanceof HiveCatalog);
     Assertions.assertTrue(jdbcOps.getCatalog() instanceof JdbcCatalog);
     Assertions.assertTrue(defaultOps.getCatalog() instanceof InMemoryCatalog);
+    Assertions.assertArrayEquals(
+        new String[] {defaultCatalogName, hiveCatalogName, jdbcCatalogName},
+        provider.listCatalogs());
+  }
+
+  @Test
+  public void testLegacyProviderListsDefaultCatalog() {
+    IcebergConfigProvider provider =
+        new IcebergConfigProvider() {
+          @Override
+          public void initialize(Map<String, String> properties) {}
+
+          @Override
+          public Optional<IcebergConfig> getIcebergCatalogConfig(String catalogName) {
+            return Optional.empty();
+          }
+
+          @Override
+          public String getDefaultCatalogName() {
+            return "legacy_default";
+          }
+
+          @Override
+          public void close() {}
+        };
+
+    Assertions.assertArrayEquals(new String[] {"legacy_default"}, provider.listCatalogs());
   }
 
   @ParameterizedTest

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergCatalogOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergCatalogOperations.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergObjectMapperProvider;
+import org.apache.gravitino.iceberg.service.provider.IcebergConfigProvider;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestIcebergCatalogOperations extends IcebergTestBase {
+
+  private static final String CATALOGS_PATH = "gravitino/v1/management/catalogs";
+  private static final IcebergConfigProvider CONFIG_PROVIDER = mock(IcebergConfigProvider.class);
+
+  @Override
+  protected Application configure() {
+    return new ResourceConfig()
+        .register(new IcebergCatalogOperations(CONFIG_PROVIDER))
+        .register(IcebergObjectMapperProvider.class)
+        .register(JacksonFeature.class)
+        .register(IcebergExceptionMapper.class);
+  }
+
+  @AfterEach
+  public void resetProvider() {
+    Mockito.reset(CONFIG_PROVIDER);
+  }
+
+  @Test
+  public void testListCatalogs() {
+    when(CONFIG_PROVIDER.listCatalogs()).thenReturn(new String[] {"zeta", "alpha", "zeta"});
+
+    Response response = getIcebergClientBuilder(CATALOGS_PATH, Optional.empty()).get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+    Assertions.assertEquals(
+        "{\"catalogs\":[{\"name\":\"alpha\"},{\"name\":\"zeta\"}]}",
+        response.readEntity(String.class));
+  }
+
+  @Test
+  public void testListCatalogsWhenEmpty() {
+    when(CONFIG_PROVIDER.listCatalogs()).thenReturn(new String[0]);
+
+    Response response = getIcebergClientBuilder(CATALOGS_PATH, Optional.empty()).get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(
+        0, response.readEntity(IcebergCatalogListResponse.class).catalogs().length);
+  }
+
+  @Test
+  public void testListCatalogsFailure() {
+    when(CONFIG_PROVIDER.listCatalogs()).thenThrow(new IllegalStateException("list failed"));
+
+    Response response = getIcebergClientBuilder(CATALOGS_PATH, Optional.empty()).get();
+
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    ErrorResponse error = response.readEntity(ErrorResponse.class);
+    Assertions.assertEquals("IllegalStateException", error.type());
+    Assertions.assertEquals("list failed", error.message());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a Gravitino-private catalog discovery endpoint to the Iceberg REST server:

`GET /iceberg/gravitino/v1/management/catalogs`

This change:

- Returns catalog names accepted by the server `warehouse` parameter.
- Supports both static and dynamic Iceberg configuration providers.
- Filters dynamic results to `lakehouse-iceberg` catalogs.
- Adds a backward-compatible `IcebergConfigProvider#listCatalogs()` SPI.
- Returns deterministic, deduplicated catalog names.
- Keeps the endpoint behind the existing Iceberg REST authentication filter.
- Adds provider, response, authentication, and endpoint tests.

The endpoint intentionally does not apply per-catalog authorization filtering.

### Why are the changes needed?

Compute engines currently cannot ask an Iceberg REST server which catalogs it serves. This forces users to maintain per-catalog engine configuration and update it whenever catalogs change.

The new endpoint provides the server-authoritative catalog list required by engine-side automatic discovery.

Fix: #12524

### Does this PR introduce _any_ user-facing change?

Yes.

The Iceberg REST server exposes a new private management endpoint:

`GET {iceberg-rest-base}/gravitino/v1/management/catalogs`

The `IcebergConfigProvider` SPI also gains a backward-compatible `listCatalogs()` method.

### How was this patch tested?

- `./gradlew :iceberg:iceberg-rest-server:spotlessCheck`
- Targeted 43 Iceberg REST endpoint, provider, and authentication tests
- `git diff --check`

The full module test suite was attempted, but existing `TestIcebergCleanupJobStoreBackend` MySQL and PostgreSQL cases could not connect to their containers because the local SOCKS proxy intercepted the connections.

### Draft follow-up

- Document the endpoint in `docs/iceberg-rest-service.md` before marking the PR ready.