### PR TITLE
[#12616] feat(web-v2): Add Semantic Model support to the Gravitino Web UI

### DIFF
--- a/web-v2/web/src/app/catalogs/TreeComponent.js
+++ b/web-v2/web/src/app/catalogs/TreeComponent.js
@@ -324,6 +324,12 @@ export const TreeComponent = forwardRef(function TreeComponent(props, ref) {
             <Icons.iconify icon='ic:outline-table-view' className='my-icon-small' />
           </span>
         )
+      case 'semanticModel':
+        return (
+          <span role='img' aria-label='semantic model' className='anticon anticon-frown'>
+            <Icons.iconify icon='mdi:graph-outline' className='my-icon-small' />
+          </span>
+        )
       default:
         return <></>
     }
@@ -350,7 +356,8 @@ export const TreeComponent = forwardRef(function TreeComponent(props, ref) {
       const topic = searchParams.get('topic')
       const model = searchParams.get('model')
       const func = searchParams.get('function')
-      const entity = table || view || fileset || topic || model || func
+      const semanticModel = searchParams.get('semanticModel')
+      const entity = table || view || semanticModel || fileset || topic || model || func
 
       if (!metalake) {
         dispatch(setExpanded([]))

--- a/web-v2/web/src/app/catalogs/page.js
+++ b/web-v2/web/src/app/catalogs/page.js
@@ -41,8 +41,10 @@ import {
   fetchModelVersions,
   fetchFunctions,
   fetchViews,
+  fetchSemanticModels,
   getFunctionDetails,
   getViewDetails,
+  getSemanticModelDetails,
   getMetalakeDetails,
   getCatalogDetails,
   getSchemaDetails,
@@ -81,7 +83,8 @@ const CatalogsListPage = () => {
       'topic',
       'model',
       'function',
-      'view'
+      'view',
+      'semanticModel'
     ]
 
     return keys.map(key => (routeParams[key] ? `{{${routeParams[key]}}}` : '')).join('')
@@ -99,6 +102,7 @@ const CatalogsListPage = () => {
       model: searchParams.get('model'),
       function: searchParams.get('function'),
       view: searchParams.get('view'),
+      semanticModel: searchParams.get('semanticModel'),
       version: searchParams.get('version')
     }
     async function fetchDependsData() {
@@ -114,6 +118,7 @@ const CatalogsListPage = () => {
           model,
           function: func,
           view,
+          semanticModel,
           version
         } = routeParams
 
@@ -182,6 +187,7 @@ const CatalogsListPage = () => {
             case 'relational':
               dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
               dispatch(fetchViews({ init: true, metalake, catalog, schema }))
+              dispatch(fetchSemanticModels({ init: true, metalake, catalog, schema }))
               break
             case 'fileset':
               dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema }))
@@ -342,6 +348,23 @@ const CatalogsListPage = () => {
             await dispatch(setActivatedDetailsLoading(true))
             await dispatch(getViewDetails({ init: true, metalake, catalog, schema, view }))
             await dispatch(setActivatedDetailsLoading(false))
+          }
+          if (semanticModel) {
+            store.semanticModels.length === 0 &&
+              (await dispatch(fetchSemanticModels({ init: true, metalake, catalog, schema })))
+            await dispatch(resetActivatedDetails())
+            await dispatch(setActivatedDetailsLoading(true))
+            await dispatch(getSemanticModelDetails({ init: true, metalake, catalog, schema, semanticModel }))
+            await dispatch(setActivatedDetailsLoading(false))
+            dispatch(
+              getCurrentEntityTags({
+                init: true,
+                metalake,
+                metadataObjectType: 'semantic_model',
+                metadataObjectFullName: `${catalog}.${schema}.${semanticModel}`,
+                details: true
+              })
+            )
           }
         }
         if (paramsSize === 6 && version) {

--- a/web-v2/web/src/app/catalogs/rightContent/CreateSemanticModelDialog.js
+++ b/web-v2/web/src/app/catalogs/rightContent/CreateSemanticModelDialog.js
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
+import { Form, Input, Modal, Spin, Typography } from 'antd'
+import { useScrolling } from 'react-use'
+import RenderPropertiesFormItem from '@/components/EntityPropertiesFormItem'
+import { validateMessages, dialogContentMaxHeigth, mismatchName } from '@/config'
+import { nameRegex } from '@/lib/utils/regex'
+import { useResetFormOnCloseModal } from '@/lib/hooks/use-reset'
+import { cn } from '@/lib/utils/tailwind'
+import { useAppDispatch } from '@/lib/hooks/useStore'
+import {
+  formatSemanticModelDefinition,
+  genSemanticModelUpdates,
+  parseSemanticModelDefinition
+} from '@/lib/utils/semanticModel'
+import { createSemanticModel, updateSemanticModel, getSemanticModelDetails } from '@/lib/store/metalakes'
+
+const { Paragraph } = Typography
+const { TextArea } = Input
+
+const definitionPlaceholder = `{
+  "datasets": [
+    {
+      "name": "orders",
+      "source": { "namespace": ["sales", "mart"], "name": "orders" },
+      "fields": []
+    }
+  ]
+}`
+
+const defaultValues = {
+  name: '',
+  comment: '',
+  definition: '',
+  properties: []
+}
+
+export default function CreateSemanticModelDialog({ ...props }) {
+  const { open, setOpen, metalake, catalog, schema, editSemanticModel } = props
+  const [confirmLoading, setConfirmLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [cacheData, setCacheData] = useState()
+  const scrollRef = useRef(null)
+  const loadedRef = useRef(false)
+  const scrolling = useScrolling(scrollRef)
+  const [bottomShadow, setBottomShadow] = useState(false)
+  const [topShadow, setTopShadow] = useState(false)
+  const [form] = Form.useForm()
+  const values = Form.useWatch([], form)
+  const dispatch = useAppDispatch()
+
+  useResetFormOnCloseModal({
+    form,
+    open
+  })
+
+  const handScroll = () => {
+    if (scrollRef.current) {
+      const { scrollTop, scrollHeight, clientHeight } = scrollRef.current
+      if (scrollHeight > clientHeight + scrollTop) {
+        setTopShadow(true)
+        setBottomShadow(scrollTop > 0)
+      } else if (scrollHeight === clientHeight + scrollTop) {
+        setTopShadow(false)
+        setBottomShadow(scrollTop > 0)
+      }
+    }
+  }
+
+  useEffect(() => {
+    scrollRef.current && handScroll()
+  }, [scrolling])
+
+  useEffect(() => {
+    if (open && editSemanticModel && !loadedRef.current) {
+      loadedRef.current = true
+
+      const initLoad = async () => {
+        setIsLoading(true)
+        try {
+          const { payload } = await dispatch(
+            getSemanticModelDetails({ metalake, catalog, schema, semanticModel: editSemanticModel })
+          )
+          const loaded = payload?.semanticModel
+          setCacheData(loaded)
+          form.setFieldValue('name', loaded?.name)
+          form.setFieldValue('comment', loaded?.comment)
+          form.setFieldValue('definition', formatSemanticModelDefinition(loaded?.definition))
+          let index = 0
+          Object.entries(loaded?.properties || {}).forEach(([key, value]) => {
+            form.setFieldValue(['properties', index, 'key'], key)
+            form.setFieldValue(['properties', index, 'value'], value)
+            index++
+          })
+          setIsLoading(false)
+        } catch (e) {
+          setIsLoading(false)
+        }
+      }
+      initLoad()
+    }
+
+    // Reset loadedRef when dialog closes
+    if (!open) {
+      loadedRef.current = false
+    }
+  }, [open, editSemanticModel, metalake, catalog, schema])
+
+  const validateDefinition = (rule, value) => {
+    const { errors } = parseSemanticModelDefinition(value)
+
+    return errors.length ? Promise.reject(new Error(errors.join(' '))) : Promise.resolve()
+  }
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    form
+      .validateFields()
+      .then(async () => {
+        const { definition } = parseSemanticModelDefinition(values.definition)
+
+        setConfirmLoading(true)
+
+        const submitData = {
+          name: values.name.trim(),
+          comment: values.comment,
+          definition,
+          properties: (values.properties || []).reduce((acc, item) => {
+            acc[item.key] = values[item.key] || item.value
+
+            return acc
+          }, {})
+        }
+
+        if (editSemanticModel) {
+          const updates = genSemanticModelUpdates(cacheData, submitData)
+          if (updates.length) {
+            await dispatch(
+              updateSemanticModel({
+                metalake,
+                catalog,
+                schema,
+                semanticModel: editSemanticModel,
+                data: { updates }
+              })
+            )
+          }
+        } else {
+          await dispatch(createSemanticModel({ data: submitData, metalake, catalog, schema }))
+        }
+
+        setConfirmLoading(false)
+        setOpen(false)
+      })
+      .catch(info => {
+        console.error(info)
+        form.scrollToField(info?.errorFields?.[0]?.name?.[0])
+      })
+  }
+
+  const handleCancel = () => {
+    setOpen(false)
+  }
+
+  return (
+    <>
+      <Modal
+        title={!editSemanticModel ? 'Create Semantic Model' : 'Edit Semantic Model'}
+        open={open}
+        onOk={handleSubmit}
+        okText='Submit'
+        okButtonProps={{ 'data-refer': 'handle-submit-semantic-model' }}
+        maskClosable={false}
+        keyboard={false}
+        width={800}
+        confirmLoading={confirmLoading}
+        onCancel={handleCancel}
+      >
+        <Paragraph type='secondary'>
+          {!editSemanticModel
+            ? 'Create a new semantic model.'
+            : `Edit the semantic model ${editSemanticModel}. The definition is replaced as a whole.`}
+        </Paragraph>
+        <div
+          className={cn('relative', {
+            'after:absolute after:-bottom-10 after:left-0 after:right-0 after:h-10 after:shadow-[0px_-10px_8px_-8px_rgba(5,5,5,0.1)]':
+              topShadow,
+            'before:absolute before:-top-10 before:left-0 before:right-0 before:h-10 before:z-10 before:shadow-[0px_10px_8px_-8px_rgba(5,5,5,0.1)]':
+              bottomShadow
+          })}
+        >
+          <div className='overflow-auto' style={{ maxHeight: `${dialogContentMaxHeigth}px` }} ref={scrollRef}>
+            <Spin spinning={isLoading}>
+              <Form
+                form={form}
+                initialValues={defaultValues}
+                layout='vertical'
+                name='semanticModelForm'
+                validateMessages={validateMessages}
+              >
+                <Form.Item
+                  name='name'
+                  label='Semantic Model Name'
+                  rules={[{ required: true }, { type: 'string', max: 64 }, { pattern: new RegExp(nameRegex) }]}
+                  messageVariables={{ label: 'semantic model name' }}
+                >
+                  <Input data-refer='semantic-model-name-field' placeholder={mismatchName} />
+                </Form.Item>
+                <Form.Item name='comment' label='Comment'>
+                  <TextArea data-refer='semantic-model-comment-field' />
+                </Form.Item>
+                <Form.Item
+                  name='definition'
+                  label='Definition'
+                  extra='The datasets, relationships and metrics of the semantic model, as JSON. The server validates the sources.'
+                  rules={[{ required: true }, { validator: validateDefinition }]}
+                  messageVariables={{ label: 'definition' }}
+                >
+                  <TextArea
+                    data-refer='semantic-model-definition-field'
+                    autoSize={{ minRows: 12, maxRows: 24 }}
+                    className='font-mono text-xs'
+                    placeholder={definitionPlaceholder}
+                  />
+                </Form.Item>
+                <Form.Item label='Properties'>
+                  <Form.List name='properties'>
+                    {(fields, subOpt) => (
+                      <RenderPropertiesFormItem
+                        fields={fields}
+                        subOpt={subOpt}
+                        form={form}
+                        isEdit={!!editSemanticModel}
+                        isDisable={false}
+                      />
+                    )}
+                  </Form.List>
+                </Form.Item>
+              </Form>
+            </Spin>
+          </div>
+        </div>
+      </Modal>
+    </>
+  )
+}

--- a/web-v2/web/src/app/catalogs/rightContent/RightContent.js
+++ b/web-v2/web/src/app/catalogs/rightContent/RightContent.js
@@ -67,6 +67,11 @@ const ViewDetailsPage = dynamic(() => import('./entitiesContent/ViewDetailsPage'
   ssr: false
 })
 
+const SemanticModelDetailsPage = dynamic(() => import('./entitiesContent/SemanticModelDetailsPage'), {
+  loading: () => <Loading height={'200px'} />,
+  ssr: false
+})
+
 const RightContent = () => {
   const searchParams = useSearchParams()
 
@@ -76,10 +81,12 @@ const RightContent = () => {
   const schema = searchParams.get('schema')
   const functionName = searchParams.get('function')
   const viewName = searchParams.get('view')
+  const semanticModelName = searchParams.get('semanticModel')
 
   const entity =
     functionName ||
     viewName ||
+    semanticModelName ||
     searchParams.get('table') ||
     searchParams.get('fileset') ||
     searchParams.get('topic') ||
@@ -101,6 +108,9 @@ const RightContent = () => {
       }
       if (viewName) {
         return <ViewDetailsPage />
+      }
+      if (semanticModelName) {
+        return <SemanticModelDetailsPage />
       }
       switch (catalogType) {
         case 'relational':

--- a/web-v2/web/src/app/catalogs/rightContent/entitiesContent/SchemaDetailsPage.js
+++ b/web-v2/web/src/app/catalogs/rightContent/entitiesContent/SchemaDetailsPage.js
@@ -59,6 +59,7 @@ import {
   deleteTopic,
   deleteTable,
   deleteView,
+  deleteSemanticModel,
   getTableDetails,
   getCurrentEntityOwner
 } from '@/lib/store/metalakes'
@@ -70,6 +71,7 @@ import CreateFilesetDialog from '../CreateFilesetDialog'
 import RegisterModelDialog from '../RegisterModelDialog'
 import CreateTopicDialog from '../CreateTopicDialog'
 import CreateTableDialog from '../CreateTableDialog'
+import CreateSemanticModelDialog from '../CreateSemanticModelDialog'
 import Functions from './Functions'
 
 const SetOwnerDialog = dynamic(() => import('@/components/SetOwnerDialog'), {
@@ -89,6 +91,8 @@ export default function SchemaDetailsPage() {
   const [openTopic, setOpenTopic] = useState(false)
   const [openOwner, setOpenOwner] = useState(false)
   const [openModel, setOpenModel] = useState(false)
+  const [openSemanticModel, setOpenSemanticModel] = useState(false)
+  const [editSemanticModel, setEditSemanticModel] = useState('')
   const [editTable, setEditTable] = useState('')
   const [editFileset, setEditFileset] = useState('')
   const [editTopic, setEditTopic] = useState('')
@@ -193,12 +197,14 @@ export default function SchemaDetailsPage() {
             ? [
                 { label: 'Tables', key: 'Tables' },
                 { label: 'Views', key: 'Views' },
+                { label: 'Semantic Models', key: 'Semantic Models' },
                 { label: 'Functions', key: 'Functions' },
                 { label: 'Associated Roles', key: 'Associated Roles' }
               ]
             : [
                 { label: 'Tables', key: 'Tables' },
                 { label: 'Views', key: 'Views' },
+                { label: 'Semantic Models', key: 'Semantic Models' },
                 { label: 'Functions', key: 'Functions' }
               ]
         )
@@ -353,6 +359,18 @@ export default function SchemaDetailsPage() {
       children: undefined
     }))
 
+  const semanticModelData = [...(store.semanticModels || [])]
+    .filter(c => {
+      if (search === '') return true
+
+      return c.name.includes(search)
+    })
+    .map(entity => ({
+      ...entity,
+      key: entity.name,
+      children: undefined
+    }))
+
   const subSchemaData = [...subSchemas]
     .filter(item => {
       if (search === '') return true
@@ -488,8 +506,10 @@ export default function SchemaDetailsPage() {
       validateFn = fn
     }
 
+    const typeLabel = type === 'semanticModel' ? 'semantic model' : type
+
     modalToUse.confirm({
-      title: `Are you sure to delete the ${type} ${entity}?`,
+      title: `Are you sure to delete the ${typeLabel} ${entity}?`,
       icon: <ExclamationCircleFilled />,
       content: (
         <ConfirmInput name={entity} isManaged={isManaged} location={location} registerValidate={registerValidate} />
@@ -513,6 +533,10 @@ export default function SchemaDetailsPage() {
             case 'relational':
               if (type === 'view') {
                 await dispatch(deleteView({ metalake: currentMetalake, catalog, schema, view: entity }))
+              } else if (type === 'semanticModel') {
+                await dispatch(
+                  deleteSemanticModel({ metalake: currentMetalake, catalog, schema, semanticModel: entity })
+                )
               } else {
                 await dispatch(deleteTable({ metalake: currentMetalake, catalog, catalogType, schema, table: entity }))
               }
@@ -631,6 +655,65 @@ export default function SchemaDetailsPage() {
     [currentMetalake, catalogType, catalog, schema, catalogData?.provider]
   )
 
+  const semanticModelColumns = useMemo(
+    () => [
+      {
+        title: 'Semantic Model Name',
+        dataIndex: 'name',
+        key: 'name',
+        width: 300,
+        ellipsis: true,
+        sorter: (a, b) => a?.name.toLowerCase().localeCompare(b?.name.toLowerCase()),
+        render: name => (
+          <Link
+            data-refer={`semantic-model-link-${name}`}
+            href={`/catalogs?metalake=${encodeURIComponent(currentMetalake)}&catalogType=${catalogType}&catalog=${encodeURIComponent(catalog)}&schema=${encodeURIComponent(schema)}&semanticModel=${encodeURIComponent(name)}`}
+          >
+            {name}
+          </Link>
+        )
+      },
+      {
+        title: 'Tags',
+        dataIndex: 'tags',
+        key: 'tags',
+        render: (_, record) => (
+          <Tags metadataObjectType={'semantic_model'} metadataObjectFullName={`${catalog}.${schema}.${record.name}`} />
+        )
+      },
+      {
+        title: 'Actions',
+        dataIndex: 'action',
+        key: 'action',
+        width: 100,
+        render: (_, record) => (
+          <Space size={4}>
+            <a data-refer={`edit-semantic-model-${record.name}`}>
+              <Tooltip title='Edit'>
+                <Icons.Pencil
+                  className='size-4 hover:cursor-pointer hover:text-defaultPrimary'
+                  onClick={() => {
+                    setEditSemanticModel(record.name)
+                    setOpenSemanticModel(true)
+                  }}
+                />
+              </Tooltip>
+            </a>
+            <a data-refer={`delete-semantic-model-${record.name}`}>
+              <Tooltip title='Delete'>
+                <Icons.Trash2Icon
+                  className='size-4 hover:cursor-pointer hover:text-defaultPrimary'
+                  onClick={() => showDeleteConfirm(record, 'semanticModel')}
+                />
+              </Tooltip>
+            </a>
+          </Space>
+        )
+      }
+    ],
+    [currentMetalake, catalogType, catalog, schema]
+  )
+
   const subSchemaColumns = useMemo(() => {
     return buildSchemaColumns({
       currentMetalake,
@@ -659,6 +742,14 @@ export default function SchemaDetailsPage() {
   } = useAntdColumnResize(() => {
     return { columns: viewColumns, minWidth: 100 }
   }, [viewColumns])
+
+  const {
+    resizableColumns: semanticModelResizableColumns,
+    components: semanticModelComponents,
+    tableWidth: semanticModelTableWidth
+  } = useAntdColumnResize(() => {
+    return { columns: semanticModelColumns, minWidth: 100 }
+  }, [semanticModelColumns])
 
   const {
     resizableColumns: subSchemaResizableColumns,
@@ -803,6 +894,47 @@ export default function SchemaDetailsPage() {
             columns={viewResizableColumns}
             components={viewComponents}
           />
+        </>
+      ) : tabKey === 'Semantic Models' ? (
+        <>
+          <Flex justify='flex-end' className='mb-4'>
+            <div className='flex w-1/2 gap-4'>
+              <Search name='searchSemanticModelInput' placeholder='Search...' value={search} onChange={onSearchTable} />
+              <Button
+                data-refer='create-semantic-model-btn'
+                type='primary'
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  setEditSemanticModel('')
+                  setOpenSemanticModel(true)
+                }}
+              >
+                Create Semantic Model
+              </Button>
+            </div>
+          </Flex>
+          <Spin spinning={store.tableLoading}>
+            <Table
+              data-refer='semantic-model-list-grid'
+              size='small'
+              style={{ maxHeight: 'calc(100vh - 30rem)' }}
+              scroll={{ x: semanticModelTableWidth, y: 'calc(100vh - 37rem)' }}
+              dataSource={semanticModelData}
+              pagination={{ position: ['bottomCenter'], showSizeChanger: true }}
+              columns={semanticModelResizableColumns}
+              components={semanticModelComponents}
+            />
+          </Spin>
+          {openSemanticModel && (
+            <CreateSemanticModelDialog
+              open={openSemanticModel}
+              setOpen={setOpenSemanticModel}
+              metalake={currentMetalake}
+              catalog={catalog}
+              schema={schema}
+              editSemanticModel={editSemanticModel}
+            />
+          )}
         </>
       ) : (
         <>

--- a/web-v2/web/src/app/catalogs/rightContent/entitiesContent/SemanticModelDetailsPage.js
+++ b/web-v2/web/src/app/catalogs/rightContent/entitiesContent/SemanticModelDetailsPage.js
@@ -1,0 +1,454 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Divider, Flex, Popover, Space, Spin, Table, Tabs, Tag, Tooltip, Typography, message } from 'antd'
+import { useAntdColumnResize } from 'react-antd-column-resize'
+import useResizeObserver from 'use-resize-observer'
+import { useSearchParams } from 'next/navigation'
+import Tags from '@/components/CustomTags'
+import GetOwner from '@/components/GetOwner'
+import Icons from '@/components/Icons'
+import PropertiesContent from '@/components/PropertiesContent'
+import { useAppSelector } from '@/lib/hooks/useStore'
+import { copyToClipboard } from '@/lib/utils'
+import { formatToDateTime, isValidDate } from '@/lib/utils/date'
+import { formatSemanticModelDefinition } from '@/lib/utils/semanticModel'
+
+const { Title, Paragraph } = Typography
+
+const sourceFullName = source => {
+  if (!source) {
+    return '-'
+  }
+
+  return [...(source.namespace || []), source.name].filter(Boolean).join('.')
+}
+
+const renderExpression = expression => {
+  const dialects = expression?.dialects || []
+
+  if (!dialects.length) {
+    return <span>-</span>
+  }
+
+  return (
+    <Space direction='vertical' size={2}>
+      {dialects.map((dialect, index) => (
+        <span key={`${dialect?.dialect}-${index}`}>
+          <Tag>{dialect?.dialect}</Tag>
+          <span className='font-mono text-xs'>{dialect?.expression}</span>
+        </span>
+      ))}
+    </Space>
+  )
+}
+
+const renderColumns = columns => <span className='font-mono text-xs'>{(columns || []).join(', ') || '-'}</span>
+
+export default function SemanticModelDetailsPage() {
+  const searchParams = useSearchParams()
+  const metalake = searchParams.get('metalake')
+  const catalog = searchParams.get('catalog')
+  const schema = searchParams.get('schema')
+  const semanticModelName = searchParams.get('semanticModel')
+  const auth = useAppSelector(state => state.auth)
+  const { anthEnable } = auth
+  const store = useAppSelector(state => state.metalakes)
+  const semanticModel = store.activatedDetails
+  const [tabKey, setTabKey] = useState('Datasets')
+  const { ref, width } = useResizeObserver()
+
+  const definition = semanticModel?.definition
+  const properties = semanticModel?.properties
+  const createdAt = semanticModel?.audit?.createTime
+  const createdAtText = !createdAt || !isValidDate(createdAt) ? '-' : formatToDateTime(createdAt)
+  const metadataObjectFullName = `${catalog}.${schema}.${semanticModelName}`
+
+  const datasets = useMemo(
+    () => (definition?.datasets || []).map(dataset => ({ ...dataset, key: dataset.name })),
+    [definition]
+  )
+
+  const relationships = useMemo(
+    () => (definition?.relationships || []).map(relationship => ({ ...relationship, key: relationship.name })),
+    [definition]
+  )
+
+  const metrics = useMemo(
+    () => (definition?.metrics || []).map(metric => ({ ...metric, key: metric.name })),
+    [definition]
+  )
+
+  const definitionText = useMemo(() => formatSemanticModelDefinition(definition), [definition])
+
+  const tagContent = (
+    <div>
+      <Tags readOnly={true} metadataObjectType={'semantic_model'} metadataObjectFullName={metadataObjectFullName} />
+    </div>
+  )
+
+  const propertyContent = <PropertiesContent properties={properties} />
+
+  const onCopyDefinition = async () => {
+    try {
+      await copyToClipboard(definitionText)
+      message.success('Definition copied!')
+    } catch (err) {
+      console.error('Failed to copy definition: ', err)
+      message.error('Failed to copy definition')
+    }
+  }
+
+  const datasetColumns = useMemo(
+    () => [
+      {
+        title: 'Dataset Name',
+        dataIndex: 'name',
+        key: 'name',
+        width: 200,
+        ellipsis: true,
+        sorter: (a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      },
+      {
+        title: 'Source',
+        dataIndex: 'source',
+        key: 'source',
+        width: 260,
+        ellipsis: true,
+        render: source => <span className='font-mono text-xs'>{sourceFullName(source)}</span>
+      },
+      {
+        title: 'Primary Key',
+        dataIndex: 'primaryKey',
+        key: 'primaryKey',
+        width: 180,
+        ellipsis: true,
+        render: renderColumns
+      },
+      {
+        title: 'Fields',
+        dataIndex: 'fields',
+        key: 'fields',
+        width: 80,
+        render: fields => <span>{(fields || []).length}</span>
+      },
+      {
+        title: 'Description',
+        dataIndex: 'description',
+        key: 'description',
+        ellipsis: true,
+        render: description => <span>{description || '-'}</span>
+      }
+    ],
+    []
+  )
+
+  const fieldColumns = useMemo(
+    () => [
+      { title: 'Field Name', dataIndex: 'name', key: 'name', width: 200, ellipsis: true },
+      {
+        title: 'Data Type',
+        dataIndex: 'datatype',
+        key: 'datatype',
+        width: 140,
+        render: datatype => (datatype ? <Tag>{datatype}</Tag> : <span>-</span>)
+      },
+      {
+        title: 'Time Dimension',
+        dataIndex: 'dimension',
+        key: 'dimension',
+        width: 140,
+        render: dimension => <span>{dimension?.isTime ? 'Yes' : 'No'}</span>
+      },
+      {
+        title: 'Expression',
+        dataIndex: 'expression',
+        key: 'expression',
+        render: renderExpression
+      },
+      {
+        title: 'Description',
+        dataIndex: 'description',
+        key: 'description',
+        ellipsis: true,
+        render: description => <span>{description || '-'}</span>
+      }
+    ],
+    []
+  )
+
+  const relationshipColumns = useMemo(
+    () => [
+      {
+        title: 'Relationship Name',
+        dataIndex: 'name',
+        key: 'name',
+        width: 220,
+        ellipsis: true,
+        sorter: (a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      },
+      { title: 'From', dataIndex: 'from', key: 'from', width: 160, ellipsis: true },
+      {
+        title: 'From Columns',
+        dataIndex: 'fromColumns',
+        key: 'fromColumns',
+        width: 200,
+        ellipsis: true,
+        render: renderColumns
+      },
+      { title: 'To', dataIndex: 'to', key: 'to', width: 160, ellipsis: true },
+      {
+        title: 'To Columns',
+        dataIndex: 'toColumns',
+        key: 'toColumns',
+        ellipsis: true,
+        render: renderColumns
+      }
+    ],
+    []
+  )
+
+  const metricColumns = useMemo(
+    () => [
+      {
+        title: 'Metric Name',
+        dataIndex: 'name',
+        key: 'name',
+        width: 200,
+        ellipsis: true,
+        sorter: (a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      },
+      {
+        title: 'Data Type',
+        dataIndex: 'datatype',
+        key: 'datatype',
+        width: 140,
+        render: datatype => (datatype ? <Tag>{datatype}</Tag> : <span>-</span>)
+      },
+      {
+        title: 'Expression',
+        dataIndex: 'expression',
+        key: 'expression',
+        render: renderExpression
+      },
+      {
+        title: 'Description',
+        dataIndex: 'description',
+        key: 'description',
+        ellipsis: true,
+        render: description => <span>{description || '-'}</span>
+      }
+    ],
+    []
+  )
+
+  const tabOptions = [
+    { label: 'Datasets', key: 'Datasets' },
+    { label: 'Relationships', key: 'Relationships' },
+    { label: 'Metrics', key: 'Metrics' },
+    { label: 'Definition', key: 'Definition' }
+  ]
+
+  const {
+    resizableColumns: datasetResizableColumns,
+    components: datasetComponents,
+    tableWidth: datasetTableWidth
+  } = useAntdColumnResize(() => {
+    return { columns: datasetColumns, minWidth: 100 }
+  }, [datasetColumns])
+
+  const {
+    resizableColumns: relationshipResizableColumns,
+    components: relationshipComponents,
+    tableWidth: relationshipTableWidth
+  } = useAntdColumnResize(() => {
+    return { columns: relationshipColumns, minWidth: 100 }
+  }, [relationshipColumns])
+
+  const {
+    resizableColumns: metricResizableColumns,
+    components: metricComponents,
+    tableWidth: metricTableWidth
+  } = useAntdColumnResize(() => {
+    return { columns: metricColumns, minWidth: 100 }
+  }, [metricColumns])
+
+  const expandedFieldsRow = dataset => (
+    <Table
+      data-refer='semantic-model-fields-grid'
+      size='small'
+      rowKey={field => field.name}
+      dataSource={dataset.fields || []}
+      columns={fieldColumns}
+      pagination={false}
+    />
+  )
+
+  return (
+    <>
+      <Spin spinning={store.activatedDetailsLoading}>
+        <Flex className='mb-2' gap='small' align='flex-start' ref={ref}>
+          <div className='size-8'>
+            <Icons.iconify icon='mdi:graph-outline' className='my-icon-large' />
+          </div>
+          <div className='grow-1 relative bottom-1'>
+            <Title level={3} style={{ marginBottom: '0.125rem' }}>
+              <span
+                title={semanticModelName}
+                className='min-w-10 truncate'
+                style={{ maxWidth: `calc(${width}px - 56px)`, display: 'inherit' }}
+              >
+                {decodeURIComponent(semanticModelName || '')}
+              </span>
+            </Title>
+            <Paragraph
+              type='secondary'
+              className='truncate'
+              title={semanticModel?.comment}
+              style={{ marginBottom: 0, maxWidth: `calc(${width}px - 56px)` }}
+            >
+              {semanticModel?.comment}
+            </Paragraph>
+          </div>
+        </Flex>
+        <Space split={<Divider type='vertical' />} wrap={true} className='mb-2'>
+          {anthEnable && (
+            <Space size={4}>
+              <Tooltip title='Owned' placement='top'>
+                <Icons.User className='size-4' color='grey' />
+              </Tooltip>
+              <GetOwner
+                metalake={metalake}
+                metadataObjectType={'semantic_model'}
+                metadataObjectFullName={metadataObjectFullName}
+              />
+            </Space>
+          )}
+          {semanticModel?.audit?.creator && (
+            <Space size={4}>
+              <Tooltip title='Creator' placement='top'>
+                <Icons.UserPen className='size-4' color='grey' />
+              </Tooltip>
+              <span>{semanticModel.audit.creator}</span>
+            </Space>
+          )}
+          <Space size={4}>
+            <Tooltip title='Created' placement='top'>
+              <Icons.iconify icon='mdi:clock-outline' className='size-4' props={{ color: 'grey' }} />
+            </Tooltip>
+            <span>{createdAtText}</span>
+          </Space>
+          <Space size={4}>
+            <Tooltip title='Tags' placement='top'>
+              <Icons.Tags className='size-4' color='grey' />
+            </Tooltip>
+            {store.currentEntityTags && store.currentEntityTags?.length > 0 ? (
+              <Popover placement='bottom' title={<span>Tags</span>} content={tagContent}>
+                <a className='text-defaultPrimary'>{store.currentEntityTags?.length}</a>
+              </Popover>
+            ) : (
+              <a className='text-defaultPrimary'>0</a>
+            )}
+          </Space>
+          <Space size={4}>
+            <Tooltip title='Properties' placement='top'>
+              <Icons.TableProperties className='size-4' color='grey' />
+            </Tooltip>
+            {properties && Object.keys(properties).length > 0 ? (
+              <Popover placement='bottom' title={<span>Properties</span>} content={propertyContent}>
+                <a className='text-defaultPrimary'>{Object.keys(properties).length}</a>
+              </Popover>
+            ) : (
+              <a className='text-defaultPrimary'>0</a>
+            )}
+          </Space>
+        </Space>
+      </Spin>
+      <Tabs data-refer='details-tabs' activeKey={tabKey} onChange={setTabKey} items={tabOptions} />
+      <Spin spinning={store.activatedDetailsLoading}>
+        {tabKey === 'Datasets' && (
+          <Table
+            data-refer='semantic-model-datasets-grid'
+            size='small'
+            style={{ maxHeight: 'calc(100vh - 30rem)' }}
+            scroll={{ x: datasetTableWidth, y: 'calc(100vh - 37rem)' }}
+            dataSource={datasets}
+            columns={datasetResizableColumns}
+            components={datasetComponents}
+            expandable={{
+              expandedRowRender: expandedFieldsRow,
+              rowExpandable: dataset => (dataset.fields || []).length > 0
+            }}
+            pagination={{ position: ['bottomCenter'], showSizeChanger: true }}
+          />
+        )}
+        {tabKey === 'Relationships' && (
+          <Table
+            data-refer='semantic-model-relationships-grid'
+            size='small'
+            style={{ maxHeight: 'calc(100vh - 30rem)' }}
+            scroll={{ x: relationshipTableWidth, y: 'calc(100vh - 37rem)' }}
+            dataSource={relationships}
+            columns={relationshipResizableColumns}
+            components={relationshipComponents}
+            pagination={{ position: ['bottomCenter'], showSizeChanger: true }}
+          />
+        )}
+        {tabKey === 'Metrics' && (
+          <Table
+            data-refer='semantic-model-metrics-grid'
+            size='small'
+            style={{ maxHeight: 'calc(100vh - 30rem)' }}
+            scroll={{ x: metricTableWidth, y: 'calc(100vh - 37rem)' }}
+            dataSource={metrics}
+            columns={metricResizableColumns}
+            components={metricComponents}
+            pagination={{ position: ['bottomCenter'], showSizeChanger: true }}
+          />
+        )}
+        {tabKey === 'Definition' &&
+          (definitionText ? (
+            <div className='relative rounded border border-borderColor p-3'>
+              <Tooltip title='Copy definition' placement='top'>
+                <button
+                  type='button'
+                  className='absolute right-3 top-3 inline-flex cursor-pointer items-center rounded border border-borderColor bg-transparent p-1 text-textSecondary transition-colors hover:text-defaultPrimary'
+                  onClick={onCopyDefinition}
+                >
+                  <Icons.Copy className='size-4' />
+                </button>
+              </Tooltip>
+              <pre
+                data-refer='semantic-model-definition'
+                className='m-0 overflow-auto whitespace-pre-wrap break-all font-mono text-sm leading-6'
+                style={{ maxHeight: 'calc(100vh - 34rem)' }}
+              >
+                {definitionText}
+              </pre>
+            </div>
+          ) : (
+            <Paragraph type='secondary'>No definition available.</Paragraph>
+          ))}
+      </Spin>
+    </>
+  )
+}

--- a/web-v2/web/src/lib/api/semanticModels/index.js
+++ b/web-v2/web/src/lib/api/semanticModels/index.js
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { defHttp } from '@/lib/utils/axios'
+
+const Apis = {
+  GET: ({ metalake, catalog, schema }) =>
+    `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(
+      catalog
+    )}/schemas/${encodeURIComponent(schema)}/semantic-models`,
+  GET_DETAIL: ({ metalake, catalog, schema, semanticModel }) =>
+    `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(
+      catalog
+    )}/schemas/${encodeURIComponent(schema)}/semantic-models/${encodeURIComponent(semanticModel)}`
+}
+
+export const getSemanticModelsApi = (params, options) => {
+  return defHttp.get(
+    {
+      url: `${Apis.GET(params)}`
+    },
+    options
+  )
+}
+
+export const getSemanticModelDetailsApi = ({ metalake, catalog, schema, semanticModel }, options) => {
+  return defHttp.get(
+    {
+      url: `${Apis.GET_DETAIL({ metalake, catalog, schema, semanticModel })}`
+    },
+    options
+  )
+}
+
+export const createSemanticModelApi = ({ metalake, catalog, schema, data }) => {
+  return defHttp.post({
+    url: `${Apis.GET({ metalake, catalog, schema })}`,
+    data
+  })
+}
+
+export const updateSemanticModelApi = ({ metalake, catalog, schema, semanticModel, data }) => {
+  return defHttp.put({
+    url: `${Apis.GET_DETAIL({ metalake, catalog, schema, semanticModel })}`,
+    data
+  })
+}
+
+export const deleteSemanticModelApi = ({ metalake, catalog, schema, semanticModel }) => {
+  return defHttp.delete({
+    url: `${Apis.GET_DETAIL({ metalake, catalog, schema, semanticModel })}`
+  })
+}

--- a/web-v2/web/src/lib/store/metalakes/index.js
+++ b/web-v2/web/src/lib/store/metalakes/index.js
@@ -79,6 +79,13 @@ import {
 } from '@/lib/api/models'
 import { getFunctionsApi, getFunctionDetailsApi } from '@/lib/api/functions'
 import { getViewsApi, getViewDetailsApi, deleteViewApi } from '@/lib/api/views'
+import {
+  getSemanticModelsApi,
+  getSemanticModelDetailsApi,
+  createSemanticModelApi,
+  updateSemanticModelApi,
+  deleteSemanticModelApi
+} from '@/lib/api/semanticModels'
 
 const remapExpandedAndLoadedNodes = ({ getState, mapNode }) => {
   const expandedNodes = getState().metalakes.expandedNodes.map(mapNode)
@@ -95,8 +102,9 @@ const mergeWithFunctionNodes = ({ tree, key, entities }) => {
   const subSchemas = existingNode?.children?.filter(child => child?.node === 'schema') || []
   const functions = existingNode?.children?.filter(child => child?.node === 'function') || []
   const views = existingNode?.children?.filter(child => child?.node === 'view') || []
+  const semanticModels = existingNode?.children?.filter(child => child?.node === 'semanticModel') || []
 
-  return _.uniqBy([...subSchemas, ...entities, ...functions, ...views], 'key')
+  return _.uniqBy([...subSchemas, ...entities, ...functions, ...views, ...semanticModels], 'key')
 }
 
 const mergeWithViewNodes = ({ tree, key, entities }) => {
@@ -104,8 +112,19 @@ const mergeWithViewNodes = ({ tree, key, entities }) => {
   const subSchemas = existingNode?.children?.filter(child => child?.node === 'schema') || []
   const tables = existingNode?.children?.filter(child => child?.node === 'table') || []
   const functions = existingNode?.children?.filter(child => child?.node === 'function') || []
+  const semanticModels = existingNode?.children?.filter(child => child?.node === 'semanticModel') || []
 
-  return _.uniqBy([...subSchemas, ...tables, ...functions, ...entities], 'key')
+  return _.uniqBy([...subSchemas, ...tables, ...functions, ...entities, ...semanticModels], 'key')
+}
+
+const mergeWithSemanticModelNodes = ({ tree, key, entities }) => {
+  const existingNode = findInTree(tree, 'key', key)
+  const subSchemas = existingNode?.children?.filter(child => child?.node === 'schema') || []
+  const tables = existingNode?.children?.filter(child => child?.node === 'table') || []
+  const functions = existingNode?.children?.filter(child => child?.node === 'function') || []
+  const views = existingNode?.children?.filter(child => child?.node === 'view') || []
+
+  return _.uniqBy([...subSchemas, ...tables, ...functions, ...views, ...entities], 'key')
 }
 
 const isAuthReady = state => {
@@ -326,10 +345,16 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
           ? getViewsApi({ metalake, catalog, schema }, { errorMessageMode: 'none' })
           : Promise.resolve(null)
 
-      const [funcResult, entityResult, viewResult, childSchemasResult] = await Promise.allSettled([
+      const semanticModelsPromise =
+        type === 'relational'
+          ? getSemanticModelsApi({ metalake, catalog, schema }, { errorMessageMode: 'none' })
+          : Promise.resolve(null)
+
+      const [funcResult, entityResult, viewResult, semanticModelResult, childSchemasResult] = await Promise.allSettled([
         getFunctionsApi({ metalake, catalog, schema, details: false }),
         entityPromise,
         viewsPromise,
+        semanticModelsPromise,
         childSchemasPromise
       ])
 
@@ -383,6 +408,23 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
                 path: `?${new URLSearchParams({ metalake, catalog, catalogType: type, schema, view: viewItem.name }).toString()}`,
                 name: viewItem.name,
                 title: viewItem.name,
+                isLeaf: true,
+                children: []
+              }
+            })
+          : []
+
+      const semanticModels =
+        semanticModelResult.status === 'fulfilled' && semanticModelResult.value
+          ? (semanticModelResult.value?.identifiers || []).map(semanticModelItem => {
+              return {
+                ...semanticModelItem,
+                node: 'semanticModel',
+                id: `{{${metalake}}}{{${catalog}}}{{${type}}}{{${schema}}}{{${semanticModelItem.name}}}`,
+                key: `{{${metalake}}}{{${catalog}}}{{${type}}}{{${schema}}}{{${semanticModelItem.name}}}`,
+                path: `?${new URLSearchParams({ metalake, catalog, catalogType: type, schema, semanticModel: semanticModelItem.name }).toString()}`,
+                name: semanticModelItem.name,
+                title: semanticModelItem.name,
                 isLeaf: true,
                 children: []
               }
@@ -463,7 +505,7 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
         }
       }
 
-      result.data = [...childSchemas, ...entities, ...functions, ...views]
+      result.data = [...childSchemas, ...entities, ...functions, ...views, ...semanticModels]
       result.entities = entities
     }
 
@@ -2332,6 +2374,136 @@ export const deleteView = createAsyncThunk(
   }
 )
 
+export const fetchSemanticModels = createAsyncThunk(
+  'appMetalakes/fetchSemanticModels',
+  async ({ init, metalake, catalog, schema }, { getState, dispatch }) => {
+    const [err, res] = await to(getSemanticModelsApi({ metalake, catalog, schema }, { errorMessageMode: 'none' }))
+
+    if (err || !res) {
+      // The catalog doesn't support semantic models (405), or the server predates the endpoint and
+      // has no route for it (404). Both mean "this schema has none" — return empty silently rather
+      // than failing every schema page against an older server.
+      if ([404, 405].includes(err?.response?.status)) {
+        return { semanticModels: [], init }
+      }
+      if (init) {
+        throw new Error(err)
+      }
+    }
+
+    const { identifiers = [] } = res || {}
+
+    const semanticModels = identifiers.map(semanticModelItem => {
+      return {
+        ...semanticModelItem,
+        node: 'semanticModel',
+        id: `{{${metalake}}}{{${catalog}}}{{${'relational'}}}{{${schema}}}{{${semanticModelItem.name}}}`,
+        key: `{{${metalake}}}{{${catalog}}}{{${'relational'}}}{{${schema}}}{{${semanticModelItem.name}}}`,
+        path: `?${new URLSearchParams({
+          metalake,
+          catalog,
+          catalogType: 'relational',
+          schema,
+          semanticModel: semanticModelItem.name
+        }).toString()}`,
+        name: semanticModelItem.name,
+        title: semanticModelItem.name,
+        isLeaf: true,
+        children: []
+      }
+    })
+
+    if (
+      init &&
+      getState().metalakes.loadedNodes.includes(`{{${metalake}}}{{${catalog}}}{{${'relational'}}}{{${schema}}}`)
+    ) {
+      const schemaKey = `{{${metalake}}}{{${catalog}}}{{${'relational'}}}{{${schema}}}`
+      dispatch(
+        setIntoTreeNodes({
+          key: schemaKey,
+          data: mergeWithSemanticModelNodes({
+            tree: getState().metalakes.metalakeTree,
+            key: schemaKey,
+            entities: semanticModels
+          })
+        })
+      )
+    }
+
+    return { semanticModels, init }
+  }
+)
+
+export const getSemanticModelDetails = createAsyncThunk(
+  'appMetalakes/getSemanticModelDetails',
+  async ({ init, metalake, catalog, schema, semanticModel }) => {
+    const [err, res] = await to(
+      getSemanticModelDetailsApi({ metalake, catalog, schema, semanticModel }, { errorMessageMode: 'none' })
+    )
+
+    if (err || !res) {
+      // Catalog doesn't support semantic models (HTTP 405) — return empty result silently
+      if (err?.response?.status === 405) {
+        return { semanticModel: null, init }
+      }
+      throw new Error(err)
+    }
+
+    return { semanticModel: res.semanticModel || res, init }
+  }
+)
+
+export const createSemanticModel = createAsyncThunk(
+  'appMetalakes/createSemanticModel',
+  async ({ data, metalake, catalog, schema }, { dispatch }) => {
+    await dispatch(setTableLoading(true))
+    const [err, res] = await to(createSemanticModelApi({ data, metalake, catalog, schema }))
+    await dispatch(setTableLoading(false))
+
+    if (err || !res) {
+      return { err: true }
+    }
+
+    await dispatch(fetchSemanticModels({ metalake, catalog, schema, init: true }))
+
+    return res.semanticModel
+  }
+)
+
+export const updateSemanticModel = createAsyncThunk(
+  'appMetalakes/updateSemanticModel',
+  async ({ metalake, catalog, schema, semanticModel, data }, { dispatch }) => {
+    await dispatch(setTableLoading(true))
+    const [err, res] = await to(updateSemanticModelApi({ metalake, catalog, schema, semanticModel, data }))
+    await dispatch(setTableLoading(false))
+
+    if (err || !res) {
+      return { err: true }
+    }
+
+    await dispatch(fetchSemanticModels({ metalake, catalog, schema, init: true }))
+
+    return res.semanticModel
+  }
+)
+
+export const deleteSemanticModel = createAsyncThunk(
+  'appMetalakes/deleteSemanticModel',
+  async ({ metalake, catalog, schema, semanticModel }, { dispatch }) => {
+    await dispatch(setTableLoading(true))
+    const [err, res] = await to(deleteSemanticModelApi({ metalake, catalog, schema, semanticModel }))
+    await dispatch(setTableLoading(false))
+
+    if (err || !res) {
+      throw new Error(err)
+    }
+
+    await dispatch(fetchSemanticModels({ metalake, catalog, schema, init: true }))
+
+    return res
+  }
+)
+
 export const appMetalakesSlice = createSlice({
   name: 'appMetalakes',
   initialState: {
@@ -2345,6 +2517,7 @@ export const appMetalakesSlice = createSlice({
     tables: [],
     functions: [],
     views: [],
+    semanticModels: [],
     columns: [],
     filesets: [],
     topics: [],
@@ -2411,6 +2584,7 @@ export const appMetalakesSlice = createSlice({
       state.tables = []
       state.functions = []
       state.views = []
+      state.semanticModels = []
       state.columns = []
       state.filesets = []
       state.topics = []
@@ -2697,6 +2871,7 @@ export const appMetalakesSlice = createSlice({
       state.schemas = []
       state.tables = []
       state.views = []
+      state.semanticModels = []
       state.columns = []
       state.filesets = []
       state.topics = []
@@ -3081,6 +3256,29 @@ export const appMetalakesSlice = createSlice({
       }
     })
     builder.addCase(deleteView.rejected, (state, action) => {
+      if (!action.error.message.includes('CanceledError')) {
+        toast.error(action.error.message)
+      }
+    })
+    builder.addCase(fetchSemanticModels.fulfilled, (state, action) => {
+      state.semanticModels = action.payload.semanticModels
+    })
+    builder.addCase(fetchSemanticModels.rejected, (state, action) => {
+      if (!action.error.message.includes('CanceledError')) {
+        toast.error(action.error.message)
+      }
+    })
+    builder.addCase(getSemanticModelDetails.fulfilled, (state, action) => {
+      if (action.payload.init) {
+        state.activatedDetails = action.payload.semanticModel
+      }
+    })
+    builder.addCase(getSemanticModelDetails.rejected, (state, action) => {
+      if (!action.error.message.includes('CanceledError')) {
+        toast.error(action.error.message)
+      }
+    })
+    builder.addCase(deleteSemanticModel.rejected, (state, action) => {
       if (!action.error.message.includes('CanceledError')) {
         toast.error(action.error.message)
       }

--- a/web-v2/web/src/lib/utils/semanticModel.js
+++ b/web-v2/web/src/lib/utils/semanticModel.js
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { isEqual, isPlainObject } from 'lodash-es'
+
+const SOURCE_NAMESPACE_LENGTH = 2
+const DEFINITION_INDENT = 2
+
+const isNonBlankString = value => typeof value === 'string' && value.trim() !== ''
+
+const duplicatesOf = names => {
+  const seen = new Set()
+  const duplicates = new Set()
+
+  names.forEach(name => {
+    if (seen.has(name)) {
+      duplicates.add(name)
+    }
+    seen.add(name)
+  })
+
+  return [...duplicates]
+}
+
+const validateSource = (dataset, errors) => {
+  const { name, source } = dataset
+
+  if (!isPlainObject(source)) {
+    errors.push(`Dataset "${name}" must have a source with a namespace and a name.`)
+
+    return
+  }
+
+  const { namespace } = source
+
+  if (!Array.isArray(namespace) || namespace.length !== SOURCE_NAMESPACE_LENGTH || !namespace.every(isNonBlankString)) {
+    errors.push(`Dataset "${name}" must have a source namespace of exactly [catalog, schema].`)
+  }
+
+  if (!isNonBlankString(source.name)) {
+    errors.push(`Dataset "${name}" must have a source with a non-empty name.`)
+  }
+}
+
+const validateDatasets = (datasets, errors) => {
+  datasets.forEach((dataset, index) => {
+    if (!isPlainObject(dataset) || !isNonBlankString(dataset.name)) {
+      errors.push(`datasets[${index}] must have a non-empty name.`)
+
+      return
+    }
+
+    validateSource(dataset, errors)
+
+    const fields = dataset.fields
+    if (fields !== undefined && !Array.isArray(fields)) {
+      errors.push(`Dataset "${dataset.name}" must declare fields as an array.`)
+
+      return
+    }
+
+    const duplicateFields = duplicatesOf((fields || []).map(field => field?.name))
+    if (duplicateFields.length) {
+      errors.push(`Field names must be unique within dataset "${dataset.name}": ${duplicateFields.join(', ')}.`)
+    }
+  })
+
+  const duplicateDatasets = duplicatesOf(datasets.map(dataset => dataset?.name).filter(isNonBlankString))
+  if (duplicateDatasets.length) {
+    errors.push(`Dataset names must be unique within the semantic model: ${duplicateDatasets.join(', ')}.`)
+  }
+}
+
+const validateRelationships = (relationships, datasetNames, errors) => {
+  relationships.forEach((relationship, index) => {
+    if (!isPlainObject(relationship) || !isNonBlankString(relationship.name)) {
+      errors.push(`relationships[${index}] must have a non-empty name.`)
+
+      return
+    }
+
+    const { name, from, to, fromColumns, toColumns } = relationship
+
+    ;[from, to].forEach(endpoint => {
+      if (!datasetNames.has(endpoint)) {
+        errors.push(`Relationship "${name}" references an unknown dataset "${endpoint}".`)
+      }
+    })
+
+    if (!Array.isArray(fromColumns) || !Array.isArray(toColumns) || !fromColumns.length || !toColumns.length) {
+      errors.push(`Relationship "${name}" must have non-empty fromColumns and toColumns.`)
+
+      return
+    }
+
+    if (fromColumns.length !== toColumns.length) {
+      errors.push(`Relationship "${name}" must have the same number of fromColumns and toColumns.`)
+    }
+  })
+
+  const duplicates = duplicatesOf(relationships.map(relationship => relationship?.name).filter(isNonBlankString))
+  if (duplicates.length) {
+    errors.push(`Relationship names must be unique within the semantic model: ${duplicates.join(', ')}.`)
+  }
+}
+
+const validateMetrics = (metrics, errors) => {
+  metrics.forEach((metric, index) => {
+    if (!isPlainObject(metric) || !isNonBlankString(metric.name)) {
+      errors.push(`metrics[${index}] must have a non-empty name.`)
+    }
+  })
+
+  const duplicates = duplicatesOf(metrics.map(metric => metric?.name).filter(isNonBlankString))
+  if (duplicates.length) {
+    errors.push(`Metric names must be unique within the semantic model: ${duplicates.join(', ')}.`)
+  }
+}
+
+/**
+ * Checks the structural rules the server also enforces, so obvious mistakes are reported before the
+ * request is sent. The server stays the authority: it additionally resolves every dataset source
+ * and its columns against the catalog, which the browser cannot do.
+ *
+ * @param {unknown} definition The parsed semantic model definition.
+ * @returns {string[]} The problems found, empty when the definition looks well formed.
+ */
+export const validateSemanticModelDefinition = definition => {
+  const errors = []
+
+  if (!isPlainObject(definition)) {
+    return ['The definition must be a JSON object.']
+  }
+
+  const { datasets, relationships, metrics } = definition
+
+  if (!Array.isArray(datasets) || !datasets.length) {
+    return ['The definition must declare at least one dataset.']
+  }
+
+  validateDatasets(datasets, errors)
+
+  const datasetNames = new Set(datasets.map(dataset => dataset?.name).filter(isNonBlankString))
+
+  if (relationships !== undefined) {
+    if (Array.isArray(relationships)) {
+      validateRelationships(relationships, datasetNames, errors)
+    } else {
+      errors.push('The definition must declare relationships as an array.')
+    }
+  }
+
+  if (metrics !== undefined) {
+    if (Array.isArray(metrics)) {
+      validateMetrics(metrics, errors)
+    } else {
+      errors.push('The definition must declare metrics as an array.')
+    }
+  }
+
+  return errors
+}
+
+/**
+ * Parses the definition authored in the dialog and validates it.
+ *
+ * @param {string} text The raw JSON text.
+ * @returns {{ definition: object|null, errors: string[] }} The definition, or the problems found.
+ */
+export const parseSemanticModelDefinition = text => {
+  if (!isNonBlankString(text)) {
+    return { definition: null, errors: ['The definition is required.'] }
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(text)
+  } catch (err) {
+    return { definition: null, errors: [`The definition is not valid JSON: ${err.message}`] }
+  }
+
+  const errors = validateSemanticModelDefinition(parsed)
+
+  return errors.length ? { definition: null, errors } : { definition: parsed, errors: [] }
+}
+
+/**
+ * Renders a definition for the JSON editor.
+ *
+ * @param {object|null|undefined} definition The definition to render.
+ * @returns {string} The pretty-printed definition, or an empty string when there is none.
+ */
+export const formatSemanticModelDefinition = definition => {
+  if (!definition) {
+    return ''
+  }
+
+  return JSON.stringify(definition, null, DEFINITION_INDENT)
+}
+
+/**
+ * Builds the atomic alter batch from what actually changed, so an unchanged definition is not
+ * revalidated against its sources.
+ *
+ * @param {object} originalData The loaded semantic model.
+ * @param {object} newData The edited semantic model.
+ * @returns {object[]} The ordered updates, empty when nothing changed.
+ */
+export const genSemanticModelUpdates = (originalData, newData) => {
+  const updates = []
+
+  if (originalData.name !== newData.name) {
+    updates.push({ '@type': 'rename', newName: newData.name })
+  }
+
+  const originalComment = originalData.comment || ''
+  const newComment = newData.comment || ''
+
+  if (originalComment !== newComment) {
+    updates.push({ '@type': 'updateComment', newComment: newComment === '' ? null : newComment })
+  }
+
+  const originalProperties = originalData.properties || {}
+  const newProperties = newData.properties || {}
+
+  for (const key in originalProperties) {
+    if (!(key in newProperties)) {
+      updates.push({ '@type': 'removeProperty', property: key })
+    }
+  }
+
+  for (const key in newProperties) {
+    if (originalProperties[key] !== newProperties[key]) {
+      updates.push({ '@type': 'setProperty', property: key, value: newProperties[key] })
+    }
+  }
+
+  if (newData.definition && !isEqual(originalData.definition, newData.definition)) {
+    updates.push({ '@type': 'replaceDefinition', definition: newData.definition })
+  }
+
+  return updates
+}

--- a/web-v2/web/src/lib/utils/semanticModel.test.js
+++ b/web-v2/web/src/lib/utils/semanticModel.test.js
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, test } from 'vitest'
+import {
+  formatSemanticModelDefinition,
+  genSemanticModelUpdates,
+  parseSemanticModelDefinition,
+  validateSemanticModelDefinition
+} from './semanticModel'
+
+const orders = {
+  name: 'orders',
+  source: { namespace: ['sales', 'mart'], name: 'orders' },
+  fields: [{ name: 'order_id', expression: { dialects: [{ dialect: 'ANSI_SQL', expression: 'order_id' }] } }]
+}
+
+const customers = {
+  name: 'customers',
+  source: { namespace: ['sales', 'mart'], name: 'customers' }
+}
+
+const definitionOf = overrides => ({ datasets: [orders], ...overrides })
+
+describe('validateSemanticModelDefinition', () => {
+  test('accepts a minimal definition with a single dataset', () => {
+    expect(validateSemanticModelDefinition(definitionOf())).toEqual([])
+  })
+
+  test('rejects a definition that is not an object', () => {
+    expect(validateSemanticModelDefinition([orders])).toEqual(['The definition must be a JSON object.'])
+  })
+
+  test('rejects a definition without datasets', () => {
+    expect(validateSemanticModelDefinition({})).toEqual(['The definition must declare at least one dataset.'])
+  })
+
+  test('rejects an empty datasets array', () => {
+    expect(validateSemanticModelDefinition({ datasets: [] })).toEqual([
+      'The definition must declare at least one dataset.'
+    ])
+  })
+
+  test('rejects a dataset without a name', () => {
+    const errors = validateSemanticModelDefinition({ datasets: [{ source: orders.source }] })
+
+    expect(errors).toEqual(['datasets[0] must have a non-empty name.'])
+  })
+
+  test('rejects a dataset whose source namespace is not catalog.schema', () => {
+    const errors = validateSemanticModelDefinition({
+      datasets: [{ name: 'orders', source: { namespace: ['sales'], name: 'orders' } }]
+    })
+
+    expect(errors).toEqual(['Dataset "orders" must have a source namespace of exactly [catalog, schema].'])
+  })
+
+  test('rejects a dataset source without a name', () => {
+    const errors = validateSemanticModelDefinition({
+      datasets: [{ name: 'orders', source: { namespace: ['sales', 'mart'] } }]
+    })
+
+    expect(errors).toEqual(['Dataset "orders" must have a source with a non-empty name.'])
+  })
+
+  test('rejects duplicate dataset names', () => {
+    const errors = validateSemanticModelDefinition({ datasets: [orders, orders] })
+
+    expect(errors).toEqual(['Dataset names must be unique within the semantic model: orders.'])
+  })
+
+  test('rejects duplicate field names within one dataset', () => {
+    const errors = validateSemanticModelDefinition({
+      datasets: [{ ...orders, fields: [...orders.fields, ...orders.fields] }]
+    })
+
+    expect(errors).toEqual(['Field names must be unique within dataset "orders": order_id.'])
+  })
+
+  test('accepts the same field name in two different datasets', () => {
+    const errors = validateSemanticModelDefinition({
+      datasets: [orders, { ...customers, fields: orders.fields }]
+    })
+
+    expect(errors).toEqual([])
+  })
+
+  test('rejects a relationship endpoint that is not a declared dataset', () => {
+    const errors = validateSemanticModelDefinition({
+      datasets: [orders],
+      relationships: [
+        { name: 'orders_customers', from: 'orders', to: 'customers', fromColumns: ['a'], toColumns: ['b'] }
+      ]
+    })
+
+    expect(errors).toEqual(['Relationship "orders_customers" references an unknown dataset "customers".'])
+  })
+
+  test('rejects a relationship whose column counts do not match', () => {
+    const errors = validateSemanticModelDefinition({
+      datasets: [orders, customers],
+      relationships: [
+        { name: 'orders_customers', from: 'orders', to: 'customers', fromColumns: ['a'], toColumns: ['b', 'c'] }
+      ]
+    })
+
+    expect(errors).toEqual(['Relationship "orders_customers" must have the same number of fromColumns and toColumns.'])
+  })
+
+  test('rejects a relationship with empty columns', () => {
+    const errors = validateSemanticModelDefinition({
+      datasets: [orders, customers],
+      relationships: [{ name: 'orders_customers', from: 'orders', to: 'customers', fromColumns: [], toColumns: [] }]
+    })
+
+    expect(errors).toEqual(['Relationship "orders_customers" must have non-empty fromColumns and toColumns.'])
+  })
+
+  test('rejects duplicate relationship names', () => {
+    const relationship = {
+      name: 'orders_customers',
+      from: 'orders',
+      to: 'customers',
+      fromColumns: ['customer_id'],
+      toColumns: ['id']
+    }
+
+    const errors = validateSemanticModelDefinition({
+      datasets: [orders, customers],
+      relationships: [relationship, relationship]
+    })
+
+    expect(errors).toEqual(['Relationship names must be unique within the semantic model: orders_customers.'])
+  })
+
+  test('rejects duplicate metric names', () => {
+    const metric = { name: 'revenue', expression: { dialects: [{ dialect: 'ANSI_SQL', expression: 'sum(amount)' }] } }
+    const errors = validateSemanticModelDefinition({ datasets: [orders], metrics: [metric, metric] })
+
+    expect(errors).toEqual(['Metric names must be unique within the semantic model: revenue.'])
+  })
+
+  test('reports every problem it finds rather than only the first', () => {
+    const errors = validateSemanticModelDefinition({
+      datasets: [{ source: orders.source }, { name: 'customers' }]
+    })
+
+    expect(errors).toEqual([
+      'datasets[0] must have a non-empty name.',
+      'Dataset "customers" must have a source with a namespace and a name.'
+    ])
+  })
+})
+
+describe('parseSemanticModelDefinition', () => {
+  test('returns the parsed definition when the text is valid', () => {
+    const { definition, errors } = parseSemanticModelDefinition(JSON.stringify(definitionOf()))
+
+    expect(errors).toEqual([])
+    expect(definition).toEqual(definitionOf())
+  })
+
+  test('reports a parse failure without throwing', () => {
+    const { definition, errors } = parseSemanticModelDefinition('{ not json }')
+
+    expect(definition).toBeNull()
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/^The definition is not valid JSON/)
+  })
+
+  test('reports a blank definition', () => {
+    expect(parseSemanticModelDefinition('   ')).toEqual({
+      definition: null,
+      errors: ['The definition is required.']
+    })
+  })
+
+  test('reports contract errors for well-formed JSON', () => {
+    const { definition, errors } = parseSemanticModelDefinition('{"datasets": []}')
+
+    expect(definition).toBeNull()
+    expect(errors).toEqual(['The definition must declare at least one dataset.'])
+  })
+})
+
+describe('formatSemanticModelDefinition', () => {
+  test('pretty-prints a definition', () => {
+    expect(formatSemanticModelDefinition({ datasets: [] })).toBe('{\n  "datasets": []\n}')
+  })
+
+  test('returns an empty string for a missing definition', () => {
+    expect(formatSemanticModelDefinition(null)).toBe('')
+  })
+})
+
+describe('genSemanticModelUpdates', () => {
+  const original = {
+    name: 'sales_model',
+    comment: 'Governed sales definitions',
+    properties: { domain: 'sales' },
+    definition: definitionOf()
+  }
+
+  test('returns no updates when nothing changed', () => {
+    expect(genSemanticModelUpdates(original, { ...original })).toEqual([])
+  })
+
+  test('emits a rename when the name changed', () => {
+    expect(genSemanticModelUpdates(original, { ...original, name: 'sales_model_v2' })).toEqual([
+      { '@type': 'rename', newName: 'sales_model_v2' }
+    ])
+  })
+
+  test('emits an updateComment when the comment changed', () => {
+    expect(genSemanticModelUpdates(original, { ...original, comment: 'Updated' })).toEqual([
+      { '@type': 'updateComment', newComment: 'Updated' }
+    ])
+  })
+
+  test('clears the comment with a null newComment', () => {
+    expect(genSemanticModelUpdates(original, { ...original, comment: '' })).toEqual([
+      { '@type': 'updateComment', newComment: null }
+    ])
+  })
+
+  test('emits removeProperty before setProperty', () => {
+    const updates = genSemanticModelUpdates(original, { ...original, properties: { region: 'emea' } })
+
+    expect(updates).toEqual([
+      { '@type': 'removeProperty', property: 'domain' },
+      { '@type': 'setProperty', property: 'region', value: 'emea' }
+    ])
+  })
+
+  test('emits setProperty only for values that actually changed', () => {
+    const updates = genSemanticModelUpdates(original, {
+      ...original,
+      properties: { domain: 'sales', region: 'emea' }
+    })
+
+    expect(updates).toEqual([{ '@type': 'setProperty', property: 'region', value: 'emea' }])
+  })
+
+  test('emits replaceDefinition when the definition changed', () => {
+    const next = definitionOf({ datasets: [orders, customers] })
+    const updates = genSemanticModelUpdates(original, { ...original, definition: next })
+
+    expect(updates).toEqual([{ '@type': 'replaceDefinition', definition: next }])
+  })
+
+  test('does not emit replaceDefinition when the definition is deeply equal but not identical', () => {
+    const updates = genSemanticModelUpdates(original, {
+      ...original,
+      definition: JSON.parse(JSON.stringify(original.definition))
+    })
+
+    expect(updates).toEqual([])
+  })
+
+  test('orders a full batch as rename, comment, properties, then definition', () => {
+    const next = definitionOf({ datasets: [orders, customers] })
+
+    const updates = genSemanticModelUpdates(original, {
+      name: 'sales_model_v2',
+      comment: 'Updated',
+      properties: { region: 'emea' },
+      definition: next
+    })
+
+    expect(updates.map(update => update['@type'])).toEqual([
+      'rename',
+      'updateComment',
+      'removeProperty',
+      'setProperty',
+      'replaceDefinition'
+    ])
+  })
+})


### PR DESCRIPTION
### What changes were proposed in this pull request?

Surface schema-scoped Semantic Models in `web-v2`, alongside tables and logical views:

- **Tree and list** — semantic models appear as schema children in the catalog tree, and in a new "Semantic Models" tab on the schema page with search and tag association.
- **Detail page** — header with comment, owner, audit, tags and properties, plus tabs for Datasets (fields expandable per dataset), Relationships, Metrics, and the raw Definition with copy-to-clipboard.
- **Create, edit and drop** — a dialog for name, comment, properties and the definition, and the same typed-name delete confirmation used elsewhere in the UI.

The definition is authored as JSON. `src/lib/utils/semanticModel.js` checks the structural rules before the request is sent: datasets non-empty and uniquely named, `source.namespace` exactly `[catalog, schema]`, unique field names within a dataset, relationship endpoints resolving to declared datasets with matching column counts, and unique metric names. The server remains the authority, since it additionally resolves every dataset source and its columns against the catalog.

Alters are built by diffing the loaded model against the edited one and emitted as a single ordered batch (`rename`, `updateComment`, `removeProperty`, `setProperty`, `replaceDefinition`), so editing only a comment does not emit `replaceDefinition` and does not make the server revalidate the definition's sources.

The wire format follows the Semantic Model definition DTOs merged in #12624 (camelCase: `aiContext`, `primaryKey`, `fromColumns`, `customExtensions`, `isTime`).

Listing degrades silently on 404 and 405, so schema pages keep working against a server that does not expose the endpoint.

### Why are the changes needed?

#12209 adds semantic metadata management to Gravitino, but the entities are not discoverable from the Web UI. This makes Semantic Models browsable and manageable next to the tables and views they are defined over.

Fix: #12616

### Does this PR introduce _any_ user-facing change?

Yes, in `web-v2` only:

- A new "Semantic Models" tab on relational schema pages, with create, edit, delete and tag association.
- New semantic model nodes in the catalog tree.
- A new semantic model detail page at `?...&semanticModel=<name>`.

No API changes and no property keys added or removed.

### How was this patch tested?

- **Unit tests** — 31 new tests in `src/lib/utils/semanticModel.test.js` covering the definition validator (each contract rule, and that all problems are reported rather than only the first) and the alter-diff builder (per-change emission, update ordering, comment clearing, and that a deeply equal definition emits no `replaceDefinition`). `pnpm test`: 74 passing.
- **CI gates** — `pnpm lint`, `pnpm prettier:check` and `NODE_ENV=production pnpm dist` all pass locally.
- **Manual, end-to-end in a browser** — against a stub server implementing the wire contract from #12624, since the REST endpoints (#12607, #12608) are not merged yet:
  - Tree nodes, list tab and detail page render; dataset rows expand to their fields; relationships, metrics and the raw definition display correctly.
  - An invalid definition is rejected client-side with all problems listed, and no request is sent.
  - Create issues `POST .../semantic-models` with `{name, comment, definition, properties}`.
  - Editing only the comment issues exactly `[{"@type":"updateComment", ...}]` — no `replaceDefinition`.
  - Rename issues `[{"@type":"rename", ...}]`, and the tree and list follow the new name.
  - Delete issues `DELETE .../semantic-models/<name>` and removes the entry from both the list and the tree.
  - With the endpoint returning 404, the schema page still renders with an empty tab and no error toast.

Once #12607 and #12608 land I will re-verify against a real server and report back on this PR.
