### PR TITLE
[#12879] fix(server): return accurate HTTP statuses for unsupported operations

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestRelationalCatalog.java
@@ -25,8 +25,8 @@ import static org.apache.gravitino.rel.expressions.sorts.SortDirection.DESCENDIN
 import static org.apache.hc.core5.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.hc.core5.http.HttpStatus.SC_CONFLICT;
 import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
-import static org.apache.hc.core5.http.HttpStatus.SC_METHOD_NOT_ALLOWED;
 import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.hc.core5.http.HttpStatus.SC_NOT_IMPLEMENTED;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -1186,7 +1186,7 @@ public class TestRelationalCatalog extends TestBase {
 
     // Test with exception
     ErrorResponse errorResp = ErrorResponse.unsupportedOperation("Unsupported operation");
-    buildMockResource(Method.DELETE, tablePath, null, errorResp, SC_METHOD_NOT_ALLOWED);
+    buildMockResource(Method.DELETE, tablePath, null, errorResp, SC_NOT_IMPLEMENTED);
 
     TableCatalog tableCatalog = catalog.asTableCatalog();
     Assertions.assertThrows(

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsPartitionStatistics.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsPartitionStatistics.java
@@ -20,7 +20,7 @@ package org.apache.gravitino.client;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static javax.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_IMPLEMENTED;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -214,7 +214,7 @@ public class TestSupportsPartitionStatistics extends TestBase {
         Collections.emptyMap(),
         expectedRequest,
         unmodifiableError,
-        SC_METHOD_NOT_ALLOWED);
+        SC_NOT_IMPLEMENTED);
 
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,
@@ -274,7 +274,7 @@ public class TestSupportsPartitionStatistics extends TestBase {
                 Collections.emptyList()));
     ErrorResponse unmodifiableError = MAPPER.readValue(unmodifiableErrorJson, ErrorResponse.class);
     buildMockResource(
-        Method.POST, path, Collections.emptyMap(), null, unmodifiableError, SC_METHOD_NOT_ALLOWED);
+        Method.POST, path, Collections.emptyMap(), null, unmodifiableError, SC_NOT_IMPLEMENTED);
 
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsPartitionStatistics.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsPartitionStatistics.java
@@ -19,8 +19,8 @@
 package org.apache.gravitino.client;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_IMPLEMENTED;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -209,12 +209,7 @@ public class TestSupportsPartitionStatistics extends TestBase {
                 Collections.emptyList()));
     ErrorResponse unmodifiableError = MAPPER.readValue(unmodifiableErrorJson, ErrorResponse.class);
     buildMockResource(
-        Method.PUT,
-        path,
-        Collections.emptyMap(),
-        expectedRequest,
-        unmodifiableError,
-        SC_NOT_IMPLEMENTED);
+        Method.PUT, path, Collections.emptyMap(), expectedRequest, unmodifiableError, SC_CONFLICT);
 
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,
@@ -274,7 +269,7 @@ public class TestSupportsPartitionStatistics extends TestBase {
                 Collections.emptyList()));
     ErrorResponse unmodifiableError = MAPPER.readValue(unmodifiableErrorJson, ErrorResponse.class);
     buildMockResource(
-        Method.POST, path, Collections.emptyMap(), null, unmodifiableError, SC_NOT_IMPLEMENTED);
+        Method.POST, path, Collections.emptyMap(), null, unmodifiableError, SC_CONFLICT);
 
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsStatistics.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsStatistics.java
@@ -20,7 +20,7 @@ package org.apache.gravitino.client;
 
 import static org.apache.hc.core5.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
-import static org.apache.hc.core5.http.HttpStatus.SC_METHOD_NOT_ALLOWED;
+import static org.apache.hc.core5.http.HttpStatus.SC_NOT_IMPLEMENTED;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -189,7 +189,7 @@ public class TestSupportsStatistics extends TestBase {
         Collections.emptyMap(),
         expectedRequest,
         unmodifiableError,
-        SC_METHOD_NOT_ALLOWED);
+        SC_NOT_IMPLEMENTED);
 
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,
@@ -246,7 +246,7 @@ public class TestSupportsStatistics extends TestBase {
                 Collections.emptyList()));
     ErrorResponse unmodifiableError = MAPPER.readValue(unmodifiableErrorJson, ErrorResponse.class);
     buildMockResource(
-        Method.POST, path, Collections.emptyMap(), null, unmodifiableError, SC_METHOD_NOT_ALLOWED);
+        Method.POST, path, Collections.emptyMap(), null, unmodifiableError, SC_NOT_IMPLEMENTED);
 
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsStatistics.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsStatistics.java
@@ -19,8 +19,8 @@
 package org.apache.gravitino.client;
 
 import static org.apache.hc.core5.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.hc.core5.http.HttpStatus.SC_CONFLICT;
 import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
-import static org.apache.hc.core5.http.HttpStatus.SC_NOT_IMPLEMENTED;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -184,12 +184,7 @@ public class TestSupportsStatistics extends TestBase {
                 Collections.emptyList()));
     ErrorResponse unmodifiableError = MAPPER.readValue(unmodifiableErrorJson, ErrorResponse.class);
     buildMockResource(
-        Method.PUT,
-        path,
-        Collections.emptyMap(),
-        expectedRequest,
-        unmodifiableError,
-        SC_NOT_IMPLEMENTED);
+        Method.PUT, path, Collections.emptyMap(), expectedRequest, unmodifiableError, SC_CONFLICT);
 
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,
@@ -246,7 +241,7 @@ public class TestSupportsStatistics extends TestBase {
                 Collections.emptyList()));
     ErrorResponse unmodifiableError = MAPPER.readValue(unmodifiableErrorJson, ErrorResponse.class);
     buildMockResource(
-        Method.POST, path, Collections.emptyMap(), null, unmodifiableError, SC_NOT_IMPLEMENTED);
+        Method.POST, path, Collections.emptyMap(), null, unmodifiableError, SC_CONFLICT);
 
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,

--- a/docs/open-api/idp/idp.yaml
+++ b/docs/open-api/idp/idp.yaml
@@ -269,8 +269,8 @@ paths:
           $ref: "../openapi.yaml#/components/responses/RemoveResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
-        "405":
-          description: Method Not Allowed - The group is not empty and force is false
+        "409":
+          description: Conflict - The group is not empty and force is false
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -666,8 +666,8 @@ components:
 
     IdpGroupNotEmptyException:
       value: {
-        "code": 1006,
-        "type": "IllegalStateException",
+        "code": 1005,
+        "type": "NonEmptyEntityException",
         "message": "Failed to operate local user store group [engineers] operation [REMOVE], reason [IdP group engineers is not empty, use force=true to delete it]"
       }
 

