### PR TITLE
[#12941] fix(jdbc): Keep internal identifiers out of table comments

### DIFF
--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableOperations.java
@@ -65,7 +65,6 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.clickhouse.ClickHouseConstants.ClusterConstants;
 import org.apache.gravitino.catalog.clickhouse.ClickHouseConstants.DistributedTableConstants;
 import org.apache.gravitino.catalog.clickhouse.ClickHouseConstants.TableConstants;
@@ -1121,18 +1120,8 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
     // Last modified comment
     if (null != updateComment) {
       String newComment = updateComment.getNewComment();
-      // Load the existing table once. We need it for two purposes:
-      //   1. Preserve the Gravitino StringIdentifier embedded in the old comment, so Gravitino can
-      //      still identify the table after the comment is changed.
-      //   2. Re-embed the cluster name so it is not lost. ClickHouse does not persist ON CLUSTER
-      //      in SHOW CREATE TABLE, so the cluster name lives only in the stored comment.
+      // Preserve the cluster routing metadata, which is not retained by SHOW CREATE TABLE.
       lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
-      if (null == StringIdentifier.fromComment(newComment)) {
-        StringIdentifier identifier = StringIdentifier.fromComment(lazyLoadTable.comment());
-        if (null != identifier) {
-          newComment = StringIdentifier.addToComment(identifier, newComment);
-        }
-      }
       String clusterName = lazyLoadTable.properties().get(ClusterConstants.CLUSTER_NAME);
       if (StringUtils.isNotBlank(clusterName)) {
         newComment = ClickHouseClusterUtils.embedClusterInComment(newComment, clusterName);

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.clickhouse.ClickHouseConstants.TableConstants;
 import org.apache.gravitino.catalog.clickhouse.ClickHouseTablePropertiesMetadata;
 import org.apache.gravitino.catalog.clickhouse.ClickHouseUtils;
@@ -68,6 +69,30 @@ public class TestClickHouseTableOperations extends TestClickHouse {
   private static final Type STRING = Types.StringType.get();
   private static final Type INT = Types.IntegerType.get();
   private static final Type LONG = Types.LongType.get();
+
+  @Test
+  void testUpdateCommentDoesNotPreserveIdentifier() {
+    StubClickHouseTableOperations ops = new StubClickHouseTableOperations();
+    ops.initialize(
+        null,
+        new ClickHouseExceptionConverter(),
+        new ClickHouseTypeConverter(),
+        new ClickHouseColumnDefaultValueConverter(),
+        new HashMap<>());
+    ops.setTable(
+        JdbcTable.builder()
+            .withName("tbl")
+            .withProperties(new HashMap<>())
+            .withComment(
+                StringIdentifier.addToComment(StringIdentifier.fromId(42), "legacy comment"))
+            .build());
+    for (String comment : new String[] {"new comment", ""}) {
+      String sql =
+          ops.buildAlterSql("db", "tbl", new TableChange[] {TableChange.updateComment(comment)});
+      Assertions.assertTrue(sql.contains("MODIFY COMMENT '" + comment + "'"), sql);
+      Assertions.assertFalse(sql.contains("gravitino.v1.uid"), sql);
+    }
+  }
 
   @Test
   public void testCreateAndAlterTable() {

--- a/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/operation/HologresTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/main/java/org/apache/gravitino/catalog/hologres/operation/HologresTableOperations.java
@@ -40,7 +40,6 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
@@ -506,15 +505,6 @@ public class HologresTableOperations extends JdbcTableOperations
   private String updateCommentDefinition(
       TableChange.UpdateComment updateComment, JdbcTable jdbcTable) {
     String newComment = updateComment.getNewComment();
-    if (null == StringIdentifier.fromComment(newComment)) {
-      // Detect and add Gravitino id.
-      if (StringUtils.isNotEmpty(jdbcTable.comment())) {
-        StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
-        if (null != identifier) {
-          newComment = StringIdentifier.addToComment(identifier, newComment);
-        }
-      }
-    }
     return String.format(
         "COMMENT ON TABLE %s IS '%s';",
         quoteIdentifier(jdbcTable.name()), newComment.replace("'", "''"));

--- a/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-hologres/src/test/java/org/apache/gravitino/catalog/hologres/operation/TestHologresTableOperations.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.hologres.converter.HologresColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.hologres.converter.HologresExceptionConverter;
 import org.apache.gravitino.catalog.hologres.converter.HologresTypeConverter;
@@ -869,9 +870,17 @@ public class TestHologresTableOperations {
 
   @Test
   void testAlterTableUpdateComment() {
-    // Note: updateComment needs a JdbcTable with StringIdentifier, which requires
-    // getOrCreateTable. Since we can't mock the DB connection, we test the SQL format
-    // via the other alter operations that don't require table loading.
+    ops.setMockTable(
+        JdbcTable.builder()
+            .withName("test_table")
+            .withComment(
+                StringIdentifier.addToComment(StringIdentifier.fromId(42), "legacy comment"))
+            .build());
+    for (String comment : new String[] {"new comment", ""}) {
+      String sql = ops.alterTableSql("public", "test_table", TableChange.updateComment(comment));
+      assertTrue(sql.contains("IS '" + comment + "'"));
+      assertFalse(sql.contains("gravitino.v1.uid"));
+    }
   }
 
   @Test

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
@@ -39,7 +39,6 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
@@ -302,14 +301,6 @@ public class OceanBaseTableOperations extends JdbcTableOperations {
     // Last modified comment
     if (null != updateComment) {
       String newComment = updateComment.getNewComment();
-      if (null == StringIdentifier.fromComment(newComment)) {
-        // Detect and add Gravitino id.
-        JdbcTable jdbcTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
-        StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
-        if (null != identifier) {
-          newComment = StringIdentifier.addToComment(identifier, newComment);
-        }
-      }
       alterSql.add("COMMENT '" + newComment + "'");
     }
 

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
@@ -19,10 +19,13 @@
 package org.apache.gravitino.catalog.oceanbase.operation;
 
 import java.util.Collections;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter;
+import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;
 import org.apache.gravitino.rel.expressions.literals.Literals;
 import org.apache.gravitino.rel.expressions.transforms.Transforms;
@@ -40,6 +43,18 @@ public class TestOceanBaseTableOperationsSqlGeneration {
       super.columnDefaultValueConverter = new JdbcColumnDefaultValueConverter();
     }
 
+    String alterTableSql(String tableName, TableChange... changes) {
+      return generateAlterTableSql("database", tableName, changes);
+    }
+
+    @Override
+    protected JdbcTable getOrCreateTable(String databaseName, String tableName, JdbcTable table) {
+      return JdbcTable.builder()
+          .withName(tableName)
+          .withComment(StringIdentifier.addToComment(StringIdentifier.fromId(42), "legacy comment"))
+          .build();
+    }
+
     public String createTableSql(String tableName, JdbcColumn[] columns) {
       return generateCreateTableSql(
           tableName,
@@ -49,6 +64,16 @@ public class TestOceanBaseTableOperationsSqlGeneration {
           Transforms.EMPTY_TRANSFORM,
           Distributions.NONE,
           Indexes.EMPTY_INDEXES);
+    }
+  }
+
+  @Test
+  void testUpdateCommentDoesNotPreserveIdentifier() {
+    TestableOceanBaseTableOperations ops = new TestableOceanBaseTableOperations();
+    for (String comment : new String[] {"new comment", ""}) {
+      String sql = ops.alterTableSql("test_table", TableChange.updateComment(comment));
+      Assertions.assertTrue(sql.contains("COMMENT '" + comment + "'"), sql);
+      Assertions.assertFalse(sql.contains("gravitino.v1.uid"), sql);
     }
   }
 

--- a/catalogs/catalog-jdbc-common/build.gradle.kts
+++ b/catalogs/catalog-jdbc-common/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
   testImplementation(libs.commons.io)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.mockito.core)
   testImplementation(libs.sqlite.jdbc)
   testImplementation(libs.testcontainers)
   testImplementation(libs.testcontainers.mysql)

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -375,10 +375,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
             : jdbcTablePropertiesMetadata.convertFromJdbcProperties(load.properties());
     String comment = load.comment();
     StringIdentifier id = StringIdentifier.fromComment(comment);
-    if (id == null) {
-      LOG.warn(
-          "The table {} comment {} does not contain Gravitino id attribute", tableName, comment);
-    } else {
+    if (id != null) {
       properties = StringIdentifier.newPropertiesWithId(id, properties);
       // Remove id from comment
       comment = StringIdentifier.removeIdFromComment(comment);
@@ -502,7 +499,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
         databaseName,
         tableName,
         jdbcColumns,
-        StringIdentifier.addToComment(identifier, comment),
+        comment,
         resultProperties,
         partitioning,
         distribution,

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcCatalogOperations.java
@@ -18,26 +18,112 @@
  */
 package org.apache.gravitino.catalog.jdbc;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.Maps;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.sql.DataSource;
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
 import org.apache.gravitino.catalog.jdbc.converter.SqliteColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.SqliteExceptionConverter;
 import org.apache.gravitino.catalog.jdbc.converter.SqliteTypeConverter;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
 import org.apache.gravitino.catalog.jdbc.operation.SqliteDatabaseOperations;
 import org.apache.gravitino.catalog.jdbc.operation.SqliteTableOperations;
 import org.apache.gravitino.catalog.jdbc.utils.DataSourceUtils;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.sorts.SortOrder;
+import org.apache.gravitino.rel.expressions.transforms.Transforms;
+import org.apache.gravitino.rel.indexes.Indexes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 public class TestJdbcCatalogOperations {
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  owner's comment  ", "line one\nline two"})
+  void testCreateTablePreservesSourceComment(String comment) throws Exception {
+    JdbcTableOperations tableOperations = mock(JdbcTableOperations.class);
+    JdbcCatalogOperations operations = newTableCatalogOperations(tableOperations);
+    Map<String, String> properties =
+        StringIdentifier.newPropertiesWithId(StringIdentifier.fromId(42), Collections.emptyMap());
+    Table table =
+        operations.createTable(
+            NameIdentifier.of("metalake", "catalog", "schema", "table"),
+            new Column[0],
+            comment,
+            properties,
+            Transforms.EMPTY_TRANSFORM,
+            Distributions.NONE,
+            new SortOrder[0],
+            Indexes.EMPTY_INDEXES);
+
+    verify(tableOperations)
+        .create(
+            eq("schema"),
+            eq("table"),
+            any(JdbcColumn[].class),
+            eq(comment),
+            eq(Collections.emptyMap()),
+            any(),
+            any(),
+            any(),
+            any());
+    Assertions.assertEquals(comment, table.comment());
+    Assertions.assertFalse(table.properties().containsKey(StringIdentifier.ID_KEY));
+    Assertions.assertEquals("gravitino.v1.uid42", properties.get(StringIdentifier.ID_KEY));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  owner's comment  ", "line one\nline two"})
+  void testLoadTableWithoutMarker(String comment) throws Exception {
+    JdbcTableOperations tableOperations = mock(JdbcTableOperations.class);
+    JdbcCatalogOperations operations = newTableCatalogOperations(tableOperations);
+    when(tableOperations.load("schema", "table"))
+        .thenReturn(JdbcTable.builder().withName("table").withComment(comment).build());
+    Table table = operations.loadTable(NameIdentifier.of("metalake", "catalog", "schema", "table"));
+    Assertions.assertEquals(comment, table.comment());
+    Assertions.assertFalse(table.properties().containsKey(StringIdentifier.ID_KEY));
+  }
+
+  @Test
+  void testLoadLegacyTableIdentifier() throws Exception {
+    JdbcTableOperations tableOperations = mock(JdbcTableOperations.class);
+    JdbcCatalogOperations operations = newTableCatalogOperations(tableOperations);
+    StringIdentifier identifier = StringIdentifier.fromId(42);
+    when(tableOperations.load("schema", "table"))
+        .thenReturn(
+            JdbcTable.builder()
+                .withName("table")
+                .withComment(StringIdentifier.addToComment(identifier, "old comment"))
+                .build());
+    Table table = operations.loadTable(NameIdentifier.of("metalake", "catalog", "schema", "table"));
+    Assertions.assertEquals("old comment", table.comment());
+    Assertions.assertEquals(
+        identifier.id(), StringIdentifier.fromProperties(table.properties()).id());
+  }
 
   @Test
   public void testExistingCatalogConnectionFailure() {
@@ -92,5 +178,22 @@ public class TestJdbcCatalogOperations {
             new SqliteColumnDefaultValueConverter());
 
     Assertions.assertDoesNotThrow(catalogOperations::close);
+  }
+
+  private JdbcCatalogOperations newTableCatalogOperations(JdbcTableOperations tableOperations)
+      throws IllegalAccessException {
+    JdbcCatalogOperations operations =
+        new JdbcCatalogOperations(
+            new SqliteExceptionConverter(),
+            new SqliteTypeConverter(),
+            mock(SqliteDatabaseOperations.class),
+            tableOperations,
+            new SqliteColumnDefaultValueConverter());
+    FieldUtils.writeField(
+        operations,
+        "jdbcTablePropertiesMetadata",
+        mock(JdbcTablePropertiesMetadata.class, Mockito.CALLS_REAL_METHODS),
+        true);
+    return operations;
   }
 }

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -51,7 +51,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.doris.utils.DorisUtils;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
@@ -791,14 +790,6 @@ public class DorisTableOperations extends JdbcTableOperations {
     // Last modified comment
     if (null != updateComment) {
       String newComment = updateComment.getNewComment();
-      if (null == StringIdentifier.fromComment(newComment)) {
-        // Detect and add Gravitino id.
-        JdbcTable jdbcTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
-        StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
-        if (null != identifier) {
-          newComment = StringIdentifier.addToComment(identifier, newComment);
-        }
-      }
       alterSql.add("MODIFY COMMENT \"" + escapeSqlLiteral(newComment, '"') + "\"");
     }
 

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperationsSqlGeneration.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.doris.converter.DorisTypeConverter;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
@@ -104,7 +105,10 @@ public class TestDorisTableOperationsSqlGeneration {
     @Override
     protected JdbcTable getOrCreateTable(
         String databaseName, String tableName, JdbcTable lazyLoadCreateTable) {
-      return JdbcTable.builder().withName(tableName).build();
+      return JdbcTable.builder()
+          .withName(tableName)
+          .withComment(StringIdentifier.addToComment(StringIdentifier.fromId(42), "legacy comment"))
+          .build();
     }
 
     public String createTableSqlWithIndexes(
@@ -117,6 +121,16 @@ public class TestDorisTableOperationsSqlGeneration {
           Transforms.EMPTY_TRANSFORM,
           distribution,
           indexes);
+    }
+  }
+
+  @Test
+  void testUpdateCommentDoesNotPreserveIdentifier() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    for (String comment : new String[] {"new comment", ""}) {
+      String sql = ops.alterTableSql("test_table", TableChange.updateComment(comment));
+      Assertions.assertTrue(sql.contains("MODIFY COMMENT \"" + comment + "\""), sql);
+      Assertions.assertFalse(sql.contains("gravitino.v1.uid"), sql);
     }
   }
 

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -42,7 +42,6 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
@@ -288,14 +287,6 @@ public class MysqlTableOperations extends JdbcTableOperations {
     // Last modified comment
     if (null != updateComment) {
       String newComment = updateComment.getNewComment();
-      if (null == StringIdentifier.fromComment(newComment)) {
-        // Detect and add Gravitino id.
-        JdbcTable jdbcTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
-        StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
-        if (null != identifier) {
-          newComment = StringIdentifier.addToComment(identifier, newComment);
-        }
-      }
       alterSql.add("COMMENT '" + escapeSqlLiteral(newComment, '\'') + "'");
     }
 

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlTableOperationsSqlGeneration.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.mysql.operation;
 
 import java.util.Collections;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
@@ -64,7 +65,20 @@ public class TestMysqlTableOperationsSqlGeneration {
     @Override
     protected JdbcTable getOrCreateTable(
         String databaseName, String tableName, JdbcTable lazyLoadCreateTable) {
-      return JdbcTable.builder().withName(tableName).build();
+      return JdbcTable.builder()
+          .withName(tableName)
+          .withComment(StringIdentifier.addToComment(StringIdentifier.fromId(42), "legacy comment"))
+          .build();
+    }
+  }
+
+  @Test
+  void testUpdateCommentDoesNotPreserveIdentifier() {
+    TestableMysqlTableOperations ops = new TestableMysqlTableOperations();
+    for (String comment : new String[] {"new comment", ""}) {
+      String sql = ops.alterTableSql("test_table", TableChange.updateComment(comment));
+      Assertions.assertTrue(sql.contains("COMMENT '" + comment + "'"), sql);
+      Assertions.assertFalse(sql.contains("gravitino.v1.uid"), sql);
     }
   }
 

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -38,7 +38,6 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
@@ -503,15 +502,6 @@ public class PostgreSqlTableOperations extends JdbcTableOperations
   private String updateCommentDefinition(
       TableChange.UpdateComment updateComment, JdbcTable jdbcTable) {
     String newComment = updateComment.getNewComment();
-    if (null == StringIdentifier.fromComment(newComment)) {
-      // Detect and add Gravitino id.
-      if (StringUtils.isNotEmpty(jdbcTable.comment())) {
-        StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
-        if (null != identifier) {
-          newComment = StringIdentifier.addToComment(identifier, newComment);
-        }
-      }
-    }
     return TABLE_COMMENT
         + PG_QUOTE
         + jdbcTable.name()

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperationsSqlGeneration.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.postgresql.operation;
 
 import java.util.Collections;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
@@ -64,7 +65,20 @@ public class TestPostgreSqlTableOperationsSqlGeneration {
     @Override
     protected JdbcTable getOrCreateTable(
         String databaseName, String tableName, JdbcTable lazyLoadCreateTable) {
-      return JdbcTable.builder().withName(tableName).build();
+      return JdbcTable.builder()
+          .withName(tableName)
+          .withComment(StringIdentifier.addToComment(StringIdentifier.fromId(42), "legacy comment"))
+          .build();
+    }
+  }
+
+  @Test
+  void testUpdateCommentDoesNotPreserveIdentifier() {
+    TestablePostgreSqlTableOperations ops = new TestablePostgreSqlTableOperations();
+    for (String comment : new String[] {"new comment", ""}) {
+      String sql = ops.alterTableSql("test_table", TableChange.updateComment(comment));
+      Assertions.assertTrue(sql.contains("IS E'" + comment + "'"), sql);
+      Assertions.assertFalse(sql.contains("gravitino.v1.uid"), sql);
     }
   }
 

--- a/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/operations/StarRocksTableOperations.java
+++ b/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/operations/StarRocksTableOperations.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
@@ -118,7 +117,6 @@ public class StarRocksTableOperations extends JdbcTableOperations {
             .collect(Collectors.joining(",\n")));
     sqlBuilder.append(")\n");
     if (StringUtils.isNotEmpty(comment)) {
-      comment = StringIdentifier.addToComment(StringIdentifier.DUMMY_ID, comment);
       sqlBuilder.append(" COMMENT \"").append(escapeSqlLiteral(comment, '"')).append("\"");
     }
 
@@ -171,16 +169,6 @@ public class StarRocksTableOperations extends JdbcTableOperations {
       } else if (change instanceof TableChange.UpdateComment) {
         TableChange.UpdateComment updateComment = (TableChange.UpdateComment) change;
         String newComment = updateComment.getNewComment();
-        if (StringIdentifier.fromComment(newComment) == null) {
-          lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
-          StringIdentifier identifier = StringIdentifier.fromComment(lazyLoadTable.comment());
-          if (identifier != null) {
-            newComment = StringIdentifier.addToComment(identifier, newComment);
-          }
-        }
-        if (StringUtils.isNotEmpty(newComment)) {
-          newComment = StringIdentifier.addToComment(StringIdentifier.DUMMY_ID, newComment);
-        }
         alterSql.add("COMMENT = \"" + escapeSqlLiteral(newComment, '"') + "\"");
       } else if (change instanceof TableChange.SetProperty) {
         if (hasSetPropertyChange) {

--- a/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/utils/StarRocksUtils.java
+++ b/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/utils/StarRocksUtils.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.utils.JdbcConnectorUtils;
 import org.apache.gravitino.rel.expressions.NamedReference;
 import org.apache.gravitino.rel.expressions.distributions.Distribution;
@@ -68,9 +69,7 @@ public class StarRocksUtils {
           "(?:^|\\s|\\))DISTRIBUTED\\s+BY\\s+(?:RANDOM\\b|\\w+\\s*\\()", Pattern.CASE_INSENSITIVE);
 
   private static final Pattern TABLE_COMMENT_PATTERN =
-      Pattern.compile(
-          "COMMENT\\s*\"((?:\\\\.|\"\"|[^\"\\\\])*)\\s+"
-              + "\\(From Gravitino, DO NOT EDIT: gravitino\\.v\\d+\\.uid-?\\d+\\)\"");
+      Pattern.compile("(?m)^[ \t]*COMMENT\\s*\"((?:\\\\.|\"\"|[^\"\\\\])*)\"");
 
   private static final String PARTITION_TYPE_VALUE_PATTERN_STRING =
       "types: \\[([^\\]]+)\\]; keys: \\[([^\\]]+)\\];";
@@ -199,7 +198,14 @@ public class StarRocksUtils {
   public static String extractTableCommentFromSql(String createTableSql) {
     Matcher matcher = TABLE_COMMENT_PATTERN.matcher(createTableSql.trim());
     if (matcher.find()) {
-      return JdbcConnectorUtils.unescapeSqlLiteral(matcher.group(1), '"');
+      String comment = JdbcConnectorUtils.unescapeSqlLiteral(matcher.group(1), '"');
+      // Older versions appended a dummy marker after the actual table identifier.
+      // Remove only that outer marker so the common JDBC layer can still read the real ID.
+      String dummyMarker = StringIdentifier.addToComment(StringIdentifier.DUMMY_ID, "");
+      if (comment.endsWith(dummyMarker)) {
+        return comment.substring(0, comment.length() - dummyMarker.length()).trim();
+      }
+      return comment;
     }
     return "";
   }

--- a/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/operation/TestStarRocksTableOperations.java
+++ b/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/operation/TestStarRocksTableOperations.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcTable;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
@@ -201,7 +200,6 @@ public class TestStarRocksTableOperations extends TestStarRocks {
     String tableName = GravitinoITUtils.genRandomName("starrocks_comment_test_table");
     String createComment = "owner's \"comment\" (created) C:\\tmp; --";
     String updatedComment = "reviewer's \"comment\" (updated) D:\\data; --";
-    StringIdentifier identifier = StringIdentifier.fromId(42);
     JdbcColumn column =
         JdbcColumn.builder().withName("col_1").withType(INT).withComment("id").build();
 
@@ -210,15 +208,14 @@ public class TestStarRocksTableOperations extends TestStarRocks {
           databaseName,
           tableName,
           new JdbcColumn[] {column},
-          StringIdentifier.addToComment(identifier, createComment),
+          createComment,
           createProperties(),
           null,
           Distributions.hash(DEFAULT_BUCKET_SIZE, NamedReference.field("col_1")),
           Indexes.EMPTY_INDEXES);
 
       Assertions.assertEquals(
-          StringIdentifier.addToComment(identifier, createComment),
-          TABLE_OPERATIONS.load(databaseName, tableName).comment());
+          createComment, TABLE_OPERATIONS.load(databaseName, tableName).comment());
 
       TABLE_OPERATIONS.alterTable(
           databaseName, tableName, TableChange.updateComment(updatedComment));
@@ -228,8 +225,7 @@ public class TestStarRocksTableOperations extends TestStarRocks {
           .untilAsserted(
               () ->
                   Assertions.assertEquals(
-                      StringIdentifier.addToComment(identifier, updatedComment),
-                      TABLE_OPERATIONS.load(databaseName, tableName).comment()));
+                      updatedComment, TABLE_OPERATIONS.load(databaseName, tableName).comment()));
 
       TABLE_OPERATIONS.alterTable(databaseName, tableName, TableChange.updateComment(""));
       Awaitility.await()
@@ -238,8 +234,7 @@ public class TestStarRocksTableOperations extends TestStarRocks {
           .untilAsserted(
               () ->
                   Assertions.assertEquals(
-                      StringIdentifier.addToComment(identifier, ""),
-                      TABLE_OPERATIONS.load(databaseName, tableName).comment()));
+                      "", TABLE_OPERATIONS.load(databaseName, tableName).comment()));
     } finally {
       TABLE_OPERATIONS.drop(databaseName, tableName);
     }

--- a/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/operation/TestStarRocksTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/operation/TestStarRocksTableOperationsSqlGeneration.java
@@ -159,27 +159,17 @@ public class TestStarRocksTableOperationsSqlGeneration {
     String createSql =
         ops.createTableSql("test_table", new JdbcColumn[] {column}, distribution, tableComment);
     Assertions.assertTrue(
-        createSql.contains("COMMENT \"owner\"\"; DROP TABLE marker; -- "), createSql);
+        createSql.contains("COMMENT \"owner\"\"; DROP TABLE marker; --\""), createSql);
     Assertions.assertTrue(
         createSql.contains("COMMENT 'owner''s comment; DROP TABLE marker; --'"), createSql);
 
-    // The existing table's identifier (uid42) is preserved, and a sacrificial DUMMY_ID (uid-1)
-    // marker is appended on top: the read path (extractTableCommentFromSql) strips exactly one
-    // (outermost) marker, so the real identifier survives the round-trip.
     String alterSql = ops.alterTableSql("test_table", TableChange.updateComment(tableComment));
     Assertions.assertTrue(
-        alterSql.contains(
-            "COMMENT = \"owner\"\"; DROP TABLE marker; -- "
-                + "(From Gravitino, DO NOT EDIT: gravitino.v1.uid42) "
-                + "(From Gravitino, DO NOT EDIT: gravitino.v1.uid-1)\""),
-        alterSql);
-
+        alterSql.contains("COMMENT = \"owner\"\"; DROP TABLE marker; --\""), alterSql);
+    Assertions.assertFalse(createSql.contains("gravitino.v1.uid"), createSql);
+    Assertions.assertFalse(alterSql.contains("gravitino.v1.uid"), alterSql);
     String clearCommentSql = ops.alterTableSql("test_table", TableChange.updateComment(""));
-    Assertions.assertTrue(
-        clearCommentSql.contains(
-            "COMMENT = \"(From Gravitino, DO NOT EDIT: gravitino.v1.uid42) "
-                + "(From Gravitino, DO NOT EDIT: gravitino.v1.uid-1)\""),
-        clearCommentSql);
+    Assertions.assertTrue(clearCommentSql.contains("COMMENT = \"\""), clearCommentSql);
   }
 
   @Test

--- a/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/utils/TestStarRocksUtils.java
+++ b/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/utils/TestStarRocksUtils.java
@@ -41,6 +41,34 @@ import org.junit.jupiter.api.Test;
 public class TestStarRocksUtils {
 
   @Test
+  void testExtractTableCommentWithoutIdentifier() {
+    String prefix = "CREATE TABLE `t` (\n`c` INT COMMENT \"column comment\"\n) ENGINE=OLAP\n";
+    assertEquals("", StarRocksUtils.extractTableCommentFromSql(prefix));
+    assertEquals(
+        "  user comment  ",
+        StarRocksUtils.extractTableCommentFromSql(
+            prefix + "COMMENT \"  user comment  \"\nDISTRIBUTED BY RANDOM"));
+    assertEquals("", StarRocksUtils.extractTableCommentFromSql(prefix + "COMMENT \"\""));
+    assertEquals(
+        "line one\nline two",
+        StarRocksUtils.extractTableCommentFromSql(prefix + "COMMENT \"line one\nline two\""));
+  }
+
+  @Test
+  void testExtractLegacyCommentPreservesRealIdentifier() {
+    String marker = "(From Gravitino, DO NOT EDIT: gravitino.v1.uid42)";
+    String dummy = "(From Gravitino, DO NOT EDIT: gravitino.v1.uid-1)";
+    String prefix = "CREATE TABLE `t` (`c` INT)\nCOMMENT \"";
+    assertEquals(
+        "legacy " + marker,
+        StarRocksUtils.extractTableCommentFromSql(
+            prefix + "legacy " + marker + " " + dummy + "\""));
+    assertEquals(
+        "legacy " + marker,
+        StarRocksUtils.extractTableCommentFromSql(prefix + "legacy " + marker + "\""));
+  }
+
+  @Test
   public void testGeneratePropertiesSql() {
     // Test when properties is null
     Map<String, String> properties = null;

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -104,6 +104,35 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
   }
 
   @Test
+  void testStoredIdentitySurvivesMissingSourceIdentifierAndRename() throws IOException {
+    Namespace namespace = Namespace.of(metalake, catalog, "schema_without_table_ids");
+    Map<String, String> properties = ImmutableMap.of("k1", "v1", "k2", "v2");
+    schemaOperationDispatcher.createSchema(NameIdentifier.of(namespace.levels()), "", properties);
+    NameIdentifier ident = NameIdentifier.of(namespace, "table_without_id");
+    Column[] columns = {
+      TestColumn.builder().withName("col1").withPosition(0).withType(Types.StringType.get()).build()
+    };
+    tableOperationDispatcher.createTable(ident, columns, "comment", properties, new Transform[0]);
+    TableEntity original = entityStore.get(ident, TABLE, TableEntity.class);
+    TestCatalog testCatalog =
+        (TestCatalog)
+            catalogManager.loadCatalogAndWrap(NameIdentifier.of(metalake, catalog)).catalog();
+    TestCatalogOperations sourceOperations = (TestCatalogOperations) testCatalog.ops();
+    sourceOperations.loadTable(ident).properties().remove(ID_KEY);
+
+    Table loaded = tableOperationDispatcher.loadTable(ident);
+    Assertions.assertFalse(loaded.properties().containsKey(ID_KEY));
+    Assertions.assertEquals(original.id(), entityStore.get(ident, TABLE, TableEntity.class).id());
+    Table altered = tableOperationDispatcher.alterTable(ident, TableChange.rename("renamed_table"));
+    Assertions.assertEquals("renamed_table", altered.name());
+    TableEntity renamed =
+        entityStore.get(NameIdentifier.of(namespace, "renamed_table"), TABLE, TableEntity.class);
+    Assertions.assertEquals(original.id(), renamed.id());
+    Assertions.assertEquals(original.columns().get(0).id(), renamed.columns().get(0).id());
+    Assertions.assertFalse(entityStore.exists(ident, TABLE));
+  }
+
+  @Test
   public void testCreateAndListTables() throws IOException {
     Namespace tableNs = Namespace.of(metalake, catalog, "schema41");
     Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");

--- a/docs/jdbc-doris-catalog.md
+++ b/docs/jdbc-doris-catalog.md
@@ -16,8 +16,14 @@ import TabItem from '@theme/TabItem';
 Apache Gravitino provides the ability to manage [Apache Doris](https://doris.apache.org/) metadata through JDBC connection.
 
 :::caution
-Gravitino saves some system information in schema and table comments, like
-`(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`, do not change or remove this message.
+Gravitino keeps table identifiers in its own metadata store and does not append them to table
+comments. Existing identifier markers remain readable for compatibility. Renames performed through
+Gravitino preserve the stored identity; renames performed directly in the source cannot be tracked
+by identity for tables without a marker. Replacing a table directly in the source with another table
+of the same name also cannot be distinguished by name alone.
+
+Schema comments may still contain internal identifier markers such as
+`(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`.
 :::
 
 ## Catalog

--- a/docs/jdbc-hologres-catalog.md
+++ b/docs/jdbc-hologres-catalog.md
@@ -18,7 +18,14 @@ Apache Gravitino provides the ability to manage [Hologres](https://help.aliyun.c
 Hologres is a real-time data warehouse service provided by Alibaba Cloud, designed for high-concurrency and low-latency online analytical processing (OLAP). Hologres is fully compatible with the PostgreSQL protocol and uses the PostgreSQL JDBC Driver for connections.
 
 :::caution
-Gravitino saves some system information in schema and table comment, like `(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`, do not change or remove this message.
+Gravitino keeps table identifiers in its own metadata store and does not append them to table
+comments. Existing identifier markers remain readable for compatibility. Renames performed through
+Gravitino preserve the stored identity; renames performed directly in the source cannot be tracked
+by identity for tables without a marker. Replacing a table directly in the source with another table
+of the same name also cannot be distinguished by name alone.
+
+Schema comments may still contain internal identifier markers such as
+`(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`.
 :::
 
 ## Catalog

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -16,7 +16,14 @@ import TabItem from '@theme/TabItem';
 Apache Gravitino provides the ability to manage MySQL metadata.
 
 :::caution
-Gravitino saves some system information in schema and table comment, like `(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`, do not change or remove this message.
+Gravitino keeps table identifiers in its own metadata store and does not append them to table
+comments. Existing identifier markers remain readable for compatibility. Renames performed through
+Gravitino preserve the stored identity; renames performed directly in the source cannot be tracked
+by identity for tables without a marker. Replacing a table directly in the source with another table
+of the same name also cannot be distinguished by name alone.
+
+Schema comments may still contain internal identifier markers such as
+`(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`.
 :::
 
 ## Catalog

--- a/docs/jdbc-oceanbase-catalog.md
+++ b/docs/jdbc-oceanbase-catalog.md
@@ -16,8 +16,16 @@ import TabItem from '@theme/TabItem';
 Apache Gravitino provides the ability to manage OceanBase metadata.
 
 :::caution
-1. Gravitino saves some system information in schema and table comment, like `(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`, do not change or remove this message.
-2. OceanBase catalog is not included in standard Gravitino distribution, but you can still build it from source if you need it. Check [build from source](./how-to-build.md) for more details.
+Gravitino keeps table identifiers in its own metadata store and does not append them to table
+comments. Existing identifier markers remain readable for compatibility. Renames performed through
+Gravitino preserve the stored identity; renames performed directly in the source cannot be tracked
+by identity for tables without a marker. Replacing a table directly in the source with another table
+of the same name also cannot be distinguished by name alone.
+
+Schema comments may still contain internal identifier markers such as
+`(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`.
+
+OceanBase catalog is not included in standard Gravitino distribution, but you can still build it from source if you need it. Check [build from source](./how-to-build.md) for more details.
 :::
 
 ## Catalog

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -16,7 +16,14 @@ import TabItem from '@theme/TabItem';
 Apache Gravitino provides the ability to manage PostgreSQL metadata.
 
 :::caution
-Gravitino saves some system information in schema and table comment, like `(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`, do not change or remove this message.
+Gravitino keeps table identifiers in its own metadata store and does not append them to table
+comments. Existing identifier markers remain readable for compatibility. Renames performed through
+Gravitino preserve the stored identity; renames performed directly in the source cannot be tracked
+by identity for tables without a marker. Replacing a table directly in the source with another table
+of the same name also cannot be distinguished by name alone.
+
+Schema comments may still contain internal identifier markers such as
+`(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`.
 :::
 
 ## Catalog

--- a/docs/jdbc-starrocks-catalog.md
+++ b/docs/jdbc-starrocks-catalog.md
@@ -16,8 +16,14 @@ import TabItem from '@theme/TabItem';
 Apache Gravitino provides the ability to manage [StarRocks](https://www.starrocks.io/) metadata through JDBC connection.
 
 :::caution
-Gravitino saves some system information in table comments, like
-`(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`, do not change or remove this message.
+Gravitino keeps table identifiers in its own metadata store and does not append them to table
+comments. Existing identifier markers remain readable for compatibility. Renames performed through
+Gravitino preserve the stored identity; renames performed directly in the source cannot be tracked
+by identity for tables without a marker. Replacing a table directly in the source with another table
+of the same name also cannot be distinguished by name alone.
+
+Schema comments may still contain internal identifier markers such as
+`(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`.
 :::
 
 ## Catalog


### PR DESCRIPTION
### What changes were proposed in this pull request?

Stop appending entity IDs when creating JDBC tables or updating table comments. Keep legacy marker reads, update StarRocks comment extraction, and document identity behavior for source-side renames and replacements.

### Why are the changes needed?

Internal IDs currently pollute source table comments while being hidden by the Gravitino API. Tables without source-side IDs can use the existing entity store lookup.

Fix: #12941

### Does this PR introduce _any_ user-facing change?

New table comments and comment updates no longer receive entity ID markers. Existing markers remain readable. Source-side renames and same-name replacements cannot be identified by name alone for tables without markers.

### How was this patch tested?

400 tests passed across eight JDBC modules and TestTableOperationDispatcher, covering comment preservation, legacy reads, and stored table/column identity across a Gravitino rename. Docker tests were excluded. Spotless passed for the affected modules.
