### PR TITLE
[#12479] fix(jobs): Handle three-column Iceberg rewrite results

### DIFF
--- a/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteDataFilesJob.java
+++ b/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteDataFilesJob.java
@@ -31,6 +31,8 @@ import org.apache.gravitino.maintenance.jobs.BuiltInJob;
 import org.apache.gravitino.maintenance.optimizer.common.util.IcebergSparkConfigUtils;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Built-in job for rewriting Iceberg table data files.
@@ -39,6 +41,8 @@ import org.apache.spark.sql.SparkSession;
  * binpack or sort strategies. Z-order is a type of sort order, not a strategy.
  */
 public class IcebergRewriteDataFilesJob implements BuiltInJob {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergRewriteDataFilesJob.class);
 
   private static final String NAME =
       JobTemplateProvider.BUILTIN_NAME_PREFIX + "iceberg-rewrite-data-files";
@@ -174,30 +178,7 @@ public class IcebergRewriteDataFilesJob implements BuiltInJob {
 
       // Print results
       if (results.length > 0) {
-        Row result = results[0];
-        // Iceberg 1.6.1 returns 4 columns, newer versions may return 5
-        if (result.size() >= 5) {
-          System.out.printf(
-              "Rewrite Data Files Results:%n"
-                  + "  Rewritten data files: %d%n"
-                  + "  Added data files: %d%n"
-                  + "  Rewritten bytes: %d%n"
-                  + "  Failed data files: %d%n"
-                  + "  Removed delete files: %d%n",
-              result.getInt(0),
-              result.getInt(1),
-              result.getLong(2),
-              result.getInt(3),
-              result.getInt(4));
-        } else {
-          System.out.printf(
-              "Rewrite Data Files Results:%n"
-                  + "  Rewritten data files: %d%n"
-                  + "  Added data files: %d%n"
-                  + "  Rewritten bytes: %d%n"
-                  + "  Failed data files: %d%n",
-              result.getInt(0), result.getInt(1), result.getLong(2), result.getInt(3));
-        }
+        LOG.info(formatResult(results[0]));
       }
 
       System.out.println("Rewrite data files job completed successfully");
@@ -208,6 +189,25 @@ public class IcebergRewriteDataFilesJob implements BuiltInJob {
     } finally {
       spark.stop();
     }
+  }
+
+  /** Formats the statistics returned by the rewrite_data_files procedure. */
+  static String formatResult(Row result) {
+    String summary =
+        String.format(
+            "Rewrite Data Files Results:%n"
+                + "  Rewritten data files: %d%n"
+                + "  Added data files: %d%n"
+                + "  Rewritten bytes: %d%n",
+            result.getInt(0), result.getInt(1), result.getLong(2));
+    // Older Iceberg versions return only the three required statistics.
+    if (result.size() >= 4) {
+      summary += String.format("  Failed data files: %d%n", result.getInt(3));
+    }
+    if (result.size() >= 5) {
+      summary += String.format("  Removed delete files: %d%n", result.getInt(4));
+    }
+    return summary;
   }
 
   /**

--- a/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteDataFilesJob.java
+++ b/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteDataFilesJob.java
@@ -27,9 +27,49 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Map;
 import org.apache.gravitino.job.JobTemplateProvider;
 import org.apache.gravitino.job.SparkJobTemplate;
+import org.apache.spark.sql.RowFactory;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergRewriteDataFilesJob {
+
+  /** Verifies that legacy three-column results retain all available statistics. */
+  @Test
+  public void testFormatThreeColumnResult() {
+    assertEquals(
+        String.format(
+            "Rewrite Data Files Results:%n"
+                + "  Rewritten data files: 2%n"
+                + "  Added data files: 1%n"
+                + "  Rewritten bytes: 4294967296%n"),
+        IcebergRewriteDataFilesJob.formatResult(RowFactory.create(2, 1, 4294967296L)));
+  }
+
+  /** Verifies that four-column results include the failed file count. */
+  @Test
+  public void testFormatFourColumnResult() {
+    assertEquals(
+        String.format(
+            "Rewrite Data Files Results:%n"
+                + "  Rewritten data files: 2%n"
+                + "  Added data files: 1%n"
+                + "  Rewritten bytes: 1024%n"
+                + "  Failed data files: 3%n"),
+        IcebergRewriteDataFilesJob.formatResult(RowFactory.create(2, 1, 1024L, 3)));
+  }
+
+  /** Verifies that five-column results include the removed delete file count. */
+  @Test
+  public void testFormatFiveColumnResult() {
+    assertEquals(
+        String.format(
+            "Rewrite Data Files Results:%n"
+                + "  Rewritten data files: 2%n"
+                + "  Added data files: 1%n"
+                + "  Rewritten bytes: 1024%n"
+                + "  Failed data files: 3%n"
+                + "  Removed delete files: 4%n"),
+        IcebergRewriteDataFilesJob.formatResult(RowFactory.create(2, 1, 1024L, 3, 4)));
+  }
 
   @Test
   public void testJobTemplateHasCorrectName() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Format the result of Iceberg's `rewrite_data_files` procedure according to the number of columns returned. The three base statistics are always read, while failed-file and removed-delete-file counts are included only when present.

Add regression tests for three-, four-, and five-column Spark rows.

### Why are the changes needed?

A three-column result currently falls into the four-column branch and reads column index 3. This throws `ArrayIndexOutOfBoundsException` after the rewrite has already succeeded, causing the job to report a failure.

Fix: #12479

### Does this PR introduce _any_ user-facing change?

The built-in Iceberg rewrite-data-files job now completes successfully when the procedure returns three result columns. It logs every statistic available in the returned row. There are no API or configuration changes.

### How was this patch tested?

- Added unit tests for three-, four-, and five-column Spark rows.
- Verified that the three-column regression test fails on the original implementation with `ArrayIndexOutOfBoundsException` and passes after the fix.
- Ran `:maintenance:jobs:check -PskipTrinoConnector=true -PskipITs -PskipDockerTests=true` on Ubuntu: 141 tests passed with no failures, errors, or skipped tests.

Validation run: https://github.com/IcebreakerSA/gravitino/actions/runs/33892876102
