### PR TITLE
[MINOR] style(client-python): Apply black formatting

### DIFF
--- a/clients/client-python/gravitino/api/catalog_change.py
+++ b/clients/client-python/gravitino/api/catalog_change.py
@@ -313,8 +313,7 @@ class CatalogChange(ABC):
             if not isinstance(other, CatalogChange.SetSecretBinding):
                 return False
             return (
-                self._property == other.property()
-                and self._binding == other.binding()
+                self._property == other.property() and self._binding == other.binding()
             )
 
         def __hash__(self):

--- a/clients/client-python/gravitino/api/file/fileset_change.py
+++ b/clients/client-python/gravitino/api/file/fileset_change.py
@@ -347,8 +347,7 @@ class FilesetChange(ABC):
             if not isinstance(other, FilesetChange.SetSecretBinding):
                 return False
             return (
-                self._property == other.property()
-                and self._binding == other.binding()
+                self._property == other.property() and self._binding == other.binding()
             )
 
         def __hash__(self):

--- a/clients/client-python/tests/integration/test_model_catalog.py
+++ b/clients/client-python/tests/integration/test_model_catalog.py
@@ -255,7 +255,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(update_property_model.name(), model_name)
         self.assertEqual(update_property_model.comment(), comment)
         self.assertEqual(update_property_model.latest_version(), 0)
-        self.assert_properties_equal({"k1": "v11", "k2": "v2", "k3": "v3"}, update_property_model.properties())
+        self.assert_properties_equal(
+            {"k1": "v11", "k2": "v2", "k3": "v3"}, update_property_model.properties()
+        )
 
     def test_register_remove_model_property(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -327,7 +329,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", model_version.uri())
         self.assertEqual(["alias1", "alias2"], model_version.aliases())
         self.assertEqual("comment", model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, model_version.properties()
+        )
 
         model_version = self._catalog.as_model_catalog().get_model_version_by_alias(
             model_ident, "alias1"
@@ -350,7 +354,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(0, updated_model_version.version())
         self.assertEqual("new comment", updated_model_version.comment())
         self.assertEqual(["alias1", "alias2"], updated_model_version.aliases())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, updated_model_version.properties()
+        )
         self.assertEqual("uri", updated_model_version.uri())
 
     def test_link_update_model_version_property(self):
@@ -379,7 +385,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", original_model_version.uri())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, original_model_version.properties()
+        )
 
         changes = [
             ModelVersionChange.set_property("k1", "v11"),
@@ -398,7 +406,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(update_property_model.uri(), "uri")
         self.assertEqual(update_property_model.comment(), comment)
         self.assertEqual(update_property_model.aliases(), aliases)
-        self.assert_properties_equal({"k1": "v11", "k3": "v3"}, update_property_model.properties())
+        self.assert_properties_equal(
+            {"k1": "v11", "k3": "v3"}, update_property_model.properties()
+        )
 
     def test_link_update_model_version_uri(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -425,7 +435,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", original_model_version.uri())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, original_model_version.properties()
+        )
 
         changes = [ModelVersionChange.update_uri("new_uri")]
         self._catalog.as_model_catalog().alter_model_version(model_ident, 0, *changes)
@@ -437,7 +449,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("new_uri", updated_model_version.uri())
         self.assertEqual(["alias1", "alias2"], updated_model_version.aliases())
         self.assertEqual("comment", updated_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, updated_model_version.properties()
+        )
 
     def test_link_add_model_version_uri(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -464,7 +478,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1"}, original_model_version.uris())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, original_model_version.properties()
+        )
 
         changes = [ModelVersionChange.add_uri("n2", "u2")]
         self._catalog.as_model_catalog().alter_model_version(model_ident, 0, *changes)
@@ -476,7 +492,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, updated_model_version.uris())
         self.assertEqual(["alias1", "alias2"], updated_model_version.aliases())
         self.assertEqual("comment", updated_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, updated_model_version.properties()
+        )
 
     def test_link_remove_model_version_uri(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -503,7 +521,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, original_model_version.uris())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, original_model_version.properties()
+        )
 
         changes = [ModelVersionChange.remove_uri("n1")]
         self._catalog.as_model_catalog().alter_model_version(model_ident, 0, *changes)
@@ -515,7 +535,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n2": "u2"}, updated_model_version.uris())
         self.assertEqual(["alias1", "alias2"], updated_model_version.aliases())
         self.assertEqual("comment", updated_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, updated_model_version.properties()
+        )
 
     def test_link_update_model_version_aliases(self):
         model_name = f"model_it_model{str(randint(0, 1000))}"
