### PR TITLE
[#12901] fix(authz): Keep preloadOwner best-effort when GravitinoEnv is uninitialized

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataAuthzHelper.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataAuthzHelper.java
@@ -549,8 +549,10 @@ public class MetadataAuthzHelper {
     if (!GravitinoEnv.getInstance().cacheEnabled()) {
       return;
     }
-    EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
     try {
+      // Resolving the entity store must stay inside the try: GravitinoEnv.entityStore() throws
+      // when the environment is not initialized, and this preload is best-effort only.
+      EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
       entityStore
           .relationOperations()
           .batchListEntitiesByRelation(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move the entity-store lookup in `MetadataAuthzHelper.preloadOwner` inside its existing `try` block.

### Why are the changes needed?

`preloadOwner` is a best-effort cache warm-up - its `catch (Exception e)` logs and ignores any failure. But `GravitinoEnv.getInstance().entityStore()` was called *outside* the `try`, and that method throws `IllegalArgumentException("GravitinoEnv is not initialized.")`. The exception therefore escaped the warm-up, propagated out of `filterByExpression`, and failed the entire list request with a 400.

This already breaks three tests in `server`, which return 400 instead of 200:

```
Failed to operate tag(s) operation [LIST] under object [...], reason [GravitinoEnv is not initialized.]
  at org.apache.gravitino.GravitinoEnv.entityStore(GravitinoEnv.java:261)
  at org.apache.gravitino.server.authorization.MetadataAuthzHelper.preloadOwner(MetadataAuthzHelper.java:552)
  at org.apache.gravitino.server.authorization.MetadataAuthzHelper.filterByExpression(MetadataAuthzHelper.java:364)
```

Fix: #12901

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```bash
./gradlew :server:test :server-common:test -PskipITs
```

`:server:test` goes from 3 failures to 0 (323 tests). `TestMetadataObjectTagOperations#testListTagsForObject`, `#testListTagsForObjectUnderHierarchicalSchema`, and `#testListTagsDeduplicatesDifferentAssignmentValues` pass again.
