### PR TITLE
[MINOR] fix(ci): Pin pnpm/action-setup to an ASF-allowlisted SHA

### DIFF
--- a/.github/workflows/web-ui-tests.yml
+++ b/.github/workflows/web-ui-tests.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       with:
         version: 9
     


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pin `pnpm/action-setup` in `web-ui-tests.yml` to the ASF-allowlisted commit SHA for `v6.0.10`, instead of the moving `v4` tag.

### Why are the changes needed?

`apache/infrastructure-actions` tightened its allowlist for `pnpm/action-setup` from a wildcard (`'*': keep: true`) to a single pinned SHA (`0977fd99725f1db4007ccb2928dbb4e90d06cc86`, tag `v6.0.10`): https://github.com/apache/infrastructure-actions/commit/db9062086b9700ef67cbfa5c2eb2e2a67d4a1c9. As a result, `asf-allowlist-check` now fails on every workflow run that still references `pnpm/action-setup@v4`. `v6.0.10`'s `action.yml` keeps the same `version` input used here, so this is a drop-in replacement.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

N/A — CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpCQ2tawE67Ur1X4nyKsV1