### PR TITLE
[Cherry-pick to branch-1.3] [#11985] fix(openapi): restore the ExternalType variant to DataType (#11991)

### DIFF
--- a/docs/open-api/datatype.yaml
+++ b/docs/open-api/datatype.yaml
@@ -27,6 +27,7 @@ components:
         - $ref: "#/components/schemas/MapType"
         - $ref: "#/components/schemas/UnionType"
         - $ref: "#/components/schemas/UnparsedType"
+        - $ref: "#/components/schemas/ExternalType"
 
     PrimitiveType:
       type: string
@@ -201,20 +202,20 @@ components:
         ]
       }
 
-  ExternalType:
-    type: object
-    required:
-      - type
-      - catalogString
-    properties:
-      type:
-        type: string
-        enum:
-          - "external"
-      catalogString:
-        type: string
-        description: The string representation of this type in the catalog
-    example: {
-      "type": "external",
-      "externalType": "user-defined"
-    }
+    ExternalType:
+      type: object
+      required:
+        - type
+        - catalogString
+      properties:
+        type:
+          type: string
+          enum:
+            - "external"
+        catalogString:
+          type: string
+          description: The string representation of this type in the catalog
+      example: {
+        "type": "external",
+        "externalType": "user-defined"
+      }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport #11991 to `branch-1.3`:

- add `ExternalType` to `DataType.oneOf`;
- move `ExternalType` under `components.schemas`.

### Why are the changes needed?

`branch-1.3` can return external column types, but its OpenAPI schema omits
`ExternalType` from the `DataType` union and declares it outside
`components.schemas`. Generated clients therefore cannot model this valid response.

Backport of #11991.

### Does this PR introduce _any_ user-facing change?

The OpenAPI contract now describes a response the server could already return.
There is no server behavior change.

### How was this patch tested?

- `./gradlew :docs:build`
- `git diff --check`