### PR TITLE
[#12516] improvement(scripts): Add IF NOT EXISTS to CREATE INDEX in upgrade SQL scripts for idempotency

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/TestSQLScripts.java
+++ b/core/src/test/java/org/apache/gravitino/storage/TestSQLScripts.java
@@ -126,6 +126,62 @@ public class TestSQLScripts extends TestJDBCBackend {
     }
   }
 
+  @TestTemplate
+  public void testUpgradeSQLScriptIdempotency() throws SQLException, IOException {
+    String gravitinoHome = System.getenv("GRAVITINO_HOME");
+    Assertions.assertNotNull(gravitinoHome, "GRAVITINO_HOME environment variable is not set");
+    Path scriptDir = Path.of(gravitinoHome, "scripts", backendType.toLowerCase());
+    File[] scriptFiles = scriptDir.toFile().listFiles();
+    Assertions.assertNotNull(scriptFiles, "No script files found in " + scriptDir);
+    Arrays.sort(scriptFiles, Comparator.comparing(File::getName));
+
+    Pattern upgradePattern =
+        Pattern.compile("upgrade-([\\d.]+)-to-([\\d.]+)-" + backendType.toLowerCase() + "\\.sql");
+    for (File upgradeScript : scriptFiles) {
+      Matcher upgradeMatcher = upgradePattern.matcher(upgradeScript.getName());
+      if (!upgradeMatcher.matches()) {
+        continue;
+      }
+
+      String fromVersion = upgradeMatcher.group(1);
+      File sourceSchema =
+          scriptDir
+              .resolve("schema-" + fromVersion + "-" + backendType.toLowerCase() + ".sql")
+              .toFile();
+      Assertions.assertTrue(
+          sourceSchema.isFile(), "No source schema found for " + upgradeScript.getName());
+
+      // First run: apply schema + upgrade script
+      dropAllTables();
+      executeScript(sourceSchema);
+      executeScript(upgradeScript);
+
+      // Second run: re-run the upgrade script to verify idempotency.
+      // Index-creation statements (CREATE INDEX IF NOT EXISTS for PostgreSQL,
+      // and prepared-statement-guarded CREATE INDEX for MySQL) must not throw.
+      // Other DDL (ALTER TABLE ADD COLUMN, etc.) may fail on re-run — those
+      // failures are expected and swallowed.
+      List<String> ddls = extractStatements(upgradeScript.toPath());
+      try (SqlSession sqlSession =
+              SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+          Connection connection = sqlSession.getConnection();
+          Statement statement = connection.createStatement()) {
+        for (String ddl : ddls) {
+          try {
+            statement.execute(ddl);
+          } catch (SQLException e) {
+            Assertions.assertFalse(
+                isIndexCreationStatement(ddl),
+                "Index-creation statement should be idempotent but failed on re-run: "
+                    + ddl
+                    + " — "
+                    + e.getMessage());
+          }
+        }
+      }
+    }
+  }
+
   private void executeScript(File scriptFile) throws IOException, SQLException {
     List<String> ddls = extractStatements(scriptFile.toPath());
     try (SqlSession sqlSession =
@@ -138,6 +194,21 @@ public class TestSQLScripts extends TestJDBCBackend {
             "Failed to execute DDL in file " + scriptFile.getName() + " ddl: " + ddl);
       }
     }
