### PR TITLE
[#12848] fix(authz): Allow getting owner of disabled metalake

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/OwnerOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/OwnerOperations.java
@@ -88,7 +88,9 @@ public class OwnerOperations {
       return Utils.doAs(
           httpRequest,
           () -> {
-            MetalakeManager.checkMetalakeInUse(metalake);
+            if (object.type() != MetadataObject.Type.METALAKE) {
+              MetalakeManager.checkMetalakeInUse(metalake);
+            }
             MetadataObjectUtil.checkMetadataObject(metalake, object);
             Optional<Owner> owner = ownerDispatcher.getOwner(metalake, object);
             if (owner.isPresent()) {

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestOwnerOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestOwnerOperations.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.dto.responses.ErrorConstants;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.dto.responses.OwnerResponse;
 import org.apache.gravitino.dto.responses.SetResponse;
+import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
 import org.apache.gravitino.exceptions.NoSuchRoleException;
 import org.apache.gravitino.exceptions.NotFoundException;
@@ -208,6 +209,41 @@ class TestOwnerOperations extends BaseOperationsTest {
             .get();
     ErrorResponse errorResponse3 = resp4.readEntity(ErrorResponse.class);
     Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse3.getCode());
+  }
+
+  @Test
+  void testGetOwnerForDisabledMetalake() throws IOException {
+    Mockito.doReturn(Optional.empty()).when(manager).getOwner(any(), any());
+    when(metalakeDispatcher.metalakeExists(any())).thenReturn(true);
+
+    BaseMetalake metalake = mock(BaseMetalake.class);
+    PropertiesMetadata propertiesMetadata = mock(PropertiesMetadata.class);
+    when(propertiesMetadata.getOrDefault(any(), any())).thenReturn(false);
+    when(metalake.propertiesMetadata()).thenReturn(propertiesMetadata);
+    when(entityStore.get(any(), any(), any())).thenReturn(metalake);
+
+    Response response =
+        target("/metalakes/metalake1/owners/metalake/metalake1")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    OwnerResponse ownerResponse = response.readEntity(OwnerResponse.class);
+    Assertions.assertEquals(0, ownerResponse.getCode());
+    Assertions.assertNull(ownerResponse.getOwner());
+
+    Response childResponse =
+        target("/metalakes/metalake1/owners/catalog/catalog1")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), childResponse.getStatus());
+    ErrorResponse errorResponse = childResponse.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.NOT_IN_USE_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        MetalakeNotInUseException.class.getSimpleName(), errorResponse.getType());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow getting the owner of a disabled metalake.

The metalake in-use check is skipped only when the target metadata object is the metalake itself. Owner queries for child objects and owner mutation operations continue to require the metalake to be in use.

Add regression coverage for both cases:
- Getting the owner of a disabled metalake returns 200.
- Getting the owner of a child object under a disabled metalake returns 409.

### Why are the changes needed?

A disabled metalake can still be loaded, but its owner could not be retrieved because the GET owner endpoint unconditionally required the metalake to be in use.

Fix: #12848

### Does this PR introduce _any_ user-facing change?

Yes. `GET /api/metalakes/{metalake}/owners/metalake/{metalake}` now returns the owner for an existing disabled metalake instead of returning `MetalakeNotInUseException`.

Owner queries for child objects and owner mutation operations remain unchanged.

### How was this patch tested?

- `./gradlew :server:test --tests org.apache.gravitino.server.web.rest.TestOwnerOperations`
- `./gradlew :server:spotlessApply`
- `git diff --check`
