### PR TITLE
[#12938] fix(jdbc): Resolve PostgreSQL database names before accepting catalogs

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalog.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalog.java
@@ -18,9 +18,12 @@
  */
 package org.apache.gravitino.catalog.jdbc;
 
+import com.google.common.base.Preconditions;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
@@ -116,6 +119,35 @@ public abstract class JdbcCatalog extends BaseCatalog<JdbcCatalog> {
   @Override
   public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
     return TABLE_PROPERTIES_META;
+  }
+
+  /**
+   * Resolves the database required by a JDBC provider before accepting its configuration.
+   *
+   * @param config The catalog configuration.
+   * @param databaseFromUrl A driver-backed parser returning the database, or null if absent.
+   * @return A copy of the configuration containing a nonblank database.
+   * @throws IllegalArgumentException if no database is configured or the database names conflict.
+   */
+  protected static Map<String, String> resolveJdbcDatabase(
+      Map<String, String> config, Function<String, String> databaseFromUrl) {
+    String database = config.get(JdbcConfig.JDBC_DATABASE.getKey());
+    Preconditions.checkArgument(
+        !config.containsKey(JdbcConfig.JDBC_DATABASE.getKey()) || StringUtils.isNotBlank(database),
+        "jdbc-database must be nonblank when explicitly configured");
+    String urlDatabase = databaseFromUrl.apply(new JdbcConfig(config).getJdbcUrl());
+    if (!config.containsKey(JdbcConfig.JDBC_DATABASE.getKey())) {
+      database = urlDatabase;
+    }
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(database),
+        "jdbc-database must be nonblank; specify it explicitly or include the database in jdbc-url");
+    Preconditions.checkArgument(
+        StringUtils.isBlank(urlDatabase) || database.equals(urlDatabase),
+        "jdbc-database must match the database specified in jdbc-url");
+    Map<String, String> resolved = new HashMap<>(config);
+    resolved.put(JdbcConfig.JDBC_DATABASE.getKey(), database);
+    return resolved;
   }
 
   @Override

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalog.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalog.java
@@ -125,9 +125,11 @@ public abstract class JdbcCatalog extends BaseCatalog<JdbcCatalog> {
    * Resolves the database required by a JDBC provider before accepting its configuration.
    *
    * @param config The catalog configuration.
-   * @param databaseFromUrl A driver-backed parser returning the database, or null if absent.
+   * @param databaseFromUrl A driver-backed parser returning the database, or null if absent, and
+   *     rejecting invalid URLs.
    * @return A copy of the configuration containing a nonblank database.
-   * @throws IllegalArgumentException if no database is configured or the database names conflict.
+   * @throws IllegalArgumentException if the URL is invalid, no database is configured, or the
+   *     database names conflict.
    */
   protected static Map<String, String> resolveJdbcDatabase(
       Map<String, String> config, Function<String, String> databaseFromUrl) {

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/config/JdbcConfig.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/config/JdbcConfig.java
@@ -39,7 +39,9 @@ public class JdbcConfig extends Config {
 
   public static final ConfigEntry<String> JDBC_DATABASE =
       new ConfigBuilder("jdbc-database")
-          .doc("The database of the jdbc connection")
+          .doc(
+              "The database of the JDBC connection. PostgreSQL requires a nonblank "
+                  + "value here or a database in jdbc-url; other JDBC providers do not require it.")
           .version(ConfigConstants.VERSION_0_3_0)
           .stringConf()
           .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)

--- a/catalogs/catalog-jdbc-postgresql/build.gradle.kts
+++ b/catalogs/catalog-jdbc-postgresql/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   compileOnly(project(":api"))
   compileOnly(project(":common"))
   compileOnly(project(":core"))
+  compileOnly(libs.postgresql.driver)
 
   implementation(project(":catalogs:catalog-jdbc-common")) {
     exclude(group = "*")

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.postgresql;
 
 import java.util.Map;
+import java.util.Properties;
 import org.apache.gravitino.catalog.jdbc.JdbcCatalog;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
@@ -32,8 +33,21 @@ import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlSchemaOperati
 import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlTableOperations;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.capability.Capability;
+import org.postgresql.Driver;
 
 public class PostgreSqlCatalog extends JdbcCatalog {
+
+  /** {@inheritDoc} */
+  @Override
+  public JdbcCatalog withCatalogConf(Map<String, String> conf) {
+    return super.withCatalogConf(
+        resolveJdbcDatabase(
+            conf,
+            url -> {
+              Properties parsed = Driver.parseURL(url, new Properties());
+              return parsed == null ? null : parsed.getProperty("PGDBNAME");
+            }));
+  }
 
   @Override
   public String shortName() {

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
@@ -18,8 +18,10 @@
  */
 package org.apache.gravitino.catalog.postgresql;
 
+import com.google.common.base.Preconditions;
 import java.util.Map;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import org.apache.gravitino.catalog.jdbc.JdbcCatalog;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
@@ -34,19 +36,14 @@ import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlTableOperatio
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.capability.Capability;
 import org.postgresql.Driver;
+import org.postgresql.PGProperty;
 
 public class PostgreSqlCatalog extends JdbcCatalog {
 
   /** {@inheritDoc} */
   @Override
   public JdbcCatalog withCatalogConf(Map<String, String> conf) {
-    return super.withCatalogConf(
-        resolveJdbcDatabase(
-            conf,
-            url -> {
-              Properties parsed = Driver.parseURL(url, new Properties());
-              return parsed == null ? null : parsed.getProperty("PGDBNAME");
-            }));
+    return super.withCatalogConf(resolveJdbcDatabase(conf, PostgreSqlCatalog::databaseFromUrl));
   }
 
   @Override
@@ -93,5 +90,12 @@ public class PostgreSqlCatalog extends JdbcCatalog {
   @Override
   protected JdbcColumnDefaultValueConverter createJdbcColumnDefaultValueConverter() {
     return new PostgreSqlColumnDefaultValueConverter();
+  }
+
+  @Nullable
+  private static String databaseFromUrl(String url) {
+    Properties parsed = Driver.parseURL(url, new Properties());
+    Preconditions.checkArgument(parsed != null, "Invalid PostgreSQL jdbc-url");
+    return parsed.getProperty(PGProperty.PG_DBNAME.getName());
   }
 }

--- a/catalogs/catalog-jdbc-postgresql/src/main/resources/jdbc-postgresql.conf
+++ b/catalogs/catalog-jdbc-postgresql/src/main/resources/jdbc-postgresql.conf
@@ -19,5 +19,6 @@
 # jdbc-url = jdbc:postgresql://localhost:5432/your_database
 # jdbc-user = strato
 # jdbc-password = strato
+# jdbc-database is optional when the database is specified in jdbc-url.
 # jdbc-database = your_database
 # jdbc-driver = org.postgresql.Driver

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/TestPostgreSqlCatalogConfiguration.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/TestPostgreSqlCatalogConfiguration.java
@@ -49,21 +49,9 @@ class TestPostgreSqlCatalogConfiguration {
       delimiter = '|')
   void testDatabaseFromUrl(String url, String database) {
     Map<String, String> config = Map.of("jdbc-url", url);
-    CapturingCatalog catalog = new CapturingCatalog();
-    catalog.withCatalogConf(config);
-    catalog.withCatalogEntity(
-        CatalogEntity.builder()
-            .withId(1L)
-            .withName("test")
-            .withNamespace(Namespace.of("metalake"))
-            .withType(Catalog.Type.RELATIONAL)
-            .withProvider(catalog.shortName())
-            .withAuditInfo(
-                AuditInfo.builder().withCreator("test").withCreateTime(Instant.EPOCH).build())
-            .build());
-    Assertions.assertThrows(UnsupportedOperationException.class, catalog::ops);
-    Assertions.assertEquals(database, catalog.config.get("jdbc-database"));
-    Assertions.assertEquals(url, catalog.config.get("jdbc-url"));
+    Map<String, String> resolved = captureOperationsConfig(config);
+    Assertions.assertEquals(database, resolved.get("jdbc-database"));
+    Assertions.assertEquals(url, resolved.get("jdbc-url"));
     Assertions.assertFalse(config.containsKey("jdbc-database"));
   }
 
@@ -76,20 +64,8 @@ class TestPostgreSqlCatalogConfiguration {
       },
       delimiter = '|')
   void testExplicitDatabase(String url, String database) {
-    CapturingCatalog catalog = new CapturingCatalog();
-    catalog.withCatalogConf(Map.of("jdbc-url", url, "jdbc-database", database));
-    catalog.withCatalogEntity(
-        CatalogEntity.builder()
-            .withId(1L)
-            .withName("test")
-            .withNamespace(Namespace.of("metalake"))
-            .withType(Catalog.Type.RELATIONAL)
-            .withProvider(catalog.shortName())
-            .withAuditInfo(
-                AuditInfo.builder().withCreator("test").withCreateTime(Instant.EPOCH).build())
-            .build());
-    Assertions.assertThrows(UnsupportedOperationException.class, catalog::ops);
-    Assertions.assertEquals(database, catalog.config.get("jdbc-database"));
+    Map<String, String> config = Map.of("jdbc-url", url, "jdbc-database", database);
+    Assertions.assertEquals(config, captureOperationsConfig(config));
   }
 
   @ParameterizedTest
@@ -131,13 +107,55 @@ class TestPostgreSqlCatalogConfiguration {
                 .withCatalogConf(Map.of("jdbc-url", "jdbc:postgresql://localhost/")));
   }
 
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "invalid|",
+        "invalid|demo",
+        "jdbc:mysql://localhost/demo|",
+        "jdbc:mysql://localhost/demo|demo",
+        "jdbc:postgresql://localhost:invalid/demo|",
+        "jdbc:postgresql://localhost:invalid/demo|demo",
+        "jdbc:postgresql://localhost:5432|",
+        "jdbc:postgresql://localhost:5432|demo"
+      },
+      delimiter = '|')
+  void testInvalidUrlRejected(String url, String database) {
+    Map<String, String> config = new HashMap<>();
+    config.put("jdbc-url", url);
+    if (database != null) {
+      config.put("jdbc-database", database);
+    }
+    IllegalArgumentException error =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> new PostgreSqlCatalog().withCatalogConf(config));
+    Assertions.assertEquals("Invalid PostgreSQL jdbc-url", error.getMessage());
+  }
+
   @Test
-  void testInvalidUrlRejected() {
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> new PostgreSqlCatalog().withCatalogConf(Map.of("jdbc-url", "invalid")));
+  void testMissingUrlRejected() {
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> new PostgreSqlCatalog().withCatalogConf(Map.of()));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new PostgreSqlCatalog().withCatalogConf(Map.of("jdbc-database", "demo")));
+  }
+
+  private static Map<String, String> captureOperationsConfig(Map<String, String> config) {
+    CapturingCatalog catalog = new CapturingCatalog();
+    catalog.withCatalogConf(config);
+    catalog.withCatalogEntity(
+        CatalogEntity.builder()
+            .withId(1L)
+            .withName("test")
+            .withNamespace(Namespace.of("metalake"))
+            .withType(Catalog.Type.RELATIONAL)
+            .withProvider(catalog.shortName())
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("test").withCreateTime(Instant.EPOCH).build())
+            .build());
+    Assertions.assertThrows(UnsupportedOperationException.class, catalog::ops);
+    return catalog.config;
   }
 
   private static class CapturingCatalog extends PostgreSqlCatalog {

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/TestPostgreSqlCatalogConfiguration.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/TestPostgreSqlCatalogConfiguration.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.connector.CatalogOperations;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.CatalogEntity;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Tests database resolution before catalog operations are initialized. */
+class TestPostgreSqlCatalogConfiguration {
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "jdbc:postgresql://localhost:5432/demo|demo",
+        "jdbc:postgresql:demo|demo",
+        "jdbc:postgresql://host1:5432,host2:5432/demo?ssl=true|demo",
+        "jdbc:postgresql://localhost/my%20db|my db",
+        "jdbc:postgresql://localhost/demo?currentSchema=other|demo",
+        "jdbc:postgresql://localhost/demo?PGDBNAME=other|other"
+      },
+      delimiter = '|')
+  void testDatabaseFromUrl(String url, String database) {
+    Map<String, String> config = Map.of("jdbc-url", url);
+    CapturingCatalog catalog = new CapturingCatalog();
+    catalog.withCatalogConf(config);
+    catalog.withCatalogEntity(
+        CatalogEntity.builder()
+            .withId(1L)
+            .withName("test")
+            .withNamespace(Namespace.of("metalake"))
+            .withType(Catalog.Type.RELATIONAL)
+            .withProvider(catalog.shortName())
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("test").withCreateTime(Instant.EPOCH).build())
+            .build());
+    Assertions.assertThrows(UnsupportedOperationException.class, catalog::ops);
+    Assertions.assertEquals(database, catalog.config.get("jdbc-database"));
+    Assertions.assertEquals(url, catalog.config.get("jdbc-url"));
+    Assertions.assertFalse(config.containsKey("jdbc-database"));
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "jdbc:postgresql://localhost:5432/demo|demo",
+        "jdbc:postgresql://localhost/my%20db|my db",
+        "jdbc:postgresql://localhost/|explicit"
+      },
+      delimiter = '|')
+  void testExplicitDatabase(String url, String database) {
+    CapturingCatalog catalog = new CapturingCatalog();
+    catalog.withCatalogConf(Map.of("jdbc-url", url, "jdbc-database", database));
+    catalog.withCatalogEntity(
+        CatalogEntity.builder()
+            .withId(1L)
+            .withName("test")
+            .withNamespace(Namespace.of("metalake"))
+            .withType(Catalog.Type.RELATIONAL)
+            .withProvider(catalog.shortName())
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("test").withCreateTime(Instant.EPOCH).build())
+            .build());
+    Assertions.assertThrows(UnsupportedOperationException.class, catalog::ops);
+    Assertions.assertEquals(database, catalog.config.get("jdbc-database"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "jdbc:postgresql://localhost/demo",
+        "jdbc:postgresql://localhost/demo?PGDBNAME=other"
+      })
+  void testConflictingDatabaseRejected(String url) {
+    IllegalArgumentException error =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new PostgreSqlCatalog()
+                    .withCatalogConf(Map.of("jdbc-url", url, "jdbc-database", "conflicting")));
+    Assertions.assertEquals(
+        "jdbc-database must match the database specified in jdbc-url", error.getMessage());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" ", "\t"})
+  void testBlankExplicitDatabaseRejected(String database) {
+    Map<String, String> config = new HashMap<>();
+    config.put("jdbc-url", "jdbc:postgresql://localhost:5432/demo");
+    config.put("jdbc-database", database);
+    IllegalArgumentException error =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> new PostgreSqlCatalog().withCatalogConf(config));
+    Assertions.assertTrue(error.getMessage().contains("jdbc-database"));
+  }
+
+  @Test
+  void testMissingDatabaseRejectedBeforeFirstOperation() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new PostgreSqlCatalog()
+                .withCatalogConf(Map.of("jdbc-url", "jdbc:postgresql://localhost/")));
+  }
+
+  @Test
+  void testInvalidUrlRejected() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new PostgreSqlCatalog().withCatalogConf(Map.of("jdbc-url", "invalid")));
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> new PostgreSqlCatalog().withCatalogConf(Map.of()));
+  }
+
+  private static class CapturingCatalog extends PostgreSqlCatalog {
+    private Map<String, String> config;
+
+    /** {@inheritDoc} */
+    @Override
+    protected CatalogOperations newOps(Map<String, String> conf) {
+      config = conf;
+      throw new UnsupportedOperationException("Configuration captured without connecting");
+    }
+  }
+}

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -41,9 +41,9 @@ Besides the [common catalog properties](./gravitino-server-config.md#catalog-pro
 
 | Configuration item      | Description                                                                                                                                                       | Default value | Required |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
-| `jdbc-url`              | JDBC URL for connecting to the database. You need to specify the database in the URL. For example `jdbc:postgresql://localhost:3306/pg_database?sslmode=require`. | (none)        | Yes      |
+| `jdbc-url`              | A valid PostgreSQL JDBC URL, for example `jdbc:postgresql://localhost:5432/pg_database?sslmode=require`. If the URL omits the database, set `jdbc-database`. | (none)        | Yes      |
 | `jdbc-driver`           | The driver of the JDBC connection. For example `org.postgresql.Driver`.                                                                                           | (none)        | Yes      |
-| `jdbc-database`         | The database of the JDBC connection. Derived from `jdbc-url` when omitted. An explicit value must be nonblank and match the URL database. | (none)        | Only if absent from `jdbc-url` |
+| `jdbc-database`         | The database of the JDBC connection. Derived from `jdbc-url` when omitted. An explicit value must be nonblank and match the URL database when both are provided. | (none)        | Only if absent from `jdbc-url` |
 | `jdbc-user`             | The JDBC user name.                                                                                                                                               | (none)        | Yes      |
 | `jdbc-password`         | The JDBC password.                                                                                                                                                | (none)        | Yes      |
 | `jdbc.pool.min-size`    | The minimum number of connections in the pool. `2` by default.                                                                                                    | `2`           | No       |
@@ -52,7 +52,7 @@ Besides the [common catalog properties](./gravitino-server-config.md#catalog-pro
 
 :::caution
 Download the corresponding JDBC driver to the `catalogs/jdbc-postgresql/libs` directory.
-When `jdbc-database` is omitted, the catalog derives it from `jdbc-url`. Catalog creation fails if neither provides a nonblank database name. When both `jdbc-database` and the URL specify a database, their names must match; catalog creation rejects conflicting values.
+When `jdbc-database` is omitted, the catalog derives it from `jdbc-url`. Catalog creation rejects invalid PostgreSQL URLs, even when `jdbc-database` is set, and fails if neither provides a nonblank database name. When both `jdbc-database` and the URL specify a database, their names must match; catalog creation rejects conflicting values.
 :::
 :::info
 In PostgreSQL, the database corresponds to the Gravitino catalog, and the schema corresponds to the Gravitino schema.

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -36,14 +36,14 @@ Check the relevant data source configuration in [data source properties](https:/
 
 When using Gravitino with Trino, pass the Trino PostgreSQL connector configuration using the `trino.bypass.` prefix. For example, using `trino.bypass.join-pushdown.strategy` to pass the `join-pushdown.strategy` to the Gravitino PostgreSQL catalog in Trino runtime.
 
-If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-database`, `jdbc-user` and `jdbc-password` to catalog properties.
+If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-user` and `jdbc-password` to catalog properties.
 Besides the [common catalog properties](./gravitino-server-config.md#catalog-properties-configuration), the PostgreSQL catalog has the following properties:
 
 | Configuration item      | Description                                                                                                                                                       | Default value | Required |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
 | `jdbc-url`              | JDBC URL for connecting to the database. You need to specify the database in the URL. For example `jdbc:postgresql://localhost:3306/pg_database?sslmode=require`. | (none)        | Yes      |
 | `jdbc-driver`           | The driver of the JDBC connection. For example `org.postgresql.Driver`.                                                                                           | (none)        | Yes      |
-| `jdbc-database`         | The database of the JDBC connection. Configure it with the same value as the database in the `jdbc-url`. For example `pg_database`.                               | (none)        | Yes      |
+| `jdbc-database`         | The database of the JDBC connection. Derived from `jdbc-url` when omitted. An explicit value must be nonblank and match the URL database. | (none)        | Only if absent from `jdbc-url` |
 | `jdbc-user`             | The JDBC user name.                                                                                                                                               | (none)        | Yes      |
 | `jdbc-password`         | The JDBC password.                                                                                                                                                | (none)        | Yes      |
 | `jdbc.pool.min-size`    | The minimum number of connections in the pool. `2` by default.                                                                                                    | `2`           | No       |
@@ -52,7 +52,7 @@ Besides the [common catalog properties](./gravitino-server-config.md#catalog-pro
 
 :::caution
 Download the corresponding JDBC driver to the `catalogs/jdbc-postgresql/libs` directory.
-Explicitly specify the database in both `jdbc-url` and `jdbc-database`. An error may occur if the values in both aren't consistent.
+When `jdbc-database` is omitted, the catalog derives it from `jdbc-url`. Catalog creation fails if neither provides a nonblank database name. When both `jdbc-database` and the URL specify a database, their names must match; catalog creation rejects conflicting values.
 :::
 :::info
 In PostgreSQL, the database corresponds to the Gravitino catalog, and the schema corresponds to the Gravitino schema.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add shared JDBC database resolution and use it in PostgreSQL catalog configuration. Derive omitted database names from the JDBC URL and reject invalid URLs and missing, blank, or conflicting database names. Update documentation and examples.

### Why are the changes needed?

PostgreSQL catalogs currently accept configurations that fail on first use, even when the database is already present in the JDBC URL.

Fix: #12938

### Does this PR introduce _any_ user-facing change?

PostgreSQL catalogs can omit `jdbc-database` when the URL supplies it. Invalid JDBC URLs and missing, blank, or conflicting database names are rejected during configuration.

### How was this patch tested?

All 97 JDBC common and PostgreSQL unit tests passed, including 25 new regression cases covering URL parsing, explicit database values, conflicts, and invalid URLs with or without an explicit database. Relevant module Spotless checks passed.