+  }
+
+  private boolean isIndexCreationStatement(String ddl) {
+    String upper = ddl.toUpperCase().trim();
+    // PostgreSQL: CREATE INDEX IF NOT EXISTS ...
+    // MySQL prepared-statement block: SET @idx := ... (check information_schema
+    //   before CREATE INDEX). These are split into individual statements by
+    //   extractStatements; the SET and PREPARE statements are safe to re-run.
+    return upper.startsWith("CREATE INDEX")
+        || upper.startsWith("CREATE UNIQUE INDEX")
+        || upper.startsWith("SET @IDX :=")
+        || upper.startsWith("SET @SQL :=")
+        || upper.startsWith("PREPARE STMT")
+        || upper.startsWith("EXECUTE STMT")
+        || upper.startsWith("DEALLOCATE PREPARE");
   }
 
   private List<String> extractStatements(Path sqlFile) throws IOException {

--- a/scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql
+++ b/scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql
@@ -33,12 +33,29 @@ ALTER TABLE `group_meta`
     ADD COLUMN `updated_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0
     COMMENT 'updated at';
 
-CREATE INDEX idx_user_meta_name_del_upd
-    ON user_meta (metalake_id, user_name, deleted_at, updated_at);
-CREATE INDEX idx_owner_meta_del_upd_obj
-    ON owner_meta (deleted_at, updated_at, metadata_object_id);
-CREATE INDEX idx_group_meta_name_del_upd
-    ON group_meta (metalake_id, group_name, deleted_at, updated_at);
+-- Use prepared statements to make CREATE INDEX idempotent (MySQL does not
+-- support CREATE INDEX IF NOT EXISTS). Re-running the upgrade script will
+-- skip indexes that already exist instead of raising ER_DUP_KEYNAME.
+SET @idx := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'user_meta' AND index_name = 'idx_user_meta_name_del_upd');
+SET @sql := IF(@idx = 0,
+    'CREATE INDEX idx_user_meta_name_del_upd ON user_meta (metalake_id, user_name, deleted_at, updated_at)',
+    'SELECT ''idx_user_meta_name_del_upd already exists''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'owner_meta' AND index_name = 'idx_owner_meta_del_upd_obj');
+SET @sql := IF(@idx = 0,
+    'CREATE INDEX idx_owner_meta_del_upd_obj ON owner_meta (deleted_at, updated_at, metadata_object_id)',
+    'SELECT ''idx_owner_meta_del_upd_obj already exists''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'group_meta' AND index_name = 'idx_group_meta_name_del_upd');
+SET @sql := IF(@idx = 0,
+    'CREATE INDEX idx_group_meta_name_del_upd ON group_meta (metalake_id, group_name, deleted_at, updated_at)',
+    'SELECT ''idx_group_meta_name_del_upd already exists''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 CREATE TABLE IF NOT EXISTS `entity_change_log` (
   `id`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',

--- a/scripts/mysql/upgrade-1.3.0-to-2.0.0-mysql.sql
+++ b/scripts/mysql/upgrade-1.3.0-to-2.0.0-mysql.sql
@@ -35,8 +35,19 @@ ALTER TABLE `idp_user_meta`
 ALTER TABLE `idp_group_meta`
     ADD COLUMN `group_comment` VARCHAR(1024) DEFAULT '' COMMENT 'idp group comment' AFTER `group_name`;
 
-CREATE UNIQUE INDEX `uk_ti_mi_mo_tv_del` ON `tag_relation_meta` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `tag_value`, `deleted_at`);
-CREATE INDEX `idx_tid_value` ON `tag_relation_meta` (`tag_id`, `tag_value`);
+SET @idx := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'tag_relation_meta' AND index_name = 'uk_ti_mi_mo_tv_del');
+SET @sql := IF(@idx = 0,
+    'CREATE UNIQUE INDEX `uk_ti_mi_mo_tv_del` ON `tag_relation_meta` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `tag_value`, `deleted_at`)',
+    'SELECT ''uk_ti_mi_mo_tv_del already exists''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'tag_relation_meta' AND index_name = 'idx_tid_value');
+SET @sql := IF(@idx = 0,
+    'CREATE INDEX `idx_tid_value` ON `tag_relation_meta` (`tag_id`, `tag_value`)',
+    'SELECT ''idx_tid_value already exists''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 -- Index names are only scoped per-table in MySQL, so the same name could be
 -- reused across tables. Prefix each reused name with its table name so that

--- a/scripts/postgresql/upgrade-1.1.0-to-1.2.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-1.1.0-to-1.2.0-postgresql.sql
@@ -32,8 +32,8 @@ CREATE TABLE IF NOT EXISTS function_meta (
     PRIMARY KEY (function_id),
     UNIQUE (schema_id, function_name, deleted_at)
 );
-CREATE INDEX idx_function_meta_metalake_id ON function_meta (metalake_id);
-CREATE INDEX idx_function_meta_catalog_id ON function_meta (catalog_id);
+CREATE INDEX IF NOT EXISTS idx_function_meta_metalake_id ON function_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_function_meta_catalog_id ON function_meta (catalog_id);
 
 COMMENT ON TABLE function_meta IS 'function metadata';
 COMMENT ON COLUMN function_meta.function_id IS 'function id';
@@ -61,9 +61,9 @@ CREATE TABLE IF NOT EXISTS function_version_info (
     PRIMARY KEY (id),
     UNIQUE (function_id, version, deleted_at)
 );
-CREATE INDEX idx_function_version_metalake_id ON function_version_info (metalake_id);
-CREATE INDEX idx_function_version_catalog_id ON function_version_info (catalog_id);
-CREATE INDEX idx_function_version_schema_id ON function_version_info (schema_id);
+CREATE INDEX IF NOT EXISTS idx_function_version_metalake_id ON function_version_info (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_function_version_catalog_id ON function_version_info (catalog_id);
+CREATE INDEX IF NOT EXISTS idx_function_version_schema_id ON function_version_info (schema_id);
 
 COMMENT ON TABLE function_version_info IS 'function version info';
 COMMENT ON COLUMN function_version_info.id IS 'auto increment id';


### PR DESCRIPTION

### What changes were proposed in this pull request?

PostgreSQL: add IF NOT EXISTS to 5 CREATE INDEX statements in upgrade-1.1.0-to-1.2.0-postgresql.sql.

MySQL: use prepared statements with information_schema check to make 7 CREATE [UNIQUE] INDEX statements idempotent across 2 upgrade scripts (upgrade-1.2.0-to-1.3.0-mysql.sql and upgrade-1.3.0-to-2.0.0-mysql.sql), since MySQL 8.0 does not support CREATE INDEX IF NOT EXISTS.

Add testUpgradeSQLScriptIdempotency to TestSQLScripts to verify that re-running upgrade scripts does not fail on index-creation statements.
### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #12516 

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

Execute the method `org.apache.gravitino.storage.TestSQLScripts#testUpgradeSQLScriptIdempotency`
