### PR TITLE
[#12407] fix(lance): Hydrate empty schema before table alteration

### DIFF
--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -114,31 +114,23 @@ public class LanceTableOperations extends ManagedTableOperations {
    * </ul>
    *
    * <p><b>Zero-column Lance dataset:</b> when the dataset has no columns, Gravitino records the
-   * checked dataset version ({@code lance.version}) plus a confirmation marker ({@code
-   * lance.empty-schema-checked-version}) without modifying stored columns. Subsequent {@code
-   * loadTable} calls skip the dataset open while both still agree, so a genuinely empty dataset
-   * costs one dataset read, not one per load.
-   *
-   * <p>The marker exists because {@code lance.version} alone cannot carry that meaning: {@code
-   * alterTable} records the version after every dataset change without reading the schema, so a
-   * table registered with no columns can hold a version whose column metadata was never captured.
-   * Such a table has no marker, is re-examined, and repairs itself. Any path that records a newer
-   * version invalidates the marker automatically.
+   * checked dataset version ({@code lance.version}) without modifying stored columns. Subsequent
+   * {@code loadTable} calls skip the dataset open because the stored version acts as a "confirmed
+   * empty" marker. The dataset is re-examined only after the stored version changes (for example
+   * via an explicit {@code alterTable}) or when the mode is switched to {@link #VERSION_CHECK}.
    */
   public enum SchemaRefreshMode {
     /**
      * Default mode. Refreshes stored columns from the Lance dataset for declared tables ({@code
-     * lance.declared=true}) and for tables whose Gravitino column list is empty and has not been
-     * confirmed empty against the dataset. Also repairs empty-column tables that were registered
-     * before their schema was captured.
+     * lance.declared=true}) and for tables whose Gravitino column list is empty. Also repairs
+     * empty-column tables that were registered before their schema was captured.
      */
     DECLARED_AND_EMPTY,
     /**
      * Opens the Lance dataset on every {@code loadTable}, compares the dataset version with the
      * stored {@code lance.version}, and refreshes columns when the version has changed. The version
-     * gates refreshes only for metadata that is complete on its own terms: a declared table, or an
-     * empty column list that was never confirmed against the dataset, is refreshed whatever the
-     * version says.
+     * is the sole gating factor: if the version is unchanged the schema read is skipped even when
+     * stored columns are empty.
      */
     VERSION_CHECK
   }
@@ -185,58 +177,7 @@ public class LanceTableOperations extends ManagedTableOperations {
 
   @Override
   public Table loadTable(NameIdentifier ident) throws NoSuchTableException {
-    Table table = super.loadTable(ident);
-    // Spark staged create can write the actual schema only to the Lance dataset path. Refresh
-    // Gravitino metadata when the stored table is declared-only, empty, or configured to track
-    // Lance dataset versions.
-    boolean declaredOnly = isDeclaredOnly(table);
-    SchemaRefreshMode refreshMode = schemaRefreshMode();
-    // Whether the stored metadata is incomplete on its own terms, independent of the dataset
-    // version. Both modes share this: DECLARED_AND_EMPTY reads the dataset only when it is true,
-    // VERSION_CHECK additionally reads whenever the dataset version moved.
-    boolean datasetReadNeeded = isDatasetReadNeeded(table);
-    if (!datasetReadNeeded && refreshMode == SchemaRefreshMode.DECLARED_AND_EMPTY) {
-      return table;
-    }
-    String location = table.properties().get(Table.PROPERTY_LOCATION);
-    if (StringUtils.isBlank(location)) {
-      return table;
-    }
-
-    Map<String, String> storageOptions =
-        LancePropertiesUtils.resolveLanceStorageOptions(catalogProperties, table.properties());
-    Column[] columns;
-    long datasetVersion;
-    try (Dataset dataset = openDataset(location, storageOptions)) {
-      datasetVersion = dataset.version();
-      if (refreshMode == SchemaRefreshMode.VERSION_CHECK
-          && !datasetReadNeeded
-          && !isDatasetVersionChanged(table, datasetVersion)) {
-        return table;
-      }
-      columns = extractColumns(dataset.getSchema());
-    } catch (Exception e) {
-      LOG.debug(
-          "Failed to load Lance schema from location {} for table {}. Return stored metadata.",
-          location,
-          ident,
-          e);
-      return table;
-    }
-
-    if (columns.length == 0) {
-      // Confirm the emptiness against the dataset so later loads can trust the empty column list.
-      // Skipped once the table already carries that confirmation for this very version, which is
-      // what stops a genuinely empty dataset from being rewritten on every load. Declared tables
-      // are excluded because their lance.declared flag is the authoritative "not yet written"
-      // signal.
-      if (!declaredOnly && isEmptyConfirmationNeeded(table.properties(), datasetVersion)) {
-        return recordCheckedEmptyVersion(ident, datasetVersion);
-      }
-      return table;
-    }
-
-    return repairTableMetadata(ident, columns, datasetVersion);
+    return loadTableInternal(ident, false);
   }
 
   @Override
@@ -304,7 +245,21 @@ public class LanceTableOperations extends ManagedTableOperations {
   public Table alterTable(NameIdentifier ident, TableChange... changes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
 
-    Table loadedTable = super.loadTable(ident);
+    // Hydrate an empty stored schema before changing the dataset. Otherwise this method can write
+    // the latest lance.version while leaving columns empty, making that incomplete metadata look
+    // like a zero-column schema already confirmed at the same version.
+    Table loadedTable = loadTableInternal(ident, true);
+    boolean unhydratedSchema =
+        isDeclaredOnly(loadedTable)
+            || (loadedTable.columns().length == 0
+                && StringUtils.isBlank(
+                    loadedTable.properties().get(LanceConstants.LANCE_TABLE_VERSION)));
+    if (unhydratedSchema) {
+      throw new IllegalStateException(
+          "Cannot alter Lance table "
+              + ident
+              + " because its dataset schema is not initialized or could not be loaded");
+    }
     long version = handleLanceTableChange(loadedTable, changes);
     // After making changes to the Lance dataset, we need to update the table metadata in
     // Gravitino. If there's any failure during this process, the code will throw an exception
@@ -493,6 +448,72 @@ public class LanceTableOperations extends ManagedTableOperations {
     return new Schema(fields);
   }
 
+  private Table loadTableInternal(NameIdentifier ident, boolean forAlter) {
+    Table table = super.loadTable(ident);
+    // Spark staged create can write the actual schema only to the Lance dataset path. Refresh
+    // Gravitino metadata when the stored table is declared-only, empty, or configured to track
+    // Lance dataset versions.
+    boolean declaredOnly = isDeclaredOnly(table);
+    boolean emptySchema = table.columns().length == 0;
+    SchemaRefreshMode refreshMode = schemaRefreshMode();
+    if (!declaredOnly && !emptySchema && refreshMode == SchemaRefreshMode.DECLARED_AND_EMPTY) {
+      return table;
+    }
+    // Empty-schema table that was already confirmed against a stored version: skip the dataset
+    // open during ordinary loads. An alter must recheck it so an externally initialized schema is
+    // hydrated before the latest dataset version is persisted.
+    if (!forAlter
+        && !declaredOnly
+        && emptySchema
+        && StringUtils.isNotBlank(table.properties().get(LanceConstants.LANCE_TABLE_VERSION))
+        && refreshMode == SchemaRefreshMode.DECLARED_AND_EMPTY) {
+      return table;
+    }
+
+    String location = table.properties().get(Table.PROPERTY_LOCATION);
+    if (StringUtils.isBlank(location)) {
+      return table;
+    }
+
+    Map<String, String> storageOptions =
+        LancePropertiesUtils.resolveLanceStorageOptions(catalogProperties, table.properties());
+    Column[] columns;
+    long datasetVersion;
+    try (Dataset dataset = openDataset(location, storageOptions)) {
+      datasetVersion = dataset.version();
+      if (refreshMode == SchemaRefreshMode.VERSION_CHECK
+          && !declaredOnly
+          && !(forAlter && emptySchema)
+          && !isDatasetVersionChanged(table, datasetVersion)) {
+        return table;
+      }
+      columns = extractColumns(dataset.getSchema());
+    } catch (Exception e) {
+      if (forAlter) {
+        throw new IllegalStateException(
+            "Failed to load Lance schema before altering table " + ident, e);
+      }
+      LOG.debug(
+          "Failed to load Lance schema from location {} for table {}. Return stored metadata.",
+          location,
+          ident,
+          e);
+      return table;
+    }
+
+    if (columns.length == 0) {
+      // Dataset is genuinely empty: record the checked version so future DECLARED_AND_EMPTY loads
+      // can skip the dataset open (see the early-return above). Declared tables are excluded
+      // because their lance.declared flag is the authoritative "not yet written" signal.
+      if (!declaredOnly) {
+        return recordCheckedEmptyVersion(ident, datasetVersion);
+      }
+      return table;
+    }
+
+    return repairTableMetadata(ident, columns, datasetVersion);
+  }
+
   private SchemaRefreshMode schemaRefreshMode() {
     return Optional.ofNullable(catalogProperties.get(LanceConstants.LANCE_SCHEMA_REFRESH_MODE))
         .map(mode -> mode.trim().replace('-', '_').toUpperCase())
@@ -508,78 +529,6 @@ public class LanceTableOperations extends ManagedTableOperations {
     return Optional.ofNullable(properties.get(LanceConstants.LANCE_TABLE_DECLARED))
         .map(Boolean::parseBoolean)
         .orElse(false);
-  }
-
-  /**
-   * Returns whether the Lance dataset has to be read to complete this table's stored metadata,
-   * regardless of the dataset version.
-   *
-   * <p>Three cases, in order:
-   *
-   * <ul>
-   *   <li>a declared table always needs the read: {@code lance.declared} is the authoritative "the
-   *       schema was never written to Gravitino" signal;
-   *   <li>a table that already stores columns does not;
-   *   <li>a table with no stored columns needs the read unless that emptiness was confirmed against
-   *       the dataset itself, see {@link #isEmptySchemaConfirmed}.
-   * </ul>
-   *
-   * @param table the stored table
-   * @return true if the dataset schema must be read
-   */
-  private boolean isDatasetReadNeeded(Table table) {
-    if (isDeclaredOnly(table)) {
-      return true;
-    }
-    if (table.columns().length > 0) {
-      return false;
-    }
-    return !isEmptySchemaConfirmed(table.properties());
-  }
-
-  /**
-   * Returns whether an empty stored column list was confirmed by actually reading the dataset
-   * schema at the version the table still records.
-   *
-   * <p>{@code lance.version} alone does not prove it. {@link #alterTable} records that property
-   * after every dataset change without reading the schema, so a table registered with no columns
-   * ends up carrying a version while its column metadata was never captured. Treating that as
-   * "confirmed empty" is what used to leave such a table stuck with no columns forever.
-   *
-   * <p>{@code lance.empty-schema-checked-version} is written only by {@link
-   * #recordCheckedEmptyVersion}, immediately after a schema read returned no columns, and it
-   * carries the version it was observed at. Any later version recorded by another path therefore
-   * invalidates it on its own, with no need for those paths to know about this marker.
-   *
-   * @param properties the stored table properties
-   * @return true if the stored empty column list reflects a real schema read
-   */
-  private boolean isEmptySchemaConfirmed(Map<String, String> properties) {
-    String checkedVersion = properties.get(LanceConstants.LANCE_EMPTY_SCHEMA_CHECKED_VERSION);
-    String currentVersion = properties.get(LanceConstants.LANCE_TABLE_VERSION);
-    if (StringUtils.isBlank(checkedVersion) || StringUtils.isBlank(currentVersion)) {
-      return false;
-    }
-
-    try {
-      return Long.parseLong(checkedVersion) == Long.parseLong(currentVersion);
-    } catch (NumberFormatException e) {
-      // Version metadata we cannot read confirms nothing, the same way isDatasetVersionChanged
-      // treats it as changed. Re-reading the dataset is the safe answer.
-      return false;
-    }
-  }
-
-  /**
-   * Returns whether the confirmed-empty marker has to be written for the given dataset version.
-   *
-   * @param properties the stored table properties
-   * @param datasetVersion the version the dataset was just read at
-   * @return true if the stored metadata does not already record this confirmation
-   */
-  private boolean isEmptyConfirmationNeeded(Map<String, String> properties, long datasetVersion) {
-    return isDatasetVersionChanged(properties, datasetVersion)
-        || !isEmptySchemaConfirmed(properties);
   }
 
   private boolean isDatasetVersionChanged(Table table, long datasetVersion) {
@@ -697,19 +646,12 @@ public class LanceTableOperations extends ManagedTableOperations {
           updateTableWithCasRetry(
               ident,
               current -> {
-                // Re-checked under the CAS: another writer may have recorded the same
-                // confirmation between the load and this update.
-                if (!isEmptyConfirmationNeeded(current.properties(), datasetVersion)) {
+                if (!isDatasetVersionChanged(current.properties(), datasetVersion)) {
                   return current;
                 }
                 Map<String, String> updatedProperties = new HashMap<>(current.properties());
                 updatedProperties.put(
                     LanceConstants.LANCE_TABLE_VERSION, String.valueOf(datasetVersion));
-                // Mark the empty column list as confirmed against the dataset at this version, so
-                // later loads can trust it instead of re-opening the dataset every time.
-                updatedProperties.put(
-                    LanceConstants.LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
-                    String.valueOf(datasetVersion));
                 // Always use an empty column list: the dataset is confirmed empty at this version.
                 // Using current.columns() would preserve stale columns when the dataset schema was
                 // cleared externally, causing future VERSION_CHECK loads to return stale metadata
@@ -755,8 +697,6 @@ public class LanceTableOperations extends ManagedTableOperations {
     Map<String, String> updatedProperties = new HashMap<>(tableEntity.properties());
     updatedProperties.put(LanceConstants.LANCE_TABLE_VERSION, String.valueOf(datasetVersion));
     updatedProperties.remove(LanceConstants.LANCE_TABLE_DECLARED);
-    // The dataset has columns, so any earlier "confirmed empty" marker is stale.
-    updatedProperties.remove(LanceConstants.LANCE_EMPTY_SCHEMA_CHECKED_VERSION);
 
     AuditInfo columnAuditInfo =
         AuditInfo.builder()

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -115,9 +115,9 @@ public class LanceTableOperations extends ManagedTableOperations {
    *
    * <p><b>Zero-column Lance dataset:</b> when the dataset has no columns, Gravitino records the
    * checked dataset version ({@code lance.version}) without modifying stored columns. Subsequent
-   * {@code loadTable} calls skip the dataset open because the stored version acts as a "confirmed
-   * empty" marker. The dataset is re-examined only after the stored version changes (for example
-   * via an explicit {@code alterTable}) or when the mode is switched to {@link #VERSION_CHECK}.
+   * {@code loadTable} calls re-examine the dataset because the stored version alone cannot
+   * distinguish a genuinely empty dataset from incomplete Gravitino column metadata. An unchanged
+   * empty dataset does not trigger another metadata update.
    */
   public enum SchemaRefreshMode {
     /**
@@ -129,8 +129,8 @@ public class LanceTableOperations extends ManagedTableOperations {
     /**
      * Opens the Lance dataset on every {@code loadTable}, compares the dataset version with the
      * stored {@code lance.version}, and refreshes columns when the version has changed. The version
-     * is the sole gating factor: if the version is unchanged the schema read is skipped even when
-     * stored columns are empty.
+     * gates refreshes when stored columns are present. Empty stored columns are always re-examined
+     * because the version alone does not prove that the empty metadata is complete.
      */
     VERSION_CHECK
   }
@@ -187,17 +187,6 @@ public class LanceTableOperations extends ManagedTableOperations {
     if (!declaredOnly && !emptySchema && refreshMode == SchemaRefreshMode.DECLARED_AND_EMPTY) {
       return table;
     }
-    // Empty-schema table that was already confirmed against a stored version: skip the dataset
-    // open. The stored lance.version acts as a "checked at this version" marker written on the
-    // first confirmation. VERSION_CHECK mode does not take this shortcut — it opens the dataset
-    // every time to compare the current version.
-    if (!declaredOnly
-        && emptySchema
-        && StringUtils.isNotBlank(table.properties().get(LanceConstants.LANCE_TABLE_VERSION))
-        && refreshMode == SchemaRefreshMode.DECLARED_AND_EMPTY) {
-      return table;
-    }
-
     String location = table.properties().get(Table.PROPERTY_LOCATION);
     if (StringUtils.isBlank(location)) {
       return table;
@@ -211,6 +200,7 @@ public class LanceTableOperations extends ManagedTableOperations {
       datasetVersion = dataset.version();
       if (refreshMode == SchemaRefreshMode.VERSION_CHECK
           && !declaredOnly
+          && !emptySchema
           && !isDatasetVersionChanged(table, datasetVersion)) {
         return table;
       }
@@ -225,10 +215,10 @@ public class LanceTableOperations extends ManagedTableOperations {
     }
 
     if (columns.length == 0) {
-      // Dataset is genuinely empty: record the checked version so future DECLARED_AND_EMPTY loads
-      // can skip the dataset open (see the early-return above). Declared tables are excluded
-      // because their lance.declared flag is the authoritative "not yet written" signal.
-      if (!declaredOnly) {
+      // Record a newly checked empty version, but avoid a no-op metadata update when the same empty
+      // dataset is loaded again. Declared tables are excluded because their lance.declared flag is
+      // the authoritative "not yet written" signal.
+      if (!declaredOnly && isDatasetVersionChanged(table, datasetVersion)) {
         return recordCheckedEmptyVersion(ident, datasetVersion);
       }
       return table;

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -114,23 +114,31 @@ public class LanceTableOperations extends ManagedTableOperations {
    * </ul>
    *
    * <p><b>Zero-column Lance dataset:</b> when the dataset has no columns, Gravitino records the
-   * checked dataset version ({@code lance.version}) without modifying stored columns. Subsequent
-   * {@code loadTable} calls re-examine the dataset because the stored version alone cannot
-   * distinguish a genuinely empty dataset from incomplete Gravitino column metadata. An unchanged
-   * empty dataset does not trigger another metadata update.
+   * checked dataset version ({@code lance.version}) plus a confirmation marker ({@code
+   * lance.empty-schema-checked-version}) without modifying stored columns. Subsequent {@code
+   * loadTable} calls skip the dataset open while both still agree, so a genuinely empty dataset
+   * costs one dataset read, not one per load.
+   *
+   * <p>The marker exists because {@code lance.version} alone cannot carry that meaning: {@code
+   * alterTable} records the version after every dataset change without reading the schema, so a
+   * table registered with no columns can hold a version whose column metadata was never captured.
+   * Such a table has no marker, is re-examined, and repairs itself. Any path that records a newer
+   * version invalidates the marker automatically.
    */
   public enum SchemaRefreshMode {
     /**
      * Default mode. Refreshes stored columns from the Lance dataset for declared tables ({@code
-     * lance.declared=true}) and for tables whose Gravitino column list is empty. Also repairs
-     * empty-column tables that were registered before their schema was captured.
+     * lance.declared=true}) and for tables whose Gravitino column list is empty and has not been
+     * confirmed empty against the dataset. Also repairs empty-column tables that were registered
+     * before their schema was captured.
      */
     DECLARED_AND_EMPTY,
     /**
      * Opens the Lance dataset on every {@code loadTable}, compares the dataset version with the
      * stored {@code lance.version}, and refreshes columns when the version has changed. The version
-     * gates refreshes when stored columns are present. Empty stored columns are always re-examined
-     * because the version alone does not prove that the empty metadata is complete.
+     * gates refreshes only for metadata that is complete on its own terms: a declared table, or an
+     * empty column list that was never confirmed against the dataset, is refreshed whatever the
+     * version says.
      */
     VERSION_CHECK
   }
@@ -182,9 +190,12 @@ public class LanceTableOperations extends ManagedTableOperations {
     // Gravitino metadata when the stored table is declared-only, empty, or configured to track
     // Lance dataset versions.
     boolean declaredOnly = isDeclaredOnly(table);
-    boolean emptySchema = table.columns().length == 0;
     SchemaRefreshMode refreshMode = schemaRefreshMode();
-    if (!declaredOnly && !emptySchema && refreshMode == SchemaRefreshMode.DECLARED_AND_EMPTY) {
+    // Whether the stored metadata is incomplete on its own terms, independent of the dataset
+    // version. Both modes share this: DECLARED_AND_EMPTY reads the dataset only when it is true,
+    // VERSION_CHECK additionally reads whenever the dataset version moved.
+    boolean datasetReadNeeded = isDatasetReadNeeded(table);
+    if (!datasetReadNeeded && refreshMode == SchemaRefreshMode.DECLARED_AND_EMPTY) {
       return table;
     }
     String location = table.properties().get(Table.PROPERTY_LOCATION);
@@ -199,8 +210,7 @@ public class LanceTableOperations extends ManagedTableOperations {
     try (Dataset dataset = openDataset(location, storageOptions)) {
       datasetVersion = dataset.version();
       if (refreshMode == SchemaRefreshMode.VERSION_CHECK
-          && !declaredOnly
-          && !emptySchema
+          && !datasetReadNeeded
           && !isDatasetVersionChanged(table, datasetVersion)) {
         return table;
       }
@@ -215,10 +225,12 @@ public class LanceTableOperations extends ManagedTableOperations {
     }
 
     if (columns.length == 0) {
-      // Record a newly checked empty version, but avoid a no-op metadata update when the same empty
-      // dataset is loaded again. Declared tables are excluded because their lance.declared flag is
-      // the authoritative "not yet written" signal.
-      if (!declaredOnly && isDatasetVersionChanged(table, datasetVersion)) {
+      // Confirm the emptiness against the dataset so later loads can trust the empty column list.
+      // Skipped once the table already carries that confirmation for this very version, which is
+      // what stops a genuinely empty dataset from being rewritten on every load. Declared tables
+      // are excluded because their lance.declared flag is the authoritative "not yet written"
+      // signal.
+      if (!declaredOnly && isEmptyConfirmationNeeded(table.properties(), datasetVersion)) {
         return recordCheckedEmptyVersion(ident, datasetVersion);
       }
       return table;
@@ -498,6 +510,78 @@ public class LanceTableOperations extends ManagedTableOperations {
         .orElse(false);
   }
 
+  /**
+   * Returns whether the Lance dataset has to be read to complete this table's stored metadata,
+   * regardless of the dataset version.
+   *
+   * <p>Three cases, in order:
+   *
+   * <ul>
+   *   <li>a declared table always needs the read: {@code lance.declared} is the authoritative "the
+   *       schema was never written to Gravitino" signal;
+   *   <li>a table that already stores columns does not;
+   *   <li>a table with no stored columns needs the read unless that emptiness was confirmed against
+   *       the dataset itself, see {@link #isEmptySchemaConfirmed}.
+   * </ul>
+   *
+   * @param table the stored table
+   * @return true if the dataset schema must be read
+   */
+  private boolean isDatasetReadNeeded(Table table) {
+    if (isDeclaredOnly(table)) {
+      return true;
+    }
+    if (table.columns().length > 0) {
+      return false;
+    }
+    return !isEmptySchemaConfirmed(table.properties());
+  }
+
+  /**
+   * Returns whether an empty stored column list was confirmed by actually reading the dataset
+   * schema at the version the table still records.
+   *
+   * <p>{@code lance.version} alone does not prove it. {@link #alterTable} records that property
+   * after every dataset change without reading the schema, so a table registered with no columns
+   * ends up carrying a version while its column metadata was never captured. Treating that as
+   * "confirmed empty" is what used to leave such a table stuck with no columns forever.
+   *
+   * <p>{@code lance.empty-schema-checked-version} is written only by {@link
+   * #recordCheckedEmptyVersion}, immediately after a schema read returned no columns, and it
+   * carries the version it was observed at. Any later version recorded by another path therefore
+   * invalidates it on its own, with no need for those paths to know about this marker.
+   *
+   * @param properties the stored table properties
+   * @return true if the stored empty column list reflects a real schema read
+   */
+  private boolean isEmptySchemaConfirmed(Map<String, String> properties) {
+    String checkedVersion = properties.get(LanceConstants.LANCE_EMPTY_SCHEMA_CHECKED_VERSION);
+    String currentVersion = properties.get(LanceConstants.LANCE_TABLE_VERSION);
+    if (StringUtils.isBlank(checkedVersion) || StringUtils.isBlank(currentVersion)) {
+      return false;
+    }
+
+    try {
+      return Long.parseLong(checkedVersion) == Long.parseLong(currentVersion);
+    } catch (NumberFormatException e) {
+      // Version metadata we cannot read confirms nothing, the same way isDatasetVersionChanged
+      // treats it as changed. Re-reading the dataset is the safe answer.
+      return false;
+    }
+  }
+
+  /**
+   * Returns whether the confirmed-empty marker has to be written for the given dataset version.
+   *
+   * @param properties the stored table properties
+   * @param datasetVersion the version the dataset was just read at
+   * @return true if the stored metadata does not already record this confirmation
+   */
+  private boolean isEmptyConfirmationNeeded(Map<String, String> properties, long datasetVersion) {
+    return isDatasetVersionChanged(properties, datasetVersion)
+        || !isEmptySchemaConfirmed(properties);
+  }
+
   private boolean isDatasetVersionChanged(Table table, long datasetVersion) {
     return isDatasetVersionChanged(table.properties(), datasetVersion);
   }
@@ -613,12 +697,19 @@ public class LanceTableOperations extends ManagedTableOperations {
           updateTableWithCasRetry(
               ident,
               current -> {
-                if (!isDatasetVersionChanged(current.properties(), datasetVersion)) {
+                // Re-checked under the CAS: another writer may have recorded the same
+                // confirmation between the load and this update.
+                if (!isEmptyConfirmationNeeded(current.properties(), datasetVersion)) {
                   return current;
                 }
                 Map<String, String> updatedProperties = new HashMap<>(current.properties());
                 updatedProperties.put(
                     LanceConstants.LANCE_TABLE_VERSION, String.valueOf(datasetVersion));
+                // Mark the empty column list as confirmed against the dataset at this version, so
+                // later loads can trust it instead of re-opening the dataset every time.
+                updatedProperties.put(
+                    LanceConstants.LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
+                    String.valueOf(datasetVersion));
                 // Always use an empty column list: the dataset is confirmed empty at this version.
                 // Using current.columns() would preserve stale columns when the dataset schema was
                 // cleared externally, causing future VERSION_CHECK loads to return stale metadata
@@ -664,6 +755,8 @@ public class LanceTableOperations extends ManagedTableOperations {
     Map<String, String> updatedProperties = new HashMap<>(tableEntity.properties());
     updatedProperties.put(LanceConstants.LANCE_TABLE_VERSION, String.valueOf(datasetVersion));
     updatedProperties.remove(LanceConstants.LANCE_TABLE_DECLARED);
+    // The dataset has columns, so any earlier "confirmed empty" marker is stale.
+    updatedProperties.remove(LanceConstants.LANCE_EMPTY_SCHEMA_CHECKED_VERSION);
 
     AuditInfo columnAuditInfo =
         AuditInfo.builder()

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.lakehouse.lance;
 
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_CREATION_MODE;
+import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_EMPTY_SCHEMA_CHECKED_VERSION;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_SCHEMA_REFRESH_MODE;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_STORAGE_OPTIONS_PREFIX;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_DECLARED;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -657,6 +659,8 @@ public class TestLanceTableOperations {
 
     Assertions.assertEquals(0, loaded.columns().length);
     Assertions.assertEquals("3", loaded.properties().get(LANCE_TABLE_VERSION));
+    // The emptiness was confirmed against the dataset, so later loads can trust it.
+    Assertions.assertEquals("3", loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
     verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
 
@@ -697,8 +701,9 @@ public class TestLanceTableOperations {
   }
 
   @Test
-  public void testEmptyDatasetWithRecordedVersionIsRecheckedWithoutMetadataUpdate()
-      throws Exception {
+  public void testEmptyDatasetWithRecordedVersionIsConfirmedOnce() throws Exception {
+    // lance.version on its own is not a confirmation: it is also written by alterTable, which
+    // never reads the schema. The dataset is re-read and the confirmation marker recorded.
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("empty-dataset-recheck").toString();
     TableEntity tableEntity =
@@ -706,18 +711,178 @@ public class TestLanceTableOperations {
             ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              return updater.apply(tableEntity);
+            });
 
     Dataset dataset = mock(Dataset.class);
     when(dataset.getSchema()).thenReturn(new Schema(List.of()));
     when(dataset.version()).thenReturn(3L);
     Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
 
+    Table loaded =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+
+    Assertions.assertEquals(0, loaded.columns().length);
+    Assertions.assertEquals("3", loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
+    verify(dataset).getSchema();
+    verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
+  }
+
+  @Test
+  public void testConfirmedEmptyTableSkipsDatasetOpen() throws Exception {
+    // A table whose empty column list was confirmed against the dataset at the version it still
+    // records costs no dataset read at all. This is what keeps a genuinely empty dataset from
+    // paying a remote open on every single load.
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("empty-dataset-confirmed").toString();
+    TableEntity tableEntity =
+        tableEntity(
+            ident,
+            List.of(),
+            Map.of(
+                Table.PROPERTY_LOCATION,
+                location,
+                LANCE_TABLE_VERSION,
+                "3",
+                LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
+                "3"));
+    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
+        .thenReturn(tableEntity);
+
     Table loaded = lanceTableOps.loadTable(ident);
 
     Assertions.assertEquals(0, loaded.columns().length);
-    verify(dataset).getSchema();
+    verify(lanceTableOps, never()).openDataset(anyString(), any());
     verify(store, never())
         .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
+  }
+
+  @Test
+  public void testStaleEmptyConfirmationIsInvalidatedByNewerVersion() throws Exception {
+    // An alterTable recorded lance.version=5 after the emptiness was confirmed at version 3. The
+    // marker no longer matches, so the dataset is read again and the real schema is picked up.
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("empty-dataset-stale-marker").toString();
+    TableEntity tableEntity =
+        tableEntity(
+            ident,
+            List.of(),
+            Map.of(
+                Table.PROPERTY_LOCATION,
+                location,
+                LANCE_TABLE_VERSION,
+                "5",
+                LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
+                "3"));
+    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
+        .thenReturn(tableEntity);
+    when(idGenerator.nextId()).thenReturn(31L);
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              return updater.apply(tableEntity);
+            });
+
+    Dataset dataset = mock(Dataset.class);
+    when(dataset.version()).thenReturn(5L);
+    when(dataset.getSchema())
+        .thenReturn(new Schema(List.of(Field.nullable("col_a", new ArrowType.Int(64, true)))));
+    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
+
+    Table loaded =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+
+    Assertions.assertEquals(1, loaded.columns().length);
+    Assertions.assertEquals("col_a", loaded.columns()[0].name());
+    // Real columns retire the confirmation.
+    Assertions.assertNull(loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
+  }
+
+  @Test
+  public void testRepairedTableStopsOpeningDatasetOnNextLoad() throws Exception {
+    // The repair must be a one-off cost: once the columns are stored, DECLARED_AND_EMPTY has no
+    // reason to touch the dataset again.
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("repair-then-skip").toString();
+    TableEntity stored =
+        tableEntity(
+            ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
+    AtomicReference<TableEntity> current = new AtomicReference<>(stored);
+    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
+        .thenAnswer(invocation -> current.get());
+    when(idGenerator.nextId()).thenReturn(32L);
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              TableEntity updated = updater.apply(current.get());
+              current.set(updated);
+              return updated;
+            });
+
+    Dataset dataset = mock(Dataset.class);
+    when(dataset.version()).thenReturn(3L);
+    when(dataset.getSchema())
+        .thenReturn(new Schema(List.of(Field.nullable("col_a", new ArrowType.Int(64, true)))));
+    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
+
+    PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+    Table second =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+
+    Assertions.assertEquals(1, second.columns().length);
+    verify(lanceTableOps, times(1)).openDataset(eq(location), any());
+    verify(store, times(1))
+        .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
+  }
+
+  @Test
+  public void testMalformedStoredVersionIsTreatedAsChanged() throws Exception {
+    // A version property that is not a number cannot confirm anything: the dataset is read and the
+    // stored metadata is rewritten with a usable version.
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("malformed-version").toString();
+    TableEntity tableEntity =
+        tableEntity(
+            ident,
+            List.of(),
+            Map.of(
+                Table.PROPERTY_LOCATION,
+                location,
+                LANCE_TABLE_VERSION,
+                "not-a-number",
+                LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
+                "not-a-number"));
+    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
+        .thenReturn(tableEntity);
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              return updater.apply(tableEntity);
+            });
+
+    Dataset dataset = mock(Dataset.class);
+    when(dataset.getSchema()).thenReturn(new Schema(List.of()));
+    when(dataset.version()).thenReturn(4L);
+    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
+
+    Table loaded =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+
+    Assertions.assertEquals(0, loaded.columns().length);
+    Assertions.assertEquals("4", loaded.properties().get(LANCE_TABLE_VERSION));
+    Assertions.assertEquals("4", loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
+    verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
 
   // ---------------------------------------------------------------------------
@@ -773,19 +938,30 @@ public class TestLanceTableOperations {
     Assertions.assertEquals(0, loaded.columns().length);
     // The new dataset version must be persisted so future VERSION_CHECK loads see the match.
     Assertions.assertEquals("9", loaded.properties().get(LANCE_TABLE_VERSION));
+    // The emptiness was observed directly, so it is recorded as confirmed at that version.
+    Assertions.assertEquals("9", loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
   }
 
   @Test
   public void testVersionCheckStaleColumnsAreNotReturnedOnSubsequentLoad() throws Exception {
-    // Once stale columns are cleared and version=9 is recorded, the next loadTable must confirm
-    // that the dataset is still empty without writing the same metadata again.
+    // Once stale columns are cleared and the emptiness is confirmed at version=9, the next
+    // loadTable must return the empty column list without reading the schema again.
     lanceTableOps.setCatalogProperties(Map.of(LANCE_SCHEMA_REFRESH_MODE, "version-check"));
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("subsequent-empty-load").toString();
-    // Simulate the store state after the first load cleared stale columns.
+    // Simulate the store state the previous test leaves behind: columns cleared, version and
+    // confirmation marker both at 9.
     TableEntity tableEntity =
         tableEntity(
-            ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "9"));
+            ident,
+            List.of(),
+            Map.of(
+                Table.PROPERTY_LOCATION,
+                location,
+                LANCE_TABLE_VERSION,
+                "9",
+                LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
+                "9"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
 
@@ -797,7 +973,8 @@ public class TestLanceTableOperations {
     Table loaded = lanceTableOps.loadTable(ident);
 
     Assertions.assertEquals(0, loaded.columns().length);
-    verify(dataset).getSchema();
+    // Version matched and the empty column list is confirmed: no schema read, no metadata write.
+    verify(dataset, never()).getSchema();
     verify(store, never())
         .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -596,28 +596,39 @@ public class TestLanceTableOperations {
   }
 
   @Test
-  public void testVersionCheckSkipsSchemaReadForEmptySchemaWhenVersionUnchanged() throws Exception {
+  public void testVersionCheckRepairsEmptyStoredColumnsWhenVersionUnchanged() throws Exception {
     lanceTableOps.setCatalogProperties(Map.of(LANCE_SCHEMA_REFRESH_MODE, "version-check"));
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("empty-version-check").toString();
-    // Table has empty columns but a known stored version (confirmed-empty state)
+    // A matching version must not hide incomplete stored column metadata.
     TableEntity tableEntity =
         tableEntity(
             ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "5"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
+    when(idGenerator.nextId()).thenReturn(19L);
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              return updater.apply(tableEntity);
+            });
 
     Dataset dataset = mock(Dataset.class);
     when(dataset.version()).thenReturn(5L);
+    when(dataset.getSchema())
+        .thenReturn(new Schema(List.of(Field.nullable("col_a", new ArrowType.Int(64, true)))));
     Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
 
-    Table loaded = lanceTableOps.loadTable(ident);
+    Table loaded =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
 
-    Assertions.assertEquals(0, loaded.columns().length);
-    // version unchanged — schema read must be skipped even though columns are empty
-    verify(dataset, never()).getSchema();
-    verify(store, never())
-        .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
+    Assertions.assertEquals(1, loaded.columns().length);
+    Assertions.assertEquals("col_a", loaded.columns()[0].name());
+    Assertions.assertEquals("5", loaded.properties().get(LANCE_TABLE_VERSION));
+    verify(dataset).getSchema();
+    verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
 
   @Test
@@ -650,20 +661,61 @@ public class TestLanceTableOperations {
   }
 
   @Test
-  public void testEmptyDatasetSkipsOpenWhenVersionAlreadyRecorded() throws Exception {
+  public void testEmptyStoredColumnsWithRecordedVersionAreRepaired() throws Exception {
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("empty-dataset-second").toString();
-    // Simulate the table after first-load recorded lance.version=3 but columns still empty
+    // Simulate incomplete stored metadata: the dataset version was recorded, but its columns were
+    // not persisted. The version alone must not prevent schema repair.
+    TableEntity tableEntity =
+        tableEntity(
+            ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
+    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
+        .thenReturn(tableEntity);
+    when(idGenerator.nextId()).thenReturn(20L);
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              return updater.apply(tableEntity);
+            });
+
+    Dataset dataset = mock(Dataset.class);
+    when(dataset.getSchema())
+        .thenReturn(new Schema(List.of(Field.nullable("col_a", new ArrowType.Int(64, true)))));
+    when(dataset.version()).thenReturn(3L);
+    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
+
+    Table loaded =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+
+    Assertions.assertEquals(1, loaded.columns().length);
+    Assertions.assertEquals("col_a", loaded.columns()[0].name());
+    Assertions.assertEquals("3", loaded.properties().get(LANCE_TABLE_VERSION));
+    verify(dataset).getSchema();
+    verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
+  }
+
+  @Test
+  public void testEmptyDatasetWithRecordedVersionIsRecheckedWithoutMetadataUpdate()
+      throws Exception {
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("empty-dataset-recheck").toString();
     TableEntity tableEntity =
         tableEntity(
             ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
 
+    Dataset dataset = mock(Dataset.class);
+    when(dataset.getSchema()).thenReturn(new Schema(List.of()));
+    when(dataset.version()).thenReturn(3L);
+    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
+
     Table loaded = lanceTableOps.loadTable(ident);
 
     Assertions.assertEquals(0, loaded.columns().length);
-    verify(lanceTableOps, never()).openDataset(anyString(), any());
+    verify(dataset).getSchema();
     verify(store, never())
         .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
@@ -725,8 +777,8 @@ public class TestLanceTableOperations {
 
   @Test
   public void testVersionCheckStaleColumnsAreNotReturnedOnSubsequentLoad() throws Exception {
-    // After the fix: once stale columns are cleared and version=9 is recorded, the next loadTable
-    // must early-return with empty columns (not re-open the dataset and not return stale data).
+    // Once stale columns are cleared and version=9 is recorded, the next loadTable must confirm
+    // that the dataset is still empty without writing the same metadata again.
     lanceTableOps.setCatalogProperties(Map.of(LANCE_SCHEMA_REFRESH_MODE, "version-check"));
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("subsequent-empty-load").toString();
@@ -739,13 +791,13 @@ public class TestLanceTableOperations {
 
     Dataset dataset = mock(Dataset.class);
     when(dataset.version()).thenReturn(9L);
+    when(dataset.getSchema()).thenReturn(new Schema(List.of()));
     Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
 
     Table loaded = lanceTableOps.loadTable(ident);
 
     Assertions.assertEquals(0, loaded.columns().length);
-    // Version matched: schema read must be skipped entirely.
-    verify(dataset, never()).getSchema();
+    verify(dataset).getSchema();
     verify(store, never())
         .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
@@ -887,11 +939,13 @@ public class TestLanceTableOperations {
   @Test
   public void testLoadTableFallsBackToStoredMetadataWhenDatasetOpenFails() throws Exception {
     // If the Lance dataset cannot be opened (e.g. storage not accessible), loadTable must return
-    // the stored metadata rather than propagating the exception.
+    // the stored metadata rather than propagating the exception. A recorded version must not skip
+    // the open attempt or be lost from the fallback result.
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("broken-dataset").toString();
     TableEntity tableEntity =
-        tableEntity(ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location));
+        tableEntity(
+            ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
     Mockito.doThrow(new RuntimeException("storage unavailable"))
@@ -901,6 +955,8 @@ public class TestLanceTableOperations {
     Table loaded = lanceTableOps.loadTable(ident);
 
     Assertions.assertEquals(0, loaded.columns().length);
+    Assertions.assertEquals("3", loaded.properties().get(LANCE_TABLE_VERSION));
+    verify(lanceTableOps).openDataset(eq(location), any());
     verify(store, never())
         .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -19,10 +19,10 @@
 package org.apache.gravitino.catalog.lakehouse.lance;
 
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_CREATION_MODE;
-import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_EMPTY_SCHEMA_CHECKED_VERSION;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_SCHEMA_REFRESH_MODE;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_STORAGE_OPTIONS_PREFIX;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_DECLARED;
+import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_REGISTER;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_VERSION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -31,7 +31,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -67,6 +66,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.lance.Dataset;
 import org.lance.Version;
 import org.lance.index.IndexOptions;
@@ -528,6 +529,111 @@ public class TestLanceTableOperations {
     Assertions.assertEquals("9", storedTable.get().properties().get(LANCE_TABLE_VERSION));
   }
 
+  @ParameterizedTest(name = "recordedVersion={0}")
+  @ValueSource(booleans = {false, true})
+  public void testAlterTableHydratesRegisteredSchemaBeforeRecordingVersion(boolean recordedVersion)
+      throws Exception {
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("alter-registered-table-" + recordedVersion).toString();
+    Map<String, String> properties =
+        recordedVersion
+            ? Map.of(
+                Table.PROPERTY_LOCATION,
+                location,
+                LANCE_TABLE_REGISTER,
+                Boolean.TRUE.toString(),
+                LANCE_TABLE_VERSION,
+                "2")
+            : Map.of(
+                Table.PROPERTY_LOCATION, location, LANCE_TABLE_REGISTER, Boolean.TRUE.toString());
+    AtomicReference<TableEntity> storedTable =
+        new AtomicReference<>(tableEntity(ident, List.of(), properties));
+    stubMutableTable(ident, storedTable);
+    when(idGenerator.nextId()).thenReturn(10L);
+
+    Dataset schemaDataset = mock(Dataset.class);
+    when(schemaDataset.version()).thenReturn(3L);
+    when(schemaDataset.getSchema())
+        .thenReturn(new Schema(List.of(Field.nullable("embedding", new ArrowType.Utf8()))));
+    Dataset alterDataset = mock(Dataset.class);
+    Version alteredVersion = mock(Version.class);
+    when(alterDataset.getVersion()).thenReturn(alteredVersion);
+    when(alteredVersion.getId()).thenReturn(4L);
+    Mockito.doReturn(schemaDataset, alterDataset)
+        .when(lanceTableOps)
+        .openDataset(location, Map.of());
+
+    Table alteredTable =
+        PrincipalUtils.doAs(
+            new UserPrincipal("tester"),
+            () ->
+                lanceTableOps.alterTable(
+                    ident,
+                    TableChange.addIndex(
+                        Index.IndexType.SCALAR, "embedding_idx", new String[][] {{"embedding"}})));
+
+    Assertions.assertEquals(1, alteredTable.columns().length);
+    Assertions.assertEquals("embedding", alteredTable.columns()[0].name());
+    Assertions.assertEquals("4", alteredTable.properties().get(LANCE_TABLE_VERSION));
+    Assertions.assertEquals(1, alteredTable.index().length);
+    Assertions.assertEquals("embedding_idx", alteredTable.index()[0].name());
+    Assertions.assertEquals(1, storedTable.get().columns().size());
+    Assertions.assertEquals("4", storedTable.get().properties().get(LANCE_TABLE_VERSION));
+
+    InOrder inOrder = Mockito.inOrder(schemaDataset, alterDataset);
+    inOrder.verify(schemaDataset).getSchema();
+    inOrder.verify(alterDataset).createIndex(any(IndexOptions.class));
+    inOrder.verify(alterDataset).getVersion();
+    verify(store, Mockito.times(2))
+        .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
+  }
+
+  @Test
+  public void testAlterTableStopsWhenRegisteredSchemaCannotBeHydrated() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("unavailable-registered-table").toString();
+    AtomicReference<TableEntity> storedTable =
+        new AtomicReference<>(
+            tableEntity(
+                ident,
+                List.of(),
+                Map.of(
+                    Table.PROPERTY_LOCATION,
+                    location,
+                    LANCE_TABLE_REGISTER,
+                    Boolean.TRUE.toString(),
+                    LANCE_TABLE_VERSION,
+                    "3")));
+    stubMutableTable(ident, storedTable);
+
+    Dataset alterDataset = mock(Dataset.class);
+    Version alteredVersion = mock(Version.class);
+    when(alterDataset.getVersion()).thenReturn(alteredVersion);
+    when(alteredVersion.getId()).thenReturn(4L);
+    Mockito.doThrow(new RuntimeException("storage unavailable"))
+        .doReturn(alterDataset)
+        .when(lanceTableOps)
+        .openDataset(location, Map.of());
+
+    IllegalStateException failure =
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () ->
+                lanceTableOps.alterTable(
+                    ident,
+                    TableChange.addIndex(
+                        Index.IndexType.SCALAR, "embedding_idx", new String[][] {{"embedding"}})));
+
+    Assertions.assertTrue(failure.getMessage().contains("schema"));
+    Assertions.assertEquals("storage unavailable", failure.getCause().getMessage());
+    Assertions.assertTrue(storedTable.get().columns().isEmpty());
+    Assertions.assertEquals("3", storedTable.get().properties().get(LANCE_TABLE_VERSION));
+    verify(lanceTableOps).openDataset(location, Map.of());
+    verify(alterDataset, never()).createIndex(any(IndexOptions.class));
+    verify(store, never())
+        .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
+  }
+
   @Test
   public void testHandleLanceTableChangeRespectsOrder() {
     Table table = mock(Table.class);
@@ -598,39 +704,28 @@ public class TestLanceTableOperations {
   }
 
   @Test
-  public void testVersionCheckRepairsEmptyStoredColumnsWhenVersionUnchanged() throws Exception {
+  public void testVersionCheckSkipsSchemaReadForEmptySchemaWhenVersionUnchanged() throws Exception {
     lanceTableOps.setCatalogProperties(Map.of(LANCE_SCHEMA_REFRESH_MODE, "version-check"));
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("empty-version-check").toString();
-    // A matching version must not hide incomplete stored column metadata.
+    // Table has empty columns but a known stored version (confirmed-empty state)
     TableEntity tableEntity =
         tableEntity(
             ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "5"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
-    when(idGenerator.nextId()).thenReturn(19L);
-    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
-              return updater.apply(tableEntity);
-            });
 
     Dataset dataset = mock(Dataset.class);
     when(dataset.version()).thenReturn(5L);
-    when(dataset.getSchema())
-        .thenReturn(new Schema(List.of(Field.nullable("col_a", new ArrowType.Int(64, true)))));
     Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
 
-    Table loaded =
-        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+    Table loaded = lanceTableOps.loadTable(ident);
 
-    Assertions.assertEquals(1, loaded.columns().length);
-    Assertions.assertEquals("col_a", loaded.columns()[0].name());
-    Assertions.assertEquals("5", loaded.properties().get(LANCE_TABLE_VERSION));
-    verify(dataset).getSchema();
-    verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
+    Assertions.assertEquals(0, loaded.columns().length);
+    // version unchanged — schema read must be skipped even though columns are empty
+    verify(dataset, never()).getSchema();
+    verify(store, never())
+        .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
 
   @Test
@@ -659,98 +754,17 @@ public class TestLanceTableOperations {
 
     Assertions.assertEquals(0, loaded.columns().length);
     Assertions.assertEquals("3", loaded.properties().get(LANCE_TABLE_VERSION));
-    // The emptiness was confirmed against the dataset, so later loads can trust it.
-    Assertions.assertEquals("3", loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
     verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
 
   @Test
-  public void testEmptyStoredColumnsWithRecordedVersionAreRepaired() throws Exception {
+  public void testEmptyDatasetSkipsOpenWhenVersionAlreadyRecorded() throws Exception {
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("empty-dataset-second").toString();
-    // Simulate incomplete stored metadata: the dataset version was recorded, but its columns were
-    // not persisted. The version alone must not prevent schema repair.
+    // Simulate the table after first-load recorded lance.version=3 but columns still empty
     TableEntity tableEntity =
         tableEntity(
             ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
-    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
-        .thenReturn(tableEntity);
-    when(idGenerator.nextId()).thenReturn(20L);
-    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
-              return updater.apply(tableEntity);
-            });
-
-    Dataset dataset = mock(Dataset.class);
-    when(dataset.getSchema())
-        .thenReturn(new Schema(List.of(Field.nullable("col_a", new ArrowType.Int(64, true)))));
-    when(dataset.version()).thenReturn(3L);
-    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
-
-    Table loaded =
-        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
-
-    Assertions.assertEquals(1, loaded.columns().length);
-    Assertions.assertEquals("col_a", loaded.columns()[0].name());
-    Assertions.assertEquals("3", loaded.properties().get(LANCE_TABLE_VERSION));
-    verify(dataset).getSchema();
-    verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
-  }
-
-  @Test
-  public void testEmptyDatasetWithRecordedVersionIsConfirmedOnce() throws Exception {
-    // lance.version on its own is not a confirmation: it is also written by alterTable, which
-    // never reads the schema. The dataset is re-read and the confirmation marker recorded.
-    NameIdentifier ident = NameIdentifier.of("schema", "table");
-    String location = tempDir.resolve("empty-dataset-recheck").toString();
-    TableEntity tableEntity =
-        tableEntity(
-            ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
-    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
-        .thenReturn(tableEntity);
-    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
-              return updater.apply(tableEntity);
-            });
-
-    Dataset dataset = mock(Dataset.class);
-    when(dataset.getSchema()).thenReturn(new Schema(List.of()));
-    when(dataset.version()).thenReturn(3L);
-    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
-
-    Table loaded =
-        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
-
-    Assertions.assertEquals(0, loaded.columns().length);
-    Assertions.assertEquals("3", loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
-    verify(dataset).getSchema();
-    verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
-  }
-
-  @Test
-  public void testConfirmedEmptyTableSkipsDatasetOpen() throws Exception {
-    // A table whose empty column list was confirmed against the dataset at the version it still
-    // records costs no dataset read at all. This is what keeps a genuinely empty dataset from
-    // paying a remote open on every single load.
-    NameIdentifier ident = NameIdentifier.of("schema", "table");
-    String location = tempDir.resolve("empty-dataset-confirmed").toString();
-    TableEntity tableEntity =
-        tableEntity(
-            ident,
-            List.of(),
-            Map.of(
-                Table.PROPERTY_LOCATION,
-                location,
-                LANCE_TABLE_VERSION,
-                "3",
-                LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
-                "3"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
 
@@ -760,129 +774,6 @@ public class TestLanceTableOperations {
     verify(lanceTableOps, never()).openDataset(anyString(), any());
     verify(store, never())
         .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
-  }
-
-  @Test
-  public void testStaleEmptyConfirmationIsInvalidatedByNewerVersion() throws Exception {
-    // An alterTable recorded lance.version=5 after the emptiness was confirmed at version 3. The
-    // marker no longer matches, so the dataset is read again and the real schema is picked up.
-    NameIdentifier ident = NameIdentifier.of("schema", "table");
-    String location = tempDir.resolve("empty-dataset-stale-marker").toString();
-    TableEntity tableEntity =
-        tableEntity(
-            ident,
-            List.of(),
-            Map.of(
-                Table.PROPERTY_LOCATION,
-                location,
-                LANCE_TABLE_VERSION,
-                "5",
-                LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
-                "3"));
-    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
-        .thenReturn(tableEntity);
-    when(idGenerator.nextId()).thenReturn(31L);
-    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
-              return updater.apply(tableEntity);
-            });
-
-    Dataset dataset = mock(Dataset.class);
-    when(dataset.version()).thenReturn(5L);
-    when(dataset.getSchema())
-        .thenReturn(new Schema(List.of(Field.nullable("col_a", new ArrowType.Int(64, true)))));
-    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
-
-    Table loaded =
-        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
-
-    Assertions.assertEquals(1, loaded.columns().length);
-    Assertions.assertEquals("col_a", loaded.columns()[0].name());
-    // Real columns retire the confirmation.
-    Assertions.assertNull(loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
-  }
-
-  @Test
-  public void testRepairedTableStopsOpeningDatasetOnNextLoad() throws Exception {
-    // The repair must be a one-off cost: once the columns are stored, DECLARED_AND_EMPTY has no
-    // reason to touch the dataset again.
-    NameIdentifier ident = NameIdentifier.of("schema", "table");
-    String location = tempDir.resolve("repair-then-skip").toString();
-    TableEntity stored =
-        tableEntity(
-            ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
-    AtomicReference<TableEntity> current = new AtomicReference<>(stored);
-    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
-        .thenAnswer(invocation -> current.get());
-    when(idGenerator.nextId()).thenReturn(32L);
-    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
-              TableEntity updated = updater.apply(current.get());
-              current.set(updated);
-              return updated;
-            });
-
-    Dataset dataset = mock(Dataset.class);
-    when(dataset.version()).thenReturn(3L);
-    when(dataset.getSchema())
-        .thenReturn(new Schema(List.of(Field.nullable("col_a", new ArrowType.Int(64, true)))));
-    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
-
-    PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
-    Table second =
-        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
-
-    Assertions.assertEquals(1, second.columns().length);
-    verify(lanceTableOps, times(1)).openDataset(eq(location), any());
-    verify(store, times(1))
-        .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
-  }
-
-  @Test
-  public void testMalformedStoredVersionIsTreatedAsChanged() throws Exception {
-    // A version property that is not a number cannot confirm anything: the dataset is read and the
-    // stored metadata is rewritten with a usable version.
-    NameIdentifier ident = NameIdentifier.of("schema", "table");
-    String location = tempDir.resolve("malformed-version").toString();
-    TableEntity tableEntity =
-        tableEntity(
-            ident,
-            List.of(),
-            Map.of(
-                Table.PROPERTY_LOCATION,
-                location,
-                LANCE_TABLE_VERSION,
-                "not-a-number",
-                LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
-                "not-a-number"));
-    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
-        .thenReturn(tableEntity);
-    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
-              return updater.apply(tableEntity);
-            });
-
-    Dataset dataset = mock(Dataset.class);
-    when(dataset.getSchema()).thenReturn(new Schema(List.of()));
-    when(dataset.version()).thenReturn(4L);
-    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
-
-    Table loaded =
-        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
-
-    Assertions.assertEquals(0, loaded.columns().length);
-    Assertions.assertEquals("4", loaded.properties().get(LANCE_TABLE_VERSION));
-    Assertions.assertEquals("4", loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
-    verify(store).update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
 
   // ---------------------------------------------------------------------------
@@ -938,42 +829,30 @@ public class TestLanceTableOperations {
     Assertions.assertEquals(0, loaded.columns().length);
     // The new dataset version must be persisted so future VERSION_CHECK loads see the match.
     Assertions.assertEquals("9", loaded.properties().get(LANCE_TABLE_VERSION));
-    // The emptiness was observed directly, so it is recorded as confirmed at that version.
-    Assertions.assertEquals("9", loaded.properties().get(LANCE_EMPTY_SCHEMA_CHECKED_VERSION));
   }
 
   @Test
   public void testVersionCheckStaleColumnsAreNotReturnedOnSubsequentLoad() throws Exception {
-    // Once stale columns are cleared and the emptiness is confirmed at version=9, the next
-    // loadTable must return the empty column list without reading the schema again.
+    // After the fix: once stale columns are cleared and version=9 is recorded, the next loadTable
+    // must early-return with empty columns (not re-open the dataset and not return stale data).
     lanceTableOps.setCatalogProperties(Map.of(LANCE_SCHEMA_REFRESH_MODE, "version-check"));
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("subsequent-empty-load").toString();
-    // Simulate the store state the previous test leaves behind: columns cleared, version and
-    // confirmation marker both at 9.
+    // Simulate the store state after the first load cleared stale columns.
     TableEntity tableEntity =
         tableEntity(
-            ident,
-            List.of(),
-            Map.of(
-                Table.PROPERTY_LOCATION,
-                location,
-                LANCE_TABLE_VERSION,
-                "9",
-                LANCE_EMPTY_SCHEMA_CHECKED_VERSION,
-                "9"));
+            ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "9"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
 
     Dataset dataset = mock(Dataset.class);
     when(dataset.version()).thenReturn(9L);
-    when(dataset.getSchema()).thenReturn(new Schema(List.of()));
     Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
 
     Table loaded = lanceTableOps.loadTable(ident);
 
     Assertions.assertEquals(0, loaded.columns().length);
-    // Version matched and the empty column list is confirmed: no schema read, no metadata write.
+    // Version matched: schema read must be skipped entirely.
     verify(dataset, never()).getSchema();
     verify(store, never())
         .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
@@ -1116,13 +995,11 @@ public class TestLanceTableOperations {
   @Test
   public void testLoadTableFallsBackToStoredMetadataWhenDatasetOpenFails() throws Exception {
     // If the Lance dataset cannot be opened (e.g. storage not accessible), loadTable must return
-    // the stored metadata rather than propagating the exception. A recorded version must not skip
-    // the open attempt or be lost from the fallback result.
+    // the stored metadata rather than propagating the exception.
     NameIdentifier ident = NameIdentifier.of("schema", "table");
     String location = tempDir.resolve("broken-dataset").toString();
     TableEntity tableEntity =
-        tableEntity(
-            ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "3"));
+        tableEntity(ident, List.of(), Map.of(Table.PROPERTY_LOCATION, location));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
         .thenReturn(tableEntity);
     Mockito.doThrow(new RuntimeException("storage unavailable"))
@@ -1132,8 +1009,6 @@ public class TestLanceTableOperations {
     Table loaded = lanceTableOps.loadTable(ident);
 
     Assertions.assertEquals(0, loaded.columns().length);
-    Assertions.assertEquals("3", loaded.properties().get(LANCE_TABLE_VERSION));
-    verify(lanceTableOps).openDataset(eq(location), any());
     verify(store, never())
         .update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any());
   }
@@ -1239,6 +1114,21 @@ public class TestLanceTableOperations {
         .withAuditInfo(
             AuditInfo.builder().withCreator("creator").withCreateTime(Instant.EPOCH).build())
         .build();
+  }
+
+  private void stubMutableTable(NameIdentifier ident, AtomicReference<TableEntity> storedTable)
+      throws IOException {
+    when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
+        .thenAnswer(invocation -> storedTable.get());
+    when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
+              TableEntity updated = updater.apply(storedTable.get());
+              storedTable.set(updated);
+              return updated;
+            });
   }
 
   private NameIdentifier prepareDeclaredTableForRepair(String directoryName) throws Exception {

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -127,16 +127,17 @@ Lakehouse catalog supports catalog-level schema refresh modes:
 | Mode                 | Behavior                                                                                                                                                                                                                                                                         |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DECLARED_AND_EMPTY` | Default. Refreshes schema from the Lance dataset for two cases: (1) declared tables (`lance.declared=true`) whose schema has not yet been written to Gravitino; (2) tables whose Gravitino column list is empty, for example tables registered before their schema was captured. |
-| `VERSION_CHECK`      | Opens the Lance dataset on every `loadTable`, compares the dataset version with `lance.version`, and refreshes columns when the version has changed.                                                                                                                             |
+| `VERSION_CHECK`      | Opens the Lance dataset on every `loadTable`, compares the dataset version with `lance.version`, and refreshes columns when the version has changed or stored columns are empty.                                                                                                 |
 
 Use `VERSION_CHECK` only when tables may be modified directly through the Lance path outside
 Gravitino. It adds a dataset version check to every `loadTable` call.
 
 :::note Zero-column Lance dataset
 If a Lance dataset genuinely has no columns, `DECLARED_AND_EMPTY` mode records the checked dataset
-version (`lance.version`) on the first `loadTable` call. Subsequent loads skip opening the dataset
-as long as the stored version is unchanged. Once columns are written to the dataset, the next
-`VERSION_CHECK` load or an explicit `alterTable` will detect the change and repair the schema.
+version (`lance.version`) on the first `loadTable` call. Subsequent loads re-examine the dataset
+because the stored version alone cannot distinguish a genuinely empty dataset from incomplete
+Gravitino column metadata. If the dataset is still empty and its version is unchanged, Gravitino
+does not write another metadata update.
 :::
 
 ### Table Operations

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -124,28 +124,20 @@ For Lance tables, Gravitino stores table columns in its metadata store. Some Lan
 update the dataset directly at the Lance location. To keep Gravitino metadata in sync, the Generic
 Lakehouse catalog supports catalog-level schema refresh modes:
 
-| Mode                 | Behavior                                                                                                                                                                                                                                                                                                                              |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DECLARED_AND_EMPTY` | Default. Refreshes schema from the Lance dataset for two cases: (1) declared tables (`lance.declared=true`) whose schema has not yet been written to Gravitino; (2) tables whose Gravitino column list is empty and has not been confirmed empty against the dataset, for example tables registered before their schema was captured. |
-| `VERSION_CHECK`      | Opens the Lance dataset on every `loadTable`, compares the dataset version with `lance.version`, and refreshes columns when the version has changed, or when the stored column list is empty and unconfirmed.                                                                                                                         |
+| Mode                 | Behavior                                                                                                                                                                                                                                                                         |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DECLARED_AND_EMPTY` | Default. Refreshes schema from the Lance dataset for two cases: (1) declared tables (`lance.declared=true`) whose schema has not yet been written to Gravitino; (2) tables whose Gravitino column list is empty, for example tables registered before their schema was captured. |
+| `VERSION_CHECK`      | Opens the Lance dataset on every `loadTable`, compares the dataset version with `lance.version`, and refreshes columns when the version has changed.                                                                                                                             |
 
 Use `VERSION_CHECK` only when tables may be modified directly through the Lance path outside
 Gravitino. It adds a dataset version check to every `loadTable` call.
 
 :::note Zero-column Lance dataset
-If a Lance dataset genuinely has no columns, the first `loadTable` call records the checked dataset
-version (`lance.version`) together with a confirmation marker
-(`lance.empty-schema-checked-version`). While the two still agree, later loads return the empty
-column list without opening the dataset, so a genuinely empty dataset costs one dataset read rather
-than one per load.
-
-`lance.version` on its own is not that confirmation: `alterTable` records it after every dataset
-change without reading the schema, so a table registered with `"columns": []` can carry a version
-whose column metadata was never captured. Such a table has no marker, is re-examined on the next
-`loadTable`, and repairs its columns from the dataset. Any path that records a newer
-`lance.version` invalidates the marker on its own, and columns read from the dataset clear it.
-
-Both properties are managed by Gravitino; do not set them by hand.
+If a Lance dataset genuinely has no columns, `DECLARED_AND_EMPTY` mode records the checked dataset
+version (`lance.version`) on the first `loadTable` call. Subsequent loads skip opening the dataset
+as long as the stored version is unchanged. Before recording a new version, Lance table
+alterations recheck an empty stored schema and abort if it cannot be loaded, so incomplete column
+metadata is not associated with the latest dataset version.
 :::
 
 ### Table Operations

--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -124,20 +124,28 @@ For Lance tables, Gravitino stores table columns in its metadata store. Some Lan
 update the dataset directly at the Lance location. To keep Gravitino metadata in sync, the Generic
 Lakehouse catalog supports catalog-level schema refresh modes:
 
-| Mode                 | Behavior                                                                                                                                                                                                                                                                         |
-|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DECLARED_AND_EMPTY` | Default. Refreshes schema from the Lance dataset for two cases: (1) declared tables (`lance.declared=true`) whose schema has not yet been written to Gravitino; (2) tables whose Gravitino column list is empty, for example tables registered before their schema was captured. |
-| `VERSION_CHECK`      | Opens the Lance dataset on every `loadTable`, compares the dataset version with `lance.version`, and refreshes columns when the version has changed or stored columns are empty.                                                                                                 |
+| Mode                 | Behavior                                                                                                                                                                                                                                                                                                                              |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DECLARED_AND_EMPTY` | Default. Refreshes schema from the Lance dataset for two cases: (1) declared tables (`lance.declared=true`) whose schema has not yet been written to Gravitino; (2) tables whose Gravitino column list is empty and has not been confirmed empty against the dataset, for example tables registered before their schema was captured. |
+| `VERSION_CHECK`      | Opens the Lance dataset on every `loadTable`, compares the dataset version with `lance.version`, and refreshes columns when the version has changed, or when the stored column list is empty and unconfirmed.                                                                                                                         |
 
 Use `VERSION_CHECK` only when tables may be modified directly through the Lance path outside
 Gravitino. It adds a dataset version check to every `loadTable` call.
 
 :::note Zero-column Lance dataset
-If a Lance dataset genuinely has no columns, `DECLARED_AND_EMPTY` mode records the checked dataset
-version (`lance.version`) on the first `loadTable` call. Subsequent loads re-examine the dataset
-because the stored version alone cannot distinguish a genuinely empty dataset from incomplete
-Gravitino column metadata. If the dataset is still empty and its version is unchanged, Gravitino
-does not write another metadata update.
+If a Lance dataset genuinely has no columns, the first `loadTable` call records the checked dataset
+version (`lance.version`) together with a confirmation marker
+(`lance.empty-schema-checked-version`). While the two still agree, later loads return the empty
+column list without opening the dataset, so a genuinely empty dataset costs one dataset read rather
+than one per load.
+
+`lance.version` on its own is not that confirmation: `alterTable` records it after every dataset
+change without reading the schema, so a table registered with `"columns": []` can carry a version
+whose column metadata was never captured. Such a table has no marker, is re-examined on the next
+`loadTable`, and repairs its columns from the dataset. Any path that records a newer
+`lance.version` invalidates the marker on its own, and columns read from the dataset clear it.
+
+Both properties are managed by Gravitino; do not set them by hand.
 :::
 
 ### Table Operations

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/utils/LanceConstants.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/utils/LanceConstants.java
@@ -38,6 +38,11 @@ public class LanceConstants {
   public static final String LANCE_TABLE_REGISTER = "lance.register";
 
   public static final String LANCE_TABLE_VERSION = "lance.version";
+  // Records the dataset version at which Gravitino read the Lance schema and found no columns.
+  // Written only after an actual schema read, so it distinguishes a dataset that is genuinely
+  // empty from a table whose column metadata was never captured. See LanceTableOperations.
+  public static final String LANCE_EMPTY_SCHEMA_CHECKED_VERSION =
+      "lance.empty-schema-checked-version";
   // Mark whether the table is declared only in metadata without creating a Lance dataset.
   public static final String LANCE_TABLE_DECLARED = "lance.declared";
   public static final String LANCE_SCHEMA_REFRESH_MODE = "lance.schema-refresh-mode";

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/utils/LanceConstants.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/utils/LanceConstants.java
@@ -38,11 +38,6 @@ public class LanceConstants {
   public static final String LANCE_TABLE_REGISTER = "lance.register";
 
   public static final String LANCE_TABLE_VERSION = "lance.version";
-  // Records the dataset version at which Gravitino read the Lance schema and found no columns.
-  // Written only after an actual schema read, so it distinguishes a dataset that is genuinely
-  // empty from a table whose column metadata was never captured. See LanceTableOperations.
-  public static final String LANCE_EMPTY_SCHEMA_CHECKED_VERSION =
-      "lance.empty-schema-checked-version";
   // Mark whether the table is declared only in metadata without creating a Lance dataset.
   public static final String LANCE_TABLE_DECLARED = "lance.declared";
   public static final String LANCE_SCHEMA_REFRESH_MODE = "lance.schema-refresh-mode";


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Recheck the Lance dataset schema before altering a table whose stored columns are empty, including when lance.version is already recorded.
- Reuse the existing repair-on-load path to persist hydrated columns before applying the physical alteration and its new version.
- Abort before modifying the dataset when the required schema cannot be initialized or loaded.
- Preserve ordinary loadTable behavior for confirmed zero-column datasets and remove the lance.empty-schema-checked-version property from the earlier iteration.

### Why are the changes needed?

Registering an existing Lance table accepts an empty column list and defers schema hydration. alterTable previously used the metadata-only parent load method, so an index alteration could update the Lance dataset and persist its latest version while the Gravitino columns remained empty. A later default load would interpret that version as confirmation of a genuinely zero-column schema and skip the dataset read.

This patch prevents that concrete inconsistent state. It was found while investigating #12407, but the issue does not show that an alter operation caused the reported UI symptom, so the API and authorization path still needs separate investigation.

Related: #12407

### Does this PR introduce _any_ user-facing change?

No API or configuration key is added. For a table with empty stored columns, alterTable now performs a schema read first and fails without changing the dataset if that read cannot complete. Ordinary loadTable behavior is unchanged.

### How was this patch tested?

Added tests covering:

- a registered table with empty columns and no stored version;
- a previously confirmed zero-column table whose dataset was initialized at a newer version;
- a schema-read failure that must not execute the physical alteration or update metadata.

Ran:

- ./gradlew :catalogs:catalog-lakehouse-generic:test -PskipWeb=true -PskipDockerTests=true
- ./gradlew :docs:build -PskipWeb=true
- ./gradlew :catalogs:catalog-lakehouse-generic:spotlessApply