### PR TITLE
[#12947] fix(catalog): reject unknown catalog properties to prevent credential leaks

### DIFF
--- a/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogPropertiesMetadata.java
@@ -225,6 +225,16 @@ public class FilesetCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
                   DEFAULT_DISABLE_FILESYSTEM_OPS,
                   false /* hidden */,
                   false /* reserved */))
+          .put(
+              FS_GRAVITINO_PATH_CONFIG_PREFIX,
+              PropertyEntry.stringOptionalPropertyPrefixEntry(
+                  FS_GRAVITINO_PATH_CONFIG_PREFIX,
+                  "Location-scoped filesystem configs: fs.path.config.<name> and"
+                      + " fs.path.config.<name>.<key>",
+                  false /* immutable */,
+                  null /* default value */,
+                  false /* hidden */,
+                  false /* reserved */))
           // The following two are about authentication.
           .putAll(KERBEROS_PROPERTY_ENTRIES)
           .putAll(AUTHENTICATION_PROPERTY_ENTRIES)

--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/TestFilesetCloudPropertiesMetadata.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/TestFilesetCloudPropertiesMetadata.java
@@ -18,8 +18,11 @@
  */
 package org.apache.gravitino.catalog.fileset;
 
+import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -90,5 +93,32 @@ public class TestFilesetCloudPropertiesMetadata {
     assertEquals(
         HiddenPropertyMaskUtils.MASKED_VALUE,
         response.get(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY));
+  }
+
+
+  @Test
+  void testAcceptsDeclaredS3CredentialsOnCreate() {
+    FilesetCatalogPropertiesMetadata metadata = new FilesetCatalogPropertiesMetadata();
+    Map<String, String> properties =
+        ImmutableMap.of(
+            FilesetCatalogPropertiesMetadata.LOCATION,
+            "s3a://bucket/path",
+            S3Properties.GRAVITINO_S3_ACCESS_KEY_ID,
+            "AKIATEST",
+            S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY,
+            "secret-value");
+    assertDoesNotThrow(() -> validatePropertyForCreate(metadata, properties));
+  }
+
+  @Test
+  void testRejectsUnknownCatalogProperty() {
+    FilesetCatalogPropertiesMetadata metadata = new FilesetCatalogPropertiesMetadata();
+    Map<String, String> properties = ImmutableMap.of("foo-bar", "value");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> validatePropertyForCreate(metadata, properties));
+    assertTrue(exception.getMessage().contains("Unknown properties"));
+    assertTrue(exception.getMessage().contains("foo-bar"));
   }
 }

--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/TestFilesetCloudPropertiesMetadata.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/TestFilesetCloudPropertiesMetadata.java
@@ -95,7 +95,6 @@ public class TestFilesetCloudPropertiesMetadata {
         response.get(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY));
   }
 
-
   @Test
   void testAcceptsDeclaredS3CredentialsOnCreate() {
     FilesetCatalogPropertiesMetadata metadata = new FilesetCatalogPropertiesMetadata();
@@ -120,5 +119,18 @@ public class TestFilesetCloudPropertiesMetadata {
             IllegalArgumentException.class, () -> validatePropertyForCreate(metadata, properties));
     assertTrue(exception.getMessage().contains("Unknown properties"));
     assertTrue(exception.getMessage().contains("foo-bar"));
+  }
+
+  @Test
+  void testAcceptsFsPathConfigPrefix() {
+    FilesetCatalogPropertiesMetadata metadata = new FilesetCatalogPropertiesMetadata();
+    Map<String, String> properties =
+        ImmutableMap.of(
+            FilesetCatalogPropertiesMetadata.FS_GRAVITINO_PATH_CONFIG_PREFIX + "cluster1",
+            "hdfs://cluster1/",
+            FilesetCatalogPropertiesMetadata.FS_GRAVITINO_PATH_CONFIG_PREFIX
+                + "cluster1.config.resource",
+            "/etc/core-site.xml");
+    assertDoesNotThrow(() -> validatePropertyForCreate(metadata, properties));
   }
 }

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.catalog.glue;
 
+import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForAlter;
+import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_ACCESS_KEY_ID;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_CATALOG_ID;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_ENDPOINT;
@@ -28,10 +30,17 @@ import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORM
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_VALUE;
 import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT_FILTER;
 import static org.apache.gravitino.catalog.glue.GlueConstants.WAREHOUSE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.storage.S3Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -76,6 +85,12 @@ class TestGlueCatalogPropertiesMetadata {
   }
 
   @Test
