### PR TITLE
[#8204] fix(authz): serialize dates in UTC

### DIFF
--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/reference/TestJsonDateSerializer.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/reference/TestJsonDateSerializer.java
@@ -18,28 +18,35 @@
  */
 package org.apache.gravitino.authorization.ranger.reference;
 
-import java.io.IOException;
-import java.text.SimpleDateFormat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.StringWriter;
 import java.util.Date;
 import java.util.TimeZone;
 import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
 
-/**
- * Used to serialize Java.util.Date, which is not a common JSON type, so we have to create a custom
- * serialize method
- */
-// apache/ranger/security-admin/src/main/java/org/apache/ranger/defines/JsonDateSerializer.java
-public class JsonDateSerializer extends JsonSerializer<Date> {
-  private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+public class TestJsonDateSerializer {
 
-  @Override
-  public void serialize(Date date, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
-    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_FORMAT);
-    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-    String formattedDate = simpleDateFormat.format(date);
-    gen.writeString(formattedDate);
+  @Test
+  @SuppressWarnings("JavaUtilDate")
+  public void testSerializeUsesUtcTimezone() throws Exception {
+    TimeZone original = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("GMT+8"));
+      JsonDateSerializer serializer = new JsonDateSerializer();
+      ObjectMapper mapper = new ObjectMapper();
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = mapper.getJsonFactory().createJsonGenerator(writer);
+      Date date = new Date(0L);
+
+      serializer.serialize(date, generator, mapper.getSerializerProvider());
+      generator.flush();
+
+      assertEquals("\"1970-01-01T00:00:00Z\"", writer.toString());
+    } finally {
+      TimeZone.setDefault(original);
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Configure `JsonDateSerializer` to format dates using UTC instead of the
system default timezone.

Add a unit test that changes the system default timezone and verifies
that the serialized value remains in UTC.

### Why are the changes needed?
`JsonDateSerializer` currently formats a date using the system default
timezone while appending the literal `Z` suffix. This may produce an
incorrect timestamp when Gravitino runs outside UTC.

Fix: #8204

### Does this PR introduce any user-facing change?

Yes. Serialized Ranger date values are now consistently represented in
UTC.

### How was this patch tested?

- Added `TestJsonDateSerializer.testSerializeUsesUtcTimezone`.
- Ran the authorization-ranger unit test successfully.
- Ran Spotless successfully.