### PR TITLE
[#12958] fix(iceberg): Support Azure service principal authentication for ADLS FileIO

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
@@ -65,6 +65,18 @@ public class IcebergConstants {
       "adls.auth.shared-key.account.name";
   public static final String ICEBERG_ADLS_STORAGE_ACCOUNT_KEY = "adls.auth.shared-key.account.key";
 
+  /** Iceberg property that specifies the ADLS token credential provider implementation. */
+  public static final String ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER =
+      "adls.token-credential-provider";
+
+  /** Prefix for properties passed to the Iceberg ADLS token credential provider. */
+  public static final String ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX =
+      ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER + ".";
+
+  /** Gravitino's Azure client-secret token credential provider implementation. */
+  public static final String AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER =
+      "org.apache.gravitino.iceberg.common.credential.AzureClientSecretTokenCredentialProvider";
+
   // Iceberg Table properties constants
 
   public static final String COMMENT = "comment";

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -18,8 +18,10 @@
  */
 package org.apache.gravitino.catalog.lakehouse.iceberg;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -41,6 +43,7 @@ public class IcebergPropertiesUtils {
       ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID;
   private static final String ICEBERG_AZURE_CLIENT_SECRET =
       ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET;
+  private static final List<MutuallyExclusivePropertyMapping> EXCLUSIVE_PROPERTY_MAPPINGS;
 
   // Map that maintains the mapping of keys in Gravitino to that in Iceberg, for example, users
   // will only need to set the configuration 'catalog-backend' in Gravitino and Gravitino will
@@ -111,6 +114,23 @@ public class IcebergPropertiesUtils {
         });
     ICEBERG_CATALOG_CONFIG_TO_GRAVITINO =
         Collections.unmodifiableMap(icebergCatalogConfigToGravitino);
+
+    PropertyMappingAlternative azureSharedKey =
+        new PropertyMappingAlternative(
+            Arrays.asList(
+                IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME,
+                IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY),
+            Collections.emptyMap());
+    PropertyMappingAlternative azureServicePrincipal =
+        new PropertyMappingAlternative(
+            Arrays.asList(
+                ICEBERG_AZURE_TENANT_ID, ICEBERG_AZURE_CLIENT_ID, ICEBERG_AZURE_CLIENT_SECRET),
+            Collections.singletonMap(
+                ADLS_TOKEN_CREDENTIAL_PROVIDER, AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER));
+    EXCLUSIVE_PROPERTY_MAPPINGS =
+        Collections.singletonList(
+            new MutuallyExclusivePropertyMapping(
+                Arrays.asList(azureSharedKey, azureServicePrincipal), azureSharedKey));
   }
 
   /**
@@ -124,50 +144,8 @@ public class IcebergPropertiesUtils {
       Map<String, String> gravitinoProperties) {
     Map<String, String> icebergProperties = new HashMap<>();
     convertProperties(GRAVITINO_CONFIG_TO_ICEBERG, gravitinoProperties, icebergProperties);
-    configureAzureAuthentication(gravitinoProperties, icebergProperties);
+    EXCLUSIVE_PROPERTY_MAPPINGS.forEach(mapping -> mapping.apply(icebergProperties));
     return icebergProperties;
-  }
-
-  private static void configureAzureAuthentication(
-      Map<String, String> gravitinoProperties, Map<String, String> icebergProperties) {
-    String storageAccountName =
-        gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME);
-    String storageAccountKey =
-        gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_KEY);
-    boolean hasSharedKey = StringUtils.isNoneBlank(storageAccountName, storageAccountKey);
-
-    String tenantId = gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_TENANT_ID);
-    String clientId = gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_CLIENT_ID);
-    String clientSecret = gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET);
-    boolean hasServicePrincipal = StringUtils.isNoneBlank(tenantId, clientId, clientSecret);
-
-    if (hasSharedKey || !hasServicePrincipal) {
-      removeAzureServicePrincipalProperties(icebergProperties);
-      return;
-    }
-
-    icebergProperties.remove(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME);
-    icebergProperties.remove(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY);
-    icebergProperties.put(
-        ADLS_TOKEN_CREDENTIAL_PROVIDER, AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER);
-  }
-
-  private static void removeAzureServicePrincipalProperties(Map<String, String> icebergProperties) {
-    icebergProperties.remove(ICEBERG_AZURE_TENANT_ID);
-    icebergProperties.remove(ICEBERG_AZURE_CLIENT_ID);
-    icebergProperties.remove(ICEBERG_AZURE_CLIENT_SECRET);
-  }
-
-  private static void convertProperties(
-      Map<String, String> propertyMapping,
-      Map<String, String> gravitinoProperties,
-      Map<String, String> icebergProperties) {
-    propertyMapping.forEach(
-        (gravitinoKey, icebergKey) -> {
-          if (gravitinoProperties.containsKey(gravitinoKey)) {
-            icebergProperties.put(icebergKey, gravitinoProperties.get(gravitinoKey));
-          }
-        });
   }
 
   /**
@@ -186,5 +164,61 @@ public class IcebergPropertiesUtils {
     return Optional.ofNullable(catalogBackend)
         .map(s -> s.toLowerCase(Locale.ROOT))
         .orElse("memory");
+  }
+
+  private static void convertProperties(
+      Map<String, String> propertyMapping,
+      Map<String, String> gravitinoProperties,
+      Map<String, String> icebergProperties) {
+    propertyMapping.forEach(
+        (gravitinoKey, icebergKey) -> {
+          if (gravitinoProperties.containsKey(gravitinoKey)) {
+            icebergProperties.put(icebergKey, gravitinoProperties.get(gravitinoKey));
+          }
+        });
+  }
+
+  private static final class MutuallyExclusivePropertyMapping {
+    private final List<PropertyMappingAlternative> alternatives;
+    private final PropertyMappingAlternative fallback;
+
+    private MutuallyExclusivePropertyMapping(
+        List<PropertyMappingAlternative> alternatives, PropertyMappingAlternative fallback) {
+      this.alternatives = alternatives;
+      this.fallback = fallback;
+    }
+
+    private void apply(Map<String, String> properties) {
+      PropertyMappingAlternative selected =
+          alternatives.stream()
+              .filter(alternative -> alternative.isComplete(properties))
+              .findFirst()
+              .orElse(fallback);
+
+      alternatives.stream()
+          .filter(alternative -> alternative != selected)
+          .flatMap(alternative -> alternative.requiredProperties.stream())
+          .forEach(properties::remove);
+
+      if (selected.isComplete(properties)) {
+        properties.putAll(selected.additionalProperties);
+      }
+    }
+  }
+
+  private static final class PropertyMappingAlternative {
+    private final List<String> requiredProperties;
+    private final Map<String, String> additionalProperties;
+
+    private PropertyMappingAlternative(
+        List<String> requiredProperties, Map<String, String> additionalProperties) {
+      this.requiredProperties = requiredProperties;
+      this.additionalProperties = additionalProperties;
+    }
+
+    private boolean isComplete(Map<String, String> properties) {
+      return requiredProperties.stream()
+          .allMatch(property -> StringUtils.isNotBlank(properties.get(property)));
+    }
   }
 }

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -32,17 +32,15 @@ import org.apache.gravitino.storage.S3Properties;
 
 public class IcebergPropertiesUtils {
 
-  private static final String ADLS_TOKEN_CREDENTIAL_PROVIDER = "adls.token-credential-provider";
-  private static final String ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX =
-      ADLS_TOKEN_CREDENTIAL_PROVIDER + ".";
-  private static final String AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER =
-      "org.apache.gravitino.iceberg.common.credential.AzureClientSecretTokenCredentialProvider";
   private static final String ICEBERG_AZURE_TENANT_ID =
-      ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID;
+      IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX
+          + AzureProperties.GRAVITINO_AZURE_TENANT_ID;
   private static final String ICEBERG_AZURE_CLIENT_ID =
-      ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID;
+      IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX
+          + AzureProperties.GRAVITINO_AZURE_CLIENT_ID;
   private static final String ICEBERG_AZURE_CLIENT_SECRET =
-      ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET;
+      IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX
+          + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET;
   private static final List<String> ICEBERG_AZURE_SHARED_KEY_PROPERTIES =
       Arrays.asList(
           IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME,
@@ -51,7 +49,8 @@ public class IcebergPropertiesUtils {
       Arrays.asList(ICEBERG_AZURE_TENANT_ID, ICEBERG_AZURE_CLIENT_ID, ICEBERG_AZURE_CLIENT_SECRET);
   private static final Map<String, String> ICEBERG_AZURE_SERVICE_PRINCIPAL_DEFAULTS =
       Collections.singletonMap(
-          ADLS_TOKEN_CREDENTIAL_PROVIDER, AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER);
+          IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER,
+          IcebergConstants.AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER);
 
   // Map that maintains the mapping of keys in Gravitino to that in Iceberg, for example, users
   // will only need to set the configuration 'catalog-backend' in Gravitino and Gravitino will

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -35,6 +35,7 @@ public class IcebergPropertiesUtils {
       ADLS_TOKEN_CREDENTIAL_PROVIDER + ".";
   private static final String AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER =
       "org.apache.gravitino.iceberg.common.credential.AzureClientSecretTokenCredentialProvider";
+  private static final Map<String, String> AZURE_SERVICE_PRINCIPAL_CONFIG_TO_ICEBERG;
 
   // Map that maintains the mapping of keys in Gravitino to that in Iceberg, for example, users
   // will only need to set the configuration 'catalog-backend' in Gravitino and Gravitino will
@@ -102,6 +103,19 @@ public class IcebergPropertiesUtils {
         });
     ICEBERG_CATALOG_CONFIG_TO_GRAVITINO =
         Collections.unmodifiableMap(icebergCatalogConfigToGravitino);
+
+    Map<String, String> azureServicePrincipalConfigToIceberg = new HashMap<>();
+    azureServicePrincipalConfigToIceberg.put(
+        AzureProperties.GRAVITINO_AZURE_TENANT_ID,
+        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID);
+    azureServicePrincipalConfigToIceberg.put(
+        AzureProperties.GRAVITINO_AZURE_CLIENT_ID,
+        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID);
+    azureServicePrincipalConfigToIceberg.put(
+        AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
+        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET);
+    AZURE_SERVICE_PRINCIPAL_CONFIG_TO_ICEBERG =
+        Collections.unmodifiableMap(azureServicePrincipalConfigToIceberg);
   }
 
   /**
@@ -114,12 +128,7 @@ public class IcebergPropertiesUtils {
   public static Map<String, String> toIcebergCatalogProperties(
       Map<String, String> gravitinoProperties) {
     Map<String, String> icebergProperties = new HashMap<>();
-    gravitinoProperties.forEach(
-        (key, value) -> {
-          if (GRAVITINO_CONFIG_TO_ICEBERG.containsKey(key)) {
-            icebergProperties.put(GRAVITINO_CONFIG_TO_ICEBERG.get(key), value);
-          }
-        });
+    convertProperties(GRAVITINO_CONFIG_TO_ICEBERG, gravitinoProperties, icebergProperties);
     configureAzureAuthentication(gravitinoProperties, icebergProperties);
     return icebergProperties;
   }
@@ -145,15 +154,20 @@ public class IcebergPropertiesUtils {
     icebergProperties.remove(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY);
     icebergProperties.put(
         ADLS_TOKEN_CREDENTIAL_PROVIDER, AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER);
-    icebergProperties.put(
-        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID,
-        tenantId);
-    icebergProperties.put(
-        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID,
-        clientId);
-    icebergProperties.put(
-        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
-        clientSecret);
+    convertProperties(
+        AZURE_SERVICE_PRINCIPAL_CONFIG_TO_ICEBERG, gravitinoProperties, icebergProperties);
+  }
+
+  private static void convertProperties(
+      Map<String, String> propertyMapping,
+      Map<String, String> gravitinoProperties,
+      Map<String, String> icebergProperties) {
+    propertyMapping.forEach(
+        (gravitinoKey, icebergKey) -> {
+          if (gravitinoProperties.containsKey(gravitinoKey)) {
+            icebergProperties.put(icebergKey, gravitinoProperties.get(gravitinoKey));
+          }
+        });
   }
 
   /**

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -23,11 +23,18 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.storage.AzureProperties;
 import org.apache.gravitino.storage.OSSProperties;
 import org.apache.gravitino.storage.S3Properties;
 
 public class IcebergPropertiesUtils {
+
+  private static final String ADLS_TOKEN_CREDENTIAL_PROVIDER = "adls.token-credential-provider";
+  private static final String ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX =
+      ADLS_TOKEN_CREDENTIAL_PROVIDER + ".";
+  private static final String AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER =
+      "org.apache.gravitino.iceberg.common.credential.AzureClientSecretTokenCredentialProvider";
 
   // Map that maintains the mapping of keys in Gravitino to that in Iceberg, for example, users
   // will only need to set the configuration 'catalog-backend' in Gravitino and Gravitino will
@@ -113,7 +120,40 @@ public class IcebergPropertiesUtils {
             icebergProperties.put(GRAVITINO_CONFIG_TO_ICEBERG.get(key), value);
           }
         });
+    configureAzureAuthentication(gravitinoProperties, icebergProperties);
     return icebergProperties;
+  }
+
+  private static void configureAzureAuthentication(
+      Map<String, String> gravitinoProperties, Map<String, String> icebergProperties) {
+    String storageAccountName =
+        gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME);
+    String storageAccountKey =
+        gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_KEY);
+    boolean hasSharedKey = StringUtils.isNoneBlank(storageAccountName, storageAccountKey);
+
+    String tenantId = gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_TENANT_ID);
+    String clientId = gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_CLIENT_ID);
+    String clientSecret = gravitinoProperties.get(AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET);
+    boolean hasServicePrincipal = StringUtils.isNoneBlank(tenantId, clientId, clientSecret);
+
+    if (hasSharedKey || !hasServicePrincipal) {
+      return;
+    }
+
+    icebergProperties.remove(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME);
+    icebergProperties.remove(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY);
+    icebergProperties.put(
+        ADLS_TOKEN_CREDENTIAL_PROVIDER, AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER);
+    icebergProperties.put(
+        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID,
+        tenantId);
+    icebergProperties.put(
+        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID,
+        clientId);
+    icebergProperties.put(
+        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
+        clientSecret);
   }
 
   /**

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -43,7 +43,15 @@ public class IcebergPropertiesUtils {
       ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID;
   private static final String ICEBERG_AZURE_CLIENT_SECRET =
       ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET;
-  private static final List<MutuallyExclusivePropertyMapping> EXCLUSIVE_PROPERTY_MAPPINGS;
+  private static final List<String> ICEBERG_AZURE_SHARED_KEY_PROPERTIES =
+      Arrays.asList(
+          IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME,
+          IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY);
+  private static final List<String> ICEBERG_AZURE_SERVICE_PRINCIPAL_PROPERTIES =
+      Arrays.asList(ICEBERG_AZURE_TENANT_ID, ICEBERG_AZURE_CLIENT_ID, ICEBERG_AZURE_CLIENT_SECRET);
+  private static final Map<String, String> ICEBERG_AZURE_SERVICE_PRINCIPAL_DEFAULTS =
+      Collections.singletonMap(
+          ADLS_TOKEN_CREDENTIAL_PROVIDER, AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER);
 
   // Map that maintains the mapping of keys in Gravitino to that in Iceberg, for example, users
   // will only need to set the configuration 'catalog-backend' in Gravitino and Gravitino will
@@ -114,23 +122,6 @@ public class IcebergPropertiesUtils {
         });
     ICEBERG_CATALOG_CONFIG_TO_GRAVITINO =
         Collections.unmodifiableMap(icebergCatalogConfigToGravitino);
-
-    PropertyMappingAlternative azureSharedKey =
-        new PropertyMappingAlternative(
-            Arrays.asList(
-                IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME,
-                IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY),
-            Collections.emptyMap());
-    PropertyMappingAlternative azureServicePrincipal =
-        new PropertyMappingAlternative(
-            Arrays.asList(
-                ICEBERG_AZURE_TENANT_ID, ICEBERG_AZURE_CLIENT_ID, ICEBERG_AZURE_CLIENT_SECRET),
-            Collections.singletonMap(
-                ADLS_TOKEN_CREDENTIAL_PROVIDER, AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER));
-    EXCLUSIVE_PROPERTY_MAPPINGS =
-        Collections.singletonList(
-            new MutuallyExclusivePropertyMapping(
-                Arrays.asList(azureSharedKey, azureServicePrincipal), azureSharedKey));
   }
 
   /**
@@ -144,7 +135,11 @@ public class IcebergPropertiesUtils {
       Map<String, String> gravitinoProperties) {
     Map<String, String> icebergProperties = new HashMap<>();
     convertProperties(GRAVITINO_CONFIG_TO_ICEBERG, gravitinoProperties, icebergProperties);
-    EXCLUSIVE_PROPERTY_MAPPINGS.forEach(mapping -> mapping.apply(icebergProperties));
+    applyExclusivePropertyMapping(
+        icebergProperties,
+        ICEBERG_AZURE_SHARED_KEY_PROPERTIES,
+        ICEBERG_AZURE_SERVICE_PRINCIPAL_PROPERTIES,
+        ICEBERG_AZURE_SERVICE_PRINCIPAL_DEFAULTS);
     return icebergProperties;
   }
 
@@ -178,47 +173,32 @@ public class IcebergPropertiesUtils {
         });
   }
 
-  private static final class MutuallyExclusivePropertyMapping {
-    private final List<PropertyMappingAlternative> alternatives;
-    private final PropertyMappingAlternative fallback;
+  /**
+   * Keeps the preferred property set when it is complete. Otherwise, it selects the alternative
+   * when complete and adds the properties required by that alternative. If neither set is complete,
+   * the preferred properties are retained so downstream validation remains unchanged.
+   */
+  private static void applyExclusivePropertyMapping(
+      Map<String, String> properties,
+      List<String> preferredProperties,
+      List<String> alternativeProperties,
+      Map<String, String> alternativeAdditionalProperties) {
+    boolean useAlternative =
+        !containsAllProperties(properties, preferredProperties)
+            && containsAllProperties(properties, alternativeProperties);
 
-    private MutuallyExclusivePropertyMapping(
-        List<PropertyMappingAlternative> alternatives, PropertyMappingAlternative fallback) {
-      this.alternatives = alternatives;
-      this.fallback = fallback;
-    }
-
-    private void apply(Map<String, String> properties) {
-      PropertyMappingAlternative selected =
-          alternatives.stream()
-              .filter(alternative -> alternative.isComplete(properties))
-              .findFirst()
-              .orElse(fallback);
-
-      alternatives.stream()
-          .filter(alternative -> alternative != selected)
-          .flatMap(alternative -> alternative.requiredProperties.stream())
-          .forEach(properties::remove);
-
-      if (selected.isComplete(properties)) {
-        properties.putAll(selected.additionalProperties);
-      }
+    if (useAlternative) {
+      preferredProperties.forEach(properties::remove);
+      properties.putAll(alternativeAdditionalProperties);
+    } else {
+      // Do not pass credentials for an unselected or incomplete alternative.
+      alternativeProperties.forEach(properties::remove);
     }
   }
 
-  private static final class PropertyMappingAlternative {
-    private final List<String> requiredProperties;
-    private final Map<String, String> additionalProperties;
-
-    private PropertyMappingAlternative(
-        List<String> requiredProperties, Map<String, String> additionalProperties) {
-      this.requiredProperties = requiredProperties;
-      this.additionalProperties = additionalProperties;
-    }
-
-    private boolean isComplete(Map<String, String> properties) {
-      return requiredProperties.stream()
-          .allMatch(property -> StringUtils.isNotBlank(properties.get(property)));
-    }
+  private static boolean containsAllProperties(
+      Map<String, String> properties, List<String> requiredProperties) {
+    return requiredProperties.stream()
+        .allMatch(property -> StringUtils.isNotBlank(properties.get(property)));
   }
 }

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -35,7 +35,12 @@ public class IcebergPropertiesUtils {
       ADLS_TOKEN_CREDENTIAL_PROVIDER + ".";
   private static final String AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER =
       "org.apache.gravitino.iceberg.common.credential.AzureClientSecretTokenCredentialProvider";
-  private static final Map<String, String> AZURE_SERVICE_PRINCIPAL_CONFIG_TO_ICEBERG;
+  private static final String ICEBERG_AZURE_TENANT_ID =
+      ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID;
+  private static final String ICEBERG_AZURE_CLIENT_ID =
+      ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID;
+  private static final String ICEBERG_AZURE_CLIENT_SECRET =
+      ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET;
 
   // Map that maintains the mapping of keys in Gravitino to that in Iceberg, for example, users
   // will only need to set the configuration 'catalog-backend' in Gravitino and Gravitino will
@@ -78,6 +83,9 @@ public class IcebergPropertiesUtils {
     map.put(
         AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_KEY,
         IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY);
+    map.put(AzureProperties.GRAVITINO_AZURE_TENANT_ID, ICEBERG_AZURE_TENANT_ID);
+    map.put(AzureProperties.GRAVITINO_AZURE_CLIENT_ID, ICEBERG_AZURE_CLIENT_ID);
+    map.put(AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET, ICEBERG_AZURE_CLIENT_SECRET);
     // Table metadata cache
     map.put(IcebergConstants.TABLE_METADATA_CACHE_IMPL, IcebergConstants.TABLE_METADATA_CACHE_IMPL);
     map.put(
@@ -103,19 +111,6 @@ public class IcebergPropertiesUtils {
         });
     ICEBERG_CATALOG_CONFIG_TO_GRAVITINO =
         Collections.unmodifiableMap(icebergCatalogConfigToGravitino);
-
-    Map<String, String> azureServicePrincipalConfigToIceberg = new HashMap<>();
-    azureServicePrincipalConfigToIceberg.put(
-        AzureProperties.GRAVITINO_AZURE_TENANT_ID,
-        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID);
-    azureServicePrincipalConfigToIceberg.put(
-        AzureProperties.GRAVITINO_AZURE_CLIENT_ID,
-        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID);
-    azureServicePrincipalConfigToIceberg.put(
-        AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
-        ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET);
-    AZURE_SERVICE_PRINCIPAL_CONFIG_TO_ICEBERG =
-        Collections.unmodifiableMap(azureServicePrincipalConfigToIceberg);
   }
 
   /**
@@ -147,6 +142,7 @@ public class IcebergPropertiesUtils {
     boolean hasServicePrincipal = StringUtils.isNoneBlank(tenantId, clientId, clientSecret);
 
     if (hasSharedKey || !hasServicePrincipal) {
+      removeAzureServicePrincipalProperties(icebergProperties);
       return;
     }
 
@@ -154,8 +150,12 @@ public class IcebergPropertiesUtils {
     icebergProperties.remove(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY);
     icebergProperties.put(
         ADLS_TOKEN_CREDENTIAL_PROVIDER, AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER);
-    convertProperties(
-        AZURE_SERVICE_PRINCIPAL_CONFIG_TO_ICEBERG, gravitinoProperties, icebergProperties);
+  }
+
+  private static void removeAzureServicePrincipalProperties(Map<String, String> icebergProperties) {
+    icebergProperties.remove(ICEBERG_AZURE_TENANT_ID);
+    icebergProperties.remove(ICEBERG_AZURE_CLIENT_ID);
+    icebergProperties.remove(ICEBERG_AZURE_CLIENT_SECRET);
   }
 
   private static void convertProperties(

--- a/catalogs/catalog-common/src/test/java/org/apache/gravitino/lakehouse/iceberg/TestIcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/test/java/org/apache/gravitino/lakehouse/iceberg/TestIcebergPropertiesUtils.java
@@ -124,6 +124,9 @@ public class TestIcebergPropertiesUtils {
     Assertions.assertEquals(
         "account-key", icebergProps.get(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY));
     Assertions.assertFalse(icebergProps.containsKey(ADLS_TOKEN_CREDENTIAL_PROVIDER));
+    Assertions.assertFalse(
+        icebergProps.containsKey(
+            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET));
   }
 
   @Test
@@ -141,6 +144,9 @@ public class TestIcebergPropertiesUtils {
     Assertions.assertEquals(
         "account", icebergProps.get(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME));
     Assertions.assertFalse(icebergProps.containsKey(ADLS_TOKEN_CREDENTIAL_PROVIDER));
+    Assertions.assertFalse(
+        icebergProps.containsKey(
+            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID));
   }
 
   @Test

--- a/catalogs/catalog-common/src/test/java/org/apache/gravitino/lakehouse/iceberg/TestIcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/test/java/org/apache/gravitino/lakehouse/iceberg/TestIcebergPropertiesUtils.java
@@ -23,10 +23,17 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergPropertiesUtils;
+import org.apache.gravitino.storage.AzureProperties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergPropertiesUtils {
+
+  private static final String ADLS_TOKEN_CREDENTIAL_PROVIDER = "adls.token-credential-provider";
+  private static final String ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX =
+      ADLS_TOKEN_CREDENTIAL_PROVIDER + ".";
+  private static final String AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER =
+      "org.apache.gravitino.iceberg.common.credential.AzureClientSecretTokenCredentialProvider";
 
   @Test
   void testJdbcSchemaVersionPropertyIsMapped() {
@@ -55,6 +62,85 @@ public class TestIcebergPropertiesUtils {
         "1000", icebergProps.get(IcebergConstants.ICEBERG_REST_CLIENT_CONNECTION_TIMEOUT_MS));
     Assertions.assertEquals(
         "2000", icebergProps.get(IcebergConstants.ICEBERG_REST_CLIENT_SOCKET_TIMEOUT_MS));
+  }
+
+  @Test
+  void testAzureServicePrincipalPropertiesAreMapped() {
+    Map<String, String> gravitinoProps =
+        ImmutableMap.of(
+            AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME,
+            "account",
+            AzureProperties.GRAVITINO_AZURE_TENANT_ID,
+            "tenant",
+            AzureProperties.GRAVITINO_AZURE_CLIENT_ID,
+            "client",
+            AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
+            "secret");
+
+    Map<String, String> icebergProps =
+        IcebergPropertiesUtils.toIcebergCatalogProperties(gravitinoProps);
+
+    Assertions.assertFalse(
+        icebergProps.containsKey(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME));
+    Assertions.assertFalse(
+        icebergProps.containsKey(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY));
+    Assertions.assertEquals(
+        AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER,
+        icebergProps.get(ADLS_TOKEN_CREDENTIAL_PROVIDER));
+    Assertions.assertEquals(
+        "tenant",
+        icebergProps.get(
+            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID));
+    Assertions.assertEquals(
+        "client",
+        icebergProps.get(
+            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID));
+    Assertions.assertEquals(
+        "secret",
+        icebergProps.get(
+            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET));
+  }
+
+  @Test
+  void testAzureSharedKeyTakesPrecedenceOverServicePrincipal() {
+    Map<String, String> gravitinoProps =
+        ImmutableMap.of(
+            AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME,
+            "account",
+            AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_KEY,
+            "account-key",
+            AzureProperties.GRAVITINO_AZURE_TENANT_ID,
+            "tenant",
+            AzureProperties.GRAVITINO_AZURE_CLIENT_ID,
+            "client",
+            AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
+            "secret");
+
+    Map<String, String> icebergProps =
+        IcebergPropertiesUtils.toIcebergCatalogProperties(gravitinoProps);
+
+    Assertions.assertEquals(
+        "account", icebergProps.get(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME));
+    Assertions.assertEquals(
+        "account-key", icebergProps.get(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY));
+    Assertions.assertFalse(icebergProps.containsKey(ADLS_TOKEN_CREDENTIAL_PROVIDER));
+  }
+
+  @Test
+  void testIncompleteAzureServicePrincipalPreservesSharedKeyValidation() {
+    Map<String, String> gravitinoProps =
+        ImmutableMap.of(
+            AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME,
+            "account",
+            AzureProperties.GRAVITINO_AZURE_TENANT_ID,
+            "tenant");
+
+    Map<String, String> icebergProps =
+        IcebergPropertiesUtils.toIcebergCatalogProperties(gravitinoProps);
+
+    Assertions.assertEquals(
+        "account", icebergProps.get(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME));
+    Assertions.assertFalse(icebergProps.containsKey(ADLS_TOKEN_CREDENTIAL_PROVIDER));
   }
 
   @Test

--- a/catalogs/catalog-common/src/test/java/org/apache/gravitino/lakehouse/iceberg/TestIcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/test/java/org/apache/gravitino/lakehouse/iceberg/TestIcebergPropertiesUtils.java
@@ -29,12 +29,6 @@ import org.junit.jupiter.api.Test;
 
 public class TestIcebergPropertiesUtils {
 
-  private static final String ADLS_TOKEN_CREDENTIAL_PROVIDER = "adls.token-credential-provider";
-  private static final String ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX =
-      ADLS_TOKEN_CREDENTIAL_PROVIDER + ".";
-  private static final String AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER =
-      "org.apache.gravitino.iceberg.common.credential.AzureClientSecretTokenCredentialProvider";
-
   @Test
   void testJdbcSchemaVersionPropertyIsMapped() {
     Map<String, String> gravitinoProps =
@@ -85,20 +79,23 @@ public class TestIcebergPropertiesUtils {
     Assertions.assertFalse(
         icebergProps.containsKey(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY));
     Assertions.assertEquals(
-        AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER,
-        icebergProps.get(ADLS_TOKEN_CREDENTIAL_PROVIDER));
+        IcebergConstants.AZURE_CLIENT_SECRET_TOKEN_CREDENTIAL_PROVIDER,
+        icebergProps.get(IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER));
     Assertions.assertEquals(
         "tenant",
         icebergProps.get(
-            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID));
+            IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX
+                + AzureProperties.GRAVITINO_AZURE_TENANT_ID));
     Assertions.assertEquals(
         "client",
         icebergProps.get(
-            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_ID));
+            IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX
+                + AzureProperties.GRAVITINO_AZURE_CLIENT_ID));
     Assertions.assertEquals(
         "secret",
         icebergProps.get(
-            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET));
+            IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX
+                + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET));
   }
 
   @Test
@@ -123,10 +120,12 @@ public class TestIcebergPropertiesUtils {
         "account", icebergProps.get(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME));
     Assertions.assertEquals(
         "account-key", icebergProps.get(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_KEY));
-    Assertions.assertFalse(icebergProps.containsKey(ADLS_TOKEN_CREDENTIAL_PROVIDER));
+    Assertions.assertFalse(
+        icebergProps.containsKey(IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER));
     Assertions.assertFalse(
         icebergProps.containsKey(
-            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET));
+            IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX
+                + AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET));
   }
 
   @Test
@@ -143,10 +142,12 @@ public class TestIcebergPropertiesUtils {
 
     Assertions.assertEquals(
         "account", icebergProps.get(IcebergConstants.ICEBERG_ADLS_STORAGE_ACCOUNT_NAME));
-    Assertions.assertFalse(icebergProps.containsKey(ADLS_TOKEN_CREDENTIAL_PROVIDER));
+    Assertions.assertFalse(
+        icebergProps.containsKey(IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER));
     Assertions.assertFalse(
         icebergProps.containsKey(
-            ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID));
+            IcebergConstants.ICEBERG_ADLS_TOKEN_CREDENTIAL_PROVIDER_PREFIX
+                + AzureProperties.GRAVITINO_AZURE_TENANT_ID));
   }
 
   @Test

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -77,6 +77,7 @@ import org.apache.gravitino.rel.expressions.sorts.SortOrder;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.storage.AzureProperties;
 import org.apache.gravitino.utils.ClientPool;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.thrift.TException;
@@ -90,7 +91,7 @@ class TestHiveCatalogOperations {
     Map<String, PropertyEntry<?>> propertyEntryMap =
         HIVE_PROPERTIES_METADATA.catalogPropertiesMetadata().propertyEntries();
 
-    Assertions.assertEquals(25, propertyEntryMap.size());
+    Assertions.assertEquals(26, propertyEntryMap.size());
     Assertions.assertTrue(propertyEntryMap.containsKey(METASTORE_URIS));
     Assertions.assertTrue(propertyEntryMap.containsKey(Catalog.PROPERTY_PACKAGE));
     Assertions.assertTrue(propertyEntryMap.containsKey(BaseCatalog.CATALOG_OPERATION_IMPL));
@@ -100,6 +101,8 @@ class TestHiveCatalogOperations {
     Assertions.assertTrue(propertyEntryMap.containsKey(IMPERSONATION_ENABLE));
     Assertions.assertTrue(propertyEntryMap.containsKey(LIST_ALL_TABLES));
     Assertions.assertTrue(propertyEntryMap.containsKey(DEFAULT_CATALOG));
+    Assertions.assertTrue(
+        propertyEntryMap.get(AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET).isHidden());
     Assertions.assertTrue(propertyEntryMap.get(METASTORE_URIS).isRequired());
     Assertions.assertFalse(propertyEntryMap.get(Catalog.PROPERTY_PACKAGE).isRequired());
     Assertions.assertFalse(propertyEntryMap.get(CLIENT_POOL_SIZE).isRequired());

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
@@ -29,6 +29,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.PropertiesMetadataHelpers;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
+import org.apache.gravitino.connector.HiddenPropertyMaskUtils;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.credential.AzureAccountKeyCredential;
 import org.apache.gravitino.credential.CredentialConstants;
@@ -85,6 +86,30 @@ public class TestIcebergCatalog {
           throw new UnsupportedOperationException("Does not support model version properties");
         }
       };
+
+  @Test
+  void testCatalogPropertiesMaskAzureClientSecret() {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+    Map<String, String> properties =
+        Map.of(AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET, "azure-client-secret");
+    CatalogEntity entity =
+        CatalogEntity.builder()
+            .withId(1L)
+            .withName("azure-catalog")
+            .withNamespace(Namespace.of("metalake"))
+            .withType(IcebergCatalog.Type.RELATIONAL)
+            .withProvider("iceberg")
+            .withAuditInfo(auditInfo)
+            .withProperties(properties)
+            .build();
+    IcebergCatalog catalog =
+        new IcebergCatalog().withCatalogConf(properties).withCatalogEntity(entity);
+
+    Assertions.assertEquals(
+        HiddenPropertyMaskUtils.MASKED_VALUE,
+        catalog.properties().get(AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET));
+  }
 
   @Test
   public void testListDatabases() {

--- a/core/src/main/java/org/apache/gravitino/cloud/storage/AzurePropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/cloud/storage/AzurePropertiesMetadata.java
@@ -46,6 +46,14 @@ public class AzurePropertiesMetadata {
                   false /* immutable */,
                   null /* defaultValue */,
                   true /* hidden */))
+          .put(
+              AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
+              stringOptionalPropertyEntry(
+                  AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
+                  "Azure Active Directory client secret",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  true /* hidden */))
           .build();
 
   private AzurePropertiesMetadata() {}

--- a/iceberg/iceberg-common/build.gradle.kts
+++ b/iceberg/iceberg-common/build.gradle.kts
@@ -108,8 +108,10 @@ dependencies {
 
   annotationProcessor(libs.lombok)
   compileOnly(libs.lombok)
+  compileOnly(libs.azure.identity)
 
   testImplementation(project(":server-common"))
+  testImplementation(libs.azure.identity)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
   testImplementation(libs.mockito.core)

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/AzureClientSecretTokenCredentialProvider.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/AzureClientSecretTokenCredentialProvider.java
@@ -21,7 +21,6 @@ package org.apache.gravitino.iceberg.common.credential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import java.util.Map;
-import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.gravitino.credential.config.AzureCredentialConfig;
 import org.apache.iceberg.azure.AdlsTokenCredentialProvider;
@@ -34,7 +33,11 @@ public class AzureClientSecretTokenCredentialProvider implements AdlsTokenCreden
   /** {@inheritDoc} */
   @Override
   public TokenCredential credential() {
-    return Objects.requireNonNull(credential, "The Azure credential provider is not initialized");
+    if (credential == null) {
+      throw new IllegalStateException(
+          "The Azure credential provider has not been initialized. Call initialize(properties) first.");
+    }
+    return credential;
   }
 
   /** {@inheritDoc} */

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/AzureClientSecretTokenCredentialProvider.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/AzureClientSecretTokenCredentialProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.credential;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.credential.config.AzureCredentialConfig;
+import org.apache.iceberg.azure.AdlsTokenCredentialProvider;
+
+/** Supplies an Azure client-secret credential to Iceberg's ADLS FileIO. */
+public class AzureClientSecretTokenCredentialProvider implements AdlsTokenCredentialProvider {
+
+  @Nullable private TokenCredential credential;
+
+  /** {@inheritDoc} */
+  @Override
+  public TokenCredential credential() {
+    return Objects.requireNonNull(credential, "The Azure credential provider is not initialized");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void initialize(Map<String, String> properties) {
+    AzureCredentialConfig config = new AzureCredentialConfig(properties);
+    credential =
+        new ClientSecretCredentialBuilder()
+            .tenantId(config.tenantId())
+            .clientId(config.clientId())
+            .clientSecret(config.clientSecret())
+            .build();
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestAzureClientSecretTokenCredentialProvider.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestAzureClientSecretTokenCredentialProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.iceberg.common.credential;
+
+import com.azure.identity.ClientSecretCredential;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergPropertiesUtils;
+import org.apache.gravitino.storage.AzureProperties;
+import org.apache.iceberg.azure.AdlsTokenCredentialProvider;
+import org.apache.iceberg.azure.AdlsTokenCredentialProviders;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestAzureClientSecretTokenCredentialProvider {
+
+  @Test
+  void testLoadAndInitializeProviderThroughIceberg() {
+    Map<String, String> gravitinoProperties =
+        ImmutableMap.of(
+            AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME,
+            "account",
+            AzureProperties.GRAVITINO_AZURE_TENANT_ID,
+            "tenant",
+            AzureProperties.GRAVITINO_AZURE_CLIENT_ID,
+            "client",
+            AzureProperties.GRAVITINO_AZURE_CLIENT_SECRET,
+            "secret");
+    Map<String, String> icebergProperties =
+        IcebergPropertiesUtils.toIcebergCatalogProperties(gravitinoProperties);
+
+    AdlsTokenCredentialProvider provider = AdlsTokenCredentialProviders.from(icebergProperties);
+
+    Assertions.assertInstanceOf(AzureClientSecretTokenCredentialProvider.class, provider);
+    Assertions.assertInstanceOf(ClientSecretCredential.class, provider.credential());
+    Assertions.assertSame(provider.credential(), provider.credential());
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestAzureClientSecretTokenCredentialProvider.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestAzureClientSecretTokenCredentialProvider.java
@@ -32,6 +32,18 @@ import org.junit.jupiter.api.Test;
 public class TestAzureClientSecretTokenCredentialProvider {
 
   @Test
+  void testCredentialBeforeInitialize() {
+    AzureClientSecretTokenCredentialProvider provider =
+        new AzureClientSecretTokenCredentialProvider();
+
+    IllegalStateException exception =
+        Assertions.assertThrows(IllegalStateException.class, provider::credential);
+    Assertions.assertEquals(
+        "The Azure credential provider has not been initialized. Call initialize(properties) first.",
+        exception.getMessage());
+  }
+
+  @Test
   void testLoadAndInitializeProviderThroughIceberg() {
     Map<String, String> gravitinoProperties =
         ImmutableMap.of(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTADLSTokenIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTADLSTokenIT.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 public class IcebergRESTADLSTokenIT extends IcebergRESTJdbcCatalogIT {
 
   private String storageAccountName;
-  private String storageAccountKey;
   private String tenantId;
   private String clientId;
   private String clientSecret;
@@ -49,9 +48,6 @@ public class IcebergRESTADLSTokenIT extends IcebergRESTJdbcCatalogIT {
     this.storageAccountName =
         System.getenv()
             .getOrDefault("GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME", "{STORAGE_ACCOUNT_NAME}");
-    this.storageAccountKey =
-        System.getenv()
-            .getOrDefault("GRAVITINO_AZURE_STORAGE_ACCOUNT_KEY", "{STORAGE_ACCOUNT_KEY}");
     this.tenantId = System.getenv().getOrDefault("GRAVITINO_AZURE_TENANT_ID", "{TENANT_ID}");
     this.clientId = System.getenv().getOrDefault("GRAVITINO_AZURE_CLIENT_ID", "{CLIENT_ID}");
     this.clientSecret =
@@ -89,9 +85,6 @@ public class IcebergRESTADLSTokenIT extends IcebergRESTJdbcCatalogIT {
     configMap.put(
         IcebergConfig.ICEBERG_CONFIG_PREFIX + AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME,
         storageAccountName);
-    configMap.put(
-        IcebergConfig.ICEBERG_CONFIG_PREFIX + AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_KEY,
-        storageAccountKey);
     configMap.put(
         IcebergConfig.ICEBERG_CONFIG_PREFIX + AzureProperties.GRAVITINO_AZURE_TENANT_ID, tenantId);
     configMap.put(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTServiceBaseIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTServiceBaseIT.java
@@ -126,7 +126,8 @@ public abstract class IcebergRESTServiceBaseIT {
         IcebergConfig.ICEBERG_CONFIG_PREFIX + IcebergConfig.TABLE_METADATA_CACHE_IMPL.getKey(),
         LocalTableMetadataCache.class.getName());
     icebergRESTServerManager.registerCustomConfigs(icebergConfigs);
-    LOG.info("Iceberg REST service config registered, {}", StringUtils.join(icebergConfigs));
+    // Configuration values may contain credentials. Log only keys for test diagnostics.
+    LOG.info("Iceberg REST service config keys registered: {}", icebergConfigs.keySet());
   }
 
   protected int getServerPort() {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/util/IcebergRESTServerManager.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/util/IcebergRESTServerManager.java
@@ -139,7 +139,8 @@ public abstract class IcebergRESTServerManager {
     Properties properties = serverConfig.loadPropertiesFromFile(configFile.toFile());
     serverConfig.loadFromProperties(properties);
 
-    LOG.info("Server config:{}.", serverConfig.getAllConfig());
+    // Configuration values may contain credentials. Log only keys for test diagnostics.
+    LOG.info("Server config keys: {}.", serverConfig.getAllConfig().keySet());
 
     JettyServerConfig jettyServerConfig =
         JettyServerConfig.fromConfig(serverConfig, IcebergConfig.ICEBERG_CONFIG_PREFIX);


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Configure Iceberg ADLS FileIO with a token credential provider when a complete Azure service principal is supplied without a shared account key.
- Add `AzureClientSecretTokenCredentialProvider` backed by Azure `ClientSecretCredential`.
- Preserve shared-key authentication when both the account name and account key are configured.
- Mark `azure-client-secret` as a hidden catalog property.
- Update the ADLS cloud integration test to operate without a shared account key.
- Add tests for authentication-property conversion, Iceberg provider loading, and client-secret masking.

### Why are the changes needed?

The Azure storage account name was always translated to Iceberg's shared-key account-name property. When no account key was provided, Iceberg treated the configuration as incomplete shared-key authentication and rejected every storage operation.

As a result, a valid service principal could be used for credential vending but not by the server-side ADLS FileIO, forcing users to additionally provide an account-wide shared key.

Fix: #12958

### Does this PR introduce _any_ user-facing change?

Yes.

An ADLS-backed Iceberg catalog can now use `azure-tenant-id`, `azure-client-id`, and `azure-client-secret` for FileIO authentication without configuring `azure-storage-account-key`.

The value of `azure-client-secret` is now masked when catalog properties are returned.

No new user-facing property keys are introduced.

### How was this patch tested?

- `./gradlew spotlessApply`
- `./gradlew :catalogs:catalog-common:test --tests org.apache.gravitino.lakehouse.iceberg.TestIcebergPropertiesUtils`
- `./gradlew :iceberg:iceberg-common:test --tests org.apache.gravitino.iceberg.common.credential.TestAzureClientSecretTokenCredentialProvider`
- `./gradlew :catalogs:catalog-lakehouse-iceberg:test --tests org.apache.gravitino.catalog.lakehouse.iceberg.TestIcebergCatalog`
- `./gradlew :iceberg:iceberg-rest-server:compileTestJava`

The Azure cloud integration test was updated to omit the shared account key. It requires the external Azure cloud-test environment and was compiled locally but not executed.