--- a/docs/open-api/statistics.yaml
+++ b/docs/open-api/statistics.yaml
@@ -41,6 +41,8 @@ paths:
                 examples:
                   StatisticListResponse:
                     $ref: "#/components/examples/StatisticListResponse"
+        "400":
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
         "404":
           description: Not Found - The specified metadata object doesn't exist
           content:
@@ -50,6 +52,12 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
+        "501":
+          description: Not Implemented - Statistics are not supported for the specified object
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
@@ -71,7 +79,7 @@ paths:
         "200":
           $ref: "./openapi.yaml#/components/responses/DropResponse"
         "400":
-          description: Bad Request - The request contains illegal statistic names
+          description: Bad Request - The object type or statistic names are invalid
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -88,8 +96,8 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
-        "405":
-          description: Method Not Allowed - The specified statistic is unmodifiable
+        "501":
+          description: Not Implemented - The requested statistics operation is not supported
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -118,7 +126,7 @@ paths:
         "200":
           $ref: "./openapi.yaml#/components/responses/BaseResponse"
         "400":
-          description: Bad Request - The request contains illegal statistic names
+          description: Bad Request - The object type or statistic names are invalid
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -135,8 +143,8 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
-        "405":
-          description: Method Not Allowed - The specified statistic is unmodifiable
+        "501":
+          description: Not Implemented - The requested statistics operation is not supported
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -184,6 +192,12 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
+        "501":
+          description: Not Implemented - Partition statistics are not supported for the specified object
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
@@ -205,7 +219,7 @@ paths:
         "200":
           $ref: "./openapi.yaml#/components/responses/DropResponse"
         "400":
-          description: Bad Request - The request contains illegal statistic names
+          description: Bad Request - The object type or statistic names are invalid
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -222,8 +236,8 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
-        "405":
-          description: Method Not Allowed - The specified statistic is unmodifiable
+        "501":
+          description: Not Implemented - The requested partition statistics operation is not supported
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -252,7 +266,7 @@ paths:
         "200":
           $ref: "./openapi.yaml#/components/responses/BaseResponse"
         "400":
-          description: Bad Request - The request contains illegal statistic names
+          description: Bad Request - The object type or statistic names are invalid
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -269,8 +283,8 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
-        "405":
-          description: Method Not Allowed - The specified statistic is unmodifiable
+        "501":
+          description: Not Implemented - The requested partition statistics operation is not supported
           content:
             application/vnd.gravitino.v1+json:
               schema:

--- a/docs/open-api/statistics.yaml
+++ b/docs/open-api/statistics.yaml
@@ -96,8 +96,8 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
-        "501":
-          description: Not Implemented - The requested statistics operation is not supported
+        "409":
+          description: Conflict - The specified statistic is unmodifiable
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -105,6 +105,12 @@ paths:
               examples:
                 UnmodifiableStatisticException:
                   $ref: "#/components/examples/UnmodifiableStatisticException"
+        "501":
+          description: Not Implemented - The requested statistics operation is not supported
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
@@ -143,8 +149,8 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
-        "501":
-          description: Not Implemented - The requested statistics operation is not supported
+        "409":
+          description: Conflict - The specified statistic is unmodifiable
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -152,6 +158,12 @@ paths:
               examples:
                 UnmodifiableStatisticException:
                   $ref: "#/components/examples/UnmodifiableStatisticException"
+        "501":
+          description: Not Implemented - The requested statistics operation is not supported
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
@@ -236,8 +248,8 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
-        "501":
-          description: Not Implemented - The requested partition statistics operation is not supported
+        "409":
+          description: Conflict - The specified statistic is unmodifiable
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -245,6 +257,12 @@ paths:
               examples:
                 UnmodifiableStatisticException:
                   $ref: "#/components/examples/UnmodifiableStatisticException"
+        "501":
+          description: Not Implemented - The requested partition statistics operation is not supported
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
@@ -283,8 +301,8 @@ paths:
               examples:
                 NoSuchMetadataObjectException:
                   $ref: "#/components/examples/NoSuchMetadataObjectException"
-        "501":
-          description: Not Implemented - The requested partition statistics operation is not supported
+        "409":
+          description: Conflict - The specified statistic is unmodifiable
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -292,6 +310,12 @@ paths:
               examples:
                 UnmodifiableStatisticException:
                   $ref: "#/components/examples/UnmodifiableStatisticException"
+        "501":
+          description: Not Implemented - The requested partition statistics operation is not supported
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/service/IdpGroupMetaService.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/service/IdpGroupMetaService.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.idp.model.IdpGroup;
 import org.apache.gravitino.idp.storage.mapper.IdpGroupMetaMapper;
