### PR TITLE
[#12246] fix(catalog-hive): Close Log4j LoggerContext in HiveClientClassLoader#close() to prevent Metaspace leak

### DIFF
--- a/catalogs/hive-metastore-common/build.gradle.kts
+++ b/catalogs/hive-metastore-common/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   compileOnly(libs.caffeine)
   compileOnly(libs.guava)
   compileOnly(libs.slf4j.api)
+  compileOnly(libs.log4j.api)
 
   implementation(project(":catalogs:catalog-common")) {
     exclude("*")

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClientClassLoader.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClientClassLoader.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
+import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,6 +148,33 @@ public final class HiveClientClassLoader extends URLClassLoader {
           .collect(Collectors.toList());
     } catch (IOException e) {
       throw new IOException("Failed to list jar files in directory: " + jarDir.toString(), e);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      shutdownLog4jContext();
+    } finally {
+      super.close();
+    }
+  }
+
+  /**
+   * When a barrier class defined by this loader (e.g. {@link Util}, {@link HiveClientImpl}) first
+   * logs, log4j-slf4j2-impl's {@code Log4jLoggerFactory} resolves the caller class and creates a
+   * {@link org.apache.logging.log4j.spi.LoggerContext} keyed by that class's defining classloader,
+   * i.e. this loader. That factory keeps a strong reference from the {@code LoggerContext} to its
+   * internal per-logger registry, so the context - and transitively this classloader - stays
+   * reachable even after {@link #close()} closes the jar handles, preventing the classloader and
+   * its loaded classes from ever being collected. Explicitly shutting the context down here removes
+   * that registration.
+   */
+  private void shutdownLog4jContext() {
+    try {
+      LogManager.shutdown(LogManager.getContext(this, false));
+    } catch (Throwable t) {
+      LOG.warn("Failed to shut down Log4j context for classloader {}", getName(), t);
     }
   }
 

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestHiveClientClassLoader.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestHiveClientClassLoader.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.hive.client;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.spi.LoggerContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+public class TestHiveClientClassLoader {
+
+  @Test
+  void testCloseRemovesLog4jLoggerContextRegistration() throws Exception {
+    HiveClientClassLoader classLoader =
+        HiveClientClassLoader.createLoader(
+            HiveClientClassLoader.HiveVersion.HIVE3, getClass().getClassLoader());
+
+    // Trigger initialization of Util, a barrier class that is defined directly inside this
+    // classloader (see HiveClientClassLoader#loadBarrierClass), just like HiveClientImpl and
+    // HiveShim are in production. Util's static logger initialization
+    // (LoggerFactory.getLogger(Util.class)) makes log4j-slf4j2-impl's Log4jLoggerFactory walk the
+    // call stack to Util as the anchor class and register a LoggerContext keyed by Util's
+    // defining classloader, i.e. this HiveClientClassLoader, in its registry map. That map is
+    // keyed by the LoggerContext object itself (a strong reference), so the LoggerContext - and
+    // through it this classloader - stays reachable until the context is explicitly shut down.
+    Class<?> utilClass = classLoader.loadClass(Util.class.getName());
+    Assertions.assertSame(
+        classLoader, utilClass.getClassLoader(), "Util should be defined by the isolated loader");
+    Method updateConfig =
+        utilClass.getMethod(
+            "updateConfigurationFromProperties", Properties.class, Configuration.class);
+    updateConfig.invoke(null, new Properties(), new Configuration());
+
+    LoggerContext context = LogManager.getContext(classLoader, false);
+    Map<LoggerContext, ?> registry = getSlf4jAdapterRegistry();
+    Assertions.assertTrue(
+        registry.containsKey(context),
+        "Precondition failed: Log4jLoggerFactory should have registered a LoggerContext for "
+            + "the isolated classloader");
+
+    classLoader.close();
+
+    Assertions.assertFalse(
+        registry.containsKey(context),
+        "HiveClientClassLoader#close() should shut down its Log4j LoggerContext so that "
+            + "Log4jLoggerFactory's registry releases its strong reference to it (and "
+            + "transitively to the classloader); otherwise the classloader can never be "
+            + "garbage collected");
+  }
+
+  /** Reflectively reads the {@code registry} field of {@code AbstractLoggerAdapter}. */
+  @SuppressWarnings("unchecked")
+  private static Map<LoggerContext, ?> getSlf4jAdapterRegistry() throws Exception {
+    ILoggerFactory adapter = LoggerFactory.getILoggerFactory();
+    Field registryField = adapter.getClass().getSuperclass().getDeclaredField("registry");
+    registryField.setAccessible(true);
+    return (Map<LoggerContext, ?>) registryField.get(adapter);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Override `HiveClientClassLoader#close()` to shut down the Log4j `LoggerContext` associated with this classloader before closing its jar handles.

### Why are the changes needed?
When a barrier class defined by `HiveClientClassLoader` (e.g. `Util`, `HiveClientImpl`, `HiveShim`) first logs, log4j-slf4j2-impl's `Log4jLoggerFactory` registers a `LoggerContext` keyed by that class's defining classloader and keeps a strong reference to it in its internal registry. Since `close()` never released that context, the classloader stayed strongly reachable through Log4j even after `close()`, leaking Metaspace on every Hive client-pool eviction/recreation cycle (reported after ~12 days of uptime with periodic Hive catalog access).

Fixes #12246

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Added `TestHiveClientClassLoader#testCloseRemovesLog4jLoggerContextRegistration`, which triggers a barrier class to log (registering a `LoggerContext`), then asserts the `Log4jLoggerFactory` registry entry is removed after `close()`. Verified the test fails without the fix and passes with it. Ran the full `hive-metastore-common` test module — all pass.
