### PR TITLE
[#12929] fix(flink-connector): Use catalog database instead of schema for PostgreSQL JDBC table scans

### DIFF
--- a/docs/flink-connector/flink-catalog-jdbc.md
+++ b/docs/flink-connector/flink-catalog-jdbc.md
@@ -14,6 +14,7 @@ This document provides a comprehensive guide on configuring and using Apache Gra
 ### JDBC Types
 
 * MYSQL
+* POSTGRESQL
 
 ## Getting Started
 
@@ -37,6 +38,8 @@ Next, when you create the JDBC catalog in Gravitino, add the `flink.bypass.defau
 ```text
 flink.bypass.default-database=db  
 ```
+
+For a PostgreSQL catalog, if `flink.bypass.default-database` is not set, it falls back to the catalog's `jdbc-database` property. This distinction matters for PostgreSQL because a Flink "database" corresponds to a PostgreSQL schema, not the PostgreSQL database itself; the JDBC connection always targets `jdbc-database` (or the `flink.bypass.default-database` override), while `SHOW TABLES FROM <schema>` and table scans address tables within that database using the schema name.
 
 ### SQL Example
 
@@ -127,9 +130,10 @@ SELECT * FROM jdbc_table_a;
 
 Gravitino Flink connector will transform below property names which are defined in catalog properties to Flink JDBC connector configuration.
 
-| Gravitino catalog property name | Flink JDBC connector configuration | Description                    |
-|:--------------------------------|------------------------------------|--------------------------------|
-| `jdbc-url`                      | `base-url`                         | JDBC URL for MYSQL             |
-| `username`                      | `username`                         | Username of MySQL account      |
-| `password`                      | `password`                         | Password of the account        |
-| `flink.bypass.default-database` | `default-database`                 | Default database to connect to |
+| Gravitino catalog property name | Flink JDBC connector configuration | Description                                                                                 |
+|:--------------------------------|:-----------------------------------|:--------------------------------------------------------------------------------------------|
+| `jdbc-url`                      | `base-url`                         | JDBC URL for the catalog                                                                    |
+| `username`                      | `username`                         | Username of the account                                                                     |
+| `password`                      | `password`                         | Password of the account                                                                     |
+| `flink.bypass.default-database` | `default-database`                 | Default database to connect to. For PostgreSQL, falls back to `jdbc-database` when not set. |
+| `jdbc-database`                 | (see above)                        | Required for PostgreSQL catalogs; the PostgreSQL database the catalog connects to.          |

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConverter.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConverter.java
@@ -59,6 +59,19 @@ public abstract class JdbcPropertiesConverter
     // The URL in FlinkJdbcCatalog does not support database and other parameters.
     flinkCatalogProperties.put(
         JdbcPropertiesConstants.FLINK_JDBC_URL, getBaseUrlFromJdbcUrl(gravitinoJdbcUrl));
+
+    // Default the Flink catalog's 'default-database' option from the Gravitino jdbc-database
+    // property when it was not already supplied (e.g. via flink.bypass.default-database). This
+    // makes the value available when building per-table scan properties, since only the Flink
+    // catalog properties (not the Gravitino table properties) reach toFlinkTableProperties, and
+    // 'default-database' -- unlike 'jdbc-database' -- is an option Flink's JdbcCatalogFactory
+    // already recognizes, so it survives that factory's strict option validation.
+    String gravitinoJdbcDatabase =
+        gravitinoProperties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_DATABASE);
+    if (gravitinoJdbcDatabase != null) {
+      flinkCatalogProperties.putIfAbsent(
+          JdbcPropertiesConstants.FLINK_JDBC_DEFAULT_DATABASE, gravitinoJdbcDatabase);
+    }
     return flinkCatalogProperties;
   }
 
@@ -75,7 +88,7 @@ public abstract class JdbcPropertiesConverter
   @Override
   public Map<String, String> toFlinkTableProperties(
       Map<String, String> flinkCatalogProperties,
-      Map<String, String> gravitinoProperties,
+      Map<String, String> gravitinoTableProperties,
       ObjectPath tablePath) {
     String jdbcUser = flinkCatalogProperties.get(JdbcPropertiesConstants.FLINK_JDBC_USER);
     String jdbcPassword = flinkCatalogProperties.get(JdbcPropertiesConstants.FLINK_JDBC_PASSWORD);
@@ -89,11 +102,30 @@ public abstract class JdbcPropertiesConverter
     Map<String, String> tableOptions = new HashMap<>();
     tableOptions.put(
         JdbcPropertiesConstants.FLINK_JDBC_TABLE_DATABASE_URL,
-        jdbcBaseUrl + tablePath.getDatabaseName());
-    tableOptions.put(JdbcPropertiesConstants.FLINK_JDBC_TABLE_NAME, tablePath.getObjectName());
+        jdbcBaseUrl + getConnectionDatabase(flinkCatalogProperties, tablePath));
+    tableOptions.put(JdbcPropertiesConstants.FLINK_JDBC_TABLE_NAME, getTableName(tablePath));
     tableOptions.put(JdbcPropertiesConstants.FLINK_JDBC_USER, jdbcUser);
     tableOptions.put(JdbcPropertiesConstants.FLINK_JDBC_PASSWORD, jdbcPassword);
     return tableOptions;
+  }
+
+  /**
+   * Returns the database name used to build the JDBC connection URL for a table scan. Defaults to
+   * the Flink "database", which corresponds to the Gravitino schema name.
+   *
+   * @param flinkCatalogProperties the Flink catalog properties produced by {@link
+   *     #toFlinkCatalogProperties(Map)}.
+   * @param tablePath the Flink table path being scanned.
+   * @return the database name to use when building the JDBC connection URL.
+   */
+  protected String getConnectionDatabase(
+      Map<String, String> flinkCatalogProperties, ObjectPath tablePath) {
+    return tablePath.getDatabaseName();
+  }
+
+  /** Returns the table name used in the JDBC connector's {@code table-name} option. */
+  protected String getTableName(ObjectPath tablePath) {
+    return tablePath.getObjectName();
   }
 
   protected abstract String defaultDriverName();

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConverter.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConverter.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.util.Preconditions;
@@ -68,7 +69,7 @@ public abstract class JdbcPropertiesConverter
     // already recognizes, so it survives that factory's strict option validation.
     String gravitinoJdbcDatabase =
         gravitinoProperties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_DATABASE);
-    if (gravitinoJdbcDatabase != null) {
+    if (StringUtils.isNotBlank(gravitinoJdbcDatabase)) {
       flinkCatalogProperties.putIfAbsent(
           JdbcPropertiesConstants.FLINK_JDBC_DEFAULT_DATABASE, gravitinoJdbcDatabase);
     }

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/postgresql/PostgresqlPropertiesConverter.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/postgresql/PostgresqlPropertiesConverter.java
@@ -19,7 +19,12 @@
 
 package org.apache.gravitino.flink.connector.jdbc.postgresql;
 
+import com.google.common.base.Strings;
+import java.util.Map;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.util.Preconditions;
 import org.apache.gravitino.flink.connector.jdbc.GravitinoJdbcCatalogFactoryOptions;
+import org.apache.gravitino.flink.connector.jdbc.JdbcPropertiesConstants;
 import org.apache.gravitino.flink.connector.jdbc.JdbcPropertiesConverter;
 
 public class PostgresqlPropertiesConverter extends JdbcPropertiesConverter {
@@ -36,5 +41,25 @@ public class PostgresqlPropertiesConverter extends JdbcPropertiesConverter {
   @Override
   public String getFlinkCatalogType() {
     return GravitinoJdbcCatalogFactoryOptions.POSTGRESQL_IDENTIFIER;
+  }
+
+  @Override
+  protected String getConnectionDatabase(
+      Map<String, String> flinkCatalogProperties, ObjectPath tablePath) {
+    // For PostgreSQL, the Flink "database" is a Gravitino schema, not the PostgreSQL database
+    // that the JDBC connection must target. The connection must use the catalog's configured
+    // jdbc-database instead, which JdbcPropertiesConverter#toFlinkCatalogProperties defaults into
+    // the 'default-database' option.
+    String database =
+        flinkCatalogProperties.get(JdbcPropertiesConstants.FLINK_JDBC_DEFAULT_DATABASE);
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(database),
+        JdbcPropertiesConstants.FLINK_JDBC_DEFAULT_DATABASE + " should not be null or empty.");
+    return database;
+  }
+
+  @Override
+  protected String getTableName(ObjectPath tablePath) {
+    return tablePath.getDatabaseName() + "." + tablePath.getObjectName();
   }
 }

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/jdbc/TestMysqlPropertiesConverter.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/jdbc/TestMysqlPropertiesConverter.java
@@ -19,13 +19,36 @@
 
 package org.apache.gravitino.flink.connector.jdbc;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.gravitino.flink.connector.jdbc.mysql.MysqlPropertiesConverter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestMysqlPropertiesConverter extends AbstractJdbcPropertiesConverterTestSuite {
 
   @Override
   protected JdbcPropertiesConverter getConverter(Map<String, String> catalogOptions) {
     return MysqlPropertiesConverter.INSTANCE;
+  }
+
+  @Test
+  public void testToFlinkTableProperties() {
+    String schema = "myDatabase";
+    String tableName = "myTable";
+    Map<String, String> flinkCatalogProperties =
+        getConverter(catalogProperties).toFlinkCatalogProperties(catalogProperties);
+    Map<String, String> tableProperties =
+        getConverter(catalogProperties)
+            .toFlinkTableProperties(
+                flinkCatalogProperties, ImmutableMap.of(), new ObjectPath(schema, tableName));
+
+    // For MySQL, the Flink "database" (schema) is itself the connection database.
+    Assertions.assertEquals(
+        flinkUrl + schema,
+        tableProperties.get(JdbcPropertiesConstants.FLINK_JDBC_TABLE_DATABASE_URL));
+    Assertions.assertEquals(
+        tableName, tableProperties.get(JdbcPropertiesConstants.FLINK_JDBC_TABLE_NAME));
   }
 }

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/jdbc/TestPostgresqlPropertiesConverter.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/jdbc/TestPostgresqlPropertiesConverter.java
@@ -19,13 +19,109 @@
 
 package org.apache.gravitino.flink.connector.jdbc;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
 import java.util.Map;
+import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.gravitino.flink.connector.jdbc.postgresql.PostgresqlPropertiesConverter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestPostgresqlPropertiesConverter extends AbstractJdbcPropertiesConverterTestSuite {
+
+  private static final String FLINK_BYPASS_DEFAULT_DATABASE = "flink.bypass.default-database";
 
   @Override
   protected JdbcPropertiesConverter getConverter(Map<String, String> catalogOptions) {
     return PostgresqlPropertiesConverter.INSTANCE;
+  }
+
+  @Test
+  public void testToFlinkTableProperties() {
+    String jdbcDatabase = "gravitino";
+    String schema = "public";
+    String tableName = "table_meta";
+    // No 'flink.bypass.default-database' is set, so the connection database must fall back to
+    // the catalog's jdbc-database.
+    Map<String, String> catalogPropertiesWithDatabase = new HashMap<>(catalogProperties);
+    catalogPropertiesWithDatabase.remove(FLINK_BYPASS_DEFAULT_DATABASE);
+    catalogPropertiesWithDatabase.put(
+        JdbcPropertiesConstants.GRAVITINO_JDBC_DATABASE, jdbcDatabase);
+
+    // Mirrors the production call in BaseCatalog#toFlinkTable: the first argument is the Flink
+    // catalog properties (as produced by toFlinkCatalogProperties), the second is the Gravitino
+    // table's own properties, which do not carry catalog-level properties like jdbc-database.
+    Map<String, String> flinkCatalogProperties =
+        getConverter(catalogPropertiesWithDatabase)
+            .toFlinkCatalogProperties(catalogPropertiesWithDatabase);
+    Map<String, String> tableProperties =
+        getConverter(catalogPropertiesWithDatabase)
+            .toFlinkTableProperties(
+                flinkCatalogProperties, ImmutableMap.of(), new ObjectPath(schema, tableName));
+
+    // The connection URL must target the PostgreSQL database (jdbc-database), not the schema.
+    Assertions.assertEquals(
+        flinkUrl + jdbcDatabase,
+        tableProperties.get(JdbcPropertiesConstants.FLINK_JDBC_TABLE_DATABASE_URL));
+    // The schema must be carried via the schema-qualified table name instead.
+    Assertions.assertEquals(
+        schema + "." + tableName,
+        tableProperties.get(JdbcPropertiesConstants.FLINK_JDBC_TABLE_NAME));
+  }
+
+  @Test
+  public void testToFlinkTablePropertiesPrefersExplicitDefaultDatabase() {
+    // When 'flink.bypass.default-database' is explicitly set, it takes precedence over
+    // jdbc-database.
+    String explicitDefaultDatabase = "explicit_db";
+    Map<String, String> catalogPropertiesWithBoth = new HashMap<>(catalogProperties);
+    catalogPropertiesWithBoth.put(FLINK_BYPASS_DEFAULT_DATABASE, explicitDefaultDatabase);
+    catalogPropertiesWithBoth.put(JdbcPropertiesConstants.GRAVITINO_JDBC_DATABASE, "gravitino");
+
+    Map<String, String> flinkCatalogProperties =
+        getConverter(catalogPropertiesWithBoth).toFlinkCatalogProperties(catalogPropertiesWithBoth);
+    Map<String, String> tableProperties =
+        getConverter(catalogPropertiesWithBoth)
+            .toFlinkTableProperties(
+                flinkCatalogProperties, ImmutableMap.of(), new ObjectPath("public", "t"));
+
+    Assertions.assertEquals(
+        flinkUrl + explicitDefaultDatabase,
+        tableProperties.get(JdbcPropertiesConstants.FLINK_JDBC_TABLE_DATABASE_URL));
+  }
+
+  @Test
+  public void testToFlinkTablePropertiesWithoutJdbcDatabase() {
+    Map<String, String> catalogPropertiesWithoutDatabase = new HashMap<>(catalogProperties);
+    catalogPropertiesWithoutDatabase.remove(FLINK_BYPASS_DEFAULT_DATABASE);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          Map<String, String> flinkCatalogProperties =
+              getConverter(catalogPropertiesWithoutDatabase)
+                  .toFlinkCatalogProperties(catalogPropertiesWithoutDatabase);
+          getConverter(catalogPropertiesWithoutDatabase)
+              .toFlinkTableProperties(
+                  flinkCatalogProperties, ImmutableMap.of(), new ObjectPath("public", "t"));
+        });
+  }
+
+  @Test
+  public void testToFlinkTablePropertiesWithEmptyJdbcDatabase() {
+    Map<String, String> catalogPropertiesWithEmptyDatabase = new HashMap<>(catalogProperties);
+    catalogPropertiesWithEmptyDatabase.remove(FLINK_BYPASS_DEFAULT_DATABASE);
+    catalogPropertiesWithEmptyDatabase.put(JdbcPropertiesConstants.GRAVITINO_JDBC_DATABASE, "");
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          Map<String, String> flinkCatalogProperties =
+              getConverter(catalogPropertiesWithEmptyDatabase)
+                  .toFlinkCatalogProperties(catalogPropertiesWithEmptyDatabase);
+          getConverter(catalogPropertiesWithEmptyDatabase)
+              .toFlinkTableProperties(
+                  flinkCatalogProperties, ImmutableMap.of(), new ObjectPath("public", "t"));
+        });
   }
 }

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/jdbc/TestPostgresqlPropertiesConverter.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/jdbc/TestPostgresqlPropertiesConverter.java
@@ -46,6 +46,8 @@ public class TestPostgresqlPropertiesConverter extends AbstractJdbcPropertiesCon
     Map<String, String> catalogPropertiesWithDatabase = new HashMap<>(catalogProperties);
     catalogPropertiesWithDatabase.remove(FLINK_BYPASS_DEFAULT_DATABASE);
     catalogPropertiesWithDatabase.put(
+        JdbcPropertiesConstants.GRAVITINO_JDBC_URL, gravitinoUrlWithDomain);
+    catalogPropertiesWithDatabase.put(
         JdbcPropertiesConstants.GRAVITINO_JDBC_DATABASE, jdbcDatabase);
 
     // Mirrors the production call in BaseCatalog#toFlinkTable: the first argument is the Flink
@@ -61,7 +63,7 @@ public class TestPostgresqlPropertiesConverter extends AbstractJdbcPropertiesCon
 
     // The connection URL must target the PostgreSQL database (jdbc-database), not the schema.
     Assertions.assertEquals(
-        flinkUrl + jdbcDatabase,
+        flinkUrlWithDomain + jdbcDatabase,
         tableProperties.get(JdbcPropertiesConstants.FLINK_JDBC_TABLE_DATABASE_URL));
     // The schema must be carried via the schema-qualified table name instead.
     Assertions.assertEquals(
@@ -76,6 +78,8 @@ public class TestPostgresqlPropertiesConverter extends AbstractJdbcPropertiesCon
     String explicitDefaultDatabase = "explicit_db";
     Map<String, String> catalogPropertiesWithBoth = new HashMap<>(catalogProperties);
     catalogPropertiesWithBoth.put(FLINK_BYPASS_DEFAULT_DATABASE, explicitDefaultDatabase);
+    catalogPropertiesWithBoth.put(
+        JdbcPropertiesConstants.GRAVITINO_JDBC_URL, gravitinoUrlWithDomain);
     catalogPropertiesWithBoth.put(JdbcPropertiesConstants.GRAVITINO_JDBC_DATABASE, "gravitino");
 
     Map<String, String> flinkCatalogProperties =
@@ -86,7 +90,7 @@ public class TestPostgresqlPropertiesConverter extends AbstractJdbcPropertiesCon
                 flinkCatalogProperties, ImmutableMap.of(), new ObjectPath("public", "t"));
 
     Assertions.assertEquals(
-        flinkUrl + explicitDefaultDatabase,
+        flinkUrlWithDomain + explicitDefaultDatabase,
         tableProperties.get(JdbcPropertiesConstants.FLINK_JDBC_TABLE_DATABASE_URL));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

For PostgreSQL catalogs, `JdbcPropertiesConverter#toFlinkTableProperties` used the Flink "database" (= Postgres schema) as the JDBC scan connection database instead of the real `jdbc-database`. This PR makes `PostgresqlPropertiesConverter` use the catalog's actual database (via `default-database`, defaulted from `jdbc-database`) for the connection, and carries the schema via a schema-qualified `table-name` instead. MySQL behavior is unchanged.

### Why are the changes needed?

Flink SQL `SELECT` on a Postgres catalog table fails with `FATAL: database "public" does not exist`.

Fix: #12929

### Does this PR introduce _any_ user-facing change?

No. PostgreSQL Flink table scans now work; previously always failed.

### How was this patch tested?

Added unit tests in `TestPostgresqlPropertiesConverter`/`TestMysqlPropertiesConverter`; ran `FlinkJdbcMysqlCatalogIT120` (passes, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqa6kk4Wkdt9VC6s5Znipo