+  void testCredentialsAreHidden() {
+    assertTrue(metadata.isHiddenProperty(AWS_ACCESS_KEY_ID));
+    assertTrue(metadata.isHiddenProperty(AWS_SECRET_ACCESS_KEY));
+  }
+
+  @Test
   void testEndpointIsOptionalAndNotHidden() {
     assertFalse(metadata.isRequiredProperty(AWS_GLUE_ENDPOINT));
     assertFalse(metadata.isHiddenProperty(AWS_GLUE_ENDPOINT));
@@ -95,5 +110,64 @@ class TestGlueCatalogPropertiesMetadata {
         DEFAULT_TABLE_FORMAT_FILTER,
         metadata.getDefaultValue(TABLE_FORMAT_FILTER),
         "Default table format filter should be 'all'");
+  }
+
+  @Test
+  void testRejectsMistypedS3CredentialProperties() {
+    Map<String, String> props =
+        ImmutableMap.of(
+            AWS_REGION,
+            "us-east-1",
+            WAREHOUSE,
+            "s3://bucket/wh",
+            S3Properties.GRAVITINO_S3_ACCESS_KEY_ID,
+            "AKIATEST",
+            S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY,
+            "secret");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> validatePropertyForCreate(metadata, props));
+    assertTrue(exception.getMessage().contains("Unknown properties"));
+    assertTrue(exception.getMessage().contains(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY));
+  }
+
+  @Test
+  void testAcceptsDeclaredAwsCredentialsAndMasksOnRead() {
+    Map<String, String> props =
+        ImmutableMap.of(
+            AWS_REGION,
+            "us-east-1",
+            WAREHOUSE,
+            "s3://bucket/wh",
+            AWS_ACCESS_KEY_ID,
+            "AKIATEST",
+            AWS_SECRET_ACCESS_KEY,
+            "secret");
+    assertDoesNotThrow(() -> validatePropertyForCreate(metadata, props));
+
+    Map<String, String> masked = HiddenPropertyMaskUtils.maskHiddenProperties(props, metadata);
+    assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, masked.get(AWS_ACCESS_KEY_ID));
+    assertEquals(HiddenPropertyMaskUtils.MASKED_VALUE, masked.get(AWS_SECRET_ACCESS_KEY));
+  }
+
+  @Test
+  void testAlterRejectsMistypedS3CredentialUpsert() {
+    Map<String, String> upserts =
+        ImmutableMap.of(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY, "secret");
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validatePropertyForAlter(metadata, upserts, Collections.emptyMap()));
+    assertTrue(exception.getMessage().contains(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY));
+  }
+
+  @Test
+  void testAlterAllowsRemovingMistypedS3Credential() {
+    Map<String, String> deletes =
+        ImmutableMap.of(
+            S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY,
+            S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY);
+    assertDoesNotThrow(() -> validatePropertyForAlter(metadata, Collections.emptyMap(), deletes));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/PropertiesMetadataHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PropertiesMetadataHelpers.java
@@ -93,6 +93,13 @@ public class PropertiesMetadataHelpers {
       PropertiesMetadata propertiesMetadata,
       Map<String, String> upserts,
       Map<String, String> deletes) {
+    if (upserts == null) {
+      upserts = Map.of();
+    }
+    if (deletes == null) {
+      deletes = Map.of();
+    }
+
     HiddenPropertyMaskUtils.validateNoMaskedPlaceholders(upserts);
 
     // Reject undeclared upserts for closed property sets (catalogs). Deletes of undeclared keys
@@ -138,6 +145,9 @@ public class PropertiesMetadataHelpers {
             .sorted()
             .collect(Collectors.toList());
     Preconditions.checkArgument(
-        unknownProperties.isEmpty(), "Unknown properties are not allowed: %s", unknownProperties);
+        unknownProperties.isEmpty(),
+        "Unknown properties are not allowed: %s. Use properties declared by the catalog"
+            + " provider, or a declared prefix such as gravitino.bypass.",
+        unknownProperties);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/PropertiesMetadataHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PropertiesMetadataHelpers.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
@@ -76,6 +77,8 @@ public class PropertiesMetadataHelpers {
         "Properties or property prefixes are required and must be set: %s",
         absentProperties);
 
+    rejectUnknownProperties(propertiesMetadata, properties.keySet());
+
     // use decode function to validate the property values
     for (Map.Entry<String, String> entry : properties.entrySet()) {
       String key = entry.getKey();
@@ -91,6 +94,10 @@ public class PropertiesMetadataHelpers {
       Map<String, String> upserts,
       Map<String, String> deletes) {
     HiddenPropertyMaskUtils.validateNoMaskedPlaceholders(upserts);
+
+    // Reject undeclared upserts for closed property sets (catalogs). Deletes of undeclared keys
+    // remain allowed so operators can remove previously persisted mistyped secrets.
+    rejectUnknownProperties(propertiesMetadata, upserts.keySet());
 
     for (Map.Entry<String, String> entry : upserts.entrySet()) {
       if (!propertiesMetadata.containsProperty(entry.getKey())) {
@@ -118,5 +125,19 @@ public class PropertiesMetadataHelpers {
             "Property " + entry.getKey() + " is immutable or reserved, cannot be deleted");
       }
     }
+  }
+
+  private static void rejectUnknownProperties(
+      PropertiesMetadata propertiesMetadata, Set<String> propertyKeys) {
+    if (!propertiesMetadata.rejectsUnknownProperties() || propertyKeys == null) {
+      return;
+    }
+    List<String> unknownProperties =
+        propertyKeys.stream()
+            .filter(key -> !propertiesMetadata.containsProperty(key))
+            .sorted()
+            .collect(Collectors.toList());
+    Preconditions.checkArgument(
+        unknownProperties.isEmpty(), "Unknown properties are not allowed: %s", unknownProperties);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
@@ -23,6 +23,8 @@ import static org.apache.gravitino.Catalog.CLOUD_NAME;
 import static org.apache.gravitino.Catalog.CLOUD_REGION_CODE;
 import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
 import static org.apache.gravitino.Catalog.PROPERTY_PACKAGE;
+import static org.apache.gravitino.connector.BaseCatalog.CATALOG_BYPASS_PREFIX;
+import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyPrefixEntry;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -41,6 +43,15 @@ public abstract class BaseCatalogPropertiesMetadata extends BasePropertiesMetada
    * metalake is disabled, this property is set to {@code false} on all its catalogs.
    */
   public static String PROPERTY_METALAKE_IN_USE = "metalake-in-use";
+
+  /** Prefix for Trino connector passthrough catalog properties. */
+  public static final String TRINO_BYPASS_PREFIX = "trino.bypass.";
+
+  /** Prefix for Flink connector passthrough catalog properties. */
+  public static final String FLINK_BYPASS_PREFIX = "flink.bypass.";
+
+  /** Prefix for Spark connector passthrough catalog properties. */
+  public static final String SPARK_BYPASS_PREFIX = "spark.bypass.";
 
   public static final PropertiesMetadata BASIC_CATALOG_PROPERTIES_METADATA =
       new BaseCatalogPropertiesMetadata() {
@@ -99,8 +110,41 @@ public abstract class BaseCatalogPropertiesMetadata extends BasePropertiesMetada
                   PROPERTY_METALAKE_IN_USE,
                   "The property indicating the metalake that holds the catalog is in use",
                   true /* default value */,
-                  true /* hidden */)),
+                  true /* hidden */),
+              stringOptionalPropertyPrefixEntry(
+                  CATALOG_BYPASS_PREFIX,
+                  "Pass-through properties forwarded to the underlying catalog implementation",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */,
+                  false /* reserved */),
+              stringOptionalPropertyPrefixEntry(
+                  TRINO_BYPASS_PREFIX,
+                  "Pass-through properties forwarded to the Trino connector",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */,
+                  false /* reserved */),
+              stringOptionalPropertyPrefixEntry(
+                  FLINK_BYPASS_PREFIX,
+                  "Pass-through properties forwarded to the Flink connector",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */,
+                  false /* reserved */),
+              stringOptionalPropertyPrefixEntry(
+                  SPARK_BYPASS_PREFIX,
+                  "Pass-through properties forwarded to the Spark connector",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */,
+                  false /* reserved */)),
           PropertyEntry::getName);
