### PR TITLE
improve(GVFS): Collapse duplicated metadata REST calls per filesystem operation

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
@@ -60,6 +60,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;
@@ -519,12 +521,78 @@ public abstract class BaseGVFSOperations implements Closeable {
       Path gvfsPath, String locationName, FilesetDataOperation operation)
       throws FileNotFoundException {
     NameIdentifier filesetIdent = extractIdentifier(metalakeName, gvfsPath.toString());
+    return buildActualFilePath(
+        filesetIdent,
+        getFilesetCatalog(catalogIdentOf(filesetIdent)),
+        gvfsPath,
+        locationName,
+        operation);
+  }
+
+  /** The catalog a fileset belongs to. */
+  private static NameIdentifier catalogIdentOf(NameIdentifier filesetIdent) {
+    return NameIdentifier.of(filesetIdent.namespace().level(0), filesetIdent.namespace().level(1));
+  }
+
+  /**
+   * Resolves a virtual path to the filesystem and storage path that serve it.
+   *
+   * <p>Yields the same results as {@link #getActualFileSystem} and {@link #getActualFilePath}
+   * called in turn, but resolves both from a single catalog lookup.
+   *
+   * @param gvfsPath the virtual path.
+   * @param locationName the location name, or null for the fileset's default.
+   * @param operation the fileset data operation being performed.
+   * @return the filesystem to act on, and the storage path to act on.
+   * @throws FileNotFoundException if the fileset or location name cannot be resolved.
+   */
+  protected Pair<FileSystem, Path> resolvePath(
+      Path gvfsPath, String locationName, FilesetDataOperation operation)
+      throws FileNotFoundException {
+    NameIdentifier filesetIdent = extractIdentifier(metalakeName, gvfsPath.toString());
+    FilesetCatalog filesetCatalog = getFilesetCatalog(catalogIdentOf(filesetIdent));
+    Fileset fileset = getFileset(filesetIdent, filesetCatalog);
+    return Pair.of(
+        buildFileSystem(filesetIdent, filesetCatalog, fileset, locationName),
+        buildActualFilePath(filesetIdent, filesetCatalog, gvfsPath, locationName, operation));
+  }
+
+  /**
+   * Resolves the source and destination of a rename to the filesystem and storage paths that serve
+   * them, sharing a single catalog lookup.
+   *
+   * <p>A rename only ever moves within one fileset -- callers assert that before getting here -- so
+   * one catalog serves both ends.
+   *
+   * @param srcGvfsPath the virtual source path.
+   * @param dstGvfsPath the virtual destination path, in the same fileset as the source.
+   * @param locationName the location name, or null for the fileset's default.
+   * @return the filesystem to act on, the storage path of the source, and that of the destination.
+   * @throws FileNotFoundException if the fileset or location name cannot be resolved.
+   */
+  protected Triple<FileSystem, Path, Path> resolveRenamePaths(
+      Path srcGvfsPath, Path dstGvfsPath, String locationName) throws FileNotFoundException {
+    NameIdentifier filesetIdent = extractIdentifier(metalakeName, srcGvfsPath.toString());
+    FilesetCatalog filesetCatalog = getFilesetCatalog(catalogIdentOf(filesetIdent));
+    Fileset fileset = getFileset(filesetIdent, filesetCatalog);
+    return Triple.of(
+        buildFileSystem(filesetIdent, filesetCatalog, fileset, locationName),
+        buildActualFilePath(
+            filesetIdent, filesetCatalog, srcGvfsPath, locationName, FilesetDataOperation.RENAME),
+        buildActualFilePath(
+            filesetIdent, filesetCatalog, dstGvfsPath, locationName, FilesetDataOperation.RENAME));
+  }
+
+  private Path buildActualFilePath(
+      NameIdentifier filesetIdent,
+      FilesetCatalog filesetCatalog,
+      Path gvfsPath,
+      String locationName,
+      FilesetDataOperation operation)
+      throws FileNotFoundException {
     String subPath = getSubPathFromGvfsPath(filesetIdent, gvfsPath.toString());
-    NameIdentifier catalogIdent =
-        NameIdentifier.of(filesetIdent.namespace().level(0), filesetIdent.namespace().level(1));
     String fileLocation;
     try {
-      FilesetCatalog filesetCatalog = getFilesetCatalog(catalogIdent);
       setCallerContextForGetFileLocation(operation);
       fileLocation =
           filesetCatalog.getFileLocation(
@@ -532,7 +600,9 @@ public abstract class BaseGVFSOperations implements Closeable {
               subPath,
               locationName);
     } catch (NoSuchCatalogException | CatalogNotInUseException e) {
-      String message = String.format("Cannot get fileset catalog by identifier: %s", catalogIdent);
+      String message =
+          String.format(
+              "Cannot get fileset catalog by identifier: %s", catalogIdentOf(filesetIdent));
       LOG.warn(message, e);
       throw (FileNotFoundException) new FileNotFoundException(message).initCause(e);
 
@@ -560,18 +630,15 @@ public abstract class BaseGVFSOperations implements Closeable {
     return new Path(fileLocation);
   }
 
-  private void createFilesetLocationIfNeed(
-      NameIdentifier filesetIdent, FileSystem fs, Path filesetPath) {
+  private void createFilesetLocationIfNeed(FileSystem fs, Path filesetPath, Catalog catalog) {
     if (!autoCreateLocation) {
       return;
     }
-    NameIdentifier catalogIdent =
-        NameIdentifier.of(filesetIdent.namespace().level(0), filesetIdent.namespace().level(1));
     // If the server-side filesystem ops are disabled, the fileset directory may not exist. In such
     // case the operations like create, open, list files under this directory will fail. So we
     // need to check the existence of the fileset directory beforehand.
     boolean fsOpsDisabled =
-        ((Catalog) getFilesetCatalog(catalogIdent))
+        catalog
             .properties()
             .getOrDefault("disable-filesystem-ops", "false")
             .equalsIgnoreCase("true");
@@ -671,15 +738,24 @@ public abstract class BaseGVFSOperations implements Closeable {
    * @return the fileset.
    */
   protected Fileset getFileset(NameIdentifier filesetIdent) {
+    return getFileset(filesetIdent, getFilesetCatalog(catalogIdentOf(filesetIdent)));
+  }
+
+  /**
+   * Get the fileset by the fileset identifier from the cache, or load it from the server through an
+   * already-resolved catalog if the cache is disabled.
+   *
+   * @param filesetIdent the fileset identifier.
+   * @param filesetCatalog the catalog owning the fileset, already loaded.
+   * @return the fileset.
+   */
+  protected Fileset getFileset(NameIdentifier filesetIdent, FilesetCatalog filesetCatalog) {
     return getFilesetMetadataCache()
         .map(cache -> cache.getFileset(filesetIdent))
         .orElseGet(
             () ->
-                getFilesetCatalog(
-                        NameIdentifier.of(
-                            filesetIdent.namespace().level(0), filesetIdent.namespace().level(1)))
-                    .loadFileset(
-                        NameIdentifier.of(filesetIdent.namespace().level(2), filesetIdent.name())));
+                filesetCatalog.loadFileset(
+                    NameIdentifier.of(filesetIdent.namespace().level(2), filesetIdent.name())));
   }
 
   /**
@@ -690,16 +766,25 @@ public abstract class BaseGVFSOperations implements Closeable {
    * @return the schema.
    */
   protected Schema getSchema(NameIdentifier schemaIdent) {
-    return filesetMetadataCache
+    return getSchema(schemaIdent, (Catalog) getFilesetCatalog(catalogIdentOf(schemaIdent)));
+  }
+
+  /**
+   * Get the schema by the schema identifier from the cache, or load it from the server through an
+   * already-resolved catalog if the cache is disabled.
+   *
+   * <p>With the metadata cache disabled, loading a catalog is a server call. Callers that already
+   * hold one pass it here so that a filesystem operation loads it once rather than once per lookup.
+   *
+   * @param schemaIdent the schema identifier.
+   * @param catalog the catalog owning the schema, already loaded.
+   * @return the schema.
+   */
+  protected Schema getSchema(NameIdentifier schemaIdent, Catalog catalog) {
+    // Use getFilesetMetadataCache() rather than the field: the cache is initialized lazily.
+    return getFilesetMetadataCache()
         .map(cache -> cache.getSchema(schemaIdent))
-        .orElseGet(
-            () -> {
-              NameIdentifier catalogIdent =
-                  NameIdentifier.of(
-                      schemaIdent.namespace().level(0), schemaIdent.namespace().level(1));
-              Catalog c = gravitinoClient.loadCatalog(catalogIdent.name());
-              return c.asSchemas().loadSchema(schemaIdent.name());
-            });
+        .orElseGet(() -> catalog.asSchemas().loadSchema(schemaIdent.name()));
   }
 
   /**
@@ -712,10 +797,18 @@ public abstract class BaseGVFSOperations implements Closeable {
    */
   protected FileSystem getActualFileSystemByLocationName(
       NameIdentifier filesetIdent, String locationName) throws FileNotFoundException {
-    NameIdentifier catalogIdent =
-        NameIdentifier.of(filesetIdent.namespace().level(0), filesetIdent.namespace().level(1));
+    FilesetCatalog filesetCatalog = getFilesetCatalog(catalogIdentOf(filesetIdent));
+    return buildFileSystem(
+        filesetIdent, filesetCatalog, getFileset(filesetIdent, filesetCatalog), locationName);
+  }
+
+  private FileSystem buildFileSystem(
+      NameIdentifier filesetIdent,
+      FilesetCatalog filesetCatalog,
+      Fileset fileset,
+      String locationName)
+      throws FileNotFoundException {
     try {
-      Fileset fileset = getFileset(filesetIdent);
       String targetLocationName =
           locationName == null
               ? fileset.properties().get(PROPERTY_DEFAULT_LOCATION_NAME)
@@ -728,7 +821,9 @@ public abstract class BaseGVFSOperations implements Closeable {
           filesetIdent);
 
       Path targetLocation = new Path(fileset.storageLocations().get(targetLocationName));
-      Map<String, String> allProperties = getAllProperties(filesetIdent);
+      Catalog catalog = (Catalog) filesetCatalog;
+
+      Map<String, String> allProperties = getAllProperties(filesetIdent, fileset, catalog);
       allProperties.putAll(
           FilesetUtil.getUserDefinedFileSystemConfigs(
               targetLocation.toUri(), allProperties, FS_GRAVITINO_PATH_CONFIG_PREFIX));
@@ -738,17 +833,19 @@ public abstract class BaseGVFSOperations implements Closeable {
             getCredentialProperties(
                 getFileSystemProviderByScheme(targetLocation.toUri().getScheme()),
                 filesetIdent,
+                fileset,
                 locationName));
       }
 
       FileSystem actualFileSystem = getActualFileSystemByPath(targetLocation, allProperties);
-      createFilesetLocationIfNeed(filesetIdent, actualFileSystem, targetLocation);
+      createFilesetLocationIfNeed(actualFileSystem, targetLocation, catalog);
       return actualFileSystem;
     } catch (RuntimeException e) {
       Throwable cause = e.getCause();
       if (cause instanceof NoSuchCatalogException || cause instanceof CatalogNotInUseException) {
         String message =
-            String.format("Cannot get fileset catalog by identifier: %s", catalogIdent);
+            String.format(
+                "Cannot get fileset catalog by identifier: %s", catalogIdentOf(filesetIdent));
         LOG.warn(message, e);
         throw (FileNotFoundException) new FileNotFoundException(message).initCause(e);
       }
@@ -963,14 +1060,17 @@ public abstract class BaseGVFSOperations implements Closeable {
     return cacheBuilder.build();
   }
 
+  /**
+   * Everything needed to construct a {@link FileSystem}: the schema's properties, and the secrets
+   * of the catalog, schema and fileset.
+   *
+   * <p>Loading the schema is a server call when the metadata cache is disabled, and each {@code
+   * getSecrets()} is another one that no cache absorbs.
+   */
   @VisibleForTesting
-  Map<String, String> getAllProperties(NameIdentifier filesetIdent) {
-    String catalogName = filesetIdent.namespace().level(1);
-    String schemaName = filesetIdent.namespace().level(2);
-    Catalog catalog = getGravitinoClient().loadCatalog(catalogName);
-    Schema schema = catalog.asSchemas().loadSchema(schemaName);
-    Fileset fileset =
-        catalog.asFilesetCatalog().loadFileset(NameIdentifier.of(schemaName, filesetIdent.name()));
+  Map<String, String> getAllProperties(
+      NameIdentifier filesetIdent, Fileset fileset, Catalog catalog) {
+    Schema schema = getSchema(NameIdentifier.of(filesetIdent.namespace().levels()), catalog);
 
     Map<String, String> all = new HashMap<>();
     putPropsAndSecrets(all, catalog.properties(), catalog.supportsSecrets());
@@ -999,6 +1099,7 @@ public abstract class BaseGVFSOperations implements Closeable {
   private Map<String, String> getCredentialProperties(
       FileSystemProvider fileSystemProvider,
       NameIdentifier filesetIdentifier,
+      Fileset fileset,
       String locationName) {
     // Do not support credential vending, we do not need to add any credential properties.
     if (!(fileSystemProvider instanceof SupportsCredentialVending)) {
@@ -1007,7 +1108,6 @@ public abstract class BaseGVFSOperations implements Closeable {
 
     ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
     try {
-      Fileset fileset = getFileset(filesetIdentifier);
       GravitinoVirtualFileSystemUtils.setCallerContextForGetCredentials(locationName);
       Credential[] credentials = fileset.supportsCredentials().getCredentials();
       if (credentials.length > 0) {

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/DefaultGVFSOperations.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/DefaultGVFSOperations.java
@@ -25,6 +25,8 @@ import com.google.common.base.Preconditions;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.audit.FilesetDataOperation;
 import org.apache.hadoop.conf.Configuration;
@@ -61,18 +63,16 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
 
   @Override
   public FSDataInputStream open(Path gvfsPath, int bufferSize) throws IOException {
-    FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-    Path actualFilePath =
-        getActualFilePath(gvfsPath, currentLocationName(), FilesetDataOperation.OPEN);
-    return actualFs.open(actualFilePath, bufferSize);
+    Pair<FileSystem, Path> resolved =
+        resolvePath(gvfsPath, currentLocationName(), FilesetDataOperation.OPEN);
+    return resolved.getLeft().open(resolved.getRight(), bufferSize);
   }
 
   @Override
   public synchronized void setWorkingDirectory(Path gvfsDir) throws FileNotFoundException {
-    FileSystem actualFs = getActualFileSystem(gvfsDir, currentLocationName());
-    Path actualFilePath =
-        getActualFilePath(gvfsDir, currentLocationName(), FilesetDataOperation.SET_WORKING_DIR);
-    actualFs.setWorkingDirectory(actualFilePath);
+    Pair<FileSystem, Path> resolved =
+        resolvePath(gvfsDir, currentLocationName(), FilesetDataOperation.SET_WORKING_DIR);
+    resolved.getLeft().setWorkingDirectory(resolved.getRight());
   }
 
   @Override
@@ -86,11 +86,18 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
       Progressable progress)
       throws IOException {
     try {
-      FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-      Path actualFilePath =
-          getActualFilePath(gvfsPath, currentLocationName(), FilesetDataOperation.CREATE);
-      return actualFs.create(
-          actualFilePath, permission, overwrite, bufferSize, replication, blockSize, progress);
+      Pair<FileSystem, Path> resolved =
+          resolvePath(gvfsPath, currentLocationName(), FilesetDataOperation.CREATE);
+      return resolved
+          .getLeft()
+          .create(
+              resolved.getRight(),
+              permission,
+              overwrite,
+              bufferSize,
+              replication,
+              blockSize,
+              progress);
     } catch (FileNotFoundException e) {
       String message =
           "Fileset is not found for path: "
@@ -105,10 +112,9 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
   @Override
   public FSDataOutputStream append(Path gvfsPath, int bufferSize, Progressable progress)
       throws IOException {
-    FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-    Path actualFilePath =
-        getActualFilePath(gvfsPath, currentLocationName(), FilesetDataOperation.APPEND);
-    return actualFs.append(actualFilePath, bufferSize, progress);
+    Pair<FileSystem, Path> resolved =
+        resolvePath(gvfsPath, currentLocationName(), FilesetDataOperation.APPEND);
+    return resolved.getLeft().append(resolved.getRight(), bufferSize, progress);
   }
 
   @Override
@@ -124,21 +130,18 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
         srcIdentifier,
         dstIdentifier);
 
-    Path srcActualPath =
-        getActualFilePath(srcGvfsPath, currentLocationName(), FilesetDataOperation.RENAME);
-    Path dstActualPath =
-        getActualFilePath(dstGvfsPath, currentLocationName(), FilesetDataOperation.RENAME);
-    FileSystem actualFs = getActualFileSystem(srcGvfsPath, currentLocationName());
-    return actualFs.rename(srcActualPath, dstActualPath);
+    // Both paths are in the same fileset, asserted above, so one catalog lookup serves both.
+    Triple<FileSystem, Path, Path> resolved =
+        resolveRenamePaths(srcGvfsPath, dstGvfsPath, currentLocationName());
+    return resolved.getLeft().rename(resolved.getMiddle(), resolved.getRight());
   }
 
   @Override
   public boolean delete(Path gvfsPath, boolean recursive) throws IOException {
     try {
-      FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-      Path actualFilePath =
-          getActualFilePath(gvfsPath, currentLocationName(), FilesetDataOperation.DELETE);
-      return actualFs.delete(actualFilePath, recursive);
+      Pair<FileSystem, Path> resolved =
+          resolvePath(gvfsPath, currentLocationName(), FilesetDataOperation.DELETE);
+      return resolved.getLeft().delete(resolved.getRight(), recursive);
     } catch (FileNotFoundException e) {
       return false;
     }
@@ -146,10 +149,10 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
 
   @Override
   public FileStatus getFileStatus(Path gvfsPath) throws IOException {
-    FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-    Path actualFilePath =
-        getActualFilePath(gvfsPath, currentLocationName(), FilesetDataOperation.GET_FILE_STATUS);
-    FileStatus fileStatus = actualFs.getFileStatus(actualFilePath);
+    Pair<FileSystem, Path> resolved =
+        resolvePath(gvfsPath, currentLocationName(), FilesetDataOperation.GET_FILE_STATUS);
+    Path actualFilePath = resolved.getRight();
+    FileStatus fileStatus = resolved.getLeft().getFileStatus(actualFilePath);
 
     NameIdentifier identifier = extractIdentifier(metalakeName(), gvfsPath.toString());
     String subPath = getSubPathFromGvfsPath(identifier, gvfsPath.toString());
@@ -164,10 +167,10 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
 
   @Override
   public FileStatus[] listStatus(Path gvfsPath) throws IOException {
-    FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-    Path actualFilePath =
-        getActualFilePath(gvfsPath, currentLocationName(), FilesetDataOperation.LIST_STATUS);
-    FileStatus[] fileStatusResults = actualFs.listStatus(actualFilePath);
+    Pair<FileSystem, Path> resolved =
+        resolvePath(gvfsPath, currentLocationName(), FilesetDataOperation.LIST_STATUS);
+    Path actualFilePath = resolved.getRight();
+    FileStatus[] fileStatusResults = resolved.getLeft().listStatus(actualFilePath);
 
     NameIdentifier identifier = extractIdentifier(metalakeName(), gvfsPath.toString());
     String subPath = getSubPathFromGvfsPath(identifier, gvfsPath.toString());
@@ -187,10 +190,9 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
   @Override
   public boolean mkdirs(Path gvfsPath, FsPermission permission) throws IOException {
     try {
-      FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-      Path actualFilePath =
-          getActualFilePath(gvfsPath, currentLocationName(), FilesetDataOperation.MKDIRS);
-      return actualFs.mkdirs(actualFilePath, permission);
+      Pair<FileSystem, Path> resolved =
+          resolvePath(gvfsPath, currentLocationName(), FilesetDataOperation.MKDIRS);
+      return resolved.getLeft().mkdirs(resolved.getRight(), permission);
     } catch (FileNotFoundException e) {
       String message =
           "Fileset is not found for path: "
@@ -205,11 +207,10 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
   @Override
   public short getDefaultReplication(Path gvfsPath) {
     try {
-      FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-      Path actualFilePath =
-          getActualFilePath(
+      Pair<FileSystem, Path> resolved =
+          resolvePath(
               gvfsPath, currentLocationName(), FilesetDataOperation.GET_DEFAULT_REPLICATION);
-      return actualFs.getDefaultReplication(actualFilePath);
+      return resolved.getLeft().getDefaultReplication(resolved.getRight());
     } catch (FileNotFoundException e) {
       return 1;
     }
@@ -218,11 +219,9 @@ public class DefaultGVFSOperations extends BaseGVFSOperations {
   @Override
   public long getDefaultBlockSize(Path gvfsPath) {
     try {
-      FileSystem actualFs = getActualFileSystem(gvfsPath, currentLocationName());
-      Path actualFilePath =
-          getActualFilePath(
-              gvfsPath, currentLocationName(), FilesetDataOperation.GET_DEFAULT_BLOCK_SIZE);
-      return actualFs.getDefaultBlockSize(actualFilePath);
+      Pair<FileSystem, Path> resolved =
+          resolvePath(gvfsPath, currentLocationName(), FilesetDataOperation.GET_DEFAULT_BLOCK_SIZE);
+      return resolved.getLeft().getDefaultBlockSize(resolved.getRight());
     } catch (FileNotFoundException e) {
       return defaultBlockSize();
     }

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/TestBaseGVFSOperationsSecrets.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/TestBaseGVFSOperationsSecrets.java
@@ -83,7 +83,7 @@ public class TestBaseGVFSOperationsSecrets {
 
     TestOps ops = new TestOps(conf, client);
     Map<String, String> all =
-        ops.getAllProperties(NameIdentifier.of("ml", "catalog", "schema", "fs"));
+        ops.getAllProperties(NameIdentifier.of("ml", "catalog", "schema", "fs"), fileset, catalog);
 
     assertEquals("1", all.get("c-vis"));
     assertEquals("cs", all.get("c-secret"));
@@ -129,7 +129,7 @@ public class TestBaseGVFSOperationsSecrets {
 
     TestOps ops = new TestOps(conf, client);
     Map<String, String> all =
-        ops.getAllProperties(NameIdentifier.of("ml", "catalog", "schema", "fs"));
+        ops.getAllProperties(NameIdentifier.of("ml", "catalog", "schema", "fs"), fileset, catalog);
 
     assertEquals("from-fileset-secret", all.get("shared"));
   }
@@ -170,7 +170,7 @@ public class TestBaseGVFSOperationsSecrets {
 
     TestOps ops = new TestOps(conf, client);
     Map<String, String> all =
-        ops.getAllProperties(NameIdentifier.of("ml", "catalog", "schema", "fs"));
+        ops.getAllProperties(NameIdentifier.of("ml", "catalog", "schema", "fs"), fileset, catalog);
 
     assertEquals("cs", all.get("c-secret"));
     assertEquals("ss", all.get("s-secret"));
@@ -216,7 +216,7 @@ public class TestBaseGVFSOperationsSecrets {
 
     TestOps ops = new TestOps(conf, client);
     Map<String, String> all =
-        ops.getAllProperties(NameIdentifier.of("ml", "catalog", "schema", "fs"));
+        ops.getAllProperties(NameIdentifier.of("ml", "catalog", "schema", "fs"), fileset, catalog);
 
     assertFalse(all.containsKey(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY));
     assertEquals("http://s3.example.com", all.get("s3-endpoint"));

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/TestGvfsBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/TestGvfsBase.java
@@ -1755,4 +1755,125 @@ public class TestGvfsBase extends GravitinoMockServerBase {
   private MockGVFSHook getHook(FileSystem gvfs) {
     return (MockGVFSHook) ((GravitinoVirtualFileSystem) gvfs).getHook();
   }
+
+  @Test
+  public void testOneCatalogLoadPerOperation() throws IOException {
+    Assumptions.assumeTrue(getClass() == TestGvfsBase.class);
+    String filesetName = "testOneCatalogLoadPerOperation";
+    Path managedFilesetPath =
+        FileSystemTestUtils.createFilesetPath(catalogName, schemaName, filesetName, true);
+    Path localPath = FileSystemTestUtils.createLocalDirPrefix(catalogName, schemaName, filesetName);
+    String catalogPath = "/api/metalakes/" + metalakeName + "/catalogs/" + catalogName;
+    String locationPath =
+        String.format(
+            "/api/metalakes/%s/catalogs/%s/schemas/%s/filesets/%s/location",
+            metalakeName, catalogName, schemaName, RESTUtils.encodeString(filesetName));
+
+    // Catalog loads only reach the server while the metadata cache is disabled. That is the
+    // default, but pin it so the expected count does not depend on a default defined elsewhere.
+    Configuration cacheOffConf = new Configuration(conf);
+    cacheOffConf.setBoolean(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_FILESET_METADATA_CACHE_ENABLE, false);
+
+    try (FileSystem gravitinoFileSystem = managedFilesetPath.getFileSystem(cacheOffConf);
+        FileSystem localFileSystem = localPath.getFileSystem(conf)) {
+      FileSystemTestUtils.mkdirs(localPath, localFileSystem);
+      mockFilesetDTO(
+          metalakeName,
+          catalogName,
+          schemaName,
+          filesetName,
+          Fileset.Type.MANAGED,
+          ImmutableMap.of("location1", localPath.toString()),
+          ImmutableMap.of(PROPERTY_DEFAULT_LOCATION_NAME, "location1"));
+      Map<String, String> queryParams = new HashMap<>();
+      queryParams.put("sub_path", "/test.txt");
+      buildMockResource(
+          Method.GET,
+          locationPath,
+          queryParams,
+          null,
+          new FileLocationResponse(localPath + "/test.txt"),
+          SC_OK);
+      buildMockResourceForCredential(filesetName, localPath + "/test.txt");
+
+      // Warm the filesystem cache first: the first operation also constructs a FileSystem, and
+      // the steady-state count is what a query engine pays per file.
+      Path filePath = new Path(managedFilesetPath + "/test.txt");
+      FileSystemTestUtils.create(filePath, gravitinoFileSystem);
+
+      HttpRequest catalogRequest = HttpRequest.request(catalogPath);
+      int before = mockServer().retrieveRecordedRequests(catalogRequest).length;
+      FileSystemTestUtils.create(filePath, gravitinoFileSystem);
+      int after = mockServer().retrieveRecordedRequests(catalogRequest).length;
+
+      assertEquals(
+          1, after - before, "one filesystem operation must load the catalog exactly once");
+
+      localFileSystem.delete(new Path(localPath + "/test.txt"), true);
+    }
+  }
+
+  @Test
+  public void testOneCatalogLoadPerRename() throws IOException {
+    Assumptions.assumeTrue(getClass() == TestGvfsBase.class);
+    String filesetName = "testOneCatalogLoadPerRename";
+    Path managedFilesetPath =
+        FileSystemTestUtils.createFilesetPath(catalogName, schemaName, filesetName, true);
+    Path localPath = FileSystemTestUtils.createLocalDirPrefix(catalogName, schemaName, filesetName);
+    String catalogPath = "/api/metalakes/" + metalakeName + "/catalogs/" + catalogName;
+    String locationPath =
+        String.format(
+            "/api/metalakes/%s/catalogs/%s/schemas/%s/filesets/%s/location",
+            metalakeName, catalogName, schemaName, RESTUtils.encodeString(filesetName));
+
+    // Catalog loads only reach the server while the metadata cache is disabled. That is the
+    // default, but pin it so the expected count does not depend on a default defined elsewhere.
+    Configuration cacheOffConf = new Configuration(conf);
+    cacheOffConf.setBoolean(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_FILESET_METADATA_CACHE_ENABLE, false);
+
+    try (FileSystem gravitinoFileSystem = managedFilesetPath.getFileSystem(cacheOffConf);
+        FileSystem localFileSystem = localPath.getFileSystem(conf)) {
+      FileSystemTestUtils.mkdirs(localPath, localFileSystem);
+      mockFilesetDTO(
+          metalakeName,
+          catalogName,
+          schemaName,
+          filesetName,
+          Fileset.Type.MANAGED,
+          ImmutableMap.of("location1", localPath.toString()),
+          ImmutableMap.of(PROPERTY_DEFAULT_LOCATION_NAME, "location1"));
+      buildMockResource(
+          Method.GET,
+          locationPath,
+          ImmutableMap.of("sub_path", "/src.txt"),
+          null,
+          new FileLocationResponse(localPath + "/src.txt"),
+          SC_OK);
+      buildMockResource(
+          Method.GET,
+          locationPath,
+          ImmutableMap.of("sub_path", "/dst.txt"),
+          null,
+          new FileLocationResponse(localPath + "/dst.txt"),
+          SC_OK);
+      buildMockResourceForCredential(filesetName, localPath + "/src.txt");
+
+      // Warm the filesystem cache first, as in testOneCatalogLoadPerOperation.
+      Path srcPath = new Path(managedFilesetPath + "/src.txt");
+      Path dstPath = new Path(managedFilesetPath + "/dst.txt");
+      FileSystemTestUtils.create(srcPath, gravitinoFileSystem);
+
+      HttpRequest catalogRequest = HttpRequest.request(catalogPath);
+      int before = mockServer().retrieveRecordedRequests(catalogRequest).length;
+      assertTrue(gravitinoFileSystem.rename(srcPath, dstPath));
+      int after = mockServer().retrieveRecordedRequests(catalogRequest).length;
+
+      // A rename resolves two paths, but both sit in one fileset, so one catalog serves both.
+      assertEquals(1, after - before, "a rename must load the catalog exactly once");
+
+      localFileSystem.delete(new Path(localPath + "/dst.txt"), true);
+    }
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Re-organize the GVFS client's internal REST calls to reduce the unnecessary REST calls

### Why are the changes needed?

Fix: https://github.com/apache/gravitino/issues/12856

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

No

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
- Ran spotless apply and check
- Verified with Unit Test
- Verified on K8s with gravitino-playground helm