@@ -542,7 +564,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", original_model_version.uri())
         self.assertEqual(["alias1", "alias2"], original_model_version.aliases())
         self.assertEqual("comment", original_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, original_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, original_model_version.properties()
+        )
 
         # todo
         changes = [
@@ -560,7 +584,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", updated_model_version.uri())
         self.assertEqual(["alias2", "alias3"], updated_model_version.aliases())
         self.assertEqual("comment", updated_model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, updated_model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, updated_model_version.properties()
+        )
 
     def test_link_update_model_version_aliases_from_empty(self):
         # Regression test for https://github.com/apache/gravitino/issues/9727:
@@ -647,7 +673,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual("uri", model_version.uri())
         self.assertEqual(["alias1", "alias2"], model_version.aliases())
         self.assertEqual("comment", model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, model_version.properties()
+        )
 
         model_version = self._catalog.as_model_catalog().get_model_version_by_alias(
             model_ident, "alias1"
@@ -768,7 +796,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual(model_versions[0].uri(), "uri1")
         self.assertEqual(model_versions[0].comment(), "comment")
         self.assertEqual(model_versions[0].aliases(), ["alias1", "alias2"])
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_versions[0].properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, model_versions[0].properties()
+        )
 
         self.assertTrue(
             self._catalog.as_model_catalog().delete_model_version(model_ident, 0)
@@ -805,7 +835,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, model_version.uris())
         self.assertEqual(["alias1", "alias2"], model_version.aliases())
         self.assertEqual("comment", model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, model_version.properties()
+        )
 
         # Test get model version by alias
         model_version = self._catalog.as_model_catalog().get_model_version_by_alias(
@@ -841,7 +873,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, model_versions[0].uris())
         self.assertEqual("comment", model_versions[0].comment())
         self.assertEqual(["alias1", "alias2"], model_versions[0].aliases())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_versions[0].properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, model_versions[0].properties()
+        )
 
     def test_get_model_version_uri(self):
         model_name = "model_it_model" + str(randint(0, 1000))
@@ -865,7 +899,9 @@ class TestModelCatalog(IntegrationTestEnv):
         self.assertEqual({"n1": "u1", "n2": "u2"}, model_version.uris())
         self.assertEqual(["alias1", "alias2"], model_version.aliases())
         self.assertEqual("comment", model_version.comment())
-        self.assert_properties_equal({"k1": "v1", "k2": "v2"}, model_version.properties())
+        self.assert_properties_equal(
+            {"k1": "v1", "k2": "v2"}, model_version.properties()
+        )
 
         # Test get model version uri
         model_version_uri = self._catalog.as_model_catalog().get_model_version_uri(

--- a/clients/client-python/tests/integration/test_relational_catalog.py
+++ b/clients/client-python/tests/integration/test_relational_catalog.py
@@ -178,7 +178,9 @@ class TestRelationalCatalog(IntegrationTestEnv):
         self.assertIsNotNone(table)
         self.assertEqual(table.name(), TestRelationalCatalog.TABLE_NAME)
         self.assertEqual(table.comment(), TestRelationalCatalog.TABLE_COMMENT)
-        self.assert_properties_equal(TestRelationalCatalog.TABLE_PROPERTIES, table.properties())
+        self.assert_properties_equal(
+            TestRelationalCatalog.TABLE_PROPERTIES, table.properties()
+        )
         self.assertEqual(len(table.columns()), 3)
 
         columns = table.columns()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reformats four files under `clients/client-python` with the `black` version pinned in `requirements-dev.txt`. The changes are line wrapping only; no behavior is affected.

- `gravitino/api/catalog_change.py`
- `gravitino/api/file/fileset_change.py`
- `tests/integration/test_model_catalog.py`
- `tests/integration/test_relational_catalog.py`

### Why are the changes needed?

These files are not formatted the way the pinned `black` version formats them, so the next unrelated change that touches them picks up incidental reformatting in its diff.

The drift is not caught today because the Gradle `pythonFormat` task runs `black` in place rather than in check mode, so CI stays green while the difference accumulates. Reformatting now keeps future diffs focused on their actual changes.

I noticed this while working on the Semantic Model Python client sub-tasks and kept it out of those PRs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Reformatted with the pinned `black` version and confirmed a second run is a no-op, then ran the unit tests.

```
./gradlew :clients:client-python:test
```
