### PR TITLE
[#12615] feat(tag): Add tag support for Semantic Models

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStoreIdResolver.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStoreIdResolver.java
@@ -60,6 +60,9 @@ public class RelationalEntityStoreIdResolver implements EntityIdResolver {
   private static final Set<Entity.EntityType> ENTITY_TYPES_REQUIRING_CATALOG_IDS =
       ImmutableSet.of(Entity.EntityType.CATALOG);
 
+  // TODO(#12600): Add Entity.EntityType.SEMANTIC_MODEL here, and a matching branch in
+  // getEntityIdsRequiringSchemaIds, once SemanticModelMetaService can resolve a Semantic Model id
+  // from its schema id and name. Tag association for Semantic Models needs that resolution.
   private static final Set<Entity.EntityType> ENTITY_TYPES_REQUIRING_SCHEMA_IDS =
       ImmutableSet.of(
           Entity.EntityType.SCHEMA,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/MetadataObjectService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/MetadataObjectService.java
@@ -94,6 +94,9 @@ public class MetadataObjectService {
               .put(
                   MetadataObject.Type.JOB_TEMPLATE,
                   MetadataObjectService::getJobTemplateObjectsFullName)
+              // TODO(#12600): Add MetadataObject.Type.SEMANTIC_MODEL once the Semantic Model PO and
+              // mapper exist. Listing the objects a tag is attached to needs full-name resolution
+              // for Semantic Models.
               .build();
 
   static final Map<MetadataObject.Type, BasePOStorageOps<?, ?>> TYPE_TO_STORAGE_OPS_MAP =

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/OrphanedMetadataObjectRelationService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/OrphanedMetadataObjectRelationService.java
@@ -45,6 +45,8 @@ public class OrphanedMetadataObjectRelationService {
   private static final OrphanedMetadataObjectRelationService INSTANCE =
       new OrphanedMetadataObjectRelationService();
 
+  private static final String SEMANTIC_MODEL_META_TABLE_NAME = "semantic_model_meta";
+
   private static final Map<MetadataObject.Type, EntityTable> ENTITY_TABLES =
       ImmutableMap.<MetadataObject.Type, EntityTable>builder()
           .put(
@@ -77,6 +79,11 @@ public class OrphanedMetadataObjectRelationService {
           .put(
               MetadataObject.Type.FUNCTION,
               new EntityTable(FunctionMetaMapper.TABLE_NAME, "function_id"))
+          // TODO(#12600): Reference SemanticModelMetaMapper.TABLE_NAME once the Semantic Model
+          // relational persistence layer introduces the mapper.
+          .put(
+              MetadataObject.Type.SEMANTIC_MODEL,
+              new EntityTable(SEMANTIC_MODEL_META_TABLE_NAME, "semantic_model_id"))
           .build();
 
   private OrphanedMetadataObjectRelationService() {}

--- a/core/src/main/java/org/apache/gravitino/tag/TagManager.java
+++ b/core/src/main/java/org/apache/gravitino/tag/TagManager.java
@@ -79,7 +79,8 @@ public class TagManager implements TagDispatcher {
           MetadataObject.Type.TOPIC,
           MetadataObject.Type.COLUMN,
           MetadataObject.Type.MODEL,
-          MetadataObject.Type.FUNCTION);
+          MetadataObject.Type.FUNCTION,
+          MetadataObject.Type.SEMANTIC_MODEL);
 
   public TagManager(IdGenerator idGenerator, EntityStore entityStore) {
     this.idGenerator = idGenerator;

--- a/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
@@ -282,6 +282,13 @@ public class MetadataObjectUtil {
         check(env.viewDispatcher().viewExists(identifier), exceptionToThrowSupplier);
         break;
 
+      case SEMANTIC_MODEL:
+        NameIdentifierUtil.checkSemanticModel(identifier);
+        check(
+            env.semanticModelDispatcher().semanticModelExists(identifier),
+            exceptionToThrowSupplier);
+        break;
+
       case ROLE:
         AuthorizationUtils.checkRole(identifier);
         try {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestOrphanedMetadataObjectRelationService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestOrphanedMetadataObjectRelationService.java
@@ -24,6 +24,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.Namespace;
+import org.apache.gravitino.meta.BaseMetalake;
+import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.storage.relational.TestJDBCBackend;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
@@ -46,7 +49,7 @@ public class TestOrphanedMetadataObjectRelationService extends TestJDBCBackend {
     TableEntity liveTable =
         createAndInsertTableEntity(Namespace.of(metalake, catalog, schema), "live_table");
 
-    insertRelations(liveTable.id(), ORPHAN_ID);
+    insertRelations("TABLE", liveTable.id(), ORPHAN_ID);
 
     Assertions.assertEquals(
         5,
@@ -60,7 +63,64 @@ public class TestOrphanedMetadataObjectRelationService extends TestJDBCBackend {
             .softDeleteOrphanedRelations(MetadataObject.Type.TABLE, 10));
   }
 
-  private void insertRelations(long liveId, long orphanId) throws SQLException {
+  @TestTemplate
+  public void testSoftDeleteOrphanedSemanticModelRelations() throws Exception {
+    String metalake = "metalake_for_semantic_model_orphan_test";
+    String catalog = "catalog_for_semantic_model_orphan_test";
+    String schema = "schema_for_semantic_model_orphan_test";
+    BaseMetalake metalakeEntity = createAndInsertMakeLake(metalake);
+    CatalogEntity catalogEntity = createAndInsertCatalog(metalake, catalog);
+    SchemaEntity schemaEntity = createAndInsertSchema(metalake, catalog, schema);
+
+    // Semantic Model relational persistence is not wired yet, so the live row is inserted directly.
+    long liveSemanticModelId = 123456789L;
+    insertSemanticModel(
+        liveSemanticModelId,
+        "live_semantic_model",
+        metalakeEntity.id(),
+        catalogEntity.id(),
+        schemaEntity.id());
+
+    insertRelations("SEMANTIC_MODEL", liveSemanticModelId, ORPHAN_ID);
+
+    Assertions.assertEquals(
+        5,
+        OrphanedMetadataObjectRelationService.getInstance()
+            .softDeleteOrphanedRelations(MetadataObject.Type.SEMANTIC_MODEL, 10));
+    Assertions.assertEquals(5, countActiveRelations(liveSemanticModelId));
+    Assertions.assertEquals(0, countActiveRelations(ORPHAN_ID));
+    Assertions.assertEquals(
+        0,
+        OrphanedMetadataObjectRelationService.getInstance()
+            .softDeleteOrphanedRelations(MetadataObject.Type.SEMANTIC_MODEL, 10));
+  }
+
+  private void insertSemanticModel(
+      long semanticModelId, String name, long metalakeId, long catalogId, long schemaId)
+      throws SQLException {
+    try (SqlSession session =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = session.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.executeUpdate(
+          "INSERT INTO semantic_model_meta (semantic_model_id, semantic_model_name, metalake_id,"
+              + " catalog_id, schema_id, audit_info, current_version, last_version, deleted_at)"
+              + " VALUES ("
+              + semanticModelId
+              + ", '"
+              + name
+              + "', "
+              + metalakeId
+              + ", "
+              + catalogId
+              + ", "
+              + schemaId
+              + ", '{}', 1, 1, 0)");
+    }
+  }
+
+  private void insertRelations(String metadataObjectType, long liveId, long orphanId)
+      throws SQLException {
     try (SqlSession session =
             SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
         Connection connection = session.getConnection();
@@ -71,14 +131,18 @@ public class TestOrphanedMetadataObjectRelationService extends TestJDBCBackend {
                 + " owner_id, owner_type, audit_info, current_version, last_version, deleted_at,"
                 + " updated_at) VALUES (1, "
                 + objectId
-                + ", 'TABLE', 1, 'USER', '{}', 0, 0, 0, 0)");
+                + ", '"
+                + metadataObjectType
+                + "', 1, 'USER', '{}', 0, 0, 0, 0)");
         statement.executeUpdate(
             "INSERT INTO tag_relation_meta (tag_id, metadata_object_id, metadata_object_type,"
                 + " audit_info, current_version, last_version, deleted_at) VALUES ("
                 + objectId
                 + ", "
                 + objectId
-                + ", 'TABLE', '{}', 0, 0, 0)");
+                + ", '"
+                + metadataObjectType
+                + "', '{}', 0, 0, 0)");
         statement.executeUpdate(
             "INSERT INTO policy_relation_meta (policy_id, metadata_object_id,"
                 + " metadata_object_type, audit_info, current_version, last_version, deleted_at)"
@@ -86,7 +150,9 @@ public class TestOrphanedMetadataObjectRelationService extends TestJDBCBackend {
                 + objectId
                 + ", "
                 + objectId
-                + ", 'TABLE', '{}', 0, 0, 0)");
+                + ", '"
+                + metadataObjectType
+                + "', '{}', 0, 0, 0)");
         statement.executeUpdate(
             "INSERT INTO statistic_meta (statistic_id, statistic_name, statistic_value,"
                 + " metalake_id, metadata_object_id, metadata_object_type, audit_info,"
@@ -96,7 +162,9 @@ public class TestOrphanedMetadataObjectRelationService extends TestJDBCBackend {
                 + objectId
                 + "', '{}', 1, "
                 + objectId
-                + ", 'TABLE', '{}', 0, 0, 0)");
+                + ", '"
+                + metadataObjectType
+                + "', '{}', 0, 0, 0)");
         statement.executeUpdate(
             "INSERT INTO role_meta_securable_object (role_id, metadata_object_id, type,"
                 + " privilege_names, privilege_conditions, current_version, last_version,"
@@ -104,7 +172,9 @@ public class TestOrphanedMetadataObjectRelationService extends TestJDBCBackend {
                 + objectId
                 + ", "
                 + objectId
-                + ", 'TABLE', 'SELECT_TABLE', '', 0, 0, 0)");
+                + ", '"
+                + metadataObjectType
+                + "', 'SELECT_TABLE', '', 0, 0, 0)");
       }
     }
   }

--- a/core/src/test/java/org/apache/gravitino/tag/TestTagManager.java
+++ b/core/src/test/java/org/apache/gravitino/tag/TestTagManager.java
@@ -64,8 +64,10 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.catalog.FunctionDispatcher;
 import org.apache.gravitino.catalog.SchemaDispatcher;
+import org.apache.gravitino.catalog.SemanticModelDispatcher;
 import org.apache.gravitino.catalog.TableDispatcher;
 import org.apache.gravitino.catalog.ViewDispatcher;
+import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
 import org.apache.gravitino.exceptions.NotFoundException;
@@ -125,12 +127,16 @@ public class TestTagManager {
 
   private static final String FUNCTION = "function_for_tag_test";
 
+  private static final String SEMANTIC_MODEL = "semantic_model_for_tag_test";
+
   private static final MetalakeDispatcher metalakeDispatcher = mock(MetalakeDispatcher.class);
   private static final CatalogDispatcher catalogDispatcher = mock(CatalogDispatcher.class);
   private static final SchemaDispatcher schemaDispatcher = mock(SchemaDispatcher.class);
   private static final TableDispatcher tableDispatcher = mock(TableDispatcher.class);
   private static final ViewDispatcher viewDispatcher = mock(ViewDispatcher.class);
   private static final FunctionDispatcher functionDispatcher = mock(FunctionDispatcher.class);
+  private static final SemanticModelDispatcher semanticModelDispatcher =
+      mock(SemanticModelDispatcher.class);
 
   private static EntityStore entityStore;
 
@@ -272,6 +278,8 @@ public class TestTagManager {
     FieldUtils.writeField(GravitinoEnv.getInstance(), "viewDispatcher", viewDispatcher, true);
     FieldUtils.writeField(
         GravitinoEnv.getInstance(), "functionDispatcher", functionDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "semanticModelDispatcher", semanticModelDispatcher, true);
 
     when(metalakeDispatcher.metalakeExists(any())).thenReturn(true);
     when(catalogDispatcher.catalogExists(any())).thenReturn(true);
@@ -1083,6 +1091,44 @@ public class TestTagManager {
             () -> tagManager.getTagForMetadataObject(METALAKE, nonExistentObject, tag1.name()));
     Assertions.assertTrue(
         e3.getMessage().contains("Failed to get tag for metadata object " + nonExistentObject));
+  }
+
+  @Test
+  public void testSemanticModelIsSupportedForTags() {
+    Tag tag1 = tagManager.createTag(METALAKE, "tag1", null, null);
+
+    MetadataObject semanticModelObject =
+        NameIdentifierUtil.toMetadataObject(
+            NameIdentifierUtil.ofSemanticModel(METALAKE, CATALOG, SCHEMA, SEMANTIC_MODEL),
+            Entity.EntityType.SEMANTIC_MODEL);
+    Assertions.assertEquals(MetadataObject.Type.SEMANTIC_MODEL, semanticModelObject.type());
+    Assertions.assertEquals(
+        CATALOG + "." + SCHEMA + "." + SEMANTIC_MODEL, semanticModelObject.fullName());
+
+    // A Semantic Model is an accepted tag target, so an absent one must fail existence validation
+    // rather than be rejected as an unsupported metadata object type.
+    when(semanticModelDispatcher.semanticModelExists(any())).thenReturn(false);
+
+    Throwable e =
+        Assertions.assertThrows(
+            NoSuchMetadataObjectException.class,
+            () ->
+                tagManager.associateTagsForMetadataObject(
+                    METALAKE, semanticModelObject, new String[] {tag1.name()}, null));
+    Assertions.assertTrue(
+        e.getMessage()
+            .contains(
+                "Metadata object "
+                    + semanticModelObject.fullName()
+                    + " type SEMANTIC_MODEL doesn't exist"),
+        e.getMessage());
+
+    Assertions.assertThrows(
+        NoSuchMetadataObjectException.class,
+        () -> tagManager.listTagsForMetadataObject(METALAKE, semanticModelObject));
+    Assertions.assertThrows(
+        NoSuchMetadataObjectException.class,
+        () -> tagManager.getTagForMetadataObject(METALAKE, semanticModelObject, tag1.name()));
   }
 
   private static Set<String> tagNames(Tag[] tags) {

--- a/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
+++ b/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
@@ -187,6 +187,14 @@ public class TestMetadataObjectUtil {
         List.of("CATALOG:catalog"),
         describe(MetadataObjectUtil.getParentMetadataObjects(schema, ":")));
 
+    // A semantic model under a flat schema inherits from [schema, catalog], so tags and policies
+    // assigned to its schema or catalog reach it.
+    MetadataObject semanticModel =
+        MetadataObjects.of("catalog.schema", "sales_model", MetadataObject.Type.SEMANTIC_MODEL);
+    Assertions.assertEquals(
+        List.of("SCHEMA:catalog.schema", "CATALOG:catalog"),
+        describe(MetadataObjectUtil.getParentMetadataObjects(semanticModel, ":")));
+
     // A catalog has no ancestors.
     MetadataObject catalog = MetadataObjects.of(null, "catalog", MetadataObject.Type.CATALOG);
     Assertions.assertTrue(MetadataObjectUtil.getParentMetadataObjects(catalog, ":").isEmpty());

--- a/docs/open-api/openapi.yaml
+++ b/docs/open-api/openapi.yaml
@@ -608,6 +608,7 @@ components:
           - "SCHEMA"
           - "TABLE"
           - "VIEW"
+          - "SEMANTIC_MODEL"
           - "COLUMN"
           - "FILESET"
           - "TOPIC"

--- a/docs/open-api/tags.yaml
+++ b/docs/open-api/tags.yaml
@@ -222,7 +222,7 @@ paths:
       tags:
         - tag
       summary: Associate tags with metadata object
-      description: Associate and disassociate tags with metadata object, please be aware that supported metadata objects are CATALOG, SCHEMA, TABLE, VIEW, FILESET, TOPIC, COLUMN, MODEL, FUNCTION
+      description: Associate and disassociate tags with metadata object, please be aware that supported metadata objects are CATALOG, SCHEMA, TABLE, VIEW, SEMANTIC_MODEL, FILESET, TOPIC, COLUMN, MODEL, FUNCTION
       operationId: associateTags
       requestBody:
         content:
@@ -458,6 +458,7 @@ components:
             - "SCHEMA"
             - "TABLE"
             - "VIEW"
+            - "SEMANTIC_MODEL"
             - "FILESET"
             - "TOPIC"
             - "MODEL"

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -49,19 +49,20 @@ attached to directly.
 ### What Can Carry a Tag
 
 A metadata object is identified by a type and a name, with each level below the catalog separated by
-a dot. Nine object types can carry a tag.
+a dot. Ten object types can carry a tag.
 
-| Object type | Name form                                                 |
-|-------------|-----------------------------------------------------------|
-| `CATALOG`   | `{catalog_name}`                                          |
-| `SCHEMA`    | `{catalog_name}.{schema_name}`                            |
-| `TABLE`     | `{catalog_name}.{schema_name}.{table_name}`               |
-| `VIEW`      | `{catalog_name}.{schema_name}.{view_name}`                |
-| `COLUMN`    | `{catalog_name}.{schema_name}.{table_name}.{column_name}` |
-| `FILESET`   | `{catalog_name}.{schema_name}.{fileset_name}`             |
-| `TOPIC`     | `{catalog_name}.{schema_name}.{topic_name}`               |
-| `MODEL`     | `{catalog_name}.{schema_name}.{model_name}`               |
-| `FUNCTION`  | `{catalog_name}.{schema_name}.{function_name}`            |
+| Object type      | Name form                                                 |
+|------------------|-----------------------------------------------------------|
+| `CATALOG`        | `{catalog_name}`                                          |
+| `SCHEMA`         | `{catalog_name}.{schema_name}`                            |
+| `TABLE`          | `{catalog_name}.{schema_name}.{table_name}`               |
+| `VIEW`           | `{catalog_name}.{schema_name}.{view_name}`                |
+| `SEMANTIC_MODEL` | `{catalog_name}.{schema_name}.{semantic_model_name}`      |
+| `COLUMN`         | `{catalog_name}.{schema_name}.{table_name}.{column_name}` |
+| `FILESET`        | `{catalog_name}.{schema_name}.{fileset_name}`             |
+| `TOPIC`          | `{catalog_name}.{schema_name}.{topic_name}`               |
+| `MODEL`          | `{catalog_name}.{schema_name}.{model_name}`               |
+| `FUNCTION`       | `{catalog_name}.{schema_name}.{function_name}`            |
 
 A metalake cannot carry a tag, so there is no single attachment point that covers everything at
 once. To reach every object in a catalog, attach the tag to the catalog.

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataAuthzHelper.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataAuthzHelper.java
@@ -549,8 +549,10 @@ public class MetadataAuthzHelper {
     if (!GravitinoEnv.getInstance().cacheEnabled()) {
       return;
     }
-    EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
     try {
+      // Resolving the entity store must stay inside the try: GravitinoEnv.entityStore() throws
+      // when the environment is not initialized, and this preload is best-effort only.
+      EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
       entityStore
           .relationOperations()
           .batchListEntitiesByRelation(

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetadataObjectTagOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetadataObjectTagOperations.java
@@ -1163,6 +1163,91 @@ public class TestMetadataObjectTagOperations extends BaseOperationsTest {
     Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), v2WithV1Shape.getStatus());
   }
 
+  @Test
+  public void testTagsForSemanticModel() {
+    MetadataObject catalog = MetadataObjects.parse("object1", MetadataObject.Type.CATALOG);
+    MetadataObject schema = MetadataObjects.parse("object1.object2", MetadataObject.Type.SCHEMA);
+    MetadataObject semanticModel =
+        MetadataObjects.parse("object1.object2.sales", MetadataObject.Type.SEMANTIC_MODEL);
+
+    when(tagManager.listTagsInfoForMetadataObject(metalake, catalog))
+        .thenReturn(tagInfos("catalogTag"));
+    when(tagManager.listTagsInfoForMetadataObject(metalake, schema))
+        .thenReturn(tagInfos("schemaTag"));
+    when(tagManager.listTagsInfoForMetadataObject(metalake, semanticModel))
+        .thenReturn(tagInfos("semanticModelTag"));
+
+    // A Semantic Model shows its own tags plus the tags inherited from its schema and catalog.
+    Response listResponse =
+        target(basePath(metalake))
+            .path(semanticModel.type().toString())
+            .path(semanticModel.fullName())
+            .path("tags")
+            .queryParam("details", true)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), listResponse.getStatus());
+    TagListResponse tagListResponse = listResponse.readEntity(TagListResponse.class);
+    Assertions.assertEquals(0, tagListResponse.getCode());
+    Assertions.assertEquals(3, tagListResponse.getTags().length);
+
+    Map<String, Tag> resultTags =
+        Arrays.stream(tagListResponse.getTags())
+            .collect(Collectors.toMap(Tag::name, Function.identity()));
+    Assertions.assertFalse(resultTags.get("semanticModelTag").inherited().get());
+    Assertions.assertTrue(resultTags.get("schemaTag").inherited().get());
+    Assertions.assertTrue(resultTags.get("catalogTag").inherited().get());
+
+    // Getting a single tag on a Semantic Model.
+    TagEntity semanticModelTag =
+        TagEntity.builder()
+            .withName("semanticModelTag")
+            .withId(1L)
+            .withAuditInfo(testAuditInfo1)
+            .build();
+    when(tagManager.getTagForMetadataObject(metalake, semanticModel, "semanticModelTag"))
+        .thenReturn(semanticModelTag);
+
+    Response getResponse =
+        target(basePath(metalake))
+            .path(semanticModel.type().toString())
+            .path(semanticModel.fullName())
+            .path("tags")
+            .path("semanticModelTag")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
+    Tag respTag = getResponse.readEntity(TagResponse.class).getTag();
+    Assertions.assertEquals("semanticModelTag", respTag.name());
+    Assertions.assertFalse(respTag.inherited().get());
+
+    // Associating and disassociating tags on a Semantic Model.
+    String[] tagsToAdd = new String[] {"semanticModelTag"};
+    String[] tagsToRemove = new String[] {"staleTag"};
+    when(tagManager.associateTagsForMetadataObject(
+            metalake, semanticModel, tagsToAdd, tagsToRemove))
+        .thenReturn(tagsToAdd);
+
+    TagsAssociateRequest request = new TagsAssociateRequest(tagsToAdd, tagsToRemove);
+    Response associateResponse =
+        target(basePath(metalake))
+            .path(semanticModel.type().toString())
+            .path(semanticModel.fullName())
+            .path("tags")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), associateResponse.getStatus());
+    NameListResponse nameListResponse = associateResponse.readEntity(NameListResponse.class);
+    Assertions.assertEquals(0, nameListResponse.getCode());
+    Assertions.assertArrayEquals(tagsToAdd, nameListResponse.getNames());
+  }
+
   private String basePath(String metalake) {
     return "/metalakes/" + metalake + "/objects";
   }


### PR DESCRIPTION
> Stacked on #12869 (fixes #12901). That commit is included in this diff until #12869 merges.

### What changes were proposed in this pull request?

Add tag association support for `SEMANTIC_MODEL` metadata objects:

- Register `SEMANTIC_MODEL` in `TagManager`'s supported metadata object types.
- Validate Semantic Model existence in `MetadataObjectUtil.checkMetadataObject` via `semanticModelDispatcher().semanticModelExists()`.
- Wire `SEMANTIC_MODEL` into `OrphanedMetadataObjectRelationService` so orphaned owner/tag/policy/statistic/securable-object rows are soft-deleted by the relational garbage collector.
- Update `docs/tags.md`, `docs/open-api/openapi.yaml`, and `docs/open-api/tags.yaml`.
- Add tests for supported-type registration, existence validation, tag inheritance from the parent schema and catalog, the REST list/get/associate paths, and orphan relation cleanup.

Two follow-up hooks carry `TODO(#12600)` because they need the Semantic Model PO/mapper/meta-service that #12600 introduces: id resolution in `RelationalEntityStoreIdResolver` and full-name resolution in `MetadataObjectService`. Neither is reachable today - no Semantic Model can be created yet, so no relation row can exist.

### Why are the changes needed?

Semantic Models are first-class metadata objects (#12209) and governance for them is expected to reuse the existing tag machinery. Policies reach Semantic Models through policy-on-tag, so tag support is the prerequisite. Direct policy associations and the Web UI stay out of scope.

Fix: #12615

### Does this PR introduce _any_ user-facing change?

Yes. Tags can be associated, listed, fetched, and removed for `SEMANTIC_MODEL` objects through the existing metadata-object tag REST APIs, and a Semantic Model inherits tags from its schema and catalog.

### How was this patch tested?

```bash
./gradlew spotlessApply && ./gradlew spotlessCheck
./gradlew :core:test :server:test :server-common:test -PskipITs
./gradlew :docs:build
```

- `:core:test` 1811 tests, `:server:test` 324, `:server-common:test` 288 - all green.
- OpenAPI spec validated by `:docs:build`.
- New tests: `TestTagManager#testSemanticModelIsSupportedForTags`, `TestMetadataObjectTagOperations#testTagsForSemanticModel`, `TestOrphanedMetadataObjectRelationService#testSoftDeleteOrphanedSemanticModelRelations`, plus a Semantic Model ancestor case in `TestMetadataObjectUtil`.
