### PR TITLE
[#12892] fix(audit): Suppress internal operation audit events

### DIFF
--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -153,8 +153,10 @@ public class GravitinoEnv {
   private TopicDispatcher internalTopicDispatcher;
 
   private ModelDispatcher modelDispatcher;
+  private ModelDispatcher internalModelDispatcher;
 
   private FunctionDispatcher functionDispatcher;
+  private FunctionDispatcher internalFunctionDispatcher;
 
   private SemanticModelDispatcher semanticModelDispatcher;
 
@@ -162,6 +164,7 @@ public class GravitinoEnv {
   private ViewDispatcher internalViewDispatcher;
 
   private MetalakeDispatcher metalakeDispatcher;
+  private MetalakeDispatcher internalMetalakeDispatcher;
 
   private CredentialOperationDispatcher credentialOperationDispatcher;
 
@@ -172,8 +175,10 @@ public class GravitinoEnv {
   private SecretManager secretManager;
 
   private TagDispatcher tagDispatcher;
+  private TagDispatcher internalTagDispatcher;
 
   private PolicyDispatcher policyDispatcher;
+  private PolicyDispatcher internalPolicyDispatcher;
 
   private AccessControlDispatcher accessControlDispatcher;
   private AccessControlDispatcher internalAccessControlDispatcher;
@@ -191,6 +196,7 @@ public class GravitinoEnv {
   private AuditLogManager auditLogManager;
 
   private JobOperationDispatcher jobOperationDispatcher;
+  private JobOperationDispatcher internalJobOperationDispatcher;
 
   private EventBus eventBus;
   private OwnerDispatcher ownerDispatcher;
@@ -348,12 +354,34 @@ public class GravitinoEnv {
   }
 
   /**
+   * Get the internal ModelDispatcher associated with the Gravitino environment.
+   *
+   * <p>The internal dispatcher preserves normalization but skips hooks and event emission.
+   *
+   * @return The internal ModelDispatcher instance.
+   */
+  public ModelDispatcher internalModelDispatcher() {
+    return internalModelDispatcher;
+  }
+
+  /**
    * Get the FunctionDispatcher associated with the Gravitino environment.
    *
    * @return The FunctionDispatcher instance.
    */
   public FunctionDispatcher functionDispatcher() {
     return functionDispatcher;
+  }
+
+  /**
+   * Get the internal FunctionDispatcher associated with the Gravitino environment.
+   *
+   * <p>The internal dispatcher preserves normalization but skips hooks and event emission.
+   *
+   * @return The internal FunctionDispatcher instance.
+   */
+  public FunctionDispatcher internalFunctionDispatcher() {
+    return internalFunctionDispatcher;
   }
 
   /**
@@ -443,6 +471,17 @@ public class GravitinoEnv {
    */
   public MetalakeDispatcher metalakeDispatcher() {
     return metalakeDispatcher;
+  }
+
+  /**
+   * Get the internal MetalakeDispatcher associated with the Gravitino environment.
+   *
+   * <p>The internal dispatcher preserves normalization but skips hooks and event emission.
+   *
+   * @return The internal MetalakeDispatcher instance.
+   */
+  public MetalakeDispatcher internalMetalakeDispatcher() {
+    return internalMetalakeDispatcher;
   }
 
   /**
@@ -583,12 +622,34 @@ public class GravitinoEnv {
   }
 
   /**
+   * Get the internal TagDispatcher associated with the Gravitino environment.
+   *
+   * <p>The internal dispatcher skips hooks and event emission.
+   *
+   * @return The internal TagDispatcher instance.
+   */
+  public TagDispatcher internalTagDispatcher() {
+    return internalTagDispatcher;
+  }
+
+  /**
    * Get the PolicyDispatcher associated with the Gravitino environment.
    *
    * @return The PolicyDispatcher instance.
    */
   public PolicyDispatcher policyDispatcher() {
     return policyDispatcher;
+  }
+
+  /**
+   * Get the internal PolicyDispatcher associated with the Gravitino environment.
+   *
+   * <p>The internal dispatcher skips hooks and event emission.
+   *
+   * @return The internal PolicyDispatcher instance.
+   */
+  public PolicyDispatcher internalPolicyDispatcher() {
+    return internalPolicyDispatcher;
   }
 
   /**
@@ -656,6 +717,19 @@ public class GravitinoEnv {
   public JobOperationDispatcher jobOperationDispatcher() {
     Preconditions.checkArgument(jobOperationDispatcher != null, "GravitinoEnv is not initialized.");
     return jobOperationDispatcher;
+  }
+
+  /**
+   * Get the internal JobOperationDispatcher associated with the Gravitino environment.
+   *
+   * <p>The internal dispatcher preserves validation but skips hooks and event emission.
+   *
+   * @return The internal JobOperationDispatcher instance.
+   */
+  public JobOperationDispatcher internalJobOperationDispatcher() {
+    Preconditions.checkArgument(
+        internalJobOperationDispatcher != null, "GravitinoEnv is not initialized.");
+    return internalJobOperationDispatcher;
   }
 
   public StatisticDispatcher statisticDispatcher() {
@@ -779,6 +853,7 @@ public class GravitinoEnv {
     this.metalakeManager = new MetalakeManager(entityStore, idGenerator, catalogManager);
     MetalakeNormalizeDispatcher metalakeNormalizeDispatcher =
         new MetalakeNormalizeDispatcher(metalakeManager);
+    this.internalMetalakeDispatcher = metalakeNormalizeDispatcher;
     MetalakeEventDispatcher metalakeEventDispatcher =
         new MetalakeEventDispatcher(eventBus, metalakeNormalizeDispatcher);
     this.metalakeDispatcher = new MetalakeHookDispatcher(metalakeEventDispatcher);
@@ -836,7 +911,8 @@ public class GravitinoEnv {
     TableEventDispatcher tableEventDispatcher =
         new TableEventDispatcher(eventBus, tableNormalizeDispatcher);
     this.tableDispatcher =
-        new TableHookDispatcher(tableEventDispatcher, this::ownerDispatcher, catalogManager);
+        new TableHookDispatcher(
+            tableEventDispatcher, this::internalOwnerDispatcher, catalogManager);
 
     // TODO: We can install hooks when we need, we only supports ownership post hook,
     //  partition doesn't have ownership, so we don't need it now.
@@ -859,6 +935,7 @@ public class GravitinoEnv {
         new ModelOperationDispatcher(catalogManager, entityStore, idGenerator, secretManager);
     ModelNormalizeDispatcher modelNormalizeDispatcher =
         new ModelNormalizeDispatcher(modelOperationDispatcher, catalogManager);
+    this.internalModelDispatcher = modelNormalizeDispatcher;
     ModelEventDispatcher modelEventDispatcher =
         new ModelEventDispatcher(eventBus, modelNormalizeDispatcher);
     this.modelDispatcher = new ModelHookDispatcher(modelEventDispatcher);
@@ -871,10 +948,12 @@ public class GravitinoEnv {
             catalogManager, schemaOperationDispatcher, entityStore, idGenerator, secretManager);
     FunctionNormalizeDispatcher functionNormalizeDispatcher =
         new FunctionNormalizeDispatcher(functionOperationDispatcher, catalogManager);
+    this.internalFunctionDispatcher = functionNormalizeDispatcher;
     FunctionEventDispatcher functionEventDispatcher =
         new FunctionEventDispatcher(eventBus, functionNormalizeDispatcher);
     this.functionDispatcher =
-        new FunctionHookDispatcher(functionEventDispatcher, this::ownerDispatcher, catalogManager);
+        new FunctionHookDispatcher(
+            functionEventDispatcher, this::internalOwnerDispatcher, catalogManager);
 
     // View operation chain: ViewHookDispatcher -> ViewEventDispatcher -> ViewNormalizeDispatcher
     // -> ViewOperationDispatcher.
@@ -895,7 +974,7 @@ public class GravitinoEnv {
     ViewEventDispatcher viewEventDispatcher =
         new ViewEventDispatcher(eventBus, viewNormalizeDispatcher);
     this.viewDispatcher =
-        new ViewHookDispatcher(viewEventDispatcher, this::ownerDispatcher, catalogManager);
+        new ViewHookDispatcher(viewEventDispatcher, this::internalOwnerDispatcher, catalogManager);
 
     // Semantic Model operation chain: SemanticModelNormalizeDispatcher ->
     // SemanticModelOperationDispatcher -> ManagedSemanticModelOperations.
@@ -939,16 +1018,20 @@ public class GravitinoEnv {
 
     // Create and initialize Tag related modules
     TagManager tagManager = new TagManager(idGenerator, entityStore);
+    this.internalTagDispatcher = tagManager;
     TagEventDispatcher tagEventDispatcher = new TagEventDispatcher(eventBus, tagManager);
     this.tagDispatcher = new TagHookDispatcher(tagEventDispatcher);
 
+    PolicyManager policyManager = new PolicyManager(idGenerator, entityStore);
+    this.internalPolicyDispatcher = policyManager;
     PolicyEventDispatcher policyEventDispatcher =
-        new PolicyEventDispatcher(eventBus, new PolicyManager(idGenerator, entityStore));
+        new PolicyEventDispatcher(eventBus, policyManager);
     this.policyDispatcher = new PolicyHookDispatcher(policyEventDispatcher);
 
     JobManager jobManager = new JobManager(config, entityStore, idGenerator);
     JobTemplateValidationDispatcher validationDispatcher =
         new JobTemplateValidationDispatcher(jobManager);
+    this.internalJobOperationDispatcher = validationDispatcher;
     JobEventDispatcher jobEventDispatcher = new JobEventDispatcher(eventBus, validationDispatcher);
     this.jobOperationDispatcher = new JobHookDispatcher(jobEventDispatcher);
 

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -330,7 +330,7 @@ public class AuthorizationUtils {
       NameIdentifier ident, Entity.EntityType type, List<String> locations) {
     // If we enable authorization, we should remove the privileges about the entity in the
     // authorization plugin.
-    if (GravitinoEnv.getInstance().accessControlDispatcher() != null) {
+    if (GravitinoEnv.getInstance().internalAccessControlDispatcher() != null) {
       notifyEntityNameIdMappingChange(ident, type);
       MetadataObject metadataObject = NameIdentifierUtil.toMetadataObject(ident, type);
       String metalake =
@@ -369,7 +369,7 @@ public class AuthorizationUtils {
       NameIdentifier ident, Entity.EntityType type, String newName, List<String> locations) {
     // If we enable authorization, we should rename the privileges about the entity in the
     // authorization plugin.
-    if (GravitinoEnv.getInstance().accessControlDispatcher() != null) {
+    if (GravitinoEnv.getInstance().internalAccessControlDispatcher() != null) {
       notifyEntityNameIdMappingChange(ident, type);
       MetadataObject oldMetadataObject = NameIdentifierUtil.toMetadataObject(ident, type);
       MetadataObject newMetadataObject =
@@ -537,7 +537,7 @@ public class AuthorizationUtils {
     List<String> locations = new ArrayList<>();
 
     // If we don't enable authorization, the location should return empty collection.
-    if (GravitinoEnv.getInstance().accessControlDispatcher() == null) {
+    if (GravitinoEnv.getInstance().internalAccessControlDispatcher() == null) {
       return locations;
     }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -97,7 +97,7 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
         catalogManager,
         store,
         idGenerator,
-        () -> GravitinoEnv.getInstance().schemaDispatcher(),
+        () -> GravitinoEnv.getInstance().internalSchemaDispatcher(),
         secretManager);
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
@@ -83,7 +83,7 @@ public class ViewOperationDispatcher extends OperationDispatcher implements View
         catalogManager,
         store,
         idGenerator,
-        () -> GravitinoEnv.getInstance().schemaDispatcher(),
+        () -> GravitinoEnv.getInstance().internalSchemaDispatcher(),
         secretManager);
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -216,7 +216,7 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
     Role createdRole = dispatcher.createRole(metalake, role, properties, securableObjects);
 
     // Set the creator as the owner of role.
-    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerDispatcher != null) {
       ownerDispatcher.setOwner(
           metalake,

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -102,7 +102,7 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
 
     try {
       // Set the creator as the owner of the catalog.
-      OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+      OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
       if (ownerDispatcher != null) {
         ownerDispatcher.setOwner(
             ident.namespace().level(0),

--- a/core/src/main/java/org/apache/gravitino/hook/FilesetHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/FilesetHookDispatcher.java
@@ -86,7 +86,7 @@ public class FilesetHookDispatcher implements FilesetDispatcher {
             ident, comment, type, storageLocations, properties, secretBindings, secretReferences);
 
     // Set the creator as the owner of the fileset.
-    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerManager != null) {
       // The inner NormalizeDispatcher case-folds the fileset name (and its schema namespace)
       // based on catalog capabilities, so the entity is stored under the normalized identifier.

--- a/core/src/main/java/org/apache/gravitino/hook/JobHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/JobHookDispatcher.java
@@ -55,7 +55,7 @@ public class JobHookDispatcher implements JobOperationDispatcher {
     jobOperationDispatcher.registerJobTemplate(metalake, jobTemplateEntity);
 
     // Set the creator as the owner of the job template.
-    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerManager != null) {
       ownerManager.setOwner(
           metalake,
@@ -101,7 +101,7 @@ public class JobHookDispatcher implements JobOperationDispatcher {
     JobEntity jobEntity = jobOperationDispatcher.runJob(metalake, jobTemplateName, jobConf);
 
     // Set the creator as the owner of the job.
-    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerManager != null) {
       ownerManager.setOwner(
           metalake,

--- a/core/src/main/java/org/apache/gravitino/hook/MetalakeHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/MetalakeHookDispatcher.java
@@ -66,13 +66,13 @@ public class MetalakeHookDispatcher implements MetalakeDispatcher {
 
     // Add the creator to the metalake.
     AccessControlDispatcher accessControlDispatcher =
-        GravitinoEnv.getInstance().accessControlDispatcher();
+        GravitinoEnv.getInstance().internalAccessControlDispatcher();
     if (accessControlDispatcher != null) {
       accessControlDispatcher.addUser(ident.name(), PrincipalUtils.getCurrentUserName());
     }
 
     // Set the creator as owner of the metalake.
-    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerDispatcher != null) {
       ownerDispatcher.setOwner(
           ident.name(),

--- a/core/src/main/java/org/apache/gravitino/hook/ModelHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/ModelHookDispatcher.java
@@ -71,7 +71,7 @@ public class ModelHookDispatcher implements ModelDispatcher {
     Model model = dispatcher.registerModel(ident, comment, properties);
 
     // Set the creator as owner of the model.
-    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerManager != null) {
       // The inner NormalizeDispatcher case-folds the model name based on catalog capabilities,
       // so the entity is stored under the normalized identifier. Apply the same normalization
@@ -165,7 +165,7 @@ public class ModelHookDispatcher implements ModelDispatcher {
     Model model = dispatcher.registerModel(ident, uris, aliases, comment, properties);
 
     // Set the creator as owner of the model.
-    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerManager != null) {
       // The inner NormalizeDispatcher case-folds the model name based on catalog capabilities,
       // so the entity is stored under the normalized identifier. Apply the same normalization

--- a/core/src/main/java/org/apache/gravitino/hook/PolicyHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/PolicyHookDispatcher.java
@@ -67,7 +67,7 @@ public class PolicyHookDispatcher implements PolicyDispatcher {
     PolicyEntity policy = dispatcher.createPolicy(metalake, name, type, comment, enabled, content);
 
     // Set the creator as the owner of the policy.
-    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerDispatcher != null) {
       ownerDispatcher.setOwner(
           metalake,

--- a/core/src/main/java/org/apache/gravitino/hook/SchemaHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/SchemaHookDispatcher.java
@@ -111,7 +111,7 @@ public class SchemaHookDispatcher implements SchemaDispatcher {
           // mirrors IcebergNamespaceHookDispatcher.createNamespace so ownership-based
           // authorization -- which treats ownership of an ancestor schema as ownership of the
           // whole subtree -- behaves the same on the Gravitino and Iceberg REST surfaces.
-          OwnerDispatcher ownerManager = GravitinoEnv.getInstance().ownerDispatcher();
+          OwnerDispatcher ownerManager = GravitinoEnv.getInstance().internalOwnerDispatcher();
           if (ownerManager != null) {
             List<MetadataObject> ownedObjects = new ArrayList<>(newAncestors.size() + 1);
             for (NameIdentifier ancestor : newAncestors) {

--- a/core/src/main/java/org/apache/gravitino/hook/TagHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TagHookDispatcher.java
@@ -72,7 +72,7 @@ public class TagHookDispatcher implements TagDispatcher {
     Tag tag = dispatcher.createTag(metalake, name, comment, properties, valueConstraint);
 
     // Set the creator as the owner of the tag.
-    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerDispatcher != null) {
       ownerDispatcher.setOwner(
           metalake,

--- a/core/src/main/java/org/apache/gravitino/hook/TopicHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TopicHookDispatcher.java
@@ -68,7 +68,7 @@ public class TopicHookDispatcher implements TopicDispatcher {
     Topic topic = dispatcher.createTopic(ident, comment, dataLayout, properties);
 
     // Set the creator as the owner of the topic.
-    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher ownerManager = GravitinoEnv.getInstance().internalOwnerDispatcher();
     if (ownerManager != null) {
       // The inner NormalizeDispatcher case-folds the topic name (and its schema namespace)
       // based on catalog capabilities, so the entity is stored under the normalized identifier.

--- a/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
@@ -233,59 +233,61 @@ public class MetadataObjectUtil {
           throw new IllegalMetadataObjectException("The metalake object name must be %s", metalake);
         }
         NameIdentifierUtil.checkMetalake(identifier);
-        check(env.metalakeDispatcher().metalakeExists(identifier), exceptionToThrowSupplier);
+        check(
+            env.internalMetalakeDispatcher().metalakeExists(identifier), exceptionToThrowSupplier);
         break;
 
       case CATALOG:
         NameIdentifierUtil.checkCatalog(identifier);
-        check(env.catalogDispatcher().catalogExists(identifier), exceptionToThrowSupplier);
+        check(env.internalCatalogDispatcher().catalogExists(identifier), exceptionToThrowSupplier);
         break;
 
       case SCHEMA:
         NameIdentifierUtil.checkSchema(identifier);
-        check(env.schemaDispatcher().schemaExists(identifier), exceptionToThrowSupplier);
+        check(env.internalSchemaDispatcher().schemaExists(identifier), exceptionToThrowSupplier);
         break;
 
       case FILESET:
         NameIdentifierUtil.checkFileset(identifier);
-        check(env.filesetDispatcher().filesetExists(identifier), exceptionToThrowSupplier);
+        check(env.internalFilesetDispatcher().filesetExists(identifier), exceptionToThrowSupplier);
         break;
 
       case TABLE:
         NameIdentifierUtil.checkTable(identifier);
-        check(env.tableDispatcher().tableExists(identifier), exceptionToThrowSupplier);
+        check(env.internalTableDispatcher().tableExists(identifier), exceptionToThrowSupplier);
         break;
 
       case COLUMN:
         NameIdentifierUtil.checkColumn(identifier);
         NameIdentifier tableIdent = NameIdentifier.of(identifier.namespace().levels());
-        check(env.tableDispatcher().tableExists(tableIdent), exceptionToThrowSupplier);
+        check(env.internalTableDispatcher().tableExists(tableIdent), exceptionToThrowSupplier);
         break;
 
       case TOPIC:
         NameIdentifierUtil.checkTopic(identifier);
-        check(env.topicDispatcher().topicExists(identifier), exceptionToThrowSupplier);
+        check(env.internalTopicDispatcher().topicExists(identifier), exceptionToThrowSupplier);
         break;
 
       case MODEL:
         NameIdentifierUtil.checkModel(identifier);
-        check(env.modelDispatcher().modelExists(identifier), exceptionToThrowSupplier);
+        check(env.internalModelDispatcher().modelExists(identifier), exceptionToThrowSupplier);
         break;
 
       case FUNCTION:
         NameIdentifierUtil.checkFunction(identifier);
-        check(env.functionDispatcher().functionExists(identifier), exceptionToThrowSupplier);
+        check(
+            env.internalFunctionDispatcher().functionExists(identifier), exceptionToThrowSupplier);
         break;
 
       case VIEW:
         NameIdentifierUtil.checkView(identifier);
-        check(env.viewDispatcher().viewExists(identifier), exceptionToThrowSupplier);
+        check(env.internalViewDispatcher().viewExists(identifier), exceptionToThrowSupplier);
         break;
 
       case ROLE:
         AuthorizationUtils.checkRole(identifier);
         try {
-          env.accessControlDispatcher().getRole(metalake, object.fullName());
+          env.internalAccessControlDispatcher().getRole(metalake, object.fullName());
         } catch (NoSuchRoleException nsr) {
           throw exceptionToThrowSupplier.get();
         }
@@ -294,7 +296,7 @@ public class MetadataObjectUtil {
       case TAG:
         NameIdentifierUtil.checkTag(identifier);
         try {
-          env.tagDispatcher().getTag(metalake, object.fullName());
+          env.internalTagDispatcher().getTag(metalake, object.fullName());
         } catch (NoSuchTagException nsr) {
           throw exceptionToThrowSupplier.get();
         }
@@ -303,7 +305,7 @@ public class MetadataObjectUtil {
       case POLICY:
         NameIdentifierUtil.checkPolicy(identifier);
         try {
-          env.policyDispatcher().getPolicy(metalake, object.fullName());
+          env.internalPolicyDispatcher().getPolicy(metalake, object.fullName());
         } catch (NoSuchPolicyException nsr) {
           throw checkNotNull(exceptionToThrowSupplier).get();
         }
@@ -312,7 +314,7 @@ public class MetadataObjectUtil {
       case JOB:
         NameIdentifierUtil.checkJob(identifier);
         try {
-          env.jobOperationDispatcher().getJob(metalake, object.fullName());
+          env.internalJobOperationDispatcher().getJob(metalake, object.fullName());
         } catch (NoSuchJobException e) {
           throw exceptionToThrowSupplier.get();
         }
@@ -321,7 +323,7 @@ public class MetadataObjectUtil {
       case JOB_TEMPLATE:
         NameIdentifierUtil.checkJobTemplate(identifier);
         try {
-          env.jobOperationDispatcher().getJobTemplate(metalake, object.fullName());
+          env.internalJobOperationDispatcher().getJobTemplate(metalake, object.fullName());
         } catch (NoSuchJobTemplateException e) {
           throw exceptionToThrowSupplier.get();
         }

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationUtils.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationUtils.java
@@ -249,7 +249,10 @@ class TestAuthorizationUtils {
     FieldUtils.writeField(
         GravitinoEnv.getInstance(), "internalTableDispatcher", tableDispatcher, true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "accessControlDispatcher", accessControlDispatcher, true);
+        GravitinoEnv.getInstance(),
+        "internalAccessControlDispatcher",
+        accessControlDispatcher,
+        true);
 
     List<String> locations =
         AuthorizationUtils.getMetadataObjectLocation(
@@ -279,7 +282,10 @@ class TestAuthorizationUtils {
     Mockito.when(catalogDispatcher.loadCatalog(Mockito.any())).thenReturn(catalog);
 
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "accessControlDispatcher", accessControlDispatcher, true);
+        GravitinoEnv.getInstance(),
+        "internalAccessControlDispatcher",
+        accessControlDispatcher,
+        true);
     FieldUtils.writeField(
         GravitinoEnv.getInstance(), "internalCatalogDispatcher", catalogDispatcher, true);
     FieldUtils.writeField(
@@ -337,7 +343,7 @@ class TestAuthorizationUtils {
 
     GravitinoEnv envMock = Mockito.mock(GravitinoEnv.class);
     Mockito.when(envMock.gravitinoAuthorizer()).thenReturn(authorizer);
-    Mockito.when(envMock.accessControlDispatcher()).thenReturn(accessControlDispatcher);
+    Mockito.when(envMock.internalAccessControlDispatcher()).thenReturn(accessControlDispatcher);
     Mockito.when(envMock.catalogManager()).thenReturn(catalogManager);
 
     try (MockedStatic<GravitinoEnv> envStatic = Mockito.mockStatic(GravitinoEnv.class)) {
@@ -391,7 +397,7 @@ class TestAuthorizationUtils {
     Mockito.when(baseCatalog.getAuthorizationPlugin()).thenReturn(authorizationPlugin);
 
     GravitinoEnv envMock = Mockito.mock(GravitinoEnv.class);
-    Mockito.when(envMock.accessControlDispatcher()).thenReturn(accessControlDispatcher);
+    Mockito.when(envMock.internalAccessControlDispatcher()).thenReturn(accessControlDispatcher);
     Mockito.when(envMock.catalogManager()).thenReturn(catalogManager);
 
     try (MockedStatic<GravitinoEnv> envStatic = Mockito.mockStatic(GravitinoEnv.class)) {
@@ -431,7 +437,7 @@ class TestAuthorizationUtils {
     Mockito.when(baseCatalog.getAuthorizationPlugin()).thenReturn(authorizationPlugin);
 
     GravitinoEnv envMock = Mockito.mock(GravitinoEnv.class);
-    Mockito.when(envMock.accessControlDispatcher()).thenReturn(accessControlDispatcher);
+    Mockito.when(envMock.internalAccessControlDispatcher()).thenReturn(accessControlDispatcher);
     Mockito.when(envMock.catalogManager()).thenReturn(catalogManager);
 
     try (MockedStatic<GravitinoEnv> envStatic = Mockito.mockStatic(GravitinoEnv.class)) {

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationUtils.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationUtils.java
@@ -368,7 +368,7 @@ class TestAuthorizationUtils {
 
     GravitinoEnv envMock = Mockito.mock(GravitinoEnv.class);
     Mockito.when(envMock.gravitinoAuthorizer()).thenReturn(authorizer);
-    Mockito.when(envMock.accessControlDispatcher()).thenReturn(accessControlDispatcher);
+    Mockito.when(envMock.internalAccessControlDispatcher()).thenReturn(accessControlDispatcher);
     Mockito.when(envMock.catalogManager()).thenReturn(catalogManager);
 
     try (MockedStatic<GravitinoEnv> envStatic = Mockito.mockStatic(GravitinoEnv.class)) {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPartitionOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPartitionOperationDispatcher.java
@@ -91,7 +91,7 @@ public class TestPartitionOperationDispatcher extends TestOperationDispatcher {
     doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "schemaDispatcher", schemaOperationDispatcher, true);
+        GravitinoEnv.getInstance(), "internalSchemaDispatcher", schemaOperationDispatcher, true);
 
     NameIdentifier schemaIdent = NameIdentifierUtil.ofSchema(metalake, catalog, SCHEMA);
     schemaOperationDispatcher.createSchema(schemaIdent, "comment", ImmutableMap.of("k1", "v1"));

--- a/core/src/test/java/org/apache/gravitino/hook/TestAccessControlHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestAccessControlHookDispatcher.java
@@ -55,9 +55,10 @@ public class TestAccessControlHookDispatcher {
     mockDispatcher = mock(AccessControlDispatcher.class);
     mockOwnerDispatcher = mock(OwnerDispatcher.class);
     mockAuthorizer = mock(GravitinoAuthorizer.class);
-    savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
     savedAuthorizer = GravitinoEnv.getInstance().gravitinoAuthorizer();
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "gravitinoAuthorizer", mockAuthorizer, true);
     hookDispatcher = new AccessControlHookDispatcher(mockDispatcher);
   }
@@ -65,7 +66,7 @@ public class TestAccessControlHookDispatcher {
   @AfterEach
   public void tearDown() throws IllegalAccessException {
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "gravitinoAuthorizer", savedAuthorizer, true);
   }
 

--- a/core/src/test/java/org/apache/gravitino/hook/TestCatalogHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestCatalogHookDispatcher.java
@@ -38,7 +38,8 @@ public class TestCatalogHookDispatcher {
   @Test
   public void testCreateCatalogThrowsPostHookExceptionWhenRollbackSucceeds() throws Exception {
     GravitinoEnv gravitinoEnv = GravitinoEnv.getInstance();
-    Object originalOwnerDispatcher = FieldUtils.readField(gravitinoEnv, "ownerDispatcher", true);
+    Object originalOwnerDispatcher =
+        FieldUtils.readField(gravitinoEnv, "internalOwnerDispatcher", true);
     Object originalFutureGrantManager =
         FieldUtils.readField(gravitinoEnv, "futureGrantManager", true);
 
@@ -62,7 +63,7 @@ public class TestCatalogHookDispatcher {
                 Mockito.anyMap()))
         .thenReturn(catalog);
 
-    FieldUtils.writeField(gravitinoEnv, "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(gravitinoEnv, "internalOwnerDispatcher", ownerDispatcher, true);
     FieldUtils.writeField(gravitinoEnv, "futureGrantManager", null, true);
 
     try {
@@ -81,7 +82,7 @@ public class TestCatalogHookDispatcher {
 
       Mockito.verify(dispatcher).dropCatalog(ident, true);
     } finally {
-      FieldUtils.writeField(gravitinoEnv, "ownerDispatcher", originalOwnerDispatcher, true);
+      FieldUtils.writeField(gravitinoEnv, "internalOwnerDispatcher", originalOwnerDispatcher, true);
       FieldUtils.writeField(gravitinoEnv, "futureGrantManager", originalFutureGrantManager, true);
     }
   }
@@ -89,7 +90,8 @@ public class TestCatalogHookDispatcher {
   @Test
   public void testCreateCatalogRollbackExceptionDoesNotMaskPostHookException() throws Exception {
     GravitinoEnv gravitinoEnv = GravitinoEnv.getInstance();
-    Object originalOwnerDispatcher = FieldUtils.readField(gravitinoEnv, "ownerDispatcher", true);
+    Object originalOwnerDispatcher =
+        FieldUtils.readField(gravitinoEnv, "internalOwnerDispatcher", true);
     Object originalFutureGrantManager =
         FieldUtils.readField(gravitinoEnv, "futureGrantManager", true);
 
@@ -115,7 +117,7 @@ public class TestCatalogHookDispatcher {
         .thenReturn(catalog);
     Mockito.doThrow(rollbackException).when(dispatcher).dropCatalog(ident, true);
 
-    FieldUtils.writeField(gravitinoEnv, "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(gravitinoEnv, "internalOwnerDispatcher", ownerDispatcher, true);
     FieldUtils.writeField(gravitinoEnv, "futureGrantManager", null, true);
 
     try {
@@ -135,7 +137,7 @@ public class TestCatalogHookDispatcher {
 
       Mockito.verify(dispatcher).dropCatalog(ident, true);
     } finally {
-      FieldUtils.writeField(gravitinoEnv, "ownerDispatcher", originalOwnerDispatcher, true);
+      FieldUtils.writeField(gravitinoEnv, "internalOwnerDispatcher", originalOwnerDispatcher, true);
       FieldUtils.writeField(gravitinoEnv, "futureGrantManager", originalFutureGrantManager, true);
     }
   }

--- a/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
@@ -107,7 +107,7 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
     // Self-contained: use a fresh hook with a directly-mocked FilesetDispatcher and a case-
     // insensitive catalog so we can verify the helper passes a normalized ident to setOwner.
     CatalogManager savedCatalogManager = GravitinoEnv.getInstance().catalogManager();
-    OwnerDispatcher savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
 
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
@@ -122,7 +122,8 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
         .thenReturn(Mockito.mock(Fileset.class));
 
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogManager", mockCatalogManager, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
 
     try {
       FilesetHookDispatcher localHook = new FilesetHookDispatcher(mockFilesetDispatcher);
@@ -151,7 +152,7 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
       FieldUtils.writeField(
           GravitinoEnv.getInstance(), "catalogManager", savedCatalogManager, true);
       FieldUtils.writeField(
-          GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+          GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
     }
   }
 
@@ -159,7 +160,7 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
   public void testCreateFilesetThrowsWhenSetOwnerFails() throws IllegalAccessException {
     // Save the original ownerDispatcher so we can restore it in the finally block instead of
     // wiping it to null and leaking that into other tests in the suite.
-    OwnerDispatcher savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
 
     // Create the schema first with the existing (non-throwing) ownerDispatcher, then swap to the
     // throwing mock only for the fileset create we actually want to exercise. Otherwise the
@@ -172,7 +173,8 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
     Mockito.doThrow(new RuntimeException("Set owner failed"))
         .when(mockOwnerDispatcher)
         .setOwner(any(), any(), any(), any());
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
 
     try {
       NameIdentifier filesetIdent = NameIdentifier.of(filesetNs, "fileset_owner_fail");
@@ -185,7 +187,7 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
       Assertions.assertEquals("Set owner failed", thrown.getMessage());
     } finally {
       FieldUtils.writeField(
-          GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+          GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
     }
   }
 

--- a/core/src/test/java/org/apache/gravitino/hook/TestJobHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestJobHookDispatcher.java
@@ -51,15 +51,16 @@ public class TestJobHookDispatcher {
   public void setUp() throws IllegalAccessException {
     mockDispatcher = mock(JobOperationDispatcher.class);
     mockOwnerDispatcher = mock(OwnerDispatcher.class);
-    savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
     hookDispatcher = new JobHookDispatcher(mockDispatcher);
   }
 
   @AfterEach
   public void tearDown() throws IllegalAccessException {
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/hook/TestMetalakeHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestMetalakeHookDispatcher.java
@@ -55,20 +55,27 @@ public class TestMetalakeHookDispatcher {
     mockDispatcher = mock(MetalakeDispatcher.class);
     mockOwnerDispatcher = mock(OwnerDispatcher.class);
     mockAccessControlDispatcher = mock(AccessControlDispatcher.class);
-    savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
-    savedAccessControlDispatcher = GravitinoEnv.getInstance().accessControlDispatcher();
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
+    savedAccessControlDispatcher = GravitinoEnv.getInstance().internalAccessControlDispatcher();
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "accessControlDispatcher", mockAccessControlDispatcher, true);
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(),
+        "internalAccessControlDispatcher",
+        mockAccessControlDispatcher,
+        true);
     hookDispatcher = new MetalakeHookDispatcher(mockDispatcher);
   }
 
   @AfterEach
   public void tearDown() throws IllegalAccessException {
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "accessControlDispatcher", savedAccessControlDispatcher, true);
+        GravitinoEnv.getInstance(),
+        "internalAccessControlDispatcher",
+        savedAccessControlDispatcher,
+        true);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/hook/TestModelHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestModelHookDispatcher.java
@@ -63,13 +63,14 @@ public class TestModelHookDispatcher {
     mockCatalogWrapper = mock(CatalogManager.CatalogWrapper.class);
     when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockCatalogWrapper);
     when(mockCatalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
-    savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
     // Read the catalogManager field directly via reflection because the public accessor
     // Preconditions-checks for non-null, which would fail when GravitinoEnv has not been
     // initialized for this test class.
     savedCatalogManager =
         (CatalogManager) FieldUtils.readField(GravitinoEnv.getInstance(), "catalogManager", true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogManager", mockCatalogManager, true);
     hookDispatcher = new ModelHookDispatcher(mockDispatcher);
   }
@@ -77,7 +78,7 @@ public class TestModelHookDispatcher {
   @AfterEach
   public void tearDown() throws IllegalAccessException {
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogManager", savedCatalogManager, true);
   }
 

--- a/core/src/test/java/org/apache/gravitino/hook/TestPolicyHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestPolicyHookDispatcher.java
@@ -48,15 +48,16 @@ public class TestPolicyHookDispatcher {
   public void setUp() throws IllegalAccessException {
     mockDispatcher = mock(PolicyDispatcher.class);
     mockOwnerDispatcher = mock(OwnerDispatcher.class);
-    savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
     hookDispatcher = new PolicyHookDispatcher(mockDispatcher);
   }
 
   @AfterEach
   public void tearDown() throws IllegalAccessException {
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/hook/TestSchemaHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestSchemaHookDispatcher.java
@@ -81,7 +81,7 @@ public class TestSchemaHookDispatcher {
     mockCatalogWrapper = mock(CatalogManager.CatalogWrapper.class);
     when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockCatalogWrapper);
     when(mockCatalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
-    savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
     // Tests in this class that rely on the singleton catalogManager always go through
     // GravitinoEnv.getInstance().catalogManager(), but we cannot call the public accessor here
     // because it Preconditions-checks for non-null and would fail when GravitinoEnv has not been
@@ -90,7 +90,8 @@ public class TestSchemaHookDispatcher {
         (CatalogManager) FieldUtils.readField(GravitinoEnv.getInstance(), "catalogManager", true);
     savedLockManager =
         (LockManager) FieldUtils.readField(GravitinoEnv.getInstance(), "lockManager", true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogManager", mockCatalogManager, true);
     // createSchema now acquires a catalog-level tree lock, so wire up a real LockManager.
     FieldUtils.writeField(
@@ -101,7 +102,7 @@ public class TestSchemaHookDispatcher {
   @AfterEach
   public void tearDown() throws IllegalAccessException {
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogManager", savedCatalogManager, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", savedLockManager, true);
   }

--- a/core/src/test/java/org/apache/gravitino/hook/TestTagHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTagHookDispatcher.java
@@ -48,15 +48,16 @@ public class TestTagHookDispatcher {
   public void setUp() throws IllegalAccessException {
     mockDispatcher = mock(TagDispatcher.class);
     mockOwnerDispatcher = mock(OwnerDispatcher.class);
-    savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
     hookDispatcher = new TagHookDispatcher(mockDispatcher);
   }
 
   @AfterEach
   public void tearDown() throws IllegalAccessException {
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
@@ -83,7 +83,7 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
     // Self-contained: use a fresh hook with a directly-mocked TopicDispatcher and a case-
     // insensitive catalog so we can verify the helper passes a normalized ident to setOwner.
     CatalogManager savedCatalogManager = GravitinoEnv.getInstance().catalogManager();
-    OwnerDispatcher savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
 
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
@@ -96,7 +96,8 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
         .thenReturn(Mockito.mock(Topic.class));
 
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogManager", mockCatalogManager, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
 
     try {
       TopicHookDispatcher localHook = new TopicHookDispatcher(mockTopicDispatcher);
@@ -119,7 +120,7 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
       FieldUtils.writeField(
           GravitinoEnv.getInstance(), "catalogManager", savedCatalogManager, true);
       FieldUtils.writeField(
-          GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+          GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
     }
   }
 
@@ -127,7 +128,7 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
   public void testCreateTopicThrowsWhenSetOwnerFails() throws IllegalAccessException {
     // Save the original ownerDispatcher so we can restore it in the finally block instead of
     // wiping it to null and leaking that into other tests in the suite.
-    OwnerDispatcher savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    OwnerDispatcher savedOwnerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
 
     // Create the schema first with the existing (non-throwing) ownerDispatcher, then swap to the
     // throwing mock only for the topic create we actually want to exercise. Otherwise the throwing
@@ -140,7 +141,8 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
     Mockito.doThrow(new RuntimeException("Set owner failed"))
         .when(mockOwnerDispatcher)
         .setOwner(any(), any(), any(), any());
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", mockOwnerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", mockOwnerDispatcher, true);
 
     try {
       NameIdentifier topicIdent = NameIdentifier.of(topicNs, "topic_owner_fail");
@@ -151,7 +153,7 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
       Assertions.assertEquals("Set owner failed", thrown.getMessage());
     } finally {
       FieldUtils.writeField(
-          GravitinoEnv.getInstance(), "ownerDispatcher", savedOwnerDispatcher, true);
+          GravitinoEnv.getInstance(), "internalOwnerDispatcher", savedOwnerDispatcher, true);
     }
   }
 

--- a/core/src/test/java/org/apache/gravitino/policy/TestPolicyManager.java
+++ b/core/src/test/java/org/apache/gravitino/policy/TestPolicyManager.java
@@ -133,13 +133,17 @@ public class TestPolicyManager {
 
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "metalakeDispatcher", metalakeDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", catalogDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "schemaDispatcher", schemaDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "tableDispatcher", tableDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "viewDispatcher", viewDispatcher, true);
+        GravitinoEnv.getInstance(), "internalMetalakeDispatcher", metalakeDispatcher, true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "functionDispatcher", functionDispatcher, true);
+        GravitinoEnv.getInstance(), "internalCatalogDispatcher", catalogDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalSchemaDispatcher", schemaDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalTableDispatcher", tableDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalViewDispatcher", viewDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalFunctionDispatcher", functionDispatcher, true);
 
     AuditInfo audit = AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
     BaseMetalake metalake =

--- a/core/src/test/java/org/apache/gravitino/tag/TestTagManager.java
+++ b/core/src/test/java/org/apache/gravitino/tag/TestTagManager.java
@@ -273,13 +273,17 @@ public class TestTagManager {
     tagManager = new TagManager(idGenerator, entityStore);
 
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "metalakeDispatcher", metalakeDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", catalogDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "schemaDispatcher", schemaDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "tableDispatcher", tableDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "viewDispatcher", viewDispatcher, true);
+        GravitinoEnv.getInstance(), "internalMetalakeDispatcher", metalakeDispatcher, true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "functionDispatcher", functionDispatcher, true);
+        GravitinoEnv.getInstance(), "internalCatalogDispatcher", catalogDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalSchemaDispatcher", schemaDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalTableDispatcher", tableDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalViewDispatcher", viewDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalFunctionDispatcher", functionDispatcher, true);
 
     when(metalakeDispatcher.metalakeExists(any())).thenReturn(true);
     when(catalogDispatcher.catalogExists(any())).thenReturn(true);

--- a/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
+++ b/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
@@ -18,14 +18,35 @@
  */
 package org.apache.gravitino.utils;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
+import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.authorization.AccessControlDispatcher;
+import org.apache.gravitino.catalog.CatalogDispatcher;
+import org.apache.gravitino.catalog.FilesetDispatcher;
+import org.apache.gravitino.catalog.FunctionDispatcher;
+import org.apache.gravitino.catalog.ModelDispatcher;
+import org.apache.gravitino.catalog.SchemaDispatcher;
+import org.apache.gravitino.catalog.TableDispatcher;
+import org.apache.gravitino.catalog.TopicDispatcher;
+import org.apache.gravitino.catalog.ViewDispatcher;
+import org.apache.gravitino.job.JobOperationDispatcher;
+import org.apache.gravitino.metalake.MetalakeDispatcher;
+import org.apache.gravitino.policy.PolicyDispatcher;
+import org.apache.gravitino.tag.TagDispatcher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 public class TestMetadataObjectUtil {
 
@@ -216,6 +237,110 @@ public class TestMetadataObjectUtil {
         List.of(
             "TABLE:catalog.a:b.table", "SCHEMA:catalog.a:b", "SCHEMA:catalog.a", "CATALOG:catalog"),
         describe(MetadataObjectUtil.getParentMetadataObjects(column, ":")));
+  }
+
+  @Test
+  public void testCheckMetadataObjectUsesInternalDispatchers() {
+    GravitinoEnv env = mock(GravitinoEnv.class);
+    MetalakeDispatcher metalakeDispatcher = mock(MetalakeDispatcher.class);
+    CatalogDispatcher catalogDispatcher = mock(CatalogDispatcher.class);
+    SchemaDispatcher schemaDispatcher = mock(SchemaDispatcher.class);
+    FilesetDispatcher filesetDispatcher = mock(FilesetDispatcher.class);
+    TableDispatcher tableDispatcher = mock(TableDispatcher.class);
+    TopicDispatcher topicDispatcher = mock(TopicDispatcher.class);
+    ModelDispatcher modelDispatcher = mock(ModelDispatcher.class);
+    FunctionDispatcher functionDispatcher = mock(FunctionDispatcher.class);
+    ViewDispatcher viewDispatcher = mock(ViewDispatcher.class);
+    AccessControlDispatcher accessControlDispatcher = mock(AccessControlDispatcher.class);
+    TagDispatcher tagDispatcher = mock(TagDispatcher.class);
+    PolicyDispatcher policyDispatcher = mock(PolicyDispatcher.class);
+    JobOperationDispatcher jobDispatcher = mock(JobOperationDispatcher.class);
+
+    when(env.internalMetalakeDispatcher()).thenReturn(metalakeDispatcher);
+    when(env.internalCatalogDispatcher()).thenReturn(catalogDispatcher);
+    when(env.internalSchemaDispatcher()).thenReturn(schemaDispatcher);
+    when(env.internalFilesetDispatcher()).thenReturn(filesetDispatcher);
+    when(env.internalTableDispatcher()).thenReturn(tableDispatcher);
+    when(env.internalTopicDispatcher()).thenReturn(topicDispatcher);
+    when(env.internalModelDispatcher()).thenReturn(modelDispatcher);
+    when(env.internalFunctionDispatcher()).thenReturn(functionDispatcher);
+    when(env.internalViewDispatcher()).thenReturn(viewDispatcher);
+    when(env.internalAccessControlDispatcher()).thenReturn(accessControlDispatcher);
+    when(env.internalTagDispatcher()).thenReturn(tagDispatcher);
+    when(env.internalPolicyDispatcher()).thenReturn(policyDispatcher);
+    when(env.internalJobOperationDispatcher()).thenReturn(jobDispatcher);
+
+    NameIdentifier metalakeIdent = NameIdentifier.of("metalake");
+    NameIdentifier catalogIdent = NameIdentifier.of("metalake", "catalog");
+    NameIdentifier schemaIdent = NameIdentifier.of("metalake", "catalog", "schema");
+    NameIdentifier filesetIdent = NameIdentifier.of("metalake", "catalog", "schema", "fileset");
+    NameIdentifier tableIdent = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    NameIdentifier topicIdent = NameIdentifier.of("metalake", "catalog", "schema", "topic");
+    NameIdentifier modelIdent = NameIdentifier.of("metalake", "catalog", "schema", "model");
+    NameIdentifier functionIdent = NameIdentifier.of("metalake", "catalog", "schema", "function");
+    NameIdentifier viewIdent = NameIdentifier.of("metalake", "catalog", "schema", "view");
+
+    when(metalakeDispatcher.metalakeExists(metalakeIdent)).thenReturn(true);
+    when(catalogDispatcher.catalogExists(catalogIdent)).thenReturn(true);
+    when(schemaDispatcher.schemaExists(schemaIdent)).thenReturn(true);
+    when(filesetDispatcher.filesetExists(filesetIdent)).thenReturn(true);
+    when(tableDispatcher.tableExists(tableIdent)).thenReturn(true);
+    when(topicDispatcher.topicExists(topicIdent)).thenReturn(true);
+    when(modelDispatcher.modelExists(modelIdent)).thenReturn(true);
+    when(functionDispatcher.functionExists(functionIdent)).thenReturn(true);
+    when(viewDispatcher.viewExists(viewIdent)).thenReturn(true);
+
+    try (MockedStatic<GravitinoEnv> mockedEnv = mockStatic(GravitinoEnv.class)) {
+      mockedEnv.when(GravitinoEnv::getInstance).thenReturn(env);
+
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of(null, "metalake", MetadataObject.Type.METALAKE));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of(null, "catalog", MetadataObject.Type.CATALOG));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of("catalog", "schema", MetadataObject.Type.SCHEMA));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of("catalog.schema", "fileset", MetadataObject.Type.FILESET));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of("catalog.schema", "table", MetadataObject.Type.TABLE));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake",
+          MetadataObjects.of("catalog.schema.table", "column", MetadataObject.Type.COLUMN));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of("catalog.schema", "topic", MetadataObject.Type.TOPIC));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of("catalog.schema", "model", MetadataObject.Type.MODEL));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake",
+          MetadataObjects.of("catalog.schema", "function", MetadataObject.Type.FUNCTION));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of("catalog.schema", "view", MetadataObject.Type.VIEW));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of(null, "role", MetadataObject.Type.ROLE));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of(null, "tag", MetadataObject.Type.TAG));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of(null, "policy", MetadataObject.Type.POLICY));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of(null, "job", MetadataObject.Type.JOB));
+      MetadataObjectUtil.checkMetadataObject(
+          "metalake", MetadataObjects.of(null, "template", MetadataObject.Type.JOB_TEMPLATE));
+    }
+
+    verify(metalakeDispatcher).metalakeExists(metalakeIdent);
+    verify(catalogDispatcher).catalogExists(catalogIdent);
+    verify(schemaDispatcher).schemaExists(schemaIdent);
+    verify(filesetDispatcher).filesetExists(filesetIdent);
+    verify(tableDispatcher, times(2)).tableExists(tableIdent);
+    verify(topicDispatcher).topicExists(topicIdent);
+    verify(modelDispatcher).modelExists(modelIdent);
+    verify(functionDispatcher).functionExists(functionIdent);
+    verify(viewDispatcher).viewExists(viewIdent);
+    verify(accessControlDispatcher).getRole("metalake", "role");
+    verify(tagDispatcher).getTag("metalake", "tag");
+    verify(policyDispatcher).getPolicy("metalake", "policy");
+    verify(jobDispatcher).getJob("metalake", "job");
+    verify(jobDispatcher).getJobTemplate("metalake", "template");
   }
 
   private static List<String> describe(List<MetadataObject> objects) {

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataAuthzHelper.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataAuthzHelper.java
@@ -551,7 +551,7 @@ public class MetadataAuthzHelper {
       Entity.EntityType entityType, NameIdentifier[] nameIdentifiers) {
     // If cache is not enabled or access control dispatcher is not set, skip preloading to cache
     if (!GravitinoEnv.getInstance().cacheEnabled()
-        || GravitinoEnv.getInstance().accessControlDispatcher() == null
+        || GravitinoEnv.getInstance().internalAccessControlDispatcher() == null
         || nameIdentifiers.length == 0) {
       return;
     }
@@ -570,7 +570,7 @@ public class MetadataAuthzHelper {
           "All identifiers must have the same schema");
 
       if (!GravitinoEnv.getInstance()
-          .schemaDispatcher()
+          .internalSchemaDispatcher()
           .schemaExists(NameIdentifier.parse(firstNamespace.toString()))) {
         return;
       }

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -400,7 +400,7 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
   @Override
   public boolean isServiceAdmin() {
     return GravitinoEnv.getInstance()
-        .accessControlDispatcher()
+        .internalAccessControlDispatcher()
         .isServiceAdmin(PrincipalUtils.getCurrentUserName());
   }
 

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/TestMetadataAuthzHelper.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/TestMetadataAuthzHelper.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -38,8 +39,10 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.UserPrincipal;
+import org.apache.gravitino.authorization.AccessControlDispatcher;
 import org.apache.gravitino.authorization.GravitinoAuthorizer;
 import org.apache.gravitino.authorization.Privilege;
+import org.apache.gravitino.catalog.SchemaDispatcher;
 import org.apache.gravitino.dto.tag.MetadataObjectDTO;
 import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -56,11 +59,12 @@ import org.mockito.MockedStatic;
 public class TestMetadataAuthzHelper {
 
   private static MockedStatic<GravitinoEnv> mockedStaticGravitinoEnv;
+  private static GravitinoEnv gravitinoEnv;
 
   @BeforeAll
   public static void setup() {
     mockedStaticGravitinoEnv = mockStatic(GravitinoEnv.class);
-    GravitinoEnv gravitinoEnv = mock(GravitinoEnv.class);
+    gravitinoEnv = mock(GravitinoEnv.class);
     mockedStaticGravitinoEnv.when(GravitinoEnv::getInstance).thenReturn(gravitinoEnv);
     Config configMock = mock(Config.class);
     when(gravitinoEnv.config()).thenReturn(configMock);
@@ -108,6 +112,33 @@ public class TestMetadataAuthzHelper {
       Assertions.assertEquals(2, filtered2.length);
       Assertions.assertEquals("testMetalake.testCatalog.testSchema", filtered2[0].toString());
       Assertions.assertEquals("testMetalake.testCatalog.testSchema2", filtered2[1].toString());
+    }
+  }
+
+  @Test
+  public void testPreloadUsesInternalDispatchers() throws Exception {
+    AccessControlDispatcher accessControlDispatcher = mock(AccessControlDispatcher.class);
+    SchemaDispatcher schemaDispatcher = mock(SchemaDispatcher.class);
+    NameIdentifier tableIdentifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    NameIdentifier schemaIdentifier = NameIdentifier.of("metalake", "catalog", "schema");
+
+    when(gravitinoEnv.cacheEnabled()).thenReturn(true);
+    when(gravitinoEnv.internalAccessControlDispatcher()).thenReturn(accessControlDispatcher);
+    when(gravitinoEnv.internalSchemaDispatcher()).thenReturn(schemaDispatcher);
+    when(schemaDispatcher.schemaExists(schemaIdentifier)).thenReturn(false);
+
+    Method preload =
+        MetadataAuthzHelper.class.getDeclaredMethod(
+            "preloadToCache", Entity.EntityType.class, NameIdentifier[].class);
+    preload.setAccessible(true);
+    try {
+      preload.invoke(
+          null, new Object[] {Entity.EntityType.TABLE, new NameIdentifier[] {tableIdentifier}});
+      verify(schemaDispatcher).schemaExists(schemaIdentifier);
+    } finally {
+      when(gravitinoEnv.cacheEnabled()).thenReturn(false);
+      when(gravitinoEnv.internalAccessControlDispatcher()).thenReturn(null);
+      when(gravitinoEnv.internalSchemaDispatcher()).thenReturn(null);
     }
   }
 

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -72,6 +72,7 @@ import org.apache.gravitino.UserGroup;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.auth.ActiveRoles;
 import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.authorization.AccessControlDispatcher;
 import org.apache.gravitino.authorization.AuthorizationRequestContext;
 import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.SecurableObject;
@@ -387,6 +388,17 @@ public class TestJcasbinAuthorizer {
   public void testIsMetalakeUserUsesUserInfoCache() {
     assertTrue(jcasbinAuthorizer.isMetalakeUser(METALAKE, new AuthorizationRequestContext()));
     verify(userMetaMapper).getUserUpdatedAt(METALAKE, USERNAME);
+  }
+
+  @Test
+  public void testIsServiceAdminUsesInternalDispatcher() {
+    AccessControlDispatcher dispatcher = mock(AccessControlDispatcher.class);
+    when(gravitinoEnv.internalAccessControlDispatcher()).thenReturn(dispatcher);
+    when(dispatcher.isServiceAdmin(USERNAME)).thenReturn(true);
+
+    assertTrue(jcasbinAuthorizer.isServiceAdmin());
+
+    verify(dispatcher).isServiceAdmin(USERNAME);
   }
 
   @Test

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/authorization/LoadTableAuthorizationExecutor.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/authorization/LoadTableAuthorizationExecutor.java
@@ -88,7 +88,7 @@ public class LoadTableAuthorizationExecutor extends CommonAuthorizerExecutor {
 
     NameIdentifier tableIdentifier = metadataContext.get(Entity.EntityType.TABLE);
     return tableIdentifier != null
-        && !GravitinoEnv.getInstance().tableDispatcher().tableExists(tableIdentifier);
+        && !GravitinoEnv.getInstance().internalTableDispatcher().tableExists(tableIdentifier);
   }
 
   private static boolean shouldCheckModifyTablePrivilege(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/BulkOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/BulkOperations.java
@@ -81,7 +81,7 @@ public class BulkOperations {
   public BulkOperations() {
     this.bulkManager = GravitinoEnv.getInstance().bulkManager();
     this.accessControlDispatcher = GravitinoEnv.getInstance().accessControlDispatcher();
-    this.ownerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    this.ownerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
   }
 
   /**

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
@@ -76,7 +76,7 @@ public class GroupOperations {
     // and Jersey injection doesn't support null value. So GroupOperations chooses to retrieve
     // accessControlManager from GravitinoEnv instead of injection here.
     this.accessControlManager = GravitinoEnv.getInstance().accessControlDispatcher();
-    this.ownerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
+    this.ownerDispatcher = GravitinoEnv.getInstance().internalOwnerDispatcher();
   }
 
   @GET

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
@@ -75,7 +75,7 @@ public class UserOperations {
     // and Jersey injection doesn't support null value. So UserOperations chooses to retrieve
     // accessControlManager from GravitinoEnv instead of injection here.
     this.accessControlManager = GravitinoEnv.getInstance().accessControlDispatcher();
-    this.ownerManager = GravitinoEnv.getInstance().ownerDispatcher();
+    this.ownerManager = GravitinoEnv.getInstance().internalOwnerDispatcher();
   }
 
   @GET

--- a/server/src/test/java/org/apache/gravitino/server/web/filter/TestGravitinoInterceptionService.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/filter/TestGravitinoInterceptionService.java
@@ -641,7 +641,7 @@ public class TestGravitinoInterceptionService {
       TableDispatcher tableDispatcher = mock(TableDispatcher.class);
       EventBus mockEventBus = mock(EventBus.class);
       envMocked.when(GravitinoEnv::getInstance).thenReturn(mockEnv);
-      when(mockEnv.tableDispatcher()).thenReturn(tableDispatcher);
+      when(mockEnv.internalTableDispatcher()).thenReturn(tableDispatcher);
       when(mockEnv.eventBus()).thenReturn(mockEventBus);
       when(tableDispatcher.tableExists(ArgumentMatchers.any())).thenReturn(false);
 
@@ -688,7 +688,7 @@ public class TestGravitinoInterceptionService {
       TableDispatcher tableDispatcher = mock(TableDispatcher.class);
       EventBus mockEventBus = spy(new EventBus(Collections.emptyList()));
       envMocked.when(GravitinoEnv::getInstance).thenReturn(mockEnv);
-      when(mockEnv.tableDispatcher()).thenReturn(tableDispatcher);
+      when(mockEnv.internalTableDispatcher()).thenReturn(tableDispatcher);
       when(mockEnv.eventBus()).thenReturn(mockEventBus);
       when(tableDispatcher.tableExists(ArgumentMatchers.any())).thenReturn(true);
 

--- a/server/src/test/java/org/apache/gravitino/server/web/filter/authorization/TestLoadTableAuthorizationExecutor.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/filter/authorization/TestLoadTableAuthorizationExecutor.java
@@ -20,17 +20,31 @@
 package org.apache.gravitino.server.web.filter.authorization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Entity;
+import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.authorization.AuthorizationRequestContext;
+import org.apache.gravitino.catalog.TableDispatcher;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationRequest;
 import org.apache.gravitino.server.authorization.annotations.ExpressionCondition;
 import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionEvaluator;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 public class TestLoadTableAuthorizationExecutor {
   private static final String PRIMARY_EXPRESSION =
@@ -61,6 +75,48 @@ public class TestLoadTableAuthorizationExecutor {
         createExecutor("SELECT_TABLE", ExpressionCondition.REQUIRED_MODIFY_PRIVILEGES);
 
     assertEquals(PRIMARY_EXPRESSION, expression(executor));
+  }
+
+  @Test
+  public void testExistenceProbeUsesInternalTableDispatcher() throws Exception {
+    Method method = TestOperations.class.getMethod("loadTable", String.class);
+    NameIdentifier tableIdentifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    LoadTableAuthorizationExecutor executor =
+        new LoadTableAuthorizationExecutor(
+            method.getParameters(),
+            new Object[] {"SELECT_TABLE"},
+            PRIMARY_EXPRESSION,
+            Map.of(Entity.EntityType.TABLE, tableIdentifier),
+            Collections.emptyMap(),
+            Optional.empty(),
+            SECONDARY_EXPRESSION,
+            ExpressionCondition.NEVER,
+            AuthorizationExpressionConstants.PROBE_TABLE_LIKE_AUTHORIZATION_EXPRESSION);
+
+    AuthorizationExpressionEvaluator primaryEvaluator =
+        mock(AuthorizationExpressionEvaluator.class);
+    AuthorizationExpressionEvaluator existenceEvaluator =
+        mock(AuthorizationExpressionEvaluator.class);
+    when(primaryEvaluator.evaluate(
+            anyMap(), anyMap(), any(AuthorizationRequestContext.class), any()))
+        .thenReturn(false);
+    when(existenceEvaluator.evaluate(
+            anyMap(), anyMap(), any(AuthorizationRequestContext.class), any()))
+        .thenReturn(true);
+    executor.authorizationExpressionEvaluator = primaryEvaluator;
+    FieldUtils.writeField(executor, "allowCheckExistenceEvaluator", existenceEvaluator, true);
+
+    GravitinoEnv env = mock(GravitinoEnv.class);
+    TableDispatcher internalTableDispatcher = mock(TableDispatcher.class);
+    when(env.internalTableDispatcher()).thenReturn(internalTableDispatcher);
+    when(internalTableDispatcher.tableExists(tableIdentifier)).thenReturn(false);
+
+    try (MockedStatic<GravitinoEnv> mockedEnv = mockStatic(GravitinoEnv.class)) {
+      mockedEnv.when(GravitinoEnv::getInstance).thenReturn(env);
+      assertTrue(executor.execute(new AuthorizationRequestContext()));
+    }
+
+    verify(internalTableDispatcher).tableExists(tableIdentifier);
   }
 
   private static LoadTableAuthorizationExecutor createExecutor(

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestBulkOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestBulkOperations.java
@@ -120,7 +120,8 @@ public class TestBulkOperations extends BaseOperationsTest {
     FieldUtils.writeField(GravitinoEnv.getInstance(), "config", config, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "accessControlDispatcher", manager, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", ownerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "bulkManager", new BulkManager(config), true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "entityStore", entityStore, true);
     bulkOperations = new BulkOperations();

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestGroupOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestGroupOperations.java
@@ -96,7 +96,8 @@ public class TestGroupOperations extends BaseOperationsTest {
     Mockito.doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "accessControlDispatcher", manager, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", ownerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "entityStore", entityStore, true);
   }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestOwnerOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestOwnerOperations.java
@@ -94,7 +94,12 @@ class TestOwnerOperations extends BaseOperationsTest {
     FieldUtils.writeField(
         GravitinoEnv.getInstance(), "metalakeDispatcher", metalakeDispatcher, true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "accessControlDispatcher", accessControlDispatcher, true);
+        GravitinoEnv.getInstance(), "internalMetalakeDispatcher", metalakeDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(),
+        "internalAccessControlDispatcher",
+        accessControlDispatcher,
+        true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "entityStore", entityStore, true);
   }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestPermissionOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestPermissionOperations.java
@@ -111,7 +111,10 @@ public class TestPermissionOperations extends BaseOperationsTest {
     FieldUtils.writeField(GravitinoEnv.getInstance(), "accessControlDispatcher", manager, true);
     FieldUtils.writeField(
         GravitinoEnv.getInstance(), "metalakeDispatcher", metalakeDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "tableDispatcher", tableDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalMetalakeDispatcher", metalakeDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalTableDispatcher", tableDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "entityStore", entityStore, true);
   }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestRoleOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestRoleOperations.java
@@ -117,12 +117,19 @@ public class TestRoleOperations extends BaseOperationsTest {
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "accessControlDispatcher", manager, true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "metalakeDispatcher", metalakeDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", catalogDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "schemaDispatcher", schemaDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "tableDispatcher", tableDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "topicDispatcher", topicDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "filesetDispatcher", filesetDispatcher, true);
+        GravitinoEnv.getInstance(), "internalAccessControlDispatcher", manager, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalMetalakeDispatcher", metalakeDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalCatalogDispatcher", catalogDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalSchemaDispatcher", schemaDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalTableDispatcher", tableDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalTopicDispatcher", topicDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalFilesetDispatcher", filesetDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "entityStore", entityStore, true);
   }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestStatisticOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestStatisticOperations.java
@@ -109,7 +109,8 @@ public class TestStatisticOperations extends BaseOperationsTest {
     Mockito.doReturn(1000L).when(config).get(TREE_LOCK_MIN_NODE_IN_MEMORY);
     Mockito.doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "tableDispatcher", tableDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalTableDispatcher", tableDispatcher, true);
   }
 
   @Override

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestUserOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestUserOperations.java
@@ -92,7 +92,8 @@ public class TestUserOperations extends BaseOperationsTest {
     Mockito.doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "accessControlDispatcher", manager, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalOwnerDispatcher", ownerDispatcher, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "entityStore", entityStore, true);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Use internal owner and access-control dispatchers for automatic ownership and metalake creator setup.
- Add internal metalake, model, function, tag, policy, and job dispatchers.
- Route metadata-object validation through internal dispatchers for every supported object type.
- Use the internal schema dispatcher for dependent table and view schema loading.
- Use internal dispatchers for authorization preloads, existence probes, service-admin checks, and user/group deletion owner checks.
- Keep explicit REST operations and other user-facing entry points on public event dispatchers.

### Why are the changes needed?

Internal helper operations currently pass through public event dispatchers and generate audit entries that do not represent independent user actions. Examples include `SET_OWNER` after `CREATE_CATALOG`, `LOAD_SCHEMA` during table/view operations, and `GET_ROLE`, `GET_TAG`, `GET_POLICY`, or `GET_JOB` during metadata-object validation.

Routing these nested operations through internal dispatchers preserves normalization, validation, ownership, and authorization behavior while avoiding misleading audit events.

Fix: #12892

### Does this PR introduce _any_ user-facing change?

Yes. Nested infrastructure operations no longer produce separate audit log entries. Explicit user-facing operations continue to be audited normally.

### How was this patch tested?

- Added a regression test covering internal metadata validation for every supported metadata-object type.
- Added focused tests for internal table existence probes, authorization cache preloading, and service-admin checks.
- Updated hook, table/view/partition, authorization, owner, role, user, group, and bulk operation tests for internal dispatcher routing.
- Ran focused `core`, `server-common`, and `server` test suites.
- Ran Spotless for all affected modules.