### PR TITLE
[#11196] feat(maintenance): Add builtin-iceberg-rewrite-manifests job

### DIFF
--- a/docs/table-maintenance-service/optimizer-cli-reference.md
+++ b/docs/table-maintenance-service/optimizer-cli-reference.md
@@ -234,13 +234,14 @@ EvaluationResult{scopeType=TABLE, identifier=rest_catalog.db.t1, partitionPath=<
 
 ## Built-in Job Templates
 
-Three job templates ship with the service, and they are complementary rather than alternatives. A full maintenance pass collects statistics, compacts data files, and then expires the snapshot history that compaction just created.
+Four job templates ship with the service, and they are complementary rather than alternatives. A full maintenance pass collects statistics, compacts data files, expires the snapshot history that compaction just created, and consolidates the manifests left behind.
 
 | Job template                          | What it does                             |
 |---------------------------------------|-------------------------------------------|
 | `builtin-iceberg-update-stats`        | Collects file statistics and metrics      |
 | `builtin-iceberg-rewrite-data-files`  | Compacts small data files                 |
 | `builtin-iceberg-expire-snapshots`    | Removes old snapshot metadata             |
+| `builtin-iceberg-rewrite-manifests`   | Consolidates small manifest files         |
 
 Each can be submitted directly over REST, and the first two are also what the policy-driven workflow submits on your behalf. See [Quick Start](./optimizer.md#walkthrough) for the policy-driven path.
 
@@ -339,6 +340,83 @@ Expire Snapshots Results:
   Deleted manifest files: 8
   Deleted manifest lists: 3
 ```
+
+## Rewrite Manifests
+
+`builtin-iceberg-rewrite-manifests` consolidates a table's manifest files. Frequent commits leave behind many small manifests, and scan planning has to open every one of them to decide which data files a filter matches. Rewriting them into fewer, larger manifests aligned with the current partition spec cuts that planning cost.
+
+This complements `builtin-iceberg-rewrite-data-files`: that job improves the data file layout, this one improves the metadata that points at it.
+
+The job calls Iceberg's `rewrite_manifests` stored procedure through Spark SQL.
+
+| Property    | Value                                                                        |
+|-------------|------------------------------------------------------------------------------|
+| Name        | `builtin-iceberg-rewrite-manifests`                                          |
+| Type        | Spark                                                                        |
+| Version     | `v1`                                                                         |
+| Main class  | `org.apache.gravitino.maintenance.jobs.iceberg.IcebergRewriteManifestsJob`   |
+
+### Parameters
+
+`catalog_name` and `table_identifier` are required. The rest are optional.
+
+| Key                | Description                                                        | Default                     |
+|--------------------|--------------------------------------------------------------------|-----------------------------|
+| `catalog_name`     | Iceberg catalog name as registered in Spark                        | Required                    |
+| `table_identifier` | Fully qualified table name, such as `db.sample`                    | Required                    |
+| `use_caching`      | Caches table metadata in Spark while rewriting; `true` or `false`  | `true` (Iceberg default)    |
+| `spark_conf`       | JSON map of Spark configuration                                    | None                        |
+
+Leave `use_caching` unset unless the driver is memory constrained. Caching keeps the table metadata in Spark for the duration of the rewrite, which is faster but holds more memory.
+
+### Submitting the Job
+
+```bash
+curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jobTemplateName": "builtin-iceberg-rewrite-manifests",
+    "jobConf": {
+      "catalog_name": "rest_catalog",
+      "table_identifier": "db.t1",
+      "spark_master": "local[2]",
+      "spark_executor_instances": "1",
+      "spark_executor_cores": "1",
+      "spark_executor_memory": "1g",
+      "spark_driver_memory": "1g",
+      "catalog_type": "rest",
+      "catalog_uri": "http://localhost:9001/iceberg",
+      "warehouse_location": ""
+    }
+  }' \
+  http://localhost:8090/api/metalakes/test/jobs
+```
+
+The job builds this statement, including `use_caching` only when you supply it:
+
+```sql
+CALL `rest_catalog`.system.rewrite_manifests(
+  table => 'db.t1',
+  use_caching => false
+)
+```
+
+### Verifying the Result
+
+```bash
+curl -sS "http://localhost:8090/api/metalakes/test/jobs/{job_id}" | jq '.job.state'
+cat /tmp/gravitino/jobs/staging/test/builtin-iceberg-rewrite-manifests/{job_id}/stdout.log
+```
+
+A successful run reports its state as `SUCCEEDED` and logs how many manifests it replaced:
+
+```text
+Rewrite Manifests Results:
+  Rewritten manifests: 24
+  Added manifests: 2
+```
+
+Both counts at zero means the table's manifests were already consolidated, which is a successful no-op rather than a failure.
 
 ## Related
 

--- a/docs/table-maintenance-service/optimizer-cli-reference.md
+++ b/docs/table-maintenance-service/optimizer-cli-reference.md
@@ -365,9 +365,12 @@ The job calls Iceberg's `rewrite_manifests` stored procedure through Spark SQL.
 | `catalog_name`     | Iceberg catalog name as registered in Spark                        | Required                    |
 | `table_identifier` | Fully qualified table name, such as `db.sample`                    | Required                    |
 | `use_caching`      | Caches table metadata in Spark while rewriting; `true` or `false`  | `true` (Iceberg default)    |
+| `spec_id`          | Partition spec ID to rewrite manifests to; non-negative integer    | The table's current spec    |
 | `spark_conf`       | JSON map of Spark configuration                                    | None                        |
 
 Leave `use_caching` unset unless the driver is memory constrained. Caching keeps the table metadata in Spark for the duration of the rewrite, which is faster but holds more memory.
+
+Leave `spec_id` unset for routine consolidation. Set it after a partition spec evolution, when manifests written under the old spec should be re-clustered onto a specific one; `GET .../tables/{table}` and the table's `partitions` metadata table show which spec IDs exist. An unknown ID fails the job rather than falling back to the current spec.
 
 ### Submitting the Job
 
@@ -392,12 +395,13 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
   http://localhost:8090/api/metalakes/test/jobs
 ```
 
-The job builds this statement, including `use_caching` only when you supply it:
+The job builds this statement, including `use_caching` and `spec_id` only when you supply them:
 
 ```sql
 CALL `rest_catalog`.system.rewrite_manifests(
   table => 'db.t1',
-  use_caching => false
+  use_caching => false,
+  spec_id => 2
 )
 ```
 

--- a/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/BuiltInJobTemplateProvider.java
+++ b/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/BuiltInJobTemplateProvider.java
@@ -27,6 +27,7 @@ import org.apache.gravitino.job.JobTemplate;
 import org.apache.gravitino.job.JobTemplateProvider;
 import org.apache.gravitino.maintenance.jobs.iceberg.IcebergExpireSnapshotsJob;
 import org.apache.gravitino.maintenance.jobs.iceberg.IcebergRewriteDataFilesJob;
+import org.apache.gravitino.maintenance.jobs.iceberg.IcebergRewriteManifestsJob;
 import org.apache.gravitino.maintenance.jobs.iceberg.IcebergUpdateStatsAndMetricsJob;
 import org.apache.gravitino.maintenance.jobs.spark.SparkPiJob;
 import org.slf4j.Logger;
@@ -46,6 +47,7 @@ public class BuiltInJobTemplateProvider implements JobTemplateProvider {
       ImmutableList.of(
           new SparkPiJob(),
           new IcebergRewriteDataFilesJob(),
+          new IcebergRewriteManifestsJob(),
           new IcebergUpdateStatsAndMetricsJob(),
           new IcebergExpireSnapshotsJob());
 

--- a/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergJobUtils.java
+++ b/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergJobUtils.java
@@ -22,16 +22,42 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Shared utility methods for Iceberg maintenance jobs.
  *
- * <p>Provides SQL escaping, argument parsing, and Spark configuration utilities used by both {@link
- * IcebergRewriteDataFilesJob} and {@link IcebergExpireSnapshotsJob}.
+ * <p>Provides SQL escaping, argument parsing, and Spark configuration utilities used by {@link
+ * IcebergRewriteDataFilesJob}, {@link IcebergExpireSnapshotsJob} and {@link
+ * IcebergRewriteManifestsJob}.
  */
 public final class IcebergJobUtils {
 
+  /**
+   * Matches a job template placeholder that no job configuration value replaced, e.g. {@code
+   * {{use_caching}}}.
+   */
+  private static final Pattern UNRESOLVED_PLACEHOLDER_PATTERN = Pattern.compile("^\\{\\{[^{}]*}}$");
+
   private IcebergJobUtils() {}
+
+  /**
+   * Return the given argument value unless it is an unresolved job template placeholder.
+   *
+   * <p>Job templates declare optional parameters as {@code {{name}}} placeholders. When the caller
+   * omits a parameter, the server leaves the placeholder untouched and it reaches the job as a
+   * literal {@code "{{name}}"} argument. Treating that as a real value would forward nonsense to
+   * Iceberg, so callers use this method to map it back to "not supplied".
+   *
+   * @param value the argument value to inspect
+   * @return the value, or null if it is null or an unresolved placeholder
+   */
+  public static String nullIfUnresolvedPlaceholder(String value) {
+    if (value == null || UNRESOLVED_PLACEHOLDER_PATTERN.matcher(value.trim()).matches()) {
+      return null;
+    }
+    return value;
+  }
 
   /**
    * Escape single quotes in SQL string literals by replacing ' with ''.

--- a/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteManifestsJob.java
+++ b/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteManifestsJob.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.maintenance.jobs.iceberg;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.job.JobTemplateProvider;
+import org.apache.gravitino.job.SparkJobTemplate;
+import org.apache.gravitino.maintenance.jobs.BuiltInJob;
+import org.apache.gravitino.maintenance.optimizer.common.util.IcebergSparkConfigUtils;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Built-in job for rewriting Iceberg table manifest files.
+ *
+ * <p>This job leverages Iceberg's RewriteManifestsProcedure to consolidate small manifest files
+ * and rewrite manifests with improved partition specs, which improves scan planning performance.
+ */
+public class IcebergRewriteManifestsJob implements BuiltInJob {
+
+  private static final String NAME =
+      JobTemplateProvider.BUILTIN_NAME_PREFIX + "iceberg-rewrite-manifests";
+  private static final String VERSION = "v1";
+
+  @Override
+  public SparkJobTemplate jobTemplate() {
+    return SparkJobTemplate.builder()
+        .withName(NAME)
+        .withComment(
+            "Built-in Iceberg rewrite manifests job template for scan planning optimization")
+        .withExecutable(resolveExecutable(IcebergRewriteManifestsJob.class))
+        .withClassName(IcebergRewriteManifestsJob.class.getName())
+        .withArguments(buildArguments())
+        .withConfigs(buildSparkConfigs())
+        .withCustomFields(
+            Collections.singletonMap(JobTemplateProvider.PROPERTY_VERSION_KEY, VERSION))
+        .build();
+  }
+
+  /**
+   * Main entry point for the rewrite manifests job.
+   *
+   * <p>Uses named arguments for flexibility:
+   *
+   * <ul>
+   *   <li>--catalog &lt;catalog_name&gt; Required. Iceberg catalog name.
+   *   <li>--table &lt;table_identifier&gt; Required. Table name (db.table)
+   *   <li>--use-caching &lt;boolean&gt; Optional. Whether to use caching (default: true)
+   *   <li>--spark-conf &lt;spark_conf_json&gt; Optional. JSON map of custom Spark configurations
+   * </ul>
+   *
+   * <p>Example via Gravitino API:
+   *
+   * <pre>{@code
+   * Map<String, String> jobConf = new HashMap<>();
+   * jobConf.put("catalog_name", "iceberg_catalog");
+   * jobConf.put("table_identifier", "db.sample");
+   * jobConf.put("use_caching", "true");
+   * metalake.runJob("builtin-iceberg-rewrite-manifests", jobConf);
+   * }</pre>
+   */
+  public static void main(String[] args) {
+    if (args.length < 4) {
+      printUsage();
+      System.exit(1);
+    }
+
+    Map<String, String> argMap = parseArguments(args);
+
+    String catalogName = argMap.get("catalog");
+    String tableIdentifier = argMap.get("table");
+
+    if (catalogName == null || tableIdentifier == null) {
+      System.err.println("Error: --catalog and --table are required arguments");
+      printUsage();
+      System.exit(1);
+    }
+
+    String useCaching = argMap.get("use-caching");
+    String sparkConfJson = argMap.get("spark-conf");
+
+    SparkSession.Builder sparkBuilder =
+        SparkSession.builder().appName("Gravitino Built-in Iceberg Rewrite Manifests");
+
+    if (sparkConfJson != null && !sparkConfJson.isEmpty()) {
+      try {
+        Map<String, String> customConfigs =
+            IcebergRewriteDataFilesJob.parseCustomSparkConfigs(sparkConfJson);
+        for (Map.Entry<String, String> entry : customConfigs.entrySet()) {
+          sparkBuilder.config(entry.getKey(), entry.getValue());
+        }
+        System.out.println("Applied custom Spark configurations: " + customConfigs);
+      } catch (IllegalArgumentException e) {
+        System.err.println("Error: " + e.getMessage());
+        printUsage();
+        System.exit(1);
+      }
+    }
+
+    SparkSession spark = sparkBuilder.getOrCreate();
+
+    try {
+      String sql = buildProcedureCall(catalogName, tableIdentifier, useCaching);
+      System.out.println("Executing Iceberg rewrite_manifests procedure: " + sql);
+
+      Row[] results = (Row[]) spark.sql(sql).collect();
+
+      if (results.length > 0) {
+        Row result = results[0];
+        System.out.printf(
+            "Rewrite Manifests Results:%n"
+                + "  Rewritten manifests: %d%n"
+                + "  Added manifests: %d%n",
+            result.getInt(0), result.getInt(1));
+      }
+
+      System.out.println("Rewrite manifests job completed successfully");
+    } catch (Exception e) {
+      System.err.println("Error executing rewrite manifests job: " + e.getMessage());
+      e.printStackTrace();
+      System.exit(1);
+    } finally {
+      spark.stop();
+    }
+  }
+
+  /**
+   * Build the SQL CALL statement for the rewrite_manifests procedure.
+   *
+   * @param catalogName Iceberg catalog name
+   * @param tableIdentifier Fully qualified table name
+   * @param useCaching Whether to use caching during rewrite
+   * @return SQL CALL statement
+   */
+  static String buildProcedureCall(
+      String catalogName, String tableIdentifier, String useCaching) {
+    StringBuilder sql = new StringBuilder();
+    sql.append("CALL ")
+        .append(IcebergRewriteDataFilesJob.escapeSqlIdentifier(catalogName))
+        .append(".system.rewrite_manifests(");
+    sql.append("table => '")
+        .append(IcebergRewriteDataFilesJob.escapeSqlString(tableIdentifier))
+        .append("'");
+
+    if (useCaching != null && !useCaching.isEmpty()) {
+      sql.append(", use_caching => ").append(Boolean.parseBoolean(useCaching));
+    }
+
+    sql.append(")");
+    return sql.toString();
+  }
+
+  /**
+   * Parse command line arguments in --key value format.
+   *
+   * @param args command line arguments
+   * @return map of argument names to values
+   */
+  static Map<String, String> parseArguments(String[] args) {
+    Map<String, String> argMap = new HashMap<>();
+    for (int i = 0; i < args.length; i++) {
+      if (args[i].startsWith("--")) {
+        String key = args[i].substring(2);
+        if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+          String value = args[i + 1];
+          if (value != null && !value.trim().isEmpty()) {
+            argMap.put(key, value);
+          }
+          i++;
+        } else {
+          System.err.println("Warning: Flag " + args[i] + " has no value, ignoring");
+        }
+      }
+    }
+    return argMap;
+  }
+
+  private static void printUsage() {
+    System.err.println(
+        "Usage: IcebergRewriteManifestsJob [OPTIONS]\n"
+            + "\n"
+            + "Required Options:\n"
+            + "  --catalog <name>          Iceberg catalog name registered in Spark\n"
+            + "  --table <identifier>      Fully qualified table name (e.g., db.table_name)\n"
+            + "\n"
+            + "Optional Options:\n"
+            + "  --use-caching <boolean>   Whether to use caching during rewrite (default: true)\n"
+            + "  --spark-conf <json>       JSON map of custom Spark configurations\n"
+            + "                              Example: '{\"spark.sql.shuffle.partitions\":\"200\"}'\n"
+            + "\n"
+            + "Examples:\n"
+            + "  # Basic rewrite\n"
+            + "  --catalog iceberg_prod --table db.sample\n"
+            + "\n"
+            + "  # Without caching\n"
+            + "  --catalog iceberg_prod --table db.sample --use-caching false\n");
+  }
+
+  private static List<String> buildArguments() {
+    return Arrays.asList(
+        "--catalog",
+        "{{catalog_name}}",
+        "--table",
+        "{{table_identifier}}",
+        "--use-caching",
+        "{{use_caching}}",
+        "--spark-conf",
+        "{{spark_conf}}");
+  }
+
+  private static Map<String, String> buildSparkConfigs() {
+    return IcebergSparkConfigUtils.buildTemplateSparkConfigs();
+  }
+}

--- a/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteManifestsJob.java
+++ b/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteManifestsJob.java
@@ -20,7 +20,6 @@ package org.apache.gravitino.maintenance.jobs.iceberg;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.job.JobTemplateProvider;
@@ -33,8 +32,8 @@ import org.apache.spark.sql.SparkSession;
 /**
  * Built-in job for rewriting Iceberg table manifest files.
  *
- * <p>This job leverages Iceberg's RewriteManifestsProcedure to consolidate small manifest files
- * and rewrite manifests with improved partition specs, which improves scan planning performance.
+ * <p>This job leverages Iceberg's RewriteManifestsProcedure to consolidate small manifest files and
+ * rewrite manifests with improved partition specs, which improves scan planning performance.
  */
 public class IcebergRewriteManifestsJob implements BuiltInJob {
 
@@ -65,9 +64,20 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
    * <ul>
    *   <li>--catalog &lt;catalog_name&gt; Required. Iceberg catalog name.
    *   <li>--table &lt;table_identifier&gt; Required. Table name (db.table)
-   *   <li>--use-caching &lt;boolean&gt; Optional. Whether to use caching (default: true)
+   *   <li>--use-caching &lt;boolean&gt; Optional. Whether to cache the table metadata in Spark
+   *       while rewriting (default: Iceberg's own default)
    *   <li>--spark-conf &lt;spark_conf_json&gt; Optional. JSON map of custom Spark configurations
    * </ul>
+   *
+   * <p><b>Important Notes on Special Characters:</b>
+   *
+   * <ul>
+   *   <li><b>Via Gravitino API:</b> Pass values as-is without shell escaping. Gravitino handles
+   *       escaping internally via ProcessBuilder.
+   *   <li><b>Via Command Line:</b> Use shell quoting for values containing whitespace.
+   * </ul>
+   *
+   * <p>Example via command line: --catalog iceberg_catalog --table db.sample --use-caching false
    *
    * <p>Example via Gravitino API:
    *
@@ -75,7 +85,7 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
    * Map<String, String> jobConf = new HashMap<>();
    * jobConf.put("catalog_name", "iceberg_catalog");
    * jobConf.put("table_identifier", "db.sample");
-   * jobConf.put("use_caching", "true");
+   * jobConf.put("use_caching", "false");
    * metalake.runJob("builtin-iceberg-rewrite-manifests", jobConf);
    * }</pre>
    */
@@ -85,8 +95,10 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
       System.exit(1);
     }
 
-    Map<String, String> argMap = parseArguments(args);
+    // Parse named arguments
+    Map<String, String> argMap = IcebergJobUtils.parseArguments(args);
 
+    // Validate required arguments
     String catalogName = argMap.get("catalog");
     String tableIdentifier = argMap.get("table");
 
@@ -96,16 +108,28 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
       System.exit(1);
     }
 
-    String useCaching = argMap.get("use-caching");
-    String sparkConfJson = argMap.get("spark-conf");
+    // Optional arguments. Unresolved template placeholders mean the caller left the parameter out,
+    // so they are dropped rather than forwarded to Iceberg as literal values.
+    String useCaching = IcebergJobUtils.nullIfUnresolvedPlaceholder(argMap.get("use-caching"));
+    String sparkConfJson = IcebergJobUtils.nullIfUnresolvedPlaceholder(argMap.get("spark-conf"));
 
+    // Validate use-caching if provided
+    try {
+      validateUseCaching(useCaching);
+    } catch (IllegalArgumentException e) {
+      System.err.println("Error: " + e.getMessage());
+      printUsage();
+      System.exit(1);
+    }
+
+    // Build Spark session with custom configs if provided
     SparkSession.Builder sparkBuilder =
         SparkSession.builder().appName("Gravitino Built-in Iceberg Rewrite Manifests");
 
+    // Apply custom Spark configurations if provided
     if (sparkConfJson != null && !sparkConfJson.isEmpty()) {
       try {
-        Map<String, String> customConfigs =
-            IcebergRewriteDataFilesJob.parseCustomSparkConfigs(sparkConfJson);
+        Map<String, String> customConfigs = IcebergJobUtils.parseCustomSparkConfigs(sparkConfJson);
         for (Map.Entry<String, String> entry : customConfigs.entrySet()) {
           sparkBuilder.config(entry.getKey(), entry.getValue());
         }
@@ -120,18 +144,23 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
     SparkSession spark = sparkBuilder.getOrCreate();
 
     try {
+      // Build the procedure call SQL
       String sql = buildProcedureCall(catalogName, tableIdentifier, useCaching);
+
       System.out.println("Executing Iceberg rewrite_manifests procedure: " + sql);
 
-      Row[] results = (Row[]) spark.sql(sql).collect();
+      // Execute the procedure
+      List<Row> results = spark.sql(sql).collectAsList();
 
-      if (results.length > 0) {
-        Row result = results[0];
+      // Print results. The procedure output columns are numeric, but their exact width is an
+      // Iceberg implementation detail, so read them as Number rather than a fixed primitive.
+      if (!results.isEmpty()) {
+        Row result = results.get(0);
         System.out.printf(
             "Rewrite Manifests Results:%n"
                 + "  Rewritten manifests: %d%n"
                 + "  Added manifests: %d%n",
-            result.getInt(0), result.getInt(1));
+            ((Number) result.get(0)).longValue(), ((Number) result.get(1)).longValue());
       }
 
       System.out.println("Rewrite manifests job completed successfully");
@@ -149,18 +178,15 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
    *
    * @param catalogName Iceberg catalog name
    * @param tableIdentifier Fully qualified table name
-   * @param useCaching Whether to use caching during rewrite
+   * @param useCaching Whether to cache table metadata during the rewrite
    * @return SQL CALL statement
    */
-  static String buildProcedureCall(
-      String catalogName, String tableIdentifier, String useCaching) {
+  static String buildProcedureCall(String catalogName, String tableIdentifier, String useCaching) {
     StringBuilder sql = new StringBuilder();
     sql.append("CALL ")
-        .append(IcebergRewriteDataFilesJob.escapeSqlIdentifier(catalogName))
+        .append(IcebergJobUtils.escapeSqlIdentifier(catalogName))
         .append(".system.rewrite_manifests(");
-    sql.append("table => '")
-        .append(IcebergRewriteDataFilesJob.escapeSqlString(tableIdentifier))
-        .append("'");
+    sql.append("table => '").append(IcebergJobUtils.escapeSqlString(tableIdentifier)).append("'");
 
     if (useCaching != null && !useCaching.isEmpty()) {
       sql.append(", use_caching => ").append(Boolean.parseBoolean(useCaching));
@@ -171,30 +197,26 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
   }
 
   /**
-   * Parse command line arguments in --key value format.
+   * Validate the use-caching parameter value.
    *
-   * @param args command line arguments
-   * @return map of argument names to values
+   * <p>{@link Boolean#parseBoolean(String)} maps anything that is not {@code "true"} to {@code
+   * false}, so a typo would silently disable caching. Reject such values instead.
+   *
+   * @param useCaching the use-caching value to validate
+   * @throws IllegalArgumentException if the value is neither "true" nor "false"
    */
-  static Map<String, String> parseArguments(String[] args) {
-    Map<String, String> argMap = new HashMap<>();
-    for (int i = 0; i < args.length; i++) {
-      if (args[i].startsWith("--")) {
-        String key = args[i].substring(2);
-        if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-          String value = args[i + 1];
-          if (value != null && !value.trim().isEmpty()) {
-            argMap.put(key, value);
-          }
-          i++;
-        } else {
-          System.err.println("Warning: Flag " + args[i] + " has no value, ignoring");
-        }
-      }
+  static void validateUseCaching(String useCaching) {
+    if (useCaching == null || useCaching.isEmpty()) {
+      return; // use-caching is optional
     }
-    return argMap;
+
+    if (!"true".equalsIgnoreCase(useCaching) && !"false".equalsIgnoreCase(useCaching)) {
+      throw new IllegalArgumentException(
+          "Invalid use-caching value '" + useCaching + "'. Must be either 'true' or 'false'");
+    }
   }
 
+  /** Print usage information. */
   private static void printUsage() {
     System.err.println(
         "Usage: IcebergRewriteManifestsJob [OPTIONS]\n"
@@ -204,18 +226,26 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
             + "  --table <identifier>      Fully qualified table name (e.g., db.table_name)\n"
             + "\n"
             + "Optional Options:\n"
-            + "  --use-caching <boolean>   Whether to use caching during rewrite (default: true)\n"
+            + "  --use-caching <boolean>   Cache table metadata in Spark while rewriting\n"
+            + "                              Must be either 'true' or 'false'\n"
+            + "                              Default: true (Iceberg default)\n"
             + "  --spark-conf <json>       JSON map of custom Spark configurations\n"
             + "                              Example: '{\"spark.sql.shuffle.partitions\":\"200\"}'\n"
+            + "                              Note: Overriding required catalog/extensions/app-name configs is unsupported\n"
             + "\n"
             + "Examples:\n"
-            + "  # Basic rewrite\n"
+            + "  # Basic rewrite with Iceberg defaults\n"
             + "  --catalog iceberg_prod --table db.sample\n"
             + "\n"
-            + "  # Without caching\n"
-            + "  --catalog iceberg_prod --table db.sample --use-caching false\n");
+            + "  # Rewrite without caching table metadata\n"
+            + "  --catalog iceberg_prod --table db.sample --use-caching false");
   }
 
+  /**
+   * Build template arguments list with named argument format.
+   *
+   * @return list of template arguments
+   */
   private static List<String> buildArguments() {
     return Arrays.asList(
         "--catalog",
@@ -228,6 +258,11 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
         "{{spark_conf}}");
   }
 
+  /**
+   * Build Spark configuration template.
+   *
+   * @return map of Spark configuration keys to template values
+   */
   private static Map<String, String> buildSparkConfigs() {
     return IcebergSparkConfigUtils.buildTemplateSparkConfigs();
   }

--- a/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteManifestsJob.java
+++ b/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteManifestsJob.java
@@ -66,6 +66,8 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
    *   <li>--table &lt;table_identifier&gt; Required. Table name (db.table)
    *   <li>--use-caching &lt;boolean&gt; Optional. Whether to cache the table metadata in Spark
    *       while rewriting (default: Iceberg's own default)
+   *   <li>--spec-id &lt;int&gt; Optional. Rewrite manifests to this partition spec ID (default: the
+   *       table's current spec)
    *   <li>--spark-conf &lt;spark_conf_json&gt; Optional. JSON map of custom Spark configurations
    * </ul>
    *
@@ -111,11 +113,13 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
     // Optional arguments. Unresolved template placeholders mean the caller left the parameter out,
     // so they are dropped rather than forwarded to Iceberg as literal values.
     String useCaching = IcebergJobUtils.nullIfUnresolvedPlaceholder(argMap.get("use-caching"));
+    String specId = IcebergJobUtils.nullIfUnresolvedPlaceholder(argMap.get("spec-id"));
     String sparkConfJson = IcebergJobUtils.nullIfUnresolvedPlaceholder(argMap.get("spark-conf"));
 
-    // Validate use-caching if provided
+    // Validate optional arguments if provided
     try {
       validateUseCaching(useCaching);
+      validateSpecId(specId);
     } catch (IllegalArgumentException e) {
       System.err.println("Error: " + e.getMessage());
       printUsage();
@@ -145,7 +149,7 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
 
     try {
       // Build the procedure call SQL
-      String sql = buildProcedureCall(catalogName, tableIdentifier, useCaching);
+      String sql = buildProcedureCall(catalogName, tableIdentifier, useCaching, specId);
 
       System.out.println("Executing Iceberg rewrite_manifests procedure: " + sql);
 
@@ -179,9 +183,11 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
    * @param catalogName Iceberg catalog name
    * @param tableIdentifier Fully qualified table name
    * @param useCaching Whether to cache table metadata during the rewrite
+   * @param specId Partition spec ID to rewrite manifests to
    * @return SQL CALL statement
    */
-  static String buildProcedureCall(String catalogName, String tableIdentifier, String useCaching) {
+  static String buildProcedureCall(
+      String catalogName, String tableIdentifier, String useCaching, String specId) {
     StringBuilder sql = new StringBuilder();
     sql.append("CALL ")
         .append(IcebergJobUtils.escapeSqlIdentifier(catalogName))
@@ -190,6 +196,10 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
 
     if (useCaching != null && !useCaching.isEmpty()) {
       sql.append(", use_caching => ").append(Boolean.parseBoolean(useCaching));
+    }
+
+    if (specId != null && !specId.isEmpty()) {
+      sql.append(", spec_id => ").append(Integer.parseInt(specId));
     }
 
     sql.append(")");
@@ -216,6 +226,31 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
     }
   }
 
+  /**
+   * Validate the spec-id parameter value.
+   *
+   * <p>Iceberg partition spec IDs start at 0 and the procedure rejects an unknown ID, but failing
+   * here keeps a malformed value from reaching Spark as an unparseable SQL literal.
+   *
+   * @param specId the spec-id value to validate
+   * @throws IllegalArgumentException if the value is not a non-negative integer
+   */
+  static void validateSpecId(String specId) {
+    if (specId == null || specId.isEmpty()) {
+      return; // spec-id is optional
+    }
+
+    try {
+      if (Integer.parseInt(specId) < 0) {
+        throw new IllegalArgumentException(
+            "Invalid spec-id value '" + specId + "'. Must be a non-negative integer");
+      }
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Invalid spec-id value '" + specId + "'. Must be a non-negative integer");
+    }
+  }
+
   /** Print usage information. */
   private static void printUsage() {
     System.err.println(
@@ -229,6 +264,9 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
             + "  --use-caching <boolean>   Cache table metadata in Spark while rewriting\n"
             + "                              Must be either 'true' or 'false'\n"
             + "                              Default: true (Iceberg default)\n"
+            + "  --spec-id <int>           Rewrite manifests to this partition spec ID\n"
+            + "                              Must be a non-negative integer\n"
+            + "                              Default: the table's current partition spec\n"
             + "  --spark-conf <json>       JSON map of custom Spark configurations\n"
             + "                              Example: '{\"spark.sql.shuffle.partitions\":\"200\"}'\n"
             + "                              Note: Overriding required catalog/extensions/app-name configs is unsupported\n"
@@ -238,7 +276,10 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
             + "  --catalog iceberg_prod --table db.sample\n"
             + "\n"
             + "  # Rewrite without caching table metadata\n"
-            + "  --catalog iceberg_prod --table db.sample --use-caching false");
+            + "  --catalog iceberg_prod --table db.sample --use-caching false\n"
+            + "\n"
+            + "  # Re-cluster manifests onto partition spec 2 after a spec evolution\n"
+            + "  --catalog iceberg_prod --table db.sample --spec-id 2");
   }
 
   /**
@@ -254,6 +295,8 @@ public class IcebergRewriteManifestsJob implements BuiltInJob {
         "{{table_identifier}}",
         "--use-caching",
         "{{use_caching}}",
+        "--spec-id",
+        "{{spec_id}}",
         "--spark-conf",
         "{{spark_conf}}");
   }

--- a/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteManifestsJob.java
+++ b/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteManifestsJob.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.maintenance.jobs.iceberg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.apache.gravitino.job.JobTemplateProvider;
+import org.apache.gravitino.job.SparkJobTemplate;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergRewriteManifestsJob {
+
+  @Test
+  public void testJobTemplateHasCorrectName() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template);
+    assertEquals("builtin-iceberg-rewrite-manifests", template.name());
+  }
+
+  @Test
+  public void testJobTemplateHasComment() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template.comment());
+    assertFalse(template.comment().trim().isEmpty());
+    assertTrue(template.comment().contains("Iceberg"));
+    assertTrue(template.comment().contains("manifests"));
+  }
+
+  @Test
+  public void testJobTemplateHasExecutable() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template.executable());
+    assertFalse(template.executable().trim().isEmpty());
+  }
+
+  @Test
+  public void testJobTemplateHasMainClass() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template.className());
+    assertEquals(IcebergRewriteManifestsJob.class.getName(), template.className());
+  }
+
+  @Test
+  public void testJobTemplateHasArguments() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template.arguments());
+    assertEquals(8, template.arguments().size()); // 4 flags * 2 (flag + value)
+
+    // Verify all expected arguments are present
+    assertTrue(template.arguments().contains("--catalog"));
+    assertTrue(template.arguments().contains("{{catalog_name}}"));
+    assertTrue(template.arguments().contains("--table"));
+    assertTrue(template.arguments().contains("{{table_identifier}}"));
+    assertTrue(template.arguments().contains("--use-caching"));
+    assertTrue(template.arguments().contains("{{use_caching}}"));
+    assertTrue(template.arguments().contains("--spark-conf"));
+    assertTrue(template.arguments().contains("{{spark_conf}}"));
+  }
+
+  @Test
+  public void testJobTemplateHasSparkConfigs() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    Map<String, String> configs = template.configs();
+    assertNotNull(configs);
+    assertFalse(configs.isEmpty());
+
+    // Verify Spark runtime configs
+    assertTrue(configs.containsKey("spark.master"));
+    assertTrue(configs.containsKey("spark.executor.instances"));
+    assertTrue(configs.containsKey("spark.executor.cores"));
+    assertTrue(configs.containsKey("spark.executor.memory"));
+    assertTrue(configs.containsKey("spark.driver.memory"));
+
+    // Verify Iceberg catalog configs
+    assertTrue(configs.containsKey("spark.sql.catalog.{{catalog_name}}"));
+    assertTrue(configs.containsKey("spark.sql.catalog.{{catalog_name}}.type"));
+    assertTrue(configs.containsKey("spark.sql.catalog.{{catalog_name}}.uri"));
+    assertTrue(configs.containsKey("spark.sql.catalog.{{catalog_name}}.warehouse"));
+  }
+
+  @Test
+  public void testJobTemplateHasVersion() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    Map<String, String> customFields = template.customFields();
+    assertNotNull(customFields);
+    assertTrue(customFields.containsKey(JobTemplateProvider.PROPERTY_VERSION_KEY));
+
+    String version = customFields.get(JobTemplateProvider.PROPERTY_VERSION_KEY);
+    assertEquals("v1", version);
+    assertTrue(version.matches(JobTemplateProvider.VERSION_VALUE_PATTERN));
+  }
+
+  @Test
+  public void testJobTemplateNameMatchesBuiltInPattern() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertTrue(template.name().matches(JobTemplateProvider.BUILTIN_NAME_PATTERN));
+    assertTrue(template.name().startsWith(JobTemplateProvider.BUILTIN_NAME_PREFIX));
+  }
+
+  // Test parseArguments method
+
+  @Test
+  public void testParseArgumentsWithAllRequired() {
+    String[] args = {"--catalog", "iceberg_prod", "--table", "db.sample"};
+    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+
+    assertEquals(2, result.size());
+    assertEquals("iceberg_prod", result.get("catalog"));
+    assertEquals("db.sample", result.get("table"));
+  }
+
+  @Test
+  public void testParseArgumentsWithOptional() {
+    String[] args = {
+      "--catalog", "iceberg_prod",
+      "--table", "db.sample",
+      "--use-caching", "false"
+    };
+    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+
+    assertEquals(3, result.size());
+    assertEquals("iceberg_prod", result.get("catalog"));
+    assertEquals("db.sample", result.get("table"));
+    assertEquals("false", result.get("use-caching"));
+  }
+
+  @Test
+  public void testParseArgumentsWithEmptyValues() {
+    String[] args = {"--catalog", "iceberg_prod", "--table", "db.sample", "--use-caching", ""};
+    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+
+    // Empty values should be ignored
+    assertEquals(2, result.size());
+    assertEquals("iceberg_prod", result.get("catalog"));
+    assertEquals("db.sample", result.get("table"));
+    assertFalse(result.containsKey("use-caching"));
+  }
+
+  @Test
+  public void testParseArgumentsWithMissingValues() {
+    String[] args = {"--catalog", "iceberg_prod", "--table"};
+    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+
+    // Only catalog should be parsed, table has no value
+    assertEquals(1, result.size());
+    assertEquals("iceberg_prod", result.get("catalog"));
+    assertFalse(result.containsKey("table"));
+  }
+
+  @Test
+  public void testParseArgumentsOrderIndependent() {
+    String[] args1 = {"--catalog", "cat1", "--table", "tbl1", "--use-caching", "true"};
+    String[] args2 = {"--use-caching", "true", "--table", "tbl1", "--catalog", "cat1"};
+
+    Map<String, String> result1 = IcebergRewriteManifestsJob.parseArguments(args1);
+    Map<String, String> result2 = IcebergRewriteManifestsJob.parseArguments(args2);
+
+    assertEquals(result1, result2);
+  }
+
+  // Test buildProcedureCall method
+
+  @Test
+  public void testBuildProcedureCallMinimal() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", null);
+
+    assertEquals("CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample')", sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithCachingTrue() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "true");
+
+    assertEquals(
+        "CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample', use_caching => true)",
+        sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithCachingFalse() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "false");
+
+    assertEquals(
+        "CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample', use_caching => false)",
+        sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithEmptyCaching() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "");
+
+    assertEquals("CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample')", sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithSqlInjectionAttempt() {
+    // Test SQL injection attempt in table name
+    String maliciousTable = "db.table' OR '1'='1";
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_catalog", maliciousTable, null);
+
+    // Verify single quotes are escaped (becomes '')
+    assertTrue(sql.contains("db.table'' OR ''1''=''1"));
+    assertFalse(sql.contains("' OR '1'='1"));
+
+    // Test SQL injection attempt in catalog name
+    String maliciousCatalog = "catalog`; DROP TABLE users; --";
+    sql =
+        IcebergRewriteManifestsJob.buildProcedureCall(maliciousCatalog, "db.table", null);
+
+    // Verify backticks are escaped
+    assertTrue(sql.contains("catalog``; DROP TABLE users; --"));
+  }
+}

--- a/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteManifestsJob.java
+++ b/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteManifestsJob.java
@@ -18,9 +18,12 @@
  */
 package org.apache.gravitino.maintenance.jobs.iceberg;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
@@ -60,7 +63,7 @@ public class TestIcebergRewriteManifestsJob {
   }
 
   @Test
-  public void testJobTemplateHasMainClass() {
+  public void testJobTemplateHasClassName() {
     IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
     SparkJobTemplate template = job.jobTemplate();
 
@@ -138,7 +141,7 @@ public class TestIcebergRewriteManifestsJob {
   @Test
   public void testParseArgumentsWithAllRequired() {
     String[] args = {"--catalog", "iceberg_prod", "--table", "db.sample"};
-    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+    Map<String, String> result = IcebergJobUtils.parseArguments(args);
 
     assertEquals(2, result.size());
     assertEquals("iceberg_prod", result.get("catalog"));
@@ -152,7 +155,7 @@ public class TestIcebergRewriteManifestsJob {
       "--table", "db.sample",
       "--use-caching", "false"
     };
-    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+    Map<String, String> result = IcebergJobUtils.parseArguments(args);
 
     assertEquals(3, result.size());
     assertEquals("iceberg_prod", result.get("catalog"));
@@ -163,7 +166,7 @@ public class TestIcebergRewriteManifestsJob {
   @Test
   public void testParseArgumentsWithEmptyValues() {
     String[] args = {"--catalog", "iceberg_prod", "--table", "db.sample", "--use-caching", ""};
-    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+    Map<String, String> result = IcebergJobUtils.parseArguments(args);
 
     // Empty values should be ignored
     assertEquals(2, result.size());
@@ -173,44 +176,95 @@ public class TestIcebergRewriteManifestsJob {
   }
 
   @Test
-  public void testParseArgumentsWithMissingValues() {
-    String[] args = {"--catalog", "iceberg_prod", "--table"};
-    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
-
-    // Only catalog should be parsed, table has no value
-    assertEquals(1, result.size());
-    assertEquals("iceberg_prod", result.get("catalog"));
-    assertFalse(result.containsKey("table"));
-  }
-
-  @Test
   public void testParseArgumentsOrderIndependent() {
     String[] args1 = {"--catalog", "cat1", "--table", "tbl1", "--use-caching", "true"};
     String[] args2 = {"--use-caching", "true", "--table", "tbl1", "--catalog", "cat1"};
 
-    Map<String, String> result1 = IcebergRewriteManifestsJob.parseArguments(args1);
-    Map<String, String> result2 = IcebergRewriteManifestsJob.parseArguments(args2);
+    Map<String, String> result1 = IcebergJobUtils.parseArguments(args1);
+    Map<String, String> result2 = IcebergJobUtils.parseArguments(args2);
 
     assertEquals(result1, result2);
+  }
+
+  // Test unresolved placeholder handling
+
+  @Test
+  public void testUnresolvedPlaceholderIsDroppedForOptionalArguments() {
+    // The server leaves placeholders untouched when the caller omits the parameter, so they reach
+    // the job as literal arguments.
+    String[] args = {
+      "--catalog", "iceberg_prod",
+      "--table", "db.sample",
+      "--use-caching", "{{use_caching}}",
+      "--spark-conf", "{{spark_conf}}"
+    };
+    Map<String, String> result = IcebergJobUtils.parseArguments(args);
+
+    assertEquals("{{use_caching}}", result.get("use-caching"));
+    assertNull(IcebergJobUtils.nullIfUnresolvedPlaceholder(result.get("use-caching")));
+    assertNull(IcebergJobUtils.nullIfUnresolvedPlaceholder(result.get("spark-conf")));
+  }
+
+  @Test
+  public void testRealValuesSurviveUnresolvedPlaceholderFiltering() {
+    assertEquals("false", IcebergJobUtils.nullIfUnresolvedPlaceholder("false"));
+    assertEquals("db.sample", IcebergJobUtils.nullIfUnresolvedPlaceholder("db.sample"));
+    // Only a value that is entirely a placeholder is dropped.
+    assertEquals("{{a}}b", IcebergJobUtils.nullIfUnresolvedPlaceholder("{{a}}b"));
+    assertNull(IcebergJobUtils.nullIfUnresolvedPlaceholder(null));
+  }
+
+  @Test
+  public void testProcedureCallOmitsUseCachingWhenPlaceholderUnresolved() {
+    String useCaching = IcebergJobUtils.nullIfUnresolvedPlaceholder("{{use_caching}}");
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", useCaching);
+
+    // Without filtering, Boolean.parseBoolean("{{use_caching}}") would silently emit
+    // use_caching => false instead of leaving Iceberg's default in place.
+    assertEquals("CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample')", sql);
+  }
+
+  // Test validateUseCaching method
+
+  @Test
+  public void testValidateUseCachingAcceptsBooleans() {
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateUseCaching("true"));
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateUseCaching("false"));
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateUseCaching("TRUE"));
+  }
+
+  @Test
+  public void testValidateUseCachingAcceptsAbsentValue() {
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateUseCaching(null));
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateUseCaching(""));
+  }
+
+  @Test
+  public void testValidateUseCachingRejectsNonBoolean() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> IcebergRewriteManifestsJob.validateUseCaching("yes"));
+
+    assertTrue(e.getMessage().contains("yes"));
   }
 
   // Test buildProcedureCall method
 
   @Test
   public void testBuildProcedureCallMinimal() {
-    String sql =
-        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", null);
+    String sql = IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", null);
 
-    assertEquals("CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample')", sql);
+    assertEquals("CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample')", sql);
   }
 
   @Test
   public void testBuildProcedureCallWithCachingTrue() {
-    String sql =
-        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "true");
+    String sql = IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "true");
 
     assertEquals(
-        "CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample', use_caching => true)",
+        "CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample', use_caching => true)",
         sql);
   }
 
@@ -220,16 +274,15 @@ public class TestIcebergRewriteManifestsJob {
         IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "false");
 
     assertEquals(
-        "CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample', use_caching => false)",
+        "CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample', use_caching => false)",
         sql);
   }
 
   @Test
   public void testBuildProcedureCallWithEmptyCaching() {
-    String sql =
-        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "");
+    String sql = IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "");
 
-    assertEquals("CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample')", sql);
+    assertEquals("CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample')", sql);
   }
 
   @Test
@@ -245,10 +298,9 @@ public class TestIcebergRewriteManifestsJob {
 
     // Test SQL injection attempt in catalog name
     String maliciousCatalog = "catalog`; DROP TABLE users; --";
-    sql =
-        IcebergRewriteManifestsJob.buildProcedureCall(maliciousCatalog, "db.table", null);
+    sql = IcebergRewriteManifestsJob.buildProcedureCall(maliciousCatalog, "db.table", null);
 
-    // Verify backticks are escaped
-    assertTrue(sql.contains("catalog``; DROP TABLE users; --"));
+    // Verify backticks are escaped and the whole identifier stays quoted
+    assertTrue(sql.startsWith("CALL `catalog``; DROP TABLE users; --`.system.rewrite_manifests("));
   }
 }

--- a/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteManifestsJob.java
+++ b/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteManifestsJob.java
@@ -77,7 +77,7 @@ public class TestIcebergRewriteManifestsJob {
     SparkJobTemplate template = job.jobTemplate();
 
     assertNotNull(template.arguments());
-    assertEquals(8, template.arguments().size()); // 4 flags * 2 (flag + value)
+    assertEquals(10, template.arguments().size()); // 5 flags * 2 (flag + value)
 
     // Verify all expected arguments are present
     assertTrue(template.arguments().contains("--catalog"));
@@ -86,6 +86,8 @@ public class TestIcebergRewriteManifestsJob {
     assertTrue(template.arguments().contains("{{table_identifier}}"));
     assertTrue(template.arguments().contains("--use-caching"));
     assertTrue(template.arguments().contains("{{use_caching}}"));
+    assertTrue(template.arguments().contains("--spec-id"));
+    assertTrue(template.arguments().contains("{{spec_id}}"));
     assertTrue(template.arguments().contains("--spark-conf"));
     assertTrue(template.arguments().contains("{{spark_conf}}"));
   }
@@ -218,7 +220,8 @@ public class TestIcebergRewriteManifestsJob {
   public void testProcedureCallOmitsUseCachingWhenPlaceholderUnresolved() {
     String useCaching = IcebergJobUtils.nullIfUnresolvedPlaceholder("{{use_caching}}");
     String sql =
-        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", useCaching);
+        IcebergRewriteManifestsJob.buildProcedureCall(
+            "iceberg_prod", "db.sample", useCaching, null);
 
     // Without filtering, Boolean.parseBoolean("{{use_caching}}") would silently emit
     // use_caching => false instead of leaving Iceberg's default in place.
@@ -250,18 +253,53 @@ public class TestIcebergRewriteManifestsJob {
     assertTrue(e.getMessage().contains("yes"));
   }
 
+  // Test validateSpecId method
+
+  @Test
+  public void testValidateSpecIdAcceptsNonNegativeIntegers() {
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateSpecId("0"));
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateSpecId("2"));
+  }
+
+  @Test
+  public void testValidateSpecIdAcceptsAbsentValue() {
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateSpecId(null));
+    assertDoesNotThrow(() -> IcebergRewriteManifestsJob.validateSpecId(""));
+  }
+
+  @Test
+  public void testValidateSpecIdRejectsNegativeValue() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> IcebergRewriteManifestsJob.validateSpecId("-1"));
+
+    assertTrue(e.getMessage().contains("-1"));
+  }
+
+  @Test
+  public void testValidateSpecIdRejectsNonNumericValue() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> IcebergRewriteManifestsJob.validateSpecId("latest"));
+
+    assertTrue(e.getMessage().contains("latest"));
+  }
+
   // Test buildProcedureCall method
 
   @Test
   public void testBuildProcedureCallMinimal() {
-    String sql = IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", null);
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", null, null);
 
     assertEquals("CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample')", sql);
   }
 
   @Test
   public void testBuildProcedureCallWithCachingTrue() {
-    String sql = IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "true");
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "true", null);
 
     assertEquals(
         "CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample', use_caching => true)",
@@ -271,7 +309,7 @@ public class TestIcebergRewriteManifestsJob {
   @Test
   public void testBuildProcedureCallWithCachingFalse() {
     String sql =
-        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "false");
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "false", null);
 
     assertEquals(
         "CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample', use_caching => false)",
@@ -280,8 +318,39 @@ public class TestIcebergRewriteManifestsJob {
 
   @Test
   public void testBuildProcedureCallWithEmptyCaching() {
-    String sql = IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "");
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "", null);
 
+    assertEquals("CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample')", sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithSpecId() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", null, "2");
+
+    assertEquals(
+        "CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample', spec_id => 2)", sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithCachingAndSpecId() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "false", "0");
+
+    assertEquals(
+        "CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample', "
+            + "use_caching => false, spec_id => 0)",
+        sql);
+  }
+
+  @Test
+  public void testProcedureCallOmitsSpecIdWhenPlaceholderUnresolved() {
+    String specId = IcebergJobUtils.nullIfUnresolvedPlaceholder("{{spec_id}}");
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", null, specId);
+
+    // An unresolved placeholder must not reach Integer.parseInt as a SQL literal.
     assertEquals("CALL `iceberg_prod`.system.rewrite_manifests(table => 'db.sample')", sql);
   }
 
@@ -290,7 +359,8 @@ public class TestIcebergRewriteManifestsJob {
     // Test SQL injection attempt in table name
     String maliciousTable = "db.table' OR '1'='1";
     String sql =
-        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_catalog", maliciousTable, null);
+        IcebergRewriteManifestsJob.buildProcedureCall(
+            "iceberg_catalog", maliciousTable, null, null);
 
     // Verify single quotes are escaped (becomes '')
     assertTrue(sql.contains("db.table'' OR ''1''=''1"));
@@ -298,7 +368,7 @@ public class TestIcebergRewriteManifestsJob {
 
     // Test SQL injection attempt in catalog name
     String maliciousCatalog = "catalog`; DROP TABLE users; --";
-    sql = IcebergRewriteManifestsJob.buildProcedureCall(maliciousCatalog, "db.table", null);
+    sql = IcebergRewriteManifestsJob.buildProcedureCall(maliciousCatalog, "db.table", null, null);
 
     // Verify backticks are escaped and the whole identifier stays quoted
     assertTrue(sql.startsWith("CALL `catalog``; DROP TABLE users; --`.system.rewrite_manifests("));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `builtin-iceberg-rewrite-manifests`, invoking Iceberg's Spark SQL procedure with `table`, optional `use_caching`, and optional `spec_id`. Registers the template, reuses shared job utilities, validates parameters, handles omitted optional arguments, and reports rewritten/added counts.

Continues #11216 by @ibrahimErbilen. Their original commits retain authorship, and follow-up commits retain their co-author credit. Design: #12942.

### Why are the changes needed?

Manifest maintenance consolidates and clusters manifest entries independently of data-file compaction. `spec_id` selects an existing spec's manifests; it does not repartition files or migrate manifests from another spec.

Fix: #11196

### Does this PR introduce _any_ user-facing change?

New job template with `catalog_name`, `table_identifier`, `use_caching`, `spec_id`, and `spark_conf` configuration. The CLI reference explains how to discover spec IDs from Iceberg metadata and includes a day-to-hour evolution example. Omitted caching uses the installed Iceberg default.

### How was this patch tested?

- Previously passed 30 job unit tests plus the module test suite.
- Latest documentation update: `:docs:build`, `:maintenance:jobs:spotlessCheck`, and `git diff --check`.
- Spec selection and caching defaults verified against Iceberg 1.11.0 source.

A dedicated Spark-backed test for this job is still pending; the module's existing integration checks do not establish its spec-selection behavior end to end.
