### PR TITLE
[#12594] feat(authz): Add Semantic Model ownership and privilege support

### DIFF
--- a/api/src/main/java/org/apache/gravitino/authorization/Privilege.java
+++ b/api/src/main/java/org/apache/gravitino/authorization/Privilege.java
@@ -157,7 +157,13 @@ public interface Privilege {
     /** The privilege to view a tag. */
     VIEW_TAG(0L, 1L << 34),
     /** The privilege to view a policy. */
-    VIEW_POLICY(0L, 1L << 35);
+    VIEW_POLICY(0L, 1L << 35),
+    /** The privilege to create a semantic model. */
+    CREATE_SEMANTIC_MODEL(0L, 1L << 36),
+    /** The privilege to discover a semantic model and load its definition. */
+    SELECT_SEMANTIC_MODEL(0L, 1L << 37),
+    /** The privilege to rename a semantic model or alter its definition and metadata. */
+    MODIFY_SEMANTIC_MODEL(0L, 1L << 38);
 
     private final long highBits;
     private final long lowBits;

--- a/api/src/main/java/org/apache/gravitino/authorization/Privileges.java
+++ b/api/src/main/java/org/apache/gravitino/authorization/Privileges.java
@@ -78,11 +78,19 @@ public class Privileges {
           MetadataObject.Type.SCHEMA,
           MetadataObject.Type.FUNCTION);
 
+  private static final Set<MetadataObject.Type> SEMANTIC_MODEL_SUPPORTED_TYPES =
+      Sets.immutableEnumSet(
+          MetadataObject.Type.METALAKE,
+          MetadataObject.Type.CATALOG,
+          MetadataObject.Type.SCHEMA,
+          MetadataObject.Type.SEMANTIC_MODEL);
+
   /**
    * Object types that {@link ManageGrants} can be bound to.
    *
    * <p>Binding at a parent level implicitly covers all children — for example, a grant on a SCHEMA
-   * lets the holder manage privileges on every TABLE, VIEW, TOPIC, FILESET, and MODEL inside it.
+   * lets the holder manage privileges on every TABLE, VIEW, TOPIC, FILESET, MODEL, FUNCTION, and
+   * SEMANTIC_MODEL inside it.
    */
   private static final Set<MetadataObject.Type> MANAGE_GRANTS_SUPPORTED_TYPES =
       Sets.immutableEnumSet(
@@ -94,7 +102,8 @@ public class Privileges {
           MetadataObject.Type.TOPIC,
           MetadataObject.Type.FILESET,
           MetadataObject.Type.MODEL,
-          MetadataObject.Type.FUNCTION);
+          MetadataObject.Type.FUNCTION,
+          MetadataObject.Type.SEMANTIC_MODEL);
 
   /**
    * Returns the Privilege with allow condition from the string representation.
@@ -218,6 +227,14 @@ public class Privileges {
         return ExecuteFunction.allow();
       case MODIFY_FUNCTION:
         return ModifyFunction.allow();
+
+        // Semantic model
+      case CREATE_SEMANTIC_MODEL:
+        return CreateSemanticModel.allow();
+      case SELECT_SEMANTIC_MODEL:
+        return SelectSemanticModel.allow();
+      case MODIFY_SEMANTIC_MODEL:
+        return ModifySemanticModel.allow();
 
       default:
         throw new IllegalArgumentException("Doesn't support the privilege: " + name);
@@ -346,6 +363,14 @@ public class Privileges {
         return ExecuteFunction.deny();
       case MODIFY_FUNCTION:
         return ModifyFunction.deny();
+
+        // Semantic model
+      case CREATE_SEMANTIC_MODEL:
+        return CreateSemanticModel.deny();
+      case SELECT_SEMANTIC_MODEL:
+        return SelectSemanticModel.deny();
+      case MODIFY_SEMANTIC_MODEL:
+        return ModifySemanticModel.deny();
 
       default:
         throw new IllegalArgumentException("Doesn't support the privilege: " + name);
@@ -1570,6 +1595,99 @@ public class Privileges {
     @Override
     public boolean canBindTo(MetadataObject.Type type) {
       return FUNCTION_SUPPORTED_TYPES.contains(type);
+    }
+  }
+
+  /** The privilege to create a semantic model. */
+  public static class CreateSemanticModel extends GenericPrivilege<CreateSemanticModel> {
+    private static final CreateSemanticModel ALLOW_INSTANCE =
+        new CreateSemanticModel(Condition.ALLOW, Name.CREATE_SEMANTIC_MODEL);
+    private static final CreateSemanticModel DENY_INSTANCE =
+        new CreateSemanticModel(Condition.DENY, Name.CREATE_SEMANTIC_MODEL);
+
+    private CreateSemanticModel(Condition condition, Name name) {
+      super(condition, name);
+    }
+
+    /**
+     * @return The instance with allow condition of the privilege.
+     */
+    public static CreateSemanticModel allow() {
+      return ALLOW_INSTANCE;
+    }
+
+    /**
+     * @return The instance with deny condition of the privilege.
+     */
+    public static CreateSemanticModel deny() {
+      return DENY_INSTANCE;
+    }
+
+    @Override
+    public boolean canBindTo(MetadataObject.Type type) {
+      return SCHEMA_SUPPORTED_TYPES.contains(type);
+    }
+  }
+
+  /** The privilege to discover a semantic model and load its definition. */
+  public static class SelectSemanticModel extends GenericPrivilege<SelectSemanticModel> {
+    private static final SelectSemanticModel ALLOW_INSTANCE =
+        new SelectSemanticModel(Condition.ALLOW, Name.SELECT_SEMANTIC_MODEL);
+    private static final SelectSemanticModel DENY_INSTANCE =
+        new SelectSemanticModel(Condition.DENY, Name.SELECT_SEMANTIC_MODEL);
+
+    private SelectSemanticModel(Condition condition, Name name) {
+      super(condition, name);
+    }
+
+    /**
+     * @return The instance with allow condition of the privilege.
+     */
+    public static SelectSemanticModel allow() {
+      return ALLOW_INSTANCE;
+    }
+
+    /**
+     * @return The instance with deny condition of the privilege.
+     */
+    public static SelectSemanticModel deny() {
+      return DENY_INSTANCE;
+    }
+
+    @Override
+    public boolean canBindTo(MetadataObject.Type type) {
+      return SEMANTIC_MODEL_SUPPORTED_TYPES.contains(type);
+    }
+  }
+
+  /** The privilege to rename a semantic model or alter its definition and metadata. */
+  public static class ModifySemanticModel extends GenericPrivilege<ModifySemanticModel> {
+    private static final ModifySemanticModel ALLOW_INSTANCE =
+        new ModifySemanticModel(Condition.ALLOW, Name.MODIFY_SEMANTIC_MODEL);
+    private static final ModifySemanticModel DENY_INSTANCE =
+        new ModifySemanticModel(Condition.DENY, Name.MODIFY_SEMANTIC_MODEL);
+
+    private ModifySemanticModel(Condition condition, Name name) {
+      super(condition, name);
+    }
+
+    /**
+     * @return The instance with allow condition of the privilege.
+     */
+    public static ModifySemanticModel allow() {
+      return ALLOW_INSTANCE;
+    }
+
+    /**
+     * @return The instance with deny condition of the privilege.
+     */
+    public static ModifySemanticModel deny() {
+      return DENY_INSTANCE;
+    }
+
+    @Override
+    public boolean canBindTo(MetadataObject.Type type) {
+      return SEMANTIC_MODEL_SUPPORTED_TYPES.contains(type);
     }
   }
 }

--- a/api/src/main/java/org/apache/gravitino/authorization/SecurableObjects.java
+++ b/api/src/main/java/org/apache/gravitino/authorization/SecurableObjects.java
@@ -171,6 +171,22 @@ public class SecurableObjects {
   }
 
   /**
+   * Create the semantic model {@link SecurableObject} with the given securable schema object,
+   * semantic model name and privileges.
+   *
+   * @param schema The schema securable object
+   * @param semanticModel The semantic model name
+   * @param privileges The privileges of the semantic model
+   * @return The created semantic model {@link SecurableObject}
+   */
+  public static SecurableObject ofSemanticModel(
+      SecurableObject schema, String semanticModel, List<Privilege> privileges) {
+    List<String> names = Lists.newArrayList(DOT_SPLITTER.splitToList(schema.fullName()));
+    names.add(semanticModel);
+    return of(MetadataObject.Type.SEMANTIC_MODEL, names, privileges);
+  }
+
+  /**
    * Create the tag {@link SecurableObject} with the given tag name and privileges.
    *
    * @param tag The tag name

--- a/api/src/test/java/org/apache/gravitino/authorization/TestSecurableObjects.java
+++ b/api/src/test/java/org/apache/gravitino/authorization/TestSecurableObjects.java
@@ -112,6 +112,19 @@ public class TestSecurableObjects {
             Lists.newArrayList(Privileges.SelectView.allow()));
     Assertions.assertEquals(view, anotherView);
 
+    SecurableObject semanticModel =
+        SecurableObjects.ofSemanticModel(
+            schema, "sales_model", Lists.newArrayList(Privileges.SelectSemanticModel.allow()));
+    Assertions.assertEquals("catalog.schema.sales_model", semanticModel.fullName());
+    Assertions.assertEquals(MetadataObject.Type.SEMANTIC_MODEL, semanticModel.type());
+
+    SecurableObject anotherSemanticModel =
+        SecurableObjects.of(
+            MetadataObject.Type.SEMANTIC_MODEL,
+            Lists.newArrayList("catalog", "schema", "sales_model"),
+            Lists.newArrayList(Privileges.SelectSemanticModel.allow()));
+    Assertions.assertEquals(semanticModel, anotherSemanticModel);
+
     Exception e =
         Assertions.assertThrows(
             IllegalArgumentException.class,
@@ -178,6 +191,16 @@ public class TestSecurableObjects {
                     Lists.newArrayList("metalake"),
                     Lists.newArrayList(Privileges.SelectView.allow())));
     Assertions.assertTrue(e.getMessage().contains("the length of names must be 3"));
+
+    e =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                SecurableObjects.of(
+                    MetadataObject.Type.SEMANTIC_MODEL,
+                    Lists.newArrayList("metalake"),
+                    Lists.newArrayList(Privileges.SelectSemanticModel.allow())));
+    Assertions.assertTrue(e.getMessage().contains("the length of names must be 3"));
   }
 
   @Test
@@ -216,6 +239,9 @@ public class TestSecurableObjects {
     Privilege registerFunction = Privileges.RegisterFunction.allow();
     Privilege executeFunction = Privileges.ExecuteFunction.allow();
     Privilege modifyFunction = Privileges.ModifyFunction.allow();
+    Privilege createSemanticModel = Privileges.CreateSemanticModel.allow();
+    Privilege selectSemanticModel = Privileges.SelectSemanticModel.allow();
+    Privilege modifySemanticModel = Privileges.ModifySemanticModel.allow();
 
     Assertions.assertTrue(viewTag.canBindTo(MetadataObject.Type.METALAKE));
     Assertions.assertTrue(viewTag.canBindTo(MetadataObject.Type.TAG));
@@ -550,5 +576,47 @@ public class TestSecurableObjects {
     Assertions.assertFalse(modifyFunction.canBindTo(MetadataObject.Type.FILESET));
     Assertions.assertFalse(modifyFunction.canBindTo(MetadataObject.Type.ROLE));
     Assertions.assertFalse(modifyFunction.canBindTo(MetadataObject.Type.COLUMN));
+
+    // Test create semantic model, which binds to the schema it creates into, not to the model
+    Assertions.assertTrue(createSemanticModel.canBindTo(MetadataObject.Type.METALAKE));
+    Assertions.assertTrue(createSemanticModel.canBindTo(MetadataObject.Type.CATALOG));
+    Assertions.assertTrue(createSemanticModel.canBindTo(MetadataObject.Type.SCHEMA));
+    Assertions.assertFalse(createSemanticModel.canBindTo(MetadataObject.Type.SEMANTIC_MODEL));
+    Assertions.assertFalse(createSemanticModel.canBindTo(MetadataObject.Type.TABLE));
+    Assertions.assertFalse(createSemanticModel.canBindTo(MetadataObject.Type.MODEL));
+    Assertions.assertFalse(createSemanticModel.canBindTo(MetadataObject.Type.ROLE));
+    Assertions.assertFalse(createSemanticModel.canBindTo(MetadataObject.Type.COLUMN));
+
+    // Test select semantic model
+    Assertions.assertTrue(selectSemanticModel.canBindTo(MetadataObject.Type.METALAKE));
+    Assertions.assertTrue(selectSemanticModel.canBindTo(MetadataObject.Type.CATALOG));
+    Assertions.assertTrue(selectSemanticModel.canBindTo(MetadataObject.Type.SCHEMA));
+    Assertions.assertTrue(selectSemanticModel.canBindTo(MetadataObject.Type.SEMANTIC_MODEL));
+    Assertions.assertFalse(selectSemanticModel.canBindTo(MetadataObject.Type.TABLE));
+    Assertions.assertFalse(selectSemanticModel.canBindTo(MetadataObject.Type.MODEL));
+    Assertions.assertFalse(selectSemanticModel.canBindTo(MetadataObject.Type.ROLE));
+    Assertions.assertFalse(selectSemanticModel.canBindTo(MetadataObject.Type.COLUMN));
+
+    // Test modify semantic model
+    Assertions.assertTrue(modifySemanticModel.canBindTo(MetadataObject.Type.METALAKE));
+    Assertions.assertTrue(modifySemanticModel.canBindTo(MetadataObject.Type.CATALOG));
+    Assertions.assertTrue(modifySemanticModel.canBindTo(MetadataObject.Type.SCHEMA));
+    Assertions.assertTrue(modifySemanticModel.canBindTo(MetadataObject.Type.SEMANTIC_MODEL));
+    Assertions.assertFalse(modifySemanticModel.canBindTo(MetadataObject.Type.TABLE));
+    Assertions.assertFalse(modifySemanticModel.canBindTo(MetadataObject.Type.MODEL));
+    Assertions.assertFalse(modifySemanticModel.canBindTo(MetadataObject.Type.ROLE));
+    Assertions.assertFalse(modifySemanticModel.canBindTo(MetadataObject.Type.COLUMN));
+
+    // Deny instances must agree with their allow counterparts on binding
+    Assertions.assertTrue(
+        Privileges.SelectSemanticModel.deny().canBindTo(MetadataObject.Type.SEMANTIC_MODEL));
+    Assertions.assertEquals(
+        Privilege.Condition.DENY, Privileges.ModifySemanticModel.deny().condition());
+    Assertions.assertEquals(
+        Privileges.CreateSemanticModel.allow(),
+        Privileges.allow(Privilege.Name.CREATE_SEMANTIC_MODEL));
+    Assertions.assertEquals(
+        Privileges.ModifySemanticModel.deny(),
+        Privileges.deny(Privilege.Name.MODIFY_SEMANTIC_MODEL));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -70,6 +70,7 @@ import org.apache.gravitino.hook.MetalakeHookDispatcher;
 import org.apache.gravitino.hook.ModelHookDispatcher;
 import org.apache.gravitino.hook.PolicyHookDispatcher;
 import org.apache.gravitino.hook.SchemaHookDispatcher;
+import org.apache.gravitino.hook.SemanticModelHookDispatcher;
 import org.apache.gravitino.hook.TableHookDispatcher;
 import org.apache.gravitino.hook.TagHookDispatcher;
 import org.apache.gravitino.hook.TopicHookDispatcher;
@@ -896,15 +897,17 @@ public class GravitinoEnv {
         new ViewEventDispatcher(eventBus, viewNormalizeDispatcher);
     this.viewDispatcher = viewEventDispatcher;
 
-    // Semantic Model operation chain: SemanticModelNormalizeDispatcher ->
-    // SemanticModelOperationDispatcher -> ManagedSemanticModelOperations.
-    // TODO(#12595): Add Semantic Model event dispatching before server integration.
-    // TODO(#12594): Add Semantic Model ownership and privilege hooks.
+    // Semantic Model operation chain: SemanticModelHookDispatcher ->
+    // SemanticModelNormalizeDispatcher -> SemanticModelOperationDispatcher ->
+    // ManagedSemanticModelOperations.
+    // TODO(#12595): Insert SemanticModelEventDispatcher between the hook and normalize dispatchers.
     SemanticModelOperationDispatcher semanticModelOperationDispatcher =
         new SemanticModelOperationDispatcher(
             catalogManager, schemaOperationDispatcher, entityStore, idGenerator, secretManager);
-    this.semanticModelDispatcher =
+    SemanticModelNormalizeDispatcher semanticModelNormalizeDispatcher =
         new SemanticModelNormalizeDispatcher(semanticModelOperationDispatcher, catalogManager);
+    this.semanticModelDispatcher =
+        new SemanticModelHookDispatcher(semanticModelNormalizeDispatcher);
 
     this.statisticDispatcher =
         new StatisticEventDispatcher(

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -96,7 +96,10 @@ public class AuthorizationUtils {
           MetadataObject.Type.JOB_TEMPLATE,
           MetadataObject.Type.TAG,
           MetadataObject.Type.POLICY,
-          MetadataObject.Type.VIEW);
+          MetadataObject.Type.VIEW,
+          // Semantic models live only in Gravitino, underlying connectors know nothing about
+          // them, so there is no privilege to push down to an authorization plugin.
+          MetadataObject.Type.SEMANTIC_MODEL);
 
   private static final Set<Privilege.Name> FILESET_PRIVILEGES =
       Sets.immutableEnumSet(
@@ -116,6 +119,12 @@ public class AuthorizationUtils {
           Privilege.Name.REGISTER_MODEL,
           Privilege.Name.USE_MODEL,
           Privilege.Name.LINK_MODEL_VERSION);
+
+  private static final Set<Privilege.Name> SEMANTIC_MODEL_PRIVILEGES =
+      Sets.immutableEnumSet(
+          Privilege.Name.CREATE_SEMANTIC_MODEL,
+          Privilege.Name.SELECT_SEMANTIC_MODEL,
+          Privilege.Name.MODIFY_SEMANTIC_MODEL);
 
   private AuthorizationUtils() {}
 
@@ -318,6 +327,10 @@ public class AuthorizationUtils {
 
         if (MODEL_PRIVILEGES.contains(privilege.name())) {
           checkCatalogType(catalogIdent, Catalog.Type.MODEL, privilege);
+        }
+
+        if (SEMANTIC_MODEL_PRIVILEGES.contains(privilege.name())) {
+          checkCatalogType(catalogIdent, Catalog.Type.RELATIONAL, privilege);
         }
       } catch (NoSuchCatalogException ne) {
         throw new NoSuchMetadataObjectException(

--- a/core/src/main/java/org/apache/gravitino/hook/SemanticModelHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/SemanticModelHookDispatcher.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.hook;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.authorization.Owner;
+import org.apache.gravitino.authorization.OwnerDispatcher;
+import org.apache.gravitino.catalog.CapabilityHelpers;
+import org.apache.gravitino.catalog.SemanticModelDispatcher;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.exceptions.IllegalSemanticModelException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchSemanticModelException;
+import org.apache.gravitino.exceptions.SemanticModelAlreadyExistsException;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelChange;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+import org.apache.gravitino.utils.PrincipalUtils;
+
+/**
+ * {@code SemanticModelHookDispatcher} is a decorator for {@link SemanticModelDispatcher} that not
+ * only delegates Semantic Model operations to the underlying dispatcher but also executes some hook
+ * operations before or after the underlying operations.
+ */
+public class SemanticModelHookDispatcher implements SemanticModelDispatcher {
+
+  private final SemanticModelDispatcher dispatcher;
+
+  /**
+   * Creates a Semantic Model hook dispatcher.
+   *
+   * @param dispatcher The underlying dispatcher.
+   */
+  public SemanticModelHookDispatcher(SemanticModelDispatcher dispatcher) {
+    this.dispatcher = dispatcher;
+  }
+
+  @Override
+  public NameIdentifier[] listSemanticModels(Namespace namespace) throws NoSuchSchemaException {
+    return dispatcher.listSemanticModels(namespace);
+  }
+
+  @Override
+  public SemanticModel loadSemanticModel(NameIdentifier ident) throws NoSuchSemanticModelException {
+    return dispatcher.loadSemanticModel(ident);
+  }
+
+  @Override
+  public boolean semanticModelExists(NameIdentifier ident) {
+    return dispatcher.semanticModelExists(ident);
+  }
+
+  @Override
+  public SemanticModel createSemanticModel(
+      NameIdentifier ident,
+      @Nullable String comment,
+      SemanticModelDefinition definition,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, SemanticModelAlreadyExistsException,
+          IllegalSemanticModelException {
+    SemanticModel semanticModel =
+        dispatcher.createSemanticModel(ident, comment, definition, properties);
+
+    // Set the creator as the owner of the Semantic Model.
+    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    if (ownerDispatcher != null) {
+      // The inner NormalizeDispatcher case-folds the parent namespace based on catalog
+      // capabilities, so the entity is stored under the normalized identifier. Rebuild that
+      // identifier here - namespace from the catalog capability, name from the created Semantic
+      // Model, which already carries the Gravitino-owned naming rules - so the owner is attached to
+      // the same identifier the manager sees.
+      Capability capability =
+          CapabilityHelpers.getCapability(ident, GravitinoEnv.getInstance().catalogManager());
+      Namespace normalizedNamespace =
+          CapabilityHelpers.applyCapabilities(
+              ident.namespace(), Capability.Scope.SEMANTIC_MODEL, capability);
+      NameIdentifier normalizedIdent = NameIdentifier.of(normalizedNamespace, semanticModel.name());
+      ownerDispatcher.setOwner(
+          normalizedIdent.namespace().level(0),
+          NameIdentifierUtil.toMetadataObject(normalizedIdent, Entity.EntityType.SEMANTIC_MODEL),
+          PrincipalUtils.getCurrentUserName(),
+          Owner.Type.USER);
+    }
+    return semanticModel;
+  }
+
+  @Override
+  public SemanticModel alterSemanticModel(NameIdentifier ident, SemanticModelChange... changes)
+      throws NoSuchSemanticModelException, SemanticModelAlreadyExistsException,
+          IllegalSemanticModelException {
+    return dispatcher.alterSemanticModel(ident, changes);
+  }
+
+  @Override
+  public boolean dropSemanticModel(NameIdentifier ident) {
+    return dispatcher.dropSemanticModel(ident);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/utils/EntityClassMapper.java
+++ b/core/src/main/java/org/apache/gravitino/utils/EntityClassMapper.java
@@ -35,6 +35,7 @@ import org.apache.gravitino.meta.ModelVersionEntity;
 import org.apache.gravitino.meta.PolicyEntity;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.SchemaEntity;
+import org.apache.gravitino.meta.SemanticModelEntity;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.meta.TagEntity;
 import org.apache.gravitino.meta.TopicEntity;
@@ -64,6 +65,7 @@ public class EntityClassMapper {
           .put(Entity.EntityType.POLICY, PolicyEntity.class)
           .put(Entity.EntityType.JOB_TEMPLATE, JobTemplateEntity.class)
           .put(Entity.EntityType.JOB, JobEntity.class)
+          .put(Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class)
           .build();
 
   private EntityClassMapper() {}

--- a/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
@@ -282,6 +282,13 @@ public class MetadataObjectUtil {
         check(env.viewDispatcher().viewExists(identifier), exceptionToThrowSupplier);
         break;
 
+      case SEMANTIC_MODEL:
+        NameIdentifierUtil.checkSemanticModel(identifier);
+        check(
+            env.semanticModelDispatcher().semanticModelExists(identifier),
+            exceptionToThrowSupplier);
+        break;
+
       case ROLE:
         AuthorizationUtils.checkRole(identifier);
         try {

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationUtils.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationUtils.java
@@ -428,4 +428,34 @@ class TestAuthorizationUtils {
     Assertions.assertEquals("catalog.schema.table", removeChange.metadataObject().fullName());
     Assertions.assertEquals(locations, removeChange.getLocations());
   }
+
+  @Test
+  void testSemanticModelPrivilegesAreNotPushedToAuthorizationPlugin() {
+    // Semantic Models exist only in Gravitino, so underlying connectors have nothing to revoke or
+    // rename. Rename and remove must leave the authorization plugin untouched.
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "schema", "sales_model");
+    NameIdentifier catalogIdent = NameIdentifier.of("metalake", "catalog");
+
+    AccessControlDispatcher accessControlDispatcher = Mockito.mock(AccessControlDispatcher.class);
+    CatalogManager catalogManager = Mockito.mock(CatalogManager.class);
+    BaseCatalog<?> baseCatalog = Mockito.mock(BaseCatalog.class);
+    AuthorizationPlugin authorizationPlugin = Mockito.mock(AuthorizationPlugin.class);
+    Mockito.when(catalogManager.loadCatalog(catalogIdent)).thenReturn(baseCatalog);
+    Mockito.when(baseCatalog.getAuthorizationPlugin()).thenReturn(authorizationPlugin);
+
+    GravitinoEnv envMock = Mockito.mock(GravitinoEnv.class);
+    Mockito.when(envMock.accessControlDispatcher()).thenReturn(accessControlDispatcher);
+    Mockito.when(envMock.catalogManager()).thenReturn(catalogManager);
+
+    try (MockedStatic<GravitinoEnv> envStatic = Mockito.mockStatic(GravitinoEnv.class)) {
+      envStatic.when(GravitinoEnv::getInstance).thenReturn(envMock);
+
+      AuthorizationUtils.authorizationPluginRenamePrivileges(
+          ident, Entity.EntityType.SEMANTIC_MODEL, "renamed_model");
+      AuthorizationUtils.authorizationPluginRemovePrivileges(
+          ident, Entity.EntityType.SEMANTIC_MODEL, null);
+    }
+
+    Mockito.verifyNoInteractions(authorizationPlugin);
+  }
 }

--- a/core/src/test/java/org/apache/gravitino/hook/TestSemanticModelHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestSemanticModelHookDispatcher.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.hook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.authorization.Owner;
+import org.apache.gravitino.authorization.OwnerDispatcher;
+import org.apache.gravitino.catalog.CatalogManager;
+import org.apache.gravitino.catalog.SemanticModelDispatcher;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
+import org.apache.gravitino.semantic.SemanticModel;
+import org.apache.gravitino.semantic.SemanticModelChange;
+import org.apache.gravitino.semantic.SemanticModelDefinition;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class TestSemanticModelHookDispatcher {
+
+  private static final NameIdentifier IDENT =
+      NameIdentifier.of("metalake1", "catalog1", "schema1", "sales_model");
+
+  @Test
+  public void testCreateSemanticModelSetsCreatorAsOwner() throws Exception {
+    GravitinoEnv env = GravitinoEnv.getInstance();
+    Object originalOwnerDispatcher = FieldUtils.readField(env, "ownerDispatcher", true);
+    Object originalCatalogManager = FieldUtils.readField(env, "catalogManager", true);
+
+    SemanticModelDispatcher dispatcher = Mockito.mock(SemanticModelDispatcher.class);
+    SemanticModelDefinition definition = Mockito.mock(SemanticModelDefinition.class);
+    SemanticModel created = Mockito.mock(SemanticModel.class);
+    Mockito.when(created.name()).thenReturn("sales_model");
+    Mockito.when(dispatcher.createSemanticModel(eq(IDENT), eq("comment"), eq(definition), any()))
+        .thenReturn(created);
+
+    OwnerDispatcher ownerDispatcher = Mockito.mock(OwnerDispatcher.class);
+
+    FieldUtils.writeField(env, "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(env, "catalogManager", mockCatalogManager(Capability.DEFAULT), true);
+    try {
+      SemanticModelHookDispatcher hook = new SemanticModelHookDispatcher(dispatcher);
+      SemanticModel result =
+          hook.createSemanticModel(IDENT, "comment", definition, ImmutableMap.of());
+
+      assertSame(created, result);
+
+      ArgumentCaptor<MetadataObject> captor = ArgumentCaptor.forClass(MetadataObject.class);
+      Mockito.verify(ownerDispatcher)
+          .setOwner(
+              eq("metalake1"),
+              captor.capture(),
+              eq(AuthConstants.ANONYMOUS_USER),
+              eq(Owner.Type.USER));
+      assertEquals(MetadataObject.Type.SEMANTIC_MODEL, captor.getValue().type());
+      assertEquals("catalog1.schema1.sales_model", captor.getValue().fullName());
+    } finally {
+      FieldUtils.writeField(env, "ownerDispatcher", originalOwnerDispatcher, true);
+      FieldUtils.writeField(env, "catalogManager", originalCatalogManager, true);
+    }
+  }
+
+  @Test
+  public void testCreateSemanticModelSetsOwnerWithNormalizedIdentifier() throws Exception {
+    // The NormalizeDispatcher case-folds the parent schema against the catalog capability while
+    // keeping the Gravitino-owned model name, so the owner must be attached to that same
+    // identifier.
+    GravitinoEnv env = GravitinoEnv.getInstance();
+    Object originalOwnerDispatcher = FieldUtils.readField(env, "ownerDispatcher", true);
+    Object originalCatalogManager = FieldUtils.readField(env, "catalogManager", true);
+
+    NameIdentifier ident = NameIdentifier.of("metalake1", "catalog1", "SCHEMA_NORM", "Sales_Model");
+    SemanticModelDispatcher dispatcher = Mockito.mock(SemanticModelDispatcher.class);
+    SemanticModelDefinition definition = Mockito.mock(SemanticModelDefinition.class);
+    SemanticModel created = Mockito.mock(SemanticModel.class);
+    Mockito.when(created.name()).thenReturn("Sales_Model");
+    Mockito.when(dispatcher.createSemanticModel(any(), any(), any(), any())).thenReturn(created);
+
+    OwnerDispatcher ownerDispatcher = Mockito.mock(OwnerDispatcher.class);
+
+    FieldUtils.writeField(env, "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(
+        env, "catalogManager", mockCatalogManager(new CaseInsensitiveCapability()), true);
+    try {
+      SemanticModelHookDispatcher hook = new SemanticModelHookDispatcher(dispatcher);
+      hook.createSemanticModel(ident, "comment", definition, ImmutableMap.of());
+
+      ArgumentCaptor<MetadataObject> captor = ArgumentCaptor.forClass(MetadataObject.class);
+      Mockito.verify(ownerDispatcher)
+          .setOwner(eq("metalake1"), captor.capture(), any(), eq(Owner.Type.USER));
+      assertEquals(
+          "catalog1.schema_norm",
+          captor.getValue().parent(),
+          "The schema component must be lowercased by the catalog capability");
+      assertEquals(
+          "Sales_Model",
+          captor.getValue().name(),
+          "The Semantic Model name is Gravitino-owned and must not be case-folded by the catalog");
+    } finally {
+      FieldUtils.writeField(env, "ownerDispatcher", originalOwnerDispatcher, true);
+      FieldUtils.writeField(env, "catalogManager", originalCatalogManager, true);
+    }
+  }
+
+  @Test
+  public void testCreateSemanticModelSucceedsWhenOwnerDispatcherIsDisabled() throws Exception {
+    GravitinoEnv env = GravitinoEnv.getInstance();
+    Object originalOwnerDispatcher = FieldUtils.readField(env, "ownerDispatcher", true);
+
+    SemanticModelDispatcher dispatcher = Mockito.mock(SemanticModelDispatcher.class);
+    SemanticModelDefinition definition = Mockito.mock(SemanticModelDefinition.class);
+    SemanticModel created = Mockito.mock(SemanticModel.class);
+    Mockito.when(dispatcher.createSemanticModel(any(), any(), any(), any())).thenReturn(created);
+
+    FieldUtils.writeField(env, "ownerDispatcher", null, true);
+    try {
+      SemanticModelHookDispatcher hook = new SemanticModelHookDispatcher(dispatcher);
+      SemanticModel result =
+          hook.createSemanticModel(IDENT, "comment", definition, ImmutableMap.of());
+
+      assertSame(created, result);
+      Mockito.verify(dispatcher)
+          .createSemanticModel(IDENT, "comment", definition, ImmutableMap.of());
+    } finally {
+      FieldUtils.writeField(env, "ownerDispatcher", originalOwnerDispatcher, true);
+    }
+  }
+
+  @Test
+  public void testCreateSemanticModelThrowsWhenSetOwnerFails() throws Exception {
+    GravitinoEnv env = GravitinoEnv.getInstance();
+    Object originalOwnerDispatcher = FieldUtils.readField(env, "ownerDispatcher", true);
+    Object originalCatalogManager = FieldUtils.readField(env, "catalogManager", true);
+
+    OwnerDispatcher ownerDispatcher = Mockito.mock(OwnerDispatcher.class);
+    Mockito.doThrow(new RuntimeException("Set owner failed"))
+        .when(ownerDispatcher)
+        .setOwner(any(), any(), any(), any());
+
+    SemanticModelDispatcher dispatcher = Mockito.mock(SemanticModelDispatcher.class);
+    SemanticModelDefinition definition = Mockito.mock(SemanticModelDefinition.class);
+    SemanticModel created = Mockito.mock(SemanticModel.class);
+    Mockito.when(created.name()).thenReturn("sales_model");
+    Mockito.when(dispatcher.createSemanticModel(any(), any(), any(), any())).thenReturn(created);
+
+    FieldUtils.writeField(env, "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(env, "catalogManager", mockCatalogManager(Capability.DEFAULT), true);
+    try {
+      SemanticModelHookDispatcher hook = new SemanticModelHookDispatcher(dispatcher);
+      RuntimeException thrown =
+          assertThrows(
+              RuntimeException.class,
+              () -> hook.createSemanticModel(IDENT, "comment", definition, ImmutableMap.of()));
+      assertEquals("Set owner failed", thrown.getMessage());
+    } finally {
+      FieldUtils.writeField(env, "ownerDispatcher", originalOwnerDispatcher, true);
+      FieldUtils.writeField(env, "catalogManager", originalCatalogManager, true);
+    }
+  }
+
+  @Test
+  public void testNonCreateOperationsDelegateWithoutOwnerChanges() throws Exception {
+    GravitinoEnv env = GravitinoEnv.getInstance();
+    Object originalOwnerDispatcher = FieldUtils.readField(env, "ownerDispatcher", true);
+
+    SemanticModelDispatcher dispatcher = Mockito.mock(SemanticModelDispatcher.class);
+    SemanticModel loaded = Mockito.mock(SemanticModel.class);
+    SemanticModel altered = Mockito.mock(SemanticModel.class);
+    NameIdentifier[] listed = new NameIdentifier[] {IDENT};
+    SemanticModelChange change = SemanticModelChange.rename("renamed_model");
+
+    Namespace namespace = Namespace.of("metalake1", "catalog1", "schema1");
+    Mockito.when(dispatcher.listSemanticModels(namespace)).thenReturn(listed);
+    Mockito.when(dispatcher.loadSemanticModel(IDENT)).thenReturn(loaded);
+    Mockito.when(dispatcher.alterSemanticModel(IDENT, change)).thenReturn(altered);
+    Mockito.when(dispatcher.dropSemanticModel(IDENT)).thenReturn(true);
+    Mockito.when(dispatcher.semanticModelExists(IDENT)).thenReturn(true);
+
+    OwnerDispatcher ownerDispatcher = Mockito.mock(OwnerDispatcher.class);
+    FieldUtils.writeField(env, "ownerDispatcher", ownerDispatcher, true);
+    try {
+      SemanticModelHookDispatcher hook = new SemanticModelHookDispatcher(dispatcher);
+
+      assertSame(listed, hook.listSemanticModels(namespace));
+      assertSame(loaded, hook.loadSemanticModel(IDENT));
+      assertSame(altered, hook.alterSemanticModel(IDENT, change));
+      assertTrue(hook.dropSemanticModel(IDENT));
+      assertTrue(hook.semanticModelExists(IDENT));
+
+      Mockito.verifyNoInteractions(ownerDispatcher);
+    } finally {
+      FieldUtils.writeField(env, "ownerDispatcher", originalOwnerDispatcher, true);
+    }
+  }
+
+  private static CatalogManager mockCatalogManager(Capability capability) throws Exception {
+    CatalogManager catalogManager = Mockito.mock(CatalogManager.class);
+    CatalogManager.CatalogWrapper wrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Mockito.when(wrapper.capabilities()).thenReturn(capability);
+    Mockito.when(catalogManager.loadCatalogAndWrap(any())).thenReturn(wrapper);
+    return catalogManager;
+  }
+
+  private static class CaseInsensitiveCapability implements Capability {
+    @Override
+    public CapabilityResult caseSensitiveOnName(Scope scope) {
+      return CapabilityResult.unsupported("case-insensitive");
+    }
+  }
+}

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -88,7 +88,8 @@ Metalake (top level)
 │       ├── Topic
 │       ├── Fileset
 │       ├── Model
-│       └── Function
+│       ├── Function
+│       └── Semantic Model
 ├── Tag
 ├── Policy
 ├── Job Template
@@ -189,6 +190,9 @@ sets the scope of the grant. Binding a privilege to a type not listed for it is 
 | `REGISTER_FUNCTION`  | Metalake, Catalog, Schema              | Register functions in any schema in scope                          |
 | `EXECUTE_FUNCTION`   | Metalake, Catalog, Schema, Function    | Read the metadata of, and execute, any function in scope           |
 | `MODIFY_FUNCTION`    | Metalake, Catalog, Schema, Function    | Alter or drop any function in scope                                |
+| `CREATE_SEMANTIC_MODEL` | Metalake, Catalog, Schema           | Create semantic models in any schema in scope                      |
+| `SELECT_SEMANTIC_MODEL` | Metalake, Catalog, Schema, Semantic Model | Discover and load the definition of any semantic model in scope |
+| `MODIFY_SEMANTIC_MODEL` | Metalake, Catalog, Schema, Semantic Model | Rename, and alter the definition and metadata of, any semantic model in scope |
 
 Either `SELECT_TABLE` or `MODIFY_TABLE` is enough to load a table's metadata, and the same pairing
 holds for views, topics, and filesets.
@@ -250,6 +254,7 @@ metalake owner is all of them.
 | Fileset  | `CREATE_FILESET`    | `READ_FILESET` or `WRITE_FILESET`    | `WRITE_FILESET`   | Owner |
 | Model    | `REGISTER_MODEL`    | `USE_MODEL`                          | Owner             | Owner |
 | Function | `REGISTER_FUNCTION` | `EXECUTE_FUNCTION` or `MODIFY_FUNCTION` | `MODIFY_FUNCTION` | Owner |
+| Semantic Model | `CREATE_SEMANTIC_MODEL` | `SELECT_SEMANTIC_MODEL` or `MODIFY_SEMANTIC_MODEL` | `MODIFY_SEMANTIC_MODEL` | Owner |
 
 Table statistics follow the table itself: reading them takes `SELECT_TABLE` or `MODIFY_TABLE`,
 writing them takes `MODIFY_TABLE`. Model versions follow the model: `USE_MODEL` to read, owner to

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataIdConverter.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataIdConverter.java
@@ -50,7 +50,8 @@ public class MetadataIdConverter {
           MetadataObject.Type.MODEL, Capability.Scope.MODEL,
           MetadataObject.Type.FILESET, Capability.Scope.FILESET,
           MetadataObject.Type.TOPIC, Capability.Scope.TOPIC,
-          MetadataObject.Type.COLUMN, Capability.Scope.COLUMN);
+          MetadataObject.Type.COLUMN, Capability.Scope.COLUMN,
+          MetadataObject.Type.SEMANTIC_MODEL, Capability.Scope.SEMANTIC_MODEL);
 
   private MetadataIdConverter() {}
 

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/expression/AuthorizationExpressionConstants.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/expression/AuthorizationExpressionConstants.java
@@ -265,6 +265,53 @@ public class AuthorizationExpressionConstants {
               ANY_WRITE_FILESET
                   """;
 
+  /**
+   * Semantic Model list and load. Only Semantic Models the caller can select, modify, or owns are
+   * returned; a metalake or catalog owner, or a schema owner holding USE_CATALOG, sees them all.
+   */
+  public static final String LOAD_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION =
+      """
+                  ANY(OWNER, METALAKE, CATALOG) ||
+                  SCHEMA_OWNER_WITH_USE_CATALOG ||
+                  ANY_USE_CATALOG && ANY_USE_SCHEMA &&
+                  (SEMANTIC_MODEL::OWNER || ANY_SELECT_SEMANTIC_MODEL || ANY_MODIFY_SEMANTIC_MODEL)
+                  """;
+
+  /** Semantic Model creation under a schema. */
+  public static final String CREATE_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION =
+      """
+                  ANY(OWNER, METALAKE, CATALOG) ||
+                  SCHEMA_OWNER_WITH_USE_CATALOG ||
+                  ANY_USE_CATALOG && ANY_USE_SCHEMA && ANY_CREATE_SEMANTIC_MODEL
+                  """;
+
+  /** Semantic Model rename and definition or metadata alteration. */
+  public static final String MODIFY_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION =
+      """
+                  ANY(OWNER, METALAKE, CATALOG) ||
+                  SCHEMA_OWNER_WITH_USE_CATALOG ||
+                  ANY_USE_CATALOG && ANY_USE_SCHEMA &&
+                  (SEMANTIC_MODEL::OWNER || ANY_MODIFY_SEMANTIC_MODEL)
+                  """;
+
+  /**
+   * Semantic Model drop. Unlike alter, MODIFY_SEMANTIC_MODEL is not enough: a caller who is neither
+   * a metalake, catalog, nor schema owner must own the Semantic Model itself.
+   */
+  public static final String DROP_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION =
+      """
+                  ANY(OWNER, METALAKE, CATALOG) ||
+                  SCHEMA_OWNER_WITH_USE_CATALOG ||
+                  ANY_USE_CATALOG && ANY_USE_SCHEMA && SEMANTIC_MODEL::OWNER
+                  """;
+
+  public static final String FILTER_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION =
+      """
+                  ANY(OWNER, METALAKE, CATALOG, SCHEMA, SEMANTIC_MODEL) ||
+                  ANY_SELECT_SEMANTIC_MODEL ||
+                  ANY_MODIFY_SEMANTIC_MODEL
+                  """;
+
   public static final String LOAD_ROLE_AUTHORIZATION_EXPRESSION =
       """
           METALAKE::OWNER || METALAKE::MANAGE_GRANTS

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/expression/AuthorizationExpressionConverter.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/expression/AuthorizationExpressionConverter.java
@@ -27,6 +27,7 @@ import static org.apache.gravitino.server.authorization.expression.Authorization
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_POLICY_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_ROLE_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_SCHEMA_AUTHORIZATION_EXPRESSION;
+import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_TABLE_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_TAG_AUTHORIZATION_EXPRESSION;
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.LOAD_TOPICS_AUTHORIZATION_EXPRESSION;
@@ -185,7 +186,8 @@ public class AuthorizationExpressionConverter {
               ( entityType == 'JOB' && (%s)) ||
               ( entityType == 'JOB_TEMPLATE' && (%s)) ||
               ( entityType == 'COLUMN' && (%s)) ||
-              ( entityType == 'FUNCTION' && (%s))
+              ( entityType == 'FUNCTION' && (%s)) ||
+              ( entityType == 'SEMANTIC_MODEL' && (%s))
               """
             .formatted(
                 LOAD_CATALOG_AUTHORIZATION_EXPRESSION,
@@ -202,7 +204,8 @@ public class AuthorizationExpressionConverter {
                 LOAD_JOB_AUTHORIZATION_EXPRESSION,
                 LOAD_JOB_TEMPLATE_AUTHORIZATION_EXPRESSION,
                 LOAD_TABLE_AUTHORIZATION_EXPRESSION,
-                LOAD_FUNCTION_AUTHORIZATION_EXPRESSION));
+                LOAD_FUNCTION_AUTHORIZATION_EXPRESSION,
+                LOAD_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION));
   }
 
   /**
@@ -317,6 +320,21 @@ public class AuthorizationExpressionConverter {
             "ANY_MODIFY_FUNCTION",
             "((ANY(MODIFY_FUNCTION, METALAKE, CATALOG, SCHEMA, FUNCTION)) "
                 + "&& !(ANY(DENY_MODIFY_FUNCTION, METALAKE, CATALOG, SCHEMA, FUNCTION)))");
+    expression =
+        expression.replaceAll(
+            "ANY_CREATE_SEMANTIC_MODEL",
+            "((ANY(CREATE_SEMANTIC_MODEL, METALAKE, CATALOG, SCHEMA)) "
+                + "&& !(ANY(DENY_CREATE_SEMANTIC_MODEL, METALAKE, CATALOG, SCHEMA)))");
+    expression =
+        expression.replaceAll(
+            "ANY_SELECT_SEMANTIC_MODEL",
+            "((ANY(SELECT_SEMANTIC_MODEL, METALAKE, CATALOG, SCHEMA, SEMANTIC_MODEL)) "
+                + "&& !(ANY(DENY_SELECT_SEMANTIC_MODEL, METALAKE, CATALOG, SCHEMA, SEMANTIC_MODEL)))");
+    expression =
+        expression.replaceAll(
+            "ANY_MODIFY_SEMANTIC_MODEL",
+            "((ANY(MODIFY_SEMANTIC_MODEL, METALAKE, CATALOG, SCHEMA, SEMANTIC_MODEL)) "
+                + "&& !(ANY(DENY_MODIFY_SEMANTIC_MODEL, METALAKE, CATALOG, SCHEMA, SEMANTIC_MODEL)))");
     expression =
         expression.replaceAll(
             "ANY_CREATE_TOPIC",

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizationCacheKeys.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizationCacheKeys.java
@@ -63,6 +63,7 @@ final class JcasbinAuthorizationCacheKeys {
       case FILESET:
       case MODEL:
       case FUNCTION:
+      case SEMANTIC_MODEL:
         appendCatalogSchemasAndLeaf(parts, names, metadataObject.type());
         break;
       default:

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/TestMetadataIdConverter.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/TestMetadataIdConverter.java
@@ -52,6 +52,7 @@ import org.apache.gravitino.meta.GroupEntity;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.meta.SchemaVersion;
+import org.apache.gravitino.meta.SemanticModelEntity;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.meta.TopicEntity;
 import org.apache.gravitino.rel.types.Types;
@@ -72,6 +73,7 @@ public class TestMetadataIdConverter {
   private NameIdentifier ident6;
   private NameIdentifier ident7;
   private NameIdentifier ident8;
+  private NameIdentifier ident9;
 
   // Test Entities
   private BaseMetalake entity1;
@@ -82,6 +84,7 @@ public class TestMetadataIdConverter {
   private FilesetEntity entity6;
   private TopicEntity entity7;
   private GroupEntity entity8;
+  private SemanticModelEntity entity9;
 
   @BeforeAll
   void initTest() throws IOException {
@@ -152,6 +155,12 @@ public class TestMetadataIdConverter {
                   MetadataIdConverter.normalizeCaseSensitive(
                       eq(ident8), eq(null), eq(mockCatalogManager)))
           .thenReturn(ident8);
+      mockedStatic
+          .when(
+              () ->
+                  MetadataIdConverter.normalizeCaseSensitive(
+                      eq(ident9), eq(Capability.Scope.SEMANTIC_MODEL), eq(mockCatalogManager)))
+          .thenReturn(ident9);
 
       Optional<Long> metalakeConvertedId =
           MetadataIdConverter.getID(
@@ -185,6 +194,12 @@ public class TestMetadataIdConverter {
               MetadataObjects.of(
                   ImmutableList.of("catalog", "schema", "topic"), MetadataObject.Type.TOPIC),
               "metalake");
+      Optional<Long> semanticModelConvertedId =
+          MetadataIdConverter.getID(
+              MetadataObjects.of(
+                  ImmutableList.of("catalog", "schema", "sales_model"),
+                  MetadataObject.Type.SEMANTIC_MODEL),
+              "metalake");
 
       Assertions.assertEquals(Optional.of(1L), metalakeConvertedId);
       Assertions.assertEquals(Optional.of(2L), catalogConvertedId);
@@ -193,6 +208,7 @@ public class TestMetadataIdConverter {
       Assertions.assertEquals(Optional.of(5L), modelConvertedId);
       Assertions.assertEquals(Optional.of(6L), filesetConvertedId);
       Assertions.assertEquals(Optional.of(7L), topicConvertedId);
+      Assertions.assertEquals(Optional.of(9L), semanticModelConvertedId);
     } finally {
       FieldUtils.writeDeclaredField(
           GravitinoEnv.getInstance(), "catalogManager", originalCatalogManager, true);
@@ -239,6 +255,7 @@ public class TestMetadataIdConverter {
     ident6 = NameIdentifier.of("metalake", "catalog", "schema", "fileset");
     ident7 = NameIdentifier.of("metalake", "catalog", "schema", "topic");
     ident8 = NameIdentifier.of("metalake", "group");
+    ident9 = NameIdentifier.of("metalake", "catalog", "schema", "sales_model");
   }
 
   private void initTestEntities() {
@@ -259,6 +276,8 @@ public class TestMetadataIdConverter {
         getTestTopicEntity(
             7L, "topic", Namespace.of("metalake", "catalog", "schema"), "test_topic");
     entity8 = getTestGroupEntity(8L, "group", Namespace.of("metalake"));
+    entity9 = mock(SemanticModelEntity.class);
+    when(entity9.id()).thenReturn(9L);
   }
 
   private void initMockCache() throws IOException {
@@ -272,6 +291,8 @@ public class TestMetadataIdConverter {
     when(mockStore.get(ident6, Entity.EntityType.FILESET, FilesetEntity.class)).thenReturn(entity6);
     when(mockStore.get(ident7, Entity.EntityType.TOPIC, TopicEntity.class)).thenReturn(entity7);
     when(mockStore.get(ident8, Entity.EntityType.GROUP, GroupEntity.class)).thenReturn(entity8);
+    when(mockStore.get(ident9, Entity.EntityType.SEMANTIC_MODEL, SemanticModelEntity.class))
+        .thenReturn(entity9);
   }
 
   private BaseMetalake getTestMetalake(long id, String name, String comment) {

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizationCacheKeys.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizationCacheKeys.java
@@ -66,6 +66,16 @@ public class TestJcasbinAuthorizationCacheKeys {
     Assertions.assertEquals(
         key("ml1", "CATALOG", "cat1", "SCHEMA", "sch1", "VIEW", "tbl1"), viewKey);
 
+    MetadataObject semanticModel =
+        MetadataObjects.of(
+            Arrays.asList("cat1", "sch1", "sales_model"), MetadataObject.Type.SEMANTIC_MODEL);
+    String semanticModelKey =
+        JcasbinAuthorizationCacheKeys.metadataIdCacheKey("ml1", semanticModel);
+    Assertions.assertEquals(
+        key("ml1", "CATALOG", "cat1", "SCHEMA", "sch1", "SEMANTIC_MODEL", "sales_model"),
+        semanticModelKey);
+    Assertions.assertTrue(semanticModelKey.startsWith(schemaKey));
+
     Assertions.assertTrue(schemaKey.startsWith(catalogKey));
     Assertions.assertTrue(tableKey.startsWith(schemaKey));
     Assertions.assertTrue(columnKey.startsWith(tableKey));
@@ -91,6 +101,8 @@ public class TestJcasbinAuthorizationCacheKeys {
         JcasbinAuthorizationCacheKeys.hasNestedMetadataObjects(MetadataObject.Type.TOPIC));
     Assertions.assertFalse(
         JcasbinAuthorizationCacheKeys.hasNestedMetadataObjects(MetadataObject.Type.COLUMN));
+    Assertions.assertFalse(
+        JcasbinAuthorizationCacheKeys.hasNestedMetadataObjects(MetadataObject.Type.SEMANTIC_MODEL));
   }
 
   @Test

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/authorization/TestSemanticModelAuthorizationExpression.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/authorization/TestSemanticModelAuthorizationExpression.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.server.web.rest.authorization;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableSet;
+import ognl.OgnlException;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the Semantic Model authorization expressions against the rules in the Semantic Model
+ * design: creation needs CREATE_SEMANTIC_MODEL under USE_CATALOG and USE_SCHEMA, list and load
+ * accept SELECT_SEMANTIC_MODEL or MODIFY_SEMANTIC_MODEL, alter needs MODIFY_SEMANTIC_MODEL, and
+ * drop needs ownership rather than any privilege.
+ */
+public class TestSemanticModelAuthorizationExpression {
+
+  @Test
+  public void testCreateSemanticModel() throws OgnlException {
+    MockAuthorizationExpressionEvaluator evaluator =
+        new MockAuthorizationExpressionEvaluator(
+            AuthorizationExpressionConstants.CREATE_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION);
+
+    assertFalse(evaluator.getResult(ImmutableSet.of()));
+    assertTrue(evaluator.getResult(ImmutableSet.of("METALAKE::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("CATALOG::OWNER")));
+
+    // A schema owner still needs USE_CATALOG to reach the schema.
+    assertFalse(evaluator.getResult(ImmutableSet.of("SCHEMA::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("SCHEMA::OWNER", "CATALOG::USE_CATALOG")));
+
+    // Everyone else needs the full USE_CATALOG + USE_SCHEMA + CREATE_SEMANTIC_MODEL chain.
+    assertFalse(evaluator.getResult(ImmutableSet.of("SCHEMA::CREATE_SEMANTIC_MODEL")));
+    assertFalse(
+        evaluator.getResult(
+            ImmutableSet.of("SCHEMA::CREATE_SEMANTIC_MODEL", "SCHEMA::USE_SCHEMA")));
+    assertTrue(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SCHEMA::CREATE_SEMANTIC_MODEL", "SCHEMA::USE_SCHEMA", "CATALOG::USE_CATALOG")));
+    assertTrue(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "METALAKE::CREATE_SEMANTIC_MODEL",
+                "METALAKE::USE_SCHEMA",
+                "METALAKE::USE_CATALOG")));
+
+    // A deny anywhere in the hierarchy defeats an allow granted lower down.
+    assertFalse(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "METALAKE::CREATE_SEMANTIC_MODEL",
+                "CATALOG::DENY_CREATE_SEMANTIC_MODEL",
+                "METALAKE::USE_SCHEMA",
+                "METALAKE::USE_CATALOG")));
+  }
+
+  @Test
+  public void testLoadSemanticModel() throws OgnlException {
+    MockAuthorizationExpressionEvaluator evaluator =
+        new MockAuthorizationExpressionEvaluator(
+            AuthorizationExpressionConstants.LOAD_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION);
+
+    assertFalse(evaluator.getResult(ImmutableSet.of()));
+    assertTrue(evaluator.getResult(ImmutableSet.of("METALAKE::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("CATALOG::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("SCHEMA::OWNER", "CATALOG::USE_CATALOG")));
+
+    // Owning the Semantic Model is enough once the parents are reachable.
+    assertFalse(evaluator.getResult(ImmutableSet.of("SEMANTIC_MODEL::OWNER")));
+    assertTrue(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SEMANTIC_MODEL::OWNER", "CATALOG::USE_CATALOG", "SCHEMA::USE_SCHEMA")));
+
+    // Either SELECT or MODIFY loads the definition.
+    assertTrue(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SEMANTIC_MODEL::SELECT_SEMANTIC_MODEL",
+                "CATALOG::USE_CATALOG",
+                "SCHEMA::USE_SCHEMA")));
+    assertTrue(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SCHEMA::MODIFY_SEMANTIC_MODEL", "CATALOG::USE_CATALOG", "SCHEMA::USE_SCHEMA")));
+
+    // Unrelated privileges do not grant visibility.
+    assertFalse(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SCHEMA::CREATE_SEMANTIC_MODEL", "CATALOG::USE_CATALOG", "SCHEMA::USE_SCHEMA")));
+    assertFalse(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "METALAKE::SELECT_SEMANTIC_MODEL",
+                "SEMANTIC_MODEL::DENY_SELECT_SEMANTIC_MODEL",
+                "CATALOG::USE_CATALOG",
+                "SCHEMA::USE_SCHEMA")));
+  }
+
+  @Test
+  public void testFilterSemanticModel() throws OgnlException {
+    MockAuthorizationExpressionEvaluator evaluator =
+        new MockAuthorizationExpressionEvaluator(
+            AuthorizationExpressionConstants.FILTER_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION);
+
+    assertFalse(evaluator.getResult(ImmutableSet.of()));
+    assertTrue(evaluator.getResult(ImmutableSet.of("METALAKE::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("CATALOG::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("SCHEMA::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("SEMANTIC_MODEL::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("SCHEMA::SELECT_SEMANTIC_MODEL")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("SEMANTIC_MODEL::MODIFY_SEMANTIC_MODEL")));
+    assertFalse(evaluator.getResult(ImmutableSet.of("SCHEMA::CREATE_SEMANTIC_MODEL")));
+    assertFalse(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "METALAKE::SELECT_SEMANTIC_MODEL", "SCHEMA::DENY_SELECT_SEMANTIC_MODEL")));
+  }
+
+  @Test
+  public void testAlterSemanticModel() throws OgnlException {
+    MockAuthorizationExpressionEvaluator evaluator =
+        new MockAuthorizationExpressionEvaluator(
+            AuthorizationExpressionConstants.MODIFY_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION);
+
+    assertFalse(evaluator.getResult(ImmutableSet.of()));
+    assertTrue(evaluator.getResult(ImmutableSet.of("METALAKE::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("SCHEMA::OWNER", "CATALOG::USE_CATALOG")));
+    assertTrue(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SEMANTIC_MODEL::OWNER", "CATALOG::USE_CATALOG", "SCHEMA::USE_SCHEMA")));
+    assertTrue(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SEMANTIC_MODEL::MODIFY_SEMANTIC_MODEL",
+                "CATALOG::USE_CATALOG",
+                "SCHEMA::USE_SCHEMA")));
+
+    // SELECT_SEMANTIC_MODEL is read-only and must not permit an alter.
+    assertFalse(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SEMANTIC_MODEL::SELECT_SEMANTIC_MODEL",
+                "CATALOG::USE_CATALOG",
+                "SCHEMA::USE_SCHEMA")));
+  }
+
+  @Test
+  public void testDropSemanticModel() throws OgnlException {
+    MockAuthorizationExpressionEvaluator evaluator =
+        new MockAuthorizationExpressionEvaluator(
+            AuthorizationExpressionConstants.DROP_SEMANTIC_MODEL_AUTHORIZATION_EXPRESSION);
+
+    assertFalse(evaluator.getResult(ImmutableSet.of()));
+    assertTrue(evaluator.getResult(ImmutableSet.of("METALAKE::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("CATALOG::OWNER")));
+    assertTrue(evaluator.getResult(ImmutableSet.of("SCHEMA::OWNER", "CATALOG::USE_CATALOG")));
+    assertTrue(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SEMANTIC_MODEL::OWNER", "CATALOG::USE_CATALOG", "SCHEMA::USE_SCHEMA")));
+
+    // Unlike alter, MODIFY_SEMANTIC_MODEL does not authorize a drop.
+    assertFalse(
+        evaluator.getResult(
+            ImmutableSet.of(
+                "SEMANTIC_MODEL::MODIFY_SEMANTIC_MODEL",
+                "CATALOG::USE_CATALOG",
+                "SCHEMA::USE_SCHEMA")));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds the authorization layer for Semantic Models, following the "Authorization and Governance" section of `design-docs/gravitino-semantic-model-design.md`.

**Privileges** (`api`)

- `CREATE_SEMANTIC_MODEL`, `SELECT_SEMANTIC_MODEL`, and `MODIFY_SEMANTIC_MODEL` in `Privilege.Name`, plus the matching `Privileges` classes and `allow`/`deny` resolution.
- Binding rules: `CREATE_SEMANTIC_MODEL` binds to METALAKE, CATALOG, and SCHEMA (the scope it creates into); `SELECT_SEMANTIC_MODEL` and `MODIFY_SEMANTIC_MODEL` additionally bind to SEMANTIC_MODEL.
- `SecurableObjects.ofSemanticModel(...)`, and `SEMANTIC_MODEL` added to `ManageGrants` bindings so grant management can be delegated per Semantic Model, as it already can for every other schema-level object.
- `AuthorizationUtils.checkPrivilege` rejects the new privileges on non-relational catalogs, matching `SemanticModelOperationDispatcher`, which only serves relational catalogs.

**Ownership** (`core`)

- New `SemanticModelHookDispatcher` sets the creator as owner after a successful create.
- The dispatcher chain becomes `SemanticModelHookDispatcher -> SemanticModelNormalizeDispatcher -> SemanticModelOperationDispatcher`, with a TODO marking where #12595's event dispatcher belongs.
- The hook rebuilds the stored identifier as normalized-namespace plus the created model's own name. `SemanticModelNormalizeDispatcher` case-folds only the parent namespace against the catalog capability and applies Gravitino-owned naming to the model name, so reusing `applyCapabilities(ident, scope, catalogManager)` the way `ModelHookDispatcher` does would attach the owner to a case-folded name the store never used.
- `SEMANTIC_MODEL` added to `AuthorizationUtils.SKIP_APPLY_TYPES`: Semantic Models exist only in Gravitino, so there is nothing for a catalog authorization plugin to grant, revoke, or rename.

**Authorization plumbing**

- LOAD, CREATE, MODIFY, DROP, and FILTER expressions in `AuthorizationExpressionConstants`. Drop deliberately requires ownership rather than `MODIFY_SEMANTIC_MODEL`, per the design doc.
- `ANY_CREATE_SEMANTIC_MODEL`, `ANY_SELECT_SEMANTIC_MODEL`, and `ANY_MODIFY_SEMANTIC_MODEL` token expansion in `AuthorizationExpressionConverter`, with deny taking precedence at every scope.
- `SEMANTIC_MODEL` in `CAN_ACCESS_METADATA`, so the owner API accepts Semantic Model objects.
- `MetadataObjectUtil.checkMetadataObject`, `EntityClassMapper`, `MetadataIdConverter` case-sensitivity scope, and `JcasbinAuthorizationCacheKeys` all handle `SEMANTIC_MODEL`.

**Docs**

- `docs/security/access-control.md`: object tree, privilege table, and required-privileges table.

### Why are the changes needed?

Semantic Models are new securable metadata objects. Without privileges and an ownership hook they would be created with no owner and no way to grant access, so the REST APIs in #12607 and #12608 have nothing to enforce.

Fix: #12594

### Does this PR introduce _any_ user-facing change?

Yes, additive only:

- Three new privilege names usable in role grants: `CREATE_SEMANTIC_MODEL`, `SELECT_SEMANTIC_MODEL`, `MODIFY_SEMANTIC_MODEL`.
- `SecurableObjects.ofSemanticModel(...)` in the public API.
- `SEMANTIC_MODEL` accepted by the owner API and as a `MANAGE_GRANTS` target.

No existing privilege, wire format, or config default changes.

### Follow-up

Two items in the issue's checklist depend on `SemanticModelMetaMapper` and `SemanticModelPO`, which land in #12602/#12603, and are deferred to a follow-up PR:

- `MetadataObjectService.TYPE_TO_FULLNAME_FUNCTION_MAP` needs a `getSemanticModelObjectsFullName` entry to resolve a Semantic Model ID back to a full name when listing owned objects.
- `OrphanedMetadataObjectRelationService.ENTITY_TABLES` needs a Semantic Model entry so owner relation rows are cleaned up after a hard delete.

Neither is reachable on `main` today: `JDBCBackend` still stubs Semantic Model persistence, so no Semantic Model, and therefore no owner relation, can exist yet.

### How was this patch tested?

New tests:

- `TestSemanticModelHookDispatcher`: owner assignment, namespace normalization versus Gravitino-owned naming, pass-through when the owner dispatcher is disabled, propagation when `setOwner` fails, and no owner interaction on list/load/alter/drop.
- `TestSemanticModelAuthorizationExpression`: create, load, filter, alter, and drop expressions, covering owner paths, the `USE_CATALOG` + `USE_SCHEMA` chain, deny precedence, and the two negative cases that matter, namely `SELECT_SEMANTIC_MODEL` not permitting alter and `MODIFY_SEMANTIC_MODEL` not permitting drop.

Extended: `TestSecurableObjects` (binding matrix, allow/deny resolution, name-length validation), `TestAuthorizationUtils` (plugin is not notified for Semantic Models), `TestMetadataIdConverter`, `TestJcasbinAuthorizationCacheKeys`.

Local verification with JDK 17:

```bash
./gradlew :api:test :server-common:test :core:test --tests "org.apache.gravitino.hook.*" --tests "org.apache.gravitino.authorization.*" --tests "org.apache.gravitino.utils.*" :server:test --tests "org.apache.gravitino.server.web.rest.authorization.*" -PskipITs
```

All green, plus `spotlessCheck` and `javadoc` clean on `:api`, `:core`, `:server-common`, and `:server`.