@@ -104,14 +105,15 @@ public class IdpGroupMetaService {
    * @param force when false, rejects deletion if the group still has members; when true, removes
    *     memberships and deletes the group
    * @return true if the group was deleted
+   * @throws NonEmptyEntityException if the group has members and force is false
    */
   @Monitored(
       metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
       baseMetricName = "deleteIdpGroup")
   public boolean deleteIdpGroup(String groupName, boolean force) {
     if (!force && !listUsernamesByGroupName(groupName).isEmpty()) {
-      throw new IllegalStateException(
-          String.format("IdP group %s is not empty, use force=true to delete it", groupName));
+      throw new NonEmptyEntityException(
+          "IdP group %s is not empty, use force=true to delete it", groupName);
     }
 
     int[] deletedCount = new int[] {0};

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/web/IdpRESTUtils.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/web/IdpRESTUtils.java
@@ -27,7 +27,9 @@ import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.server.web.Utils;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,8 +104,7 @@ public final class IdpRESTUtils {
   }
 
   public static Response unsupportedOperation(String message, Throwable throwable) {
-    return json(
-        Response.Status.METHOD_NOT_ALLOWED, ErrorResponse.unsupportedOperation(message, throwable));
+    return Utils.unsupportedOperation(message, throwable);
   }
 
   public static Response internalError(String message, Throwable throwable) {
@@ -121,7 +122,10 @@ public final class IdpRESTUtils {
     if (e instanceof AlreadyExistsException) {
       return alreadyExists(errorMsg, e);
     }
-    if (e instanceof IllegalStateException || e instanceof UnsupportedOperationException) {
+    if (e instanceof NonEmptyEntityException) {
+      return Utils.nonEmpty(errorMsg, e);
+    }
+    if (e instanceof UnsupportedOperationException) {
       return unsupportedOperation(errorMsg, e);
     }
     return internalError(errorMsg, e);

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/web/IdpRESTUtils.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/web/IdpRESTUtils.java
@@ -29,7 +29,6 @@ import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
-import org.apache.gravitino.server.web.Utils;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +103,8 @@ public final class IdpRESTUtils {
   }
 
   public static Response unsupportedOperation(String message, Throwable throwable) {
-    return Utils.unsupportedOperation(message, throwable);
+    return json(
+        Response.Status.NOT_IMPLEMENTED, ErrorResponse.unsupportedOperation(message, throwable));
   }
 
   public static Response internalError(String message, Throwable throwable) {
@@ -123,7 +123,9 @@ public final class IdpRESTUtils {
       return alreadyExists(errorMsg, e);
     }
     if (e instanceof NonEmptyEntityException) {
-      return Utils.nonEmpty(errorMsg, e);
+      return json(
+          Response.Status.CONFLICT,
+          ErrorResponse.nonEmpty(e.getClass().getSimpleName(), errorMsg, e));
     }
     if (e instanceof UnsupportedOperationException) {
       return unsupportedOperation(errorMsg, e);

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.auth.AuthenticatorType;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.exceptions.UnauthorizedException;
 import org.apache.gravitino.idp.basic.IdpCredentialValidator;
@@ -256,7 +257,7 @@ public class TestIdpUserGroupManager {
     manager.changeGroupMembership("testRemoveGroup", Lists.newArrayList("groupMember"), null);
 
     Assertions.assertThrows(
-        IllegalStateException.class, () -> manager.removeGroup("testRemoveGroup", false));
+        NonEmptyEntityException.class, () -> manager.removeGroup("testRemoveGroup", false));
 
     manager.changeGroupMembership("testRemoveGroup", null, Lists.newArrayList("groupMember"));
     Assertions.assertTrue(manager.removeGroup("testRemoveGroup", false));

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/integration/test/IdpRESTApiIT.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/integration/test/IdpRESTApiIT.java
@@ -228,7 +228,7 @@ public class IdpRESTApiIT extends BaseIT {
         putMembership(GROUP1, new GroupMembershipChangeRequest(new String[] {USER1, USER2}, null));
     Assertions.assertEquals(Set.of(USER1, USER2), Set.copyOf(group.getGroup().users()));
 
-    assertError(405, deleteGroupResponse(GROUP1, false), ErrorConstants.UNSUPPORTED_OPERATION_CODE);
+    assertError(409, deleteGroupResponse(GROUP1, false), ErrorConstants.NON_EMPTY_CODE);
 
     group =
         putMembership(GROUP1, new GroupMembershipChangeRequest(null, new String[] {USER1, USER2}));

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/service/TestIdpGroupMetaService.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/service/TestIdpGroupMetaService.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.idp.storage.po.IdpGroupPO;
 import org.junit.jupiter.api.Tag;
@@ -121,7 +122,7 @@ class TestIdpGroupMetaService extends AbstractIdpMetaServiceTest {
     IdpGroupMetaService groupMetaService = IdpGroupMetaService.getInstance();
 
     assertThrows(
-        IllegalStateException.class, () -> groupMetaService.deleteIdpGroup("group1", false));
+        NonEmptyEntityException.class, () -> groupMetaService.deleteIdpGroup("group1", false));
 
     runServiceCall(() -> assertTrue(groupMetaService.deleteIdpGroup("group1", true)));
     assertNull(idpGroupMetaMapper.selectIdpGroup("group1"));

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/web/TestIdpRESTUtils.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/web/TestIdpRESTUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.idp.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.dto.responses.ErrorConstants;
+import org.apache.gravitino.dto.responses.ErrorResponse;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.junit.jupiter.api.Test;
+
+class TestIdpRESTUtils {
+
+  @Test
+  void testUnsupportedOperationReturnsNotImplemented() {
+    Response response =
+        IdpRESTUtils.handleException(
+            "group",
+            IdpOperationType.GET,
+            "group",
+            new UnsupportedOperationException("unsupported"));
+
+    assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), response.getStatus());
+    ErrorResponse error = (ErrorResponse) response.getEntity();
+    assertEquals(ErrorConstants.UNSUPPORTED_OPERATION_CODE, error.getCode());
+  }
+
+  @Test
+  void testNonEmptyEntityReturnsConflict() {
+    Response response =
+        IdpRESTUtils.handleException(
+            "group",
+            IdpOperationType.REMOVE,
+            "group",
+            new NonEmptyEntityException("Group is not empty"));
+
+    assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+    ErrorResponse error = (ErrorResponse) response.getEntity();
+    assertEquals(ErrorConstants.NON_EMPTY_CODE, error.getCode());
+    assertEquals(NonEmptyEntityException.class.getSimpleName(), error.getType());
+  }
+
+  @Test
+  void testUnexpectedIllegalStateReturnsInternalError() {
+    Response response =
+        IdpRESTUtils.handleException(
+            "group", IdpOperationType.GET, "group", new IllegalStateException("invalid state"));
+
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    ErrorResponse error = (ErrorResponse) response.getEntity();
+    assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, error.getCode());
+  }
+}

--- a/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -213,6 +213,36 @@ public class Utils {
         .build();
   }
 
+  /**
+   * Returns an HTTP 409 response when an operation conflicts with the target object's state.
+   *
+   * <p>The unsupported-operation error payload is retained so existing clients can reconstruct
+   * domain exceptions such as {@code UnmodifiableStatisticException}.
+   *
+   * @param message the error message
+   * @param throwable the exception that caused the error
+   * @return the HTTP response
+   */
+  public static Response operationConflict(String message, Throwable throwable) {
+    return Response.status(Response.Status.CONFLICT)
+        .entity(ErrorResponse.unsupportedOperation(message, throwable))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  /**
+   * Returns an HTTP 405 response when the target resource does not allow the request method.
+   *
+   * @param message the error message
+   * @return the HTTP response
+   */
+  public static Response methodNotAllowed(String message) {
+    return Response.status(Response.Status.METHOD_NOT_ALLOWED)
+        .entity(ErrorResponse.unsupportedOperation(message))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
   public static Response forbidden(String message, Throwable throwable) {
     return Response.status(Response.Status.FORBIDDEN)
         .entity(ErrorResponse.forbidden(message, throwable))

--- a/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -189,13 +189,39 @@ public class Utils {
         .build();
   }
 
+  /**
+   * Returns an HTTP 501 response for functionality that the server does not implement.
+   *
+   * @param message the error message
+   * @return the HTTP response
+   */
   public static Response unsupportedOperation(String message) {
     return unsupportedOperation(message, null);
   }
 
+  /**
+   * Returns an HTTP 501 response for functionality that the server does not implement.
+   *
+   * @param message the error message
+   * @param throwable the exception that caused the error
+   * @return the HTTP response
+   */
   public static Response unsupportedOperation(String message, Throwable throwable) {
-    return Response.status(Response.Status.METHOD_NOT_ALLOWED)
+    return Response.status(Response.Status.NOT_IMPLEMENTED)
         .entity(ErrorResponse.unsupportedOperation(message, throwable))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  /**
+   * Returns an HTTP 405 response when the target resource does not allow the request method.
+   *
+   * @param message the error message
+   * @return the HTTP response
+   */
+  public static Response methodNotAllowed(String message) {
+    return Response.status(Response.Status.METHOD_NOT_ALLOWED)
+        .entity(ErrorResponse.unsupportedOperation(message))
         .type(MediaType.APPLICATION_JSON)
         .build();
   }

--- a/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -213,19 +213,6 @@ public class Utils {
         .build();
   }
 
-  /**
-   * Returns an HTTP 405 response when the target resource does not allow the request method.
-   *
-   * @param message the error message
-   * @return the HTTP response
-   */
-  public static Response methodNotAllowed(String message) {
-    return Response.status(Response.Status.METHOD_NOT_ALLOWED)
-        .entity(ErrorResponse.unsupportedOperation(message))
-        .type(MediaType.APPLICATION_JSON)
-        .build();
-  }
-
   public static Response forbidden(String message, Throwable throwable) {
     return Response.status(Response.Status.FORBIDDEN)
         .entity(ErrorResponse.forbidden(message, throwable))

--- a/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -233,6 +233,9 @@ public class Utils {
   /**
    * Returns an HTTP 405 response when the target resource does not allow the request method.
    *
+   * <p>The unsupported-operation error payload is retained for compatibility with clients that
+   * identify this response by its application error code.
+   *
    * @param message the error message
    * @return the HTTP response
    */

--- a/server-common/src/test/java/org/apache/gravitino/server/web/TestUtils.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/web/TestUtils.java
@@ -33,6 +33,7 @@ import org.apache.gravitino.audit.InternalClientType;
 import org.apache.gravitino.dto.responses.ErrorConstants;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.OptimisticLockException;
+import org.apache.gravitino.exceptions.UnmodifiableStatisticException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -188,6 +189,31 @@ public class TestUtils {
     assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
     ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
     assertEquals("Unsupported operation", errorResponse.getMessage());
+  }
+
+  @Test
+  public void testOperationConflict() {
+    UnmodifiableStatisticException exception =
+        new UnmodifiableStatisticException("Unmodifiable statistic");
+    Response response = Utils.operationConflict(exception.getMessage(), exception);
+
+    assertNotNull(response);
+    assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+    assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
+    ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+    assertEquals(ErrorConstants.UNSUPPORTED_OPERATION_CODE, errorResponse.getCode());
+    assertEquals(UnmodifiableStatisticException.class.getSimpleName(), errorResponse.getType());
+  }
+
+  @Test
+  public void testMethodNotAllowed() {
+    Response response = Utils.methodNotAllowed("Method not allowed");
+
+    assertNotNull(response);
+    assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
+    assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
+    ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+    assertEquals(ErrorConstants.UNSUPPORTED_OPERATION_CODE, errorResponse.getCode());
   }
 
   @Test

--- a/server-common/src/test/java/org/apache/gravitino/server/web/TestUtils.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/web/TestUtils.java
@@ -184,10 +184,21 @@ public class TestUtils {
   public void testUnsupportedOperation() {
     Response response = Utils.unsupportedOperation("Unsupported operation");
     assertNotNull(response);
-    assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
+    assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), response.getStatus());
     assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
     ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
     assertEquals("Unsupported operation", errorResponse.getMessage());
+  }
+
+  /** Tests the response used when an HTTP method is not allowed for a resource. */
+  @Test
+  public void testMethodNotAllowed() {
+    Response response = Utils.methodNotAllowed("Method not allowed");
+    assertNotNull(response);
+    assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
+    assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
+    ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+    assertEquals("Method not allowed", errorResponse.getMessage());
   }
 
   @Test

--- a/server-common/src/test/java/org/apache/gravitino/server/web/TestUtils.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/web/TestUtils.java
@@ -190,17 +190,6 @@ public class TestUtils {
     assertEquals("Unsupported operation", errorResponse.getMessage());
   }
 
-  /** Tests the response used when an HTTP method is not allowed for a resource. */
-  @Test
-  public void testMethodNotAllowed() {
-    Response response = Utils.methodNotAllowed("Method not allowed");
-    assertNotNull(response);
-    assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
-    assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
-    ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
-    assertEquals("Method not allowed", errorResponse.getMessage());
-  }
-
   @Test
   public void testFilterFilesetAuditHeaders() {
     // test invalid internal client type

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
@@ -28,8 +28,10 @@ import org.apache.gravitino.server.authorization.NameBindings;
 import org.apache.gravitino.server.web.Utils;
 
 /**
- * AccessControlNotAllowedFilter filters requests related to access control when Apache Gravitino
- * does not enable authorization.
+ * AccessControlNotAllowedFilter is used for filter the requests related to access control if Apache
+ * Gravitino doesn't enable authorization. The filter return 405 error code. You can refer to
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405. No methods will be returned in the
+ * allow methods.
  */
 @Provider
 @NameBindings.AccessControlInterfaces
@@ -38,7 +40,7 @@ public class AccessControlNotAllowedFilter implements ContainerRequestFilter {
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
     requestContext.abortWith(
-        Utils.unsupportedOperation(
+        Utils.methodNotAllowed(
             String.format(
                 "You should set '%s' to true in the server side `gravitino.conf`"
                     + " to enable the authorization of the system, otherwise these interfaces can't work.",

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
@@ -40,7 +40,7 @@ public class AccessControlNotAllowedFilter implements ContainerRequestFilter {
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
     requestContext.abortWith(
-        Utils.unsupportedOperation(
+        Utils.methodNotAllowed(
             String.format(
                 "You should set '%s' to true in the server side `gravitino.conf`"
                     + " to enable the authorization of the system, otherwise these interfaces can't work.",

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
@@ -28,10 +28,8 @@ import org.apache.gravitino.server.authorization.NameBindings;
 import org.apache.gravitino.server.web.Utils;
 
 /**
- * AccessControlNotAllowedFilter is used for filter the requests related to access control if Apache
- * Gravitino doesn't enable authorization. The filter return 405 error code. You can refer to
- * https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405. No methods will be returned in the
- * allow methods.
+ * AccessControlNotAllowedFilter filters requests related to access control when Apache Gravitino
+ * does not enable authorization.
  */
 @Provider
 @NameBindings.AccessControlInterfaces
@@ -40,7 +38,7 @@ public class AccessControlNotAllowedFilter implements ContainerRequestFilter {
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
     requestContext.abortWith(
-        Utils.methodNotAllowed(
+        Utils.unsupportedOperation(
             String.format(
                 "You should set '%s' to true in the server side `gravitino.conf`"
                     + " to enable the authorization of the system, otherwise these interfaces can't work.",

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -53,6 +53,7 @@ import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.exceptions.TagAlreadyAssociatedException;
 import org.apache.gravitino.exceptions.TagAlreadyExistsException;
 import org.apache.gravitino.exceptions.TopicAlreadyExistsException;
+import org.apache.gravitino.exceptions.UnmodifiableStatisticException;
 import org.apache.gravitino.exceptions.UserAlreadyExistsException;
 import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
 import org.apache.gravitino.server.web.Utils;
@@ -1088,6 +1089,9 @@ public class ExceptionHandlers {
       } else if (e instanceof NotFoundException) {
         return Utils.notFound(errorMsg, e);
 
+      } else if (e instanceof UnmodifiableStatisticException) {
+        return Utils.operationConflict(errorMsg, e);
+
       } else if (e instanceof UnsupportedOperationException) {
         return Utils.unsupportedOperation(errorMsg, e);
 
@@ -1119,6 +1123,9 @@ public class ExceptionHandlers {
 
       } else if (e instanceof NotFoundException) {
         return Utils.notFound(errorMsg, e);
+
+      } else if (e instanceof UnmodifiableStatisticException) {
+        return Utils.operationConflict(errorMsg, e);
 
       } else if (e instanceof UnsupportedOperationException) {
         return Utils.unsupportedOperation(errorMsg, e);
@@ -1161,6 +1168,13 @@ public class ExceptionHandlers {
       if (e instanceof OptimisticLockException) {
         LOG.warn(errorMsg, e);
         return Utils.optimisticLockConflict(errorMsg, e);
+      }
+
+      // Classify domain-specific UnsupportedOperationException subclasses before the generic
+      // capability fallback below.
+      if (e instanceof UnmodifiableStatisticException) {
+        LOG.warn(errorMsg, e);
+        return Utils.operationConflict(errorMsg, e);
       }
 
       if (e instanceof UnsupportedOperationException) {

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -1163,6 +1163,11 @@ public class ExceptionHandlers {
         return Utils.optimisticLockConflict(errorMsg, e);
       }
 
+      if (e instanceof UnsupportedOperationException) {
+        LOG.warn(errorMsg, e);
+        return Utils.unsupportedOperation(errorMsg, e);
+      }
+
       LOG.error(errorMsg, e);
       return Utils.internalError(errorMsg, e);
     }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/StatisticOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/StatisticOperations.java
@@ -122,7 +122,7 @@ public class StatisticOperations {
                 MetadataObjects.parse(
                     fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
             if (object.type() != MetadataObject.Type.TABLE) {
-              throw new UnsupportedOperationException(
+              throw new IllegalArgumentException(
                   "Listing statistics is only supported for tables now.");
             }
 
@@ -172,7 +172,7 @@ public class StatisticOperations {
                 MetadataObjects.parse(
                     fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
             if (object.type() != MetadataObject.Type.TABLE) {
-              throw new UnsupportedOperationException(
+              throw new IllegalArgumentException(
                   "Update statistics is only supported for tables now.");
             }
 
@@ -234,7 +234,7 @@ public class StatisticOperations {
                 MetadataObjects.parse(
                     fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
             if (object.type() != MetadataObject.Type.TABLE) {
-              throw new UnsupportedOperationException(
+              throw new IllegalArgumentException(
                   "Dropping statistics is only supported for tables now.");
             }
 
@@ -290,7 +290,7 @@ public class StatisticOperations {
                 MetadataObjects.parse(
                     fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
             if (object.type() != MetadataObject.Type.TABLE) {
-              throw new UnsupportedOperationException(
+              throw new IllegalArgumentException(
                   "Listing partition statistics is only supported for tables now.");
             }
 
@@ -370,7 +370,7 @@ public class StatisticOperations {
                 MetadataObjects.parse(
                     fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
             if (object.type() != MetadataObject.Type.TABLE) {
-              throw new UnsupportedOperationException(
+              throw new IllegalArgumentException(
                   "Updating partition statistics is only supported for tables now.");
             }
 
@@ -443,7 +443,7 @@ public class StatisticOperations {
                 MetadataObjects.parse(
                     fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
             if (object.type() != MetadataObject.Type.TABLE) {
-              throw new UnsupportedOperationException(
+              throw new IllegalArgumentException(
                   "Dropping partition statistics is only supported for tables now.");
             }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/filter/TestAccessControlNotAllowedFilter.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/filter/TestAccessControlNotAllowedFilter.java
@@ -18,13 +18,15 @@
  */
 package org.apache.gravitino.server.web.filter;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class TestAccessControlNotAllowedFilter {
   @Test
@@ -32,6 +34,9 @@ public class TestAccessControlNotAllowedFilter {
     AccessControlNotAllowedFilter filter = new AccessControlNotAllowedFilter();
     ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
     filter.filter(requestContext);
-    verify(requestContext).abortWith(any());
+    ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+    verify(requestContext).abortWith(responseCaptor.capture());
+    assertEquals(
+        Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), responseCaptor.getValue().getStatus());
   }
 }

--- a/server/src/test/java/org/apache/gravitino/server/web/filter/TestAccessControlNotAllowedFilter.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/filter/TestAccessControlNotAllowedFilter.java
@@ -37,6 +37,6 @@ public class TestAccessControlNotAllowedFilter {
     ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
     verify(requestContext).abortWith(responseCaptor.capture());
     assertEquals(
-        Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), responseCaptor.getValue().getStatus());
+        Response.Status.NOT_IMPLEMENTED.getStatusCode(), responseCaptor.getValue().getStatus());
   }
 }

--- a/server/src/test/java/org/apache/gravitino/server/web/filter/TestAccessControlNotAllowedFilter.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/filter/TestAccessControlNotAllowedFilter.java
@@ -37,6 +37,6 @@ public class TestAccessControlNotAllowedFilter {
     ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
     verify(requestContext).abortWith(responseCaptor.capture());
     assertEquals(
-        Response.Status.NOT_IMPLEMENTED.getStatusCode(), responseCaptor.getValue().getStatus());
+        Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), responseCaptor.getValue().getStatus());
   }
 }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.Response;
 import org.apache.gravitino.dto.responses.ErrorConstants;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.OptimisticLockException;
+import org.apache.gravitino.exceptions.UnmodifiableStatisticException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -93,6 +94,30 @@ public class TestExceptionHandlers {
               ErrorConstants.UNSUPPORTED_OPERATION_CODE, errorResponse.getCode());
           Assertions.assertEquals(
               UnsupportedOperationException.class.getSimpleName(), errorResponse.getType());
+        });
+  }
+
+  @Test
+  void testUnmodifiableOperationReturnsConflict() {
+    UnmodifiableStatisticException exception =
+        new UnmodifiableStatisticException("Statistic is unmodifiable");
+    List<Response> responses =
+        List.of(
+            ExceptionHandlers.handleStatisticException(
+                OperationType.ALTER, "statistic", "table", exception),
+            ExceptionHandlers.handlePartitionStatsException(
+                OperationType.ALTER, "partition", "table", exception),
+            new ExceptionHandlers.BaseExceptionHandler()
+                .handle(OperationType.ALTER, "statistic", "table", exception));
+
+    responses.forEach(
+        response -> {
+          Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+          ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+          Assertions.assertEquals(
+              ErrorConstants.UNSUPPORTED_OPERATION_CODE, errorResponse.getCode());
+          Assertions.assertEquals(
+              UnmodifiableStatisticException.class.getSimpleName(), errorResponse.getType());
         });
   }
 }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.server.web.rest;
 
+import java.util.List;
 import javax.ws.rs.core.Response;
 import org.apache.gravitino.dto.responses.ErrorConstants;
 import org.apache.gravitino.dto.responses.ErrorResponse;
@@ -68,5 +69,30 @@ public class TestExceptionHandlers {
     ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
     Assertions.assertEquals(ErrorConstants.OPTIMISTIC_LOCK_CONFLICT_CODE, errorResponse.getCode());
     Assertions.assertEquals(OptimisticLockException.class.getSimpleName(), errorResponse.getType());
+  }
+
+  @Test
+  void testUnsupportedOperationReturnsNotImplemented() {
+    UnsupportedOperationException exception =
+        new UnsupportedOperationException("Operation is not supported");
+    List<Response> responses =
+        List.of(
+            ExceptionHandlers.handleTableException(
+                OperationType.ALTER, "table", "schema", exception),
+            ExceptionHandlers.handlePolicyException(
+                OperationType.LIST, "policy", "metalake", exception),
+            new ExceptionHandlers.BaseExceptionHandler()
+                .handle(OperationType.LIST, "object", "parent", exception));
+
+    responses.forEach(
+        response -> {
+          Assertions.assertEquals(
+              Response.Status.NOT_IMPLEMENTED.getStatusCode(), response.getStatus());
+          ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+          Assertions.assertEquals(
+              ErrorConstants.UNSUPPORTED_OPERATION_CODE, errorResponse.getCode());
+          Assertions.assertEquals(
+              UnsupportedOperationException.class.getSimpleName(), errorResponse.getType());
+        });
   }
 }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestStatisticOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestStatisticOperations.java
@@ -235,6 +235,53 @@ public class TestStatisticOperations extends JerseyTest {
     ErrorResponse errorResp2 = resp2.readEntity(ErrorResponse.class);
     Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResp2.getCode());
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp2.getType());
+
+    // Test throw UnsupportedOperationException
+    doThrow(new UnsupportedOperationException("mock error"))
+        .when(manager)
+        .listStatistics(any(), any());
+    Response resp3 =
+        target(
+                "/metalakes/"
+                    + metalake
+                    + "/objects/"
+                    + tableObject.type()
+                    + "/"
+                    + tableObject.fullName()
+                    + "/statistics")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp3.getStatus());
+    ErrorResponse errorResp3 = resp3.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.UNSUPPORTED_OPERATION_CODE, errorResp3.getCode());
+    Assertions.assertEquals(
+        UnsupportedOperationException.class.getSimpleName(), errorResp3.getType());
+  }
+
+  /** Tests that statistics reject non-table object types as invalid request arguments. */
+  @Test
+  public void testListStatisticsRejectsNonTableObject() {
+    MetadataObject catalogObject = MetadataObjects.parse(catalog, MetadataObject.Type.CATALOG);
+    Response response =
+        target(
+                "/metalakes/"
+                    + metalake
+                    + "/objects/"
+                    + catalogObject.type()
+                    + "/"
+                    + catalogObject.fullName()
+                    + "/statistics")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
   }
 
   @Test
@@ -362,7 +409,7 @@ public class TestStatisticOperations extends JerseyTest {
             .accept("application/vnd.gravitino.v1+json")
             .put(entity(req, MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), resp4.getStatus());
+    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp4.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp4.getMediaType());
 
     ErrorResponse errorResp4 = resp4.readEntity(ErrorResponse.class);
@@ -493,7 +540,7 @@ public class TestStatisticOperations extends JerseyTest {
             .accept("application/vnd.gravitino.v1+json")
             .post(entity(req, MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), resp3.getStatus());
+    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp3.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp3.getMediaType());
 
     ErrorResponse errorResp3 = resp3.readEntity(ErrorResponse.class);
@@ -752,7 +799,7 @@ public class TestStatisticOperations extends JerseyTest {
             .accept("application/vnd.gravitino.v1+json")
             .put(entity(req, MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), resp4.getStatus());
+    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp4.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp4.getMediaType());
 
     ErrorResponse errorResp4 = resp4.readEntity(ErrorResponse.class);
@@ -924,7 +971,7 @@ public class TestStatisticOperations extends JerseyTest {
             .accept("application/vnd.gravitino.v1+json")
             .post(entity(req, MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), resp3.getStatus());
+    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp3.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp3.getMediaType());
 
     ErrorResponse errorResp3 = resp3.readEntity(ErrorResponse.class);

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestStatisticOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestStatisticOperations.java
@@ -260,28 +260,68 @@ public class TestStatisticOperations extends JerseyTest {
         UnsupportedOperationException.class.getSimpleName(), errorResp3.getType());
   }
 
-  /** Tests that statistics reject non-table object types as invalid request arguments. */
+  /** Tests that every statistics endpoint rejects non-table object types as invalid arguments. */
   @Test
-  public void testListStatisticsRejectsNonTableObject() {
+  public void testStatisticsEndpointsRejectNonTableObject() {
     MetadataObject catalogObject = MetadataObjects.parse(catalog, MetadataObject.Type.CATALOG);
-    Response response =
-        target(
-                "/metalakes/"
-                    + metalake
-                    + "/objects/"
-                    + catalogObject.type()
-                    + "/"
-                    + catalogObject.fullName()
-                    + "/statistics")
-            .request(MediaType.APPLICATION_JSON_TYPE)
-            .accept("application/vnd.gravitino.v1+json")
-            .get();
+    String path =
+        "/metalakes/"
+            + metalake
+            + "/objects/"
+            + catalogObject.type()
+            + "/"
+            + catalogObject.fullName()
+            + "/statistics";
+    Map<String, StatisticValue<?>> statistics =
+        Map.of(Statistic.CUSTOM_PREFIX + "test", StatisticValues.longValue(1L));
+    StatisticsUpdateRequest updateRequest = new StatisticsUpdateRequest(statistics);
+    StatisticsDropRequest dropRequest =
+        new StatisticsDropRequest(new String[] {Statistic.CUSTOM_PREFIX + "test"});
+    PartitionStatisticsUpdateRequest partitionUpdateRequest =
+        new PartitionStatisticsUpdateRequest(
+            List.of(PartitionStatisticsUpdateDTO.of("partition", statistics)));
+    PartitionStatisticsDropRequest partitionDropRequest =
+        new PartitionStatisticsDropRequest(
+            List.of(
+                PartitionStatisticsDropDTO.of(
+                    "partition", List.of(Statistic.CUSTOM_PREFIX + "test"))));
 
-    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
-    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
-    Assertions.assertEquals(
-        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    List<Response> responses =
+        List.of(
+            target(path)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept("application/vnd.gravitino.v1+json")
+                .get(),
+            target(path)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept("application/vnd.gravitino.v1+json")
+                .put(entity(updateRequest, MediaType.APPLICATION_JSON_TYPE)),
+            target(path)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept("application/vnd.gravitino.v1+json")
+                .post(entity(dropRequest, MediaType.APPLICATION_JSON_TYPE)),
+            target(path + "/partitions")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept("application/vnd.gravitino.v1+json")
+                .get(),
+            target(path + "/partitions")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept("application/vnd.gravitino.v1+json")
+                .put(entity(partitionUpdateRequest, MediaType.APPLICATION_JSON_TYPE)),
+            target(path + "/partitions")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept("application/vnd.gravitino.v1+json")
+                .post(entity(partitionDropRequest, MediaType.APPLICATION_JSON_TYPE)));
+
+    responses.forEach(
+        response -> {
+          Assertions.assertEquals(
+              Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+          ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
+          Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+          Assertions.assertEquals(
+              IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+        });
   }
 
   @Test
@@ -409,7 +449,7 @@ public class TestStatisticOperations extends JerseyTest {
             .accept("application/vnd.gravitino.v1+json")
             .put(entity(req, MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp4.getStatus());
+    Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), resp4.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp4.getMediaType());
 
     ErrorResponse errorResp4 = resp4.readEntity(ErrorResponse.class);
@@ -540,7 +580,7 @@ public class TestStatisticOperations extends JerseyTest {
             .accept("application/vnd.gravitino.v1+json")
             .post(entity(req, MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp3.getStatus());
+    Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), resp3.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp3.getMediaType());
 
     ErrorResponse errorResp3 = resp3.readEntity(ErrorResponse.class);
@@ -799,7 +839,7 @@ public class TestStatisticOperations extends JerseyTest {
             .accept("application/vnd.gravitino.v1+json")
             .put(entity(req, MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp4.getStatus());
+    Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), resp4.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp4.getMediaType());
 
     ErrorResponse errorResp4 = resp4.readEntity(ErrorResponse.class);
@@ -971,7 +1011,7 @@ public class TestStatisticOperations extends JerseyTest {
             .accept("application/vnd.gravitino.v1+json")
             .post(entity(req, MediaType.APPLICATION_JSON_TYPE));
 
-    Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), resp3.getStatus());
+    Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), resp3.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp3.getMediaType());
 
     ErrorResponse errorResp3 = resp3.readEntity(ErrorResponse.class);

--- a/web-v2/web/src/lib/store/metalakes/index.js
+++ b/web-v2/web/src/lib/store/metalakes/index.js
@@ -20,6 +20,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 
 import { to, extractPlaceholder, updateTreeData, findInTree } from '@/lib/utils'
+import { isUnsupportedOperationError } from '@/lib/utils/axios/unsupportedOperation'
 import toast from 'react-hot-toast'
 
 import _ from 'lodash-es'
@@ -2250,8 +2251,8 @@ export const fetchViews = createAsyncThunk(
     const [err, res] = await to(getViewsApi({ metalake, catalog, schema }, { errorMessageMode: 'none' }))
 
     if (err || !res) {
-      // Catalog doesn't support views (HTTP 405) — return empty views silently
-      if (err?.response?.status === 405) {
+      // Catalog doesn't support views (HTTP 501) — return empty views silently
+      if (isUnsupportedOperationError(err)) {
         return { views: [], init }
       }
       if (init) {
@@ -2304,8 +2305,8 @@ export const getViewDetails = createAsyncThunk(
     const [err, res] = await to(getViewDetailsApi({ metalake, catalog, schema, view }, { errorMessageMode: 'none' }))
 
     if (err || !res) {
-      // Catalog doesn't support views (HTTP 405) — return empty result silently
-      if (err?.response?.status === 405) {
+      // Catalog doesn't support views (HTTP 501) — return empty result silently
+      if (isUnsupportedOperationError(err)) {
         return { view: null, init }
       }
       throw new Error(err)

--- a/web-v2/web/src/lib/store/metalakes/index.js
+++ b/web-v2/web/src/lib/store/metalakes/index.js
@@ -2251,7 +2251,7 @@ export const fetchViews = createAsyncThunk(
     const [err, res] = await to(getViewsApi({ metalake, catalog, schema }, { errorMessageMode: 'none' }))
 
     if (err || !res) {
-      // Catalog doesn't support views (HTTP 501) — return empty views silently
+      // Catalog doesn't support views (HTTP 501, or legacy 405 with code 1006) — return empty views silently
       if (isUnsupportedOperationError(err)) {
         return { views: [], init }
       }
@@ -2305,7 +2305,7 @@ export const getViewDetails = createAsyncThunk(
     const [err, res] = await to(getViewDetailsApi({ metalake, catalog, schema, view }, { errorMessageMode: 'none' }))
 
     if (err || !res) {
-      // Catalog doesn't support views (HTTP 501) — return empty result silently
+      // Catalog doesn't support views (HTTP 501, or legacy 405 with code 1006) — return empty result silently
       if (isUnsupportedOperationError(err)) {
         return { view: null, init }
       }

--- a/web-v2/web/src/lib/utils/axios/unsupportedOperation.js
+++ b/web-v2/web/src/lib/utils/axios/unsupportedOperation.js
@@ -21,4 +21,5 @@ const UNSUPPORTED_OPERATION_CODE = 1006
 
 /** Returns whether an HTTP client error represents an unsupported server operation. */
 export const isUnsupportedOperationError = error =>
-  error?.response?.data?.code === UNSUPPORTED_OPERATION_CODE || error?.response?.status === 501
+  error?.response?.status === 501 ||
+  (error?.response?.status === 405 && error?.response?.data?.code === UNSUPPORTED_OPERATION_CODE)

--- a/web-v2/web/src/lib/utils/axios/unsupportedOperation.js
+++ b/web-v2/web/src/lib/utils/axios/unsupportedOperation.js
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** Returns whether an HTTP client error represents an unsupported server operation. */
+export const isUnsupportedOperationError = error => error?.response?.status === 501

--- a/web-v2/web/src/lib/utils/axios/unsupportedOperation.js
+++ b/web-v2/web/src/lib/utils/axios/unsupportedOperation.js
@@ -17,5 +17,8 @@
  * under the License.
  */
 
+const UNSUPPORTED_OPERATION_CODE = 1006
+
 /** Returns whether an HTTP client error represents an unsupported server operation. */
-export const isUnsupportedOperationError = error => error?.response?.status === 501
+export const isUnsupportedOperationError = error =>
+  error?.response?.data?.code === UNSUPPORTED_OPERATION_CODE || error?.response?.status === 501

--- a/web-v2/web/src/lib/utils/axios/unsupportedOperation.test.js
+++ b/web-v2/web/src/lib/utils/axios/unsupportedOperation.test.js
@@ -25,8 +25,12 @@ describe('isUnsupportedOperationError', () => {
     expect(isUnsupportedOperationError({ response: { status: 501 } })).toBe(true)
   })
 
+  it('recognizes the legacy HTTP 405 response by its application error code', () => {
+    expect(isUnsupportedOperationError({ response: { status: 405, data: { code: 1006 } } })).toBe(true)
+  })
+
   it('does not hide an actual HTTP method mismatch', () => {
-    expect(isUnsupportedOperationError({ response: { status: 405 } })).toBe(false)
+    expect(isUnsupportedOperationError({ response: { status: 405, data: { code: 1000 } } })).toBe(false)
   })
 
   it('handles errors without an HTTP response', () => {

--- a/web-v2/web/src/lib/utils/axios/unsupportedOperation.test.js
+++ b/web-v2/web/src/lib/utils/axios/unsupportedOperation.test.js
@@ -33,6 +33,10 @@ describe('isUnsupportedOperationError', () => {
     expect(isUnsupportedOperationError({ response: { status: 405, data: { code: 1000 } } })).toBe(false)
   })
 
+  it('does not treat an HTTP conflict as an unsupported operation', () => {
+    expect(isUnsupportedOperationError({ response: { status: 409, data: { code: 1006 } } })).toBe(false)
+  })
+
   it('handles errors without an HTTP response', () => {
     expect(isUnsupportedOperationError(new Error('network error'))).toBe(false)
   })

--- a/web-v2/web/src/lib/utils/axios/unsupportedOperation.test.js
+++ b/web-v2/web/src/lib/utils/axios/unsupportedOperation.test.js
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { isUnsupportedOperationError } from '@/lib/utils/axios/unsupportedOperation'
+
+describe('isUnsupportedOperationError', () => {
+  it('recognizes HTTP 501 as an unsupported operation', () => {
+    expect(isUnsupportedOperationError({ response: { status: 501 } })).toBe(true)
+  })
+
+  it('does not hide an actual HTTP method mismatch', () => {
+    expect(isUnsupportedOperationError({ response: { status: 405 } })).toBe(false)
+  })
+
+  it('handles errors without an HTTP response', () => {
+    expect(isUnsupportedOperationError(new Error('network error'))).toBe(false)
+  })
+})


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Classify REST failures by semantics at the common exception-handling boundary:
  - Return HTTP 400 when statistics endpoints receive a non-table object type.
  - Return HTTP 409 when an operation conflicts with object state, including unmodifiable statistics and non-empty IdP groups.
  - Return HTTP 501 for recognized but unsupported server or connector capabilities, including handlers that use the common fallback.
- Preserve the authorization-disabled filter's existing HTTP 405 contract through a dedicated helper instead of sharing the unsupported-capability helper.
- Align the built-in IdP mapper so unsupported operations return 501 and unexpected `IllegalStateException` returns 500.
- Keep the existing application error codes so Java clients continue reconstructing the same exceptions.
- Update OpenAPI contracts and make Web v2 recognize unsupported operations by application error code, with HTTP 501 as a fallback, so it works with both old and new servers.

### Why are the changes needed?

HTTP 405 means the request method is not supported by the target resource. The reported failures use valid registered methods and instead represent invalid input, resource conflicts, or unavailable functionality. The old mapping was also inconsistent because resource handlers without a dedicated branch returned HTTP 500 for the same unsupported-capability exception.

The fix centralizes the fallback while classifying more specific domain exceptions before the generic `UnsupportedOperationException` branch.

Fix: #12879

### Does this PR introduce _any_ user-facing change?

Yes. Invalid statistics object types return HTTP 400, state conflicts return HTTP 409, and unsupported REST capabilities return HTTP 501. Response payload codes remain compatible. The authorization-disabled filter keeps its existing HTTP 405 behavior.

### How was this patch tested?

- `./gradlew spotlessApply`
- `./gradlew :server-common:test --tests org.apache.gravitino.server.web.TestUtils -PskipITs -PskipDockerTests=true`
- `./gradlew :server:test --tests org.apache.gravitino.server.web.filter.TestAccessControlNotAllowedFilter --tests org.apache.gravitino.server.web.rest.TestExceptionHandlers --tests org.apache.gravitino.server.web.rest.TestStatisticOperations -PskipITs -PskipDockerTests=true`
- `./gradlew :clients:client-java:test --tests org.apache.gravitino.client.TestSupportsStatistics --tests org.apache.gravitino.client.TestSupportsPartitionStatistics -PskipITs -PskipDockerTests=true`
- `./gradlew :plugins:idp-basic:test --tests org.apache.gravitino.idp.web.TestIdpRESTUtils --tests org.apache.gravitino.idp.TestIdpUserGroupManager -PskipITs -PskipDockerTests=true`
- `./gradlew :plugins:idp-basic:test --tests org.apache.gravitino.idp.integration.test.IdpRESTApiIT -PskipDockerTests=true`
- `./gradlew :docs:build -PskipITs -PskipDockerTests=true`
- `pnpm exec vitest run src/lib/utils/axios/unsupportedOperation.test.js`
- `pnpm prettier:check`
- `pnpm lint`
