### PR TITLE
[#12885] fix(audit): Include role names in role assignment logs

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/event/GrantGroupRolesEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/GrantGroupRolesEvent.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.listener.api.event;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
 import org.apache.gravitino.listener.api.info.GroupInfo;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -63,6 +64,12 @@ public class GrantGroupRolesEvent extends GroupEvent {
    */
   public List<String> roles() {
     return roles;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> customInfo() {
+    return RoleAssignmentAuditInfos.of(roles);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/GrantGroupRolesFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/GrantGroupRolesFailureEvent.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.listener.api.event;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 
@@ -69,6 +70,12 @@ public class GrantGroupRolesFailureEvent extends GroupFailureEvent {
    */
   public List<String> roles() {
     return roles;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> customInfo() {
+    return RoleAssignmentAuditInfos.of(roles);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/GrantUserRolesEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/GrantUserRolesEvent.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.listener.api.event;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
 import org.apache.gravitino.listener.api.info.UserInfo;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -64,6 +65,12 @@ public class GrantUserRolesEvent extends UserEvent {
    */
   public List<String> roles() {
     return roles;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> customInfo() {
+    return RoleAssignmentAuditInfos.of(roles);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/GrantUserRolesFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/GrantUserRolesFailureEvent.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.listener.api.event;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 
@@ -63,6 +64,12 @@ public class GrantUserRolesFailureEvent extends UserFailureEvent {
    */
   public List<String> roles() {
     return roles;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> customInfo() {
+    return RoleAssignmentAuditInfos.of(roles);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/RevokeGroupRolesEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/RevokeGroupRolesEvent.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.listener.api.event;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
 import org.apache.gravitino.listener.api.info.GroupInfo;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -64,6 +65,12 @@ public class RevokeGroupRolesEvent extends GroupEvent {
    */
   public List<String> roles() {
     return roles;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> customInfo() {
+    return RoleAssignmentAuditInfos.of(roles);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/RevokeGroupRolesFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/RevokeGroupRolesFailureEvent.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.listener.api.event;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 
@@ -69,6 +70,12 @@ public class RevokeGroupRolesFailureEvent extends GroupFailureEvent {
    */
   public List<String> roles() {
     return roles;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> customInfo() {
+    return RoleAssignmentAuditInfos.of(roles);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/RevokeUserRolesEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/RevokeUserRolesEvent.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.listener.api.event;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
 import org.apache.gravitino.listener.api.info.UserInfo;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -64,6 +65,12 @@ public class RevokeUserRolesEvent extends UserEvent {
    */
   public List<String> roles() {
     return roles;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> customInfo() {
+    return RoleAssignmentAuditInfos.of(roles);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/RevokeUserRolesFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/RevokeUserRolesFailureEvent.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.listener.api.event;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 
@@ -64,6 +65,12 @@ public class RevokeUserRolesFailureEvent extends UserFailureEvent {
    */
   public List<String> roles() {
     return roles;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> customInfo() {
+    return RoleAssignmentAuditInfos.of(roles);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/RoleAssignmentAuditInfos.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/RoleAssignmentAuditInfos.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** Shared customInfo keys and values for role assignment audit events. */
+final class RoleAssignmentAuditInfos {
+
+  static final String ROLE_NAMES = "roleNames";
+
+  private RoleAssignmentAuditInfos() {}
+
+  static Map<String, String> of(@Nullable List<String> roles) {
+    if (roles == null || roles.isEmpty()) {
+      return ImmutableMap.of();
+    }
+    return ImmutableMap.of(ROLE_NAMES, String.join(",", roles));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/audit/v2/TestSimpleAuditLogV2.java
+++ b/core/src/test/java/org/apache/gravitino/audit/v2/TestSimpleAuditLogV2.java
@@ -19,12 +19,14 @@
 
 package org.apache.gravitino.audit.v2;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.listener.api.event.Event;
 import org.apache.gravitino.listener.api.event.EventSource;
+import org.apache.gravitino.listener.api.event.GrantUserRolesFailureEvent;
 import org.apache.gravitino.listener.api.event.ListCatalogEvent;
 import org.apache.gravitino.listener.api.event.ListMetalakeEvent;
 import org.apache.gravitino.listener.api.event.ListSchemaEvent;
@@ -66,6 +68,20 @@ public class TestSimpleAuditLogV2 {
     String[] fields = output.split("\t", -1);
     Assertions.assertEquals(8, fields.length);
     Assertions.assertEquals("", fields[7], "Last field should be empty when customInfo is absent");
+  }
+
+  @Test
+  public void testRoleAssignmentIncludesRoleNames() {
+    GrantUserRolesFailureEvent event =
+        new GrantUserRolesFailureEvent(
+            "admin",
+            "metalake",
+            new RuntimeException("failed"),
+            "alice",
+            ImmutableList.of("reader", "admin"));
+
+    String customInfo = new SimpleAuditLogV2(event).toString().split("\\t", -1)[7];
+    Assertions.assertEquals("{roleNames=reader,admin}", customInfo);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestGroupEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestGroupEvent.java
@@ -544,6 +544,8 @@ public class TestGroupEvent {
     GrantGroupRolesEvent grantGroupRolesEvent = (GrantGroupRolesEvent) event;
     Assertions.assertEquals(
         NameIdentifierUtil.ofGroup(METALAKE, groupName), grantGroupRolesEvent.identifier());
+    Assertions.assertEquals(
+        String.join(",", grantedRoles), grantGroupRolesEvent.customInfo().get("roleNames"));
     GroupInfo groupInfo = grantGroupRolesEvent.grantedGroupInfo();
 
     validateGroup(groupInfo, group);
@@ -566,6 +568,8 @@ public class TestGroupEvent {
         NameIdentifierUtil.ofGroup(METALAKE, groupName), grantGroupRolesFailureEvent.identifier());
     Assertions.assertEquals(groupName, grantGroupRolesFailureEvent.groupName());
     Assertions.assertEquals(grantedRoles, grantGroupRolesFailureEvent.roles());
+    Assertions.assertEquals(
+        String.join(",", grantedRoles), grantGroupRolesFailureEvent.customInfo().get("roleNames"));
   }
 
   @Test
@@ -600,6 +604,8 @@ public class TestGroupEvent {
     RevokeGroupRolesEvent revokeGroupRolesEvent = (RevokeGroupRolesEvent) event;
     Assertions.assertEquals(
         NameIdentifierUtil.ofGroup(METALAKE, otherGroupName), revokeGroupRolesEvent.identifier());
+    Assertions.assertEquals(
+        String.join(",", revokedRoles), revokeGroupRolesEvent.customInfo().get("roleNames"));
     GroupInfo groupInfo = revokeGroupRolesEvent.revokedGroupInfo();
 
     validateGroup(groupInfo, otherGroup);
@@ -624,6 +630,8 @@ public class TestGroupEvent {
         revokeGroupRolesFailureEvent.identifier());
     Assertions.assertEquals(otherGroupName, revokeGroupRolesFailureEvent.groupName());
     Assertions.assertEquals(revokedRoles, revokeGroupRolesFailureEvent.roles());
+    Assertions.assertEquals(
+        String.join(",", revokedRoles), revokeGroupRolesFailureEvent.customInfo().get("roleNames"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestUserEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestUserEvent.java
@@ -484,6 +484,8 @@ public class TestUserEvent {
 
     GrantUserRolesEvent grantUserRolesEvent = (GrantUserRolesEvent) event;
     Assertions.assertEquals(identifier, grantUserRolesEvent.identifier());
+    Assertions.assertEquals(
+        String.join(",", grantedRoles), grantUserRolesEvent.customInfo().get("roleNames"));
     UserInfo userInfo = grantUserRolesEvent.grantUserInfo();
 
     validateUserInfo(userInfo, user);
@@ -507,6 +509,8 @@ public class TestUserEvent {
         grantUserRolesFailureEvent.identifier());
     Assertions.assertEquals(inExistUserName, grantUserRolesFailureEvent.userName());
     Assertions.assertEquals(grantedRoles, grantUserRolesFailureEvent.roles());
+    Assertions.assertEquals(
+        String.join(",", grantedRoles), grantUserRolesFailureEvent.customInfo().get("roleNames"));
   }
 
   @Test
@@ -538,6 +542,8 @@ public class TestUserEvent {
 
     RevokeUserRolesEvent revokeUserRolesEvent = (RevokeUserRolesEvent) event;
     Assertions.assertEquals(otherIdentifier, revokeUserRolesEvent.identifier());
+    Assertions.assertEquals(
+        String.join(",", revokedRoles), revokeUserRolesEvent.customInfo().get("roleNames"));
     UserInfo userInfo = revokeUserRolesEvent.revokedUserInfo();
 
     validateUserInfo(userInfo, otherUser);
@@ -561,6 +567,8 @@ public class TestUserEvent {
         revokeUserRolesFailureEvent.identifier());
     Assertions.assertEquals(inExistUserName, revokeUserRolesFailureEvent.userName());
     Assertions.assertEquals(revokedRoles, revokeUserRolesFailureEvent.roles());
+    Assertions.assertEquals(
+        String.join(",", revokedRoles), revokeUserRolesFailureEvent.customInfo().get("roleNames"));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the affected role names to the audit `customInfo` for:

- `GRANT_USER_ROLES`
- `REVOKE_USER_ROLES`
- `GRANT_GROUP_ROLES`
- `REVOKE_GROUP_ROLES`

Both successful and failed operations now record `roleNames`. A shared helper keeps the audit field formatting consistent.

### Why are the changes needed?

Role assignment audit entries currently identify the user or group but omit the roles that were granted or revoked. This prevents access reviews from reconstructing which permissions were changed.

Fix: #12885

### Does this PR introduce _any_ user-facing change?

Yes. Role assignment audit entries now include the affected roles in `customInfo`, for example:

`{roleNames=reader,admin}`

### How was this patch tested?

- `./gradlew :core:spotlessApply`
- `./gradlew :core:test --tests org.apache.gravitino.listener.api.event.TestUserEvent --tests org.apache.gravitino.listener.api.event.TestGroupEvent --tests org.apache.gravitino.audit.v2.TestSimpleAuditLogV2`