### PR TITLE
[#12239] fix(web-v2): Suppress errors for optional GitHub statistics

### DIFF
--- a/web-v2/web/src/lib/api/github/index.js
+++ b/web-v2/web/src/lib/api/github/index.js
@@ -24,10 +24,14 @@ export const githubApis = {
 }
 
 export const getGitHubApi = () => {
-  return defHttp.get({
-    url: `${githubApis.GET}`,
-    headers: {
-      Accept: 'application/vnd.github+json'
-    }
-  })
+  // Optional repository statistics should not display global errors when unavailable.
+  return defHttp.get(
+    {
+      url: `${githubApis.GET}`,
+      headers: {
+        Accept: 'application/vnd.github+json'
+      }
+    },
+    { errorMessageMode: 'none' }
+  )
 }

--- a/web-v2/web/src/lib/api/github/index.test.js
+++ b/web-v2/web/src/lib/api/github/index.test.js
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AxiosError } from 'axios'
+import toast from 'react-hot-toast'
+import { defHttp } from '@/lib/utils/axios'
+import { getGitHubApi } from '@/lib/api/github'
+
+vi.mock('react-hot-toast', () => ({ default: { error: vi.fn() } }))
+vi.mock('@/lib/provider/session', () => ({ useAuth: vi.fn() }))
+vi.mock('@/lib/auth/providers/factory', () => ({ oauthProviderFactory: {} }))
+
+describe('GitHub repository statistics', () => {
+  let originalAdapter
+
+  beforeEach(() => {
+    originalAdapter = defHttp.getAxios().defaults.adapter
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    defHttp.getAxios().defaults.adapter = originalAdapter
+  })
+
+  it('rejects rate-limited requests without displaying a global error', async () => {
+    defHttp.getAxios().defaults.adapter = async config => {
+      throw new AxiosError('Request failed with status code 403', 'ERR_BAD_REQUEST', config, null, {
+        status: 403,
+        data: { message: 'API rate limit exceeded' },
+        config
+      })
+    }
+
+    await expect(getGitHubApi()).rejects.toMatchObject({ response: { status: 403 } })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('rejects network failures without reporting that Gravitino is unavailable', async () => {
+    defHttp.getAxios().defaults.adapter = async config => {
+      throw new AxiosError('Network Error', 'ERR_NETWORK', config)
+    }
+
+    await expect(getGitHubApi()).rejects.toMatchObject({ code: 'ERR_NETWORK' })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns repository statistics on success', async () => {
+    const data = { stargazers_count: 100, forks_count: 20 }
+    defHttp.getAxios().defaults.adapter = async config => ({ status: 200, data, config })
+
+    await expect(getGitHubApi()).resolves.toEqual(data)
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('preserves global error messages for Gravitino requests', async () => {
+    defHttp.getAxios().defaults.adapter = async config => {
+      throw new AxiosError('Request failed with status code 403', 'ERR_BAD_REQUEST', config, null, {
+        status: 403,
+        data: { message: 'Permission denied' },
+        config
+      })
+    }
+
+    await expect(defHttp.get({ url: '/api/metalakes' })).rejects.toMatchObject({ response: { status: 403 } })
+    expect(toast.error).toHaveBeenCalledWith('Permission denied', { id: 'global_error_message_status_403' })
+  })
+})

--- a/web-v2/web/src/lib/store/auth/index.test.js
+++ b/web-v2/web/src/lib/store/auth/index.test.js
@@ -17,8 +17,13 @@
  * under the License.
  */
 
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import authReducer, { getAuthMe, setAuthUser } from '@/lib/store/auth'
+
+// Reducer tests do not need the HTTP client's React session provider dependencies.
+vi.mock('@/lib/utils/axios', () => ({
+  defHttp: { get: vi.fn(), post: vi.fn() }
+}))
 
 describe('auth store', () => {
   beforeEach(() => {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disable global error messages for the optional Web V2 GitHub repository statistics request. Failed requests still reject so the existing UI fallback can hide the statistics. Other requests retain their error messages. Isolate the HTTP client in auth reducer tests so they do not load the React session provider.

### Why are the changes needed?

GitHub rate limits currently trigger a global error toast when opening Web V2. Network failures for the same request can also incorrectly report that Gravitino is unavailable.

Fix: #12239

### Does this PR introduce _any_ user-facing change?

Unavailable GitHub statistics no longer produce a global error toast. No API or configuration changes.

### How was this patch tested?

From `web-v2/web`:

- `node node_modules/vitest/vitest.mjs run src/lib/api/github/index.test.js --maxWorkers=1 --no-file-parallelism`: all 4 tests pass. Rate-limit and network-failure tests fail before the fix. Tests exercise the real HTTP interceptors with a mocked Axios adapter.
- Prettier and ESLint pass for all changed files.
- `node node_modules/vitest/vitest.mjs run --maxWorkers=1 --no-file-parallelism`: all 59 tests pass across 6 files, including both auth reducer tests and the four new GitHub request tests.