+
+  @Override
+  public boolean rejectsUnknownProperties() {
+    return true;
+  }
 
   @Override
   public Map<String, PropertyEntry<?>> propertyEntries() {

--- a/core/src/main/java/org/apache/gravitino/connector/PropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/connector/PropertiesMetadata.java
@@ -108,6 +108,19 @@ public interface PropertiesMetadata {
   }
 
   /**
+   * Whether create and alter upserts must use only declared property names (or declared prefixes).
+   *
+   * <p>Catalog metadata returns {@code true} so mistyped credential keys cannot be persisted and
+   * returned unredacted. Table / schema / other open property models keep the default {@code
+   * false}.
+   *
+   * @return true when undeclared property names are rejected on create and alter upsert
+   */
+  default boolean rejectsUnknownProperties() {
+    return false;
+  }
+
+  /**
    * Get the value of the property from the given properties map.
    *
    * @param properties The properties map.

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPropertiesMetadataHelpers.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPropertiesMetadataHelpers.java
@@ -21,6 +21,10 @@ package org.apache.gravitino.catalog;
 import static org.apache.gravitino.TestBasePropertiesMetadata.TEST_REQUIRED_KEY;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForAlter;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
+import static org.apache.gravitino.connector.BaseCatalog.CATALOG_BYPASS_PREFIX;
+import static org.apache.gravitino.connector.BaseCatalogPropertiesMetadata.FLINK_BYPASS_PREFIX;
+import static org.apache.gravitino.connector.BaseCatalogPropertiesMetadata.SPARK_BYPASS_PREFIX;
+import static org.apache.gravitino.connector.BaseCatalogPropertiesMetadata.TRINO_BYPASS_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,12 +33,16 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.gravitino.TestBasePropertiesMetadata;
+import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
 import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
+import org.apache.gravitino.connector.PropertiesMetadata;
 import org.junit.jupiter.api.Test;
 
 public class TestPropertiesMetadataHelpers {
 
   private static final TestBasePropertiesMetadata METADATA = new TestBasePropertiesMetadata();
+  private static final PropertiesMetadata CATALOG_METADATA =
+      BaseCatalogPropertiesMetadata.BASIC_CATALOG_PROPERTIES_METADATA;
 
   @Test
   void testCreateRejectsMaskedPlaceholder() {
@@ -69,5 +77,50 @@ public class TestPropertiesMetadataHelpers {
   void testAlterAllowsNormalUpserts() {
     Map<String, String> upserts = ImmutableMap.of("custom", "new-value");
     assertDoesNotThrow(() -> validatePropertyForAlter(METADATA, upserts, Collections.emptyMap()));
+  }
+
+  @Test
+  void testCatalogCreateRejectsUnknownProperty() {
+    Map<String, String> props = ImmutableMap.of("s3-secret-access-key", "secret");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validatePropertyForCreate(CATALOG_METADATA, props));
+    assertTrue(exception.getMessage().contains("Unknown properties"));
+    assertTrue(exception.getMessage().contains("s3-secret-access-key"));
+  }
+
+  @Test
+  void testCatalogCreateAllowsBypassPrefixes() {
+    Map<String, String> props =
+        ImmutableMap.of(
+            CATALOG_BYPASS_PREFIX + "maxWaitMillis",
+            "1000",
+            TRINO_BYPASS_PREFIX + "join-pushdown.strategy",
+            "automatic",
+            FLINK_BYPASS_PREFIX + "default-database",
+            "db",
+            SPARK_BYPASS_PREFIX + "io-impl",
+            "org.apache.iceberg.io.ResolvingFileIO");
+    assertDoesNotThrow(() -> validatePropertyForCreate(CATALOG_METADATA, props));
+  }
+
+  @Test
+  void testCatalogAlterRejectsUnknownUpsert() {
+    Map<String, String> upserts = ImmutableMap.of("s3-secret-access-key", "secret");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validatePropertyForAlter(CATALOG_METADATA, upserts, Collections.emptyMap()));
+    assertTrue(exception.getMessage().contains("s3-secret-access-key"));
+  }
+
+  @Test
+  void testCatalogAlterAllowsDeletingUnknownProperty() {
+    Map<String, String> deletes = ImmutableMap.of("s3-secret-access-key", "s3-secret-access-key");
+    assertDoesNotThrow(
+        () -> validatePropertyForAlter(CATALOG_METADATA, Collections.emptyMap(), deletes));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Catalog property metadata rejects undeclared keys on create and alter upsert (`PropertiesMetadata.rejectsUnknownProperties()`).
- Declare bypass prefixes: `gravitino.bypass.`, `trino.bypass.`, `flink.bypass.`, `spark.bypass.`.
- Declare fileset `fs.path.config.` prefix so location-scoped catalog configs remain valid.
- Allow alter delete of undeclared keys so mistyped secrets can be cleaned up.
- Unit tests for helpers, Glue mistyped `s3-*`, fileset unknown-property rejection, and `fs.path.config.*`.

Table/schema/other open property models are unchanged.

Raw Hadoop filesystem keys that are neither declared nor under `gravitino.bypass.` are now rejected on catalog create/alter; pass them with the `gravitino.bypass.` prefix.

### Why are the changes needed?

Undeclared catalog properties skip hidden-property redaction, so a mistyped credential property name becomes a plaintext disclosure on read/list paths.

Fix: #12947

### Does this PR introduce any user-facing change?

Yes. Catalog create/alter now rejects property keys that are not declared by the provider (except declared prefixes such as `gravitino.bypass.*` and fileset `fs.path.config.*`). Previously unknown keys were accepted.

### How was this patch tested?

- `TestPropertiesMetadataHelpers`
- `TestGlueCatalogPropertiesMetadata`
- `TestFilesetCloudPropertiesMetadata`