### PR TITLE
[#12970]improvement(core): Consolidate @Results into @ResultMap in PolicyMetaMapper

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetaMapper.java
@@ -24,6 +24,7 @@ import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.SelectProvider;
@@ -32,57 +33,42 @@ import org.apache.ibatis.annotations.UpdateProvider;
 public interface PolicyMetaMapper {
   String POLICY_META_TABLE_NAME = "policy_meta";
 
-  /**
-   * Checks whether a soft-deleted policy still owns the requested primary key.
-   *
-   * @param policyId the policy ID
-   * @return one if a deleted row reserves the ID, otherwise zero
-   */
-  @Select(
-      "SELECT COUNT(*) FROM "
-          + POLICY_META_TABLE_NAME
-          + " WHERE policy_id = #{policyId} AND deleted_at > 0")
-  int countDeletedPolicyMetasById(@Param("policyId") Long policyId);
+    /**
+     * Checks whether a soft-deleted policy still owns the requested primary key.
+     *
+     * @param policyId the policy ID
+     * @return one if a deleted row reserves the ID, otherwise zero
+     */
+    @Select(
+            "SELECT COUNT(*) FROM "
+                    + POLICY_META_TABLE_NAME
+                    + " WHERE policy_id = #{policyId} AND deleted_at > 0")
+    int countDeletedPolicyMetasById(@Param("policyId") Long policyId);
 
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at"),
-    @Result(property = "policyVersionPO.id", column = "id"),
-    @Result(property = "policyVersionPO.metalakeId", column = "version_metalake_id"),
-    @Result(property = "policyVersionPO.policyId", column = "version_policy_id"),
-    @Result(property = "policyVersionPO.version", column = "version"),
-    @Result(property = "policyVersionPO.policyComment", column = "policy_comment"),
-    @Result(property = "policyVersionPO.enabled", column = "enabled"),
-    @Result(property = "policyVersionPO.content", column = "content"),
-    @Result(property = "policyVersionPO.deletedAt", column = "version_deleted_at")
-  })
+  @Results(
+      id = "policyPOResultMap",
+      value = {
+        @Result(property = "policyId", column = "policy_id"),
+        @Result(property = "policyName", column = "policy_name"),
+        @Result(property = "policyType", column = "policy_type"),
+        @Result(property = "metalakeId", column = "metalake_id"),
+        @Result(property = "auditInfo", column = "audit_info"),
+        @Result(property = "currentVersion", column = "current_version"),
+        @Result(property = "lastVersion", column = "last_version"),
+        @Result(property = "deletedAt", column = "deleted_at"),
+        @Result(property = "policyVersionPO.id", column = "id"),
+        @Result(property = "policyVersionPO.metalakeId", column = "version_metalake_id"),
+        @Result(property = "policyVersionPO.policyId", column = "version_policy_id"),
+        @Result(property = "policyVersionPO.version", column = "version"),
+        @Result(property = "policyVersionPO.policyComment", column = "policy_comment"),
+        @Result(property = "policyVersionPO.enabled", column = "enabled"),
+        @Result(property = "policyVersionPO.content", column = "content"),
+        @Result(property = "policyVersionPO.deletedAt", column = "version_deleted_at")
+      })
   @SelectProvider(type = PolicyMetaSQLProviderFactory.class, method = "listPolicyPOsByMetalake")
   List<PolicyPO> listPolicyPOsByMetalake(@Param("metalakeName") String metalakeName);
 
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at"),
-    @Result(property = "policyVersionPO.id", column = "id"),
-    @Result(property = "policyVersionPO.metalakeId", column = "version_metalake_id"),
-    @Result(property = "policyVersionPO.policyId", column = "version_policy_id"),
-    @Result(property = "policyVersionPO.version", column = "version"),
-    @Result(property = "policyVersionPO.policyComment", column = "policy_comment"),
-    @Result(property = "policyVersionPO.enabled", column = "enabled"),
-    @Result(property = "policyVersionPO.content", column = "content"),
-    @Result(property = "policyVersionPO.deletedAt", column = "version_deleted_at")
-  })
+  @ResultMap("policyPOResultMap")
   @SelectProvider(
       type = PolicyMetaSQLProviderFactory.class,
       method = "listPolicyPOsByMetalakeAndPolicyNames")
@@ -92,24 +78,7 @@ public interface PolicyMetaMapper {
   @InsertProvider(type = PolicyMetaSQLProviderFactory.class, method = "insertPolicyMeta")
   void insertPolicyMeta(@Param("policyMeta") PolicyPO policyPO);
 
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at"),
-    @Result(property = "policyVersionPO.id", column = "id"),
-    @Result(property = "policyVersionPO.metalakeId", column = "version_metalake_id"),
-    @Result(property = "policyVersionPO.policyId", column = "version_policy_id"),
-    @Result(property = "policyVersionPO.version", column = "version"),
-    @Result(property = "policyVersionPO.policyComment", column = "policy_comment"),
-    @Result(property = "policyVersionPO.enabled", column = "enabled"),
-    @Result(property = "policyVersionPO.content", column = "content"),
-    @Result(property = "policyVersionPO.deletedAt", column = "version_deleted_at")
-  })
+  @ResultMap("policyPOResultMap")
   @SelectProvider(
       type = PolicyMetaSQLProviderFactory.class,
       method = "selectPolicyMetaByMetalakeAndName")
@@ -145,16 +114,18 @@ public interface PolicyMetaMapper {
   Integer deletePolicyMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
 
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at")
-  })
+  @Results(
+      id = "policyOnlyPOResultMap",
+      value = {
+        @Result(property = "policyId", column = "policy_id"),
+        @Result(property = "policyName", column = "policy_name"),
+        @Result(property = "policyType", column = "policy_type"),
+        @Result(property = "metalakeId", column = "metalake_id"),
+        @Result(property = "auditInfo", column = "audit_info"),
+        @Result(property = "currentVersion", column = "current_version"),
+        @Result(property = "lastVersion", column = "last_version"),
+        @Result(property = "deletedAt", column = "deleted_at")
+      })
   @SelectProvider(
       type = PolicyMetaSQLProviderFactory.class,
       method = "selectPolicyMetaByMetalakeIdAndName")
@@ -184,16 +155,7 @@ public interface PolicyMetaMapper {
   PolicyPO selectPolicyMetaByMetalakeIdAndNameForUpdate(
       @Param("metalakeId") long metalakeId, @Param("policyName") String policyName);
 
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at")
-  })
+  @ResultMap("policyOnlyPOResultMap")
   @SelectProvider(type = PolicyMetaSQLProviderFactory.class, method = "selectPolicyByPolicyId")
   PolicyPO selectPolicyByPolicyId(@Param("policyId") Long policyId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetaMapper.java
@@ -33,17 +33,17 @@ import org.apache.ibatis.annotations.UpdateProvider;
 public interface PolicyMetaMapper {
   String POLICY_META_TABLE_NAME = "policy_meta";
 
-    /**
-     * Checks whether a soft-deleted policy still owns the requested primary key.
-     *
-     * @param policyId the policy ID
-     * @return one if a deleted row reserves the ID, otherwise zero
-     */
-    @Select(
-            "SELECT COUNT(*) FROM "
-                    + POLICY_META_TABLE_NAME
-                    + " WHERE policy_id = #{policyId} AND deleted_at > 0")
-    int countDeletedPolicyMetasById(@Param("policyId") Long policyId);
+  /**
+   * Checks whether a soft-deleted policy still owns the requested primary key.
+   *
+   * @param policyId the policy ID
+   * @return one if a deleted row reserves the ID, otherwise zero
+   */
+  @Select(
+      "SELECT COUNT(*) FROM "
+          + POLICY_META_TABLE_NAME
+          + " WHERE policy_id = #{policyId} AND deleted_at > 0")
+  int countDeletedPolicyMetasById(@Param("policyId") Long policyId);
 
   @Results(
       id = "policyPOResultMap",
@@ -139,16 +139,7 @@ public interface PolicyMetaMapper {
    * @param policyName The policy name.
    * @return The locked policy, or null if the natural key is not active.
    */
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at")
-  })
+  @ResultMap("policyOnlyPOResultMap")
   @SelectProvider(
       type = PolicyMetaSQLProviderFactory.class,
       method = "selectPolicyMetaByMetalakeIdAndNameForUpdate")
@@ -165,31 +156,13 @@ public interface PolicyMetaMapper {
    * @param policyId The policy ID.
    * @return The locked policy, or null if it is not active.
    */
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at")
-  })
+  @ResultMap("policyOnlyPOResultMap")
   @SelectProvider(
       type = PolicyMetaSQLProviderFactory.class,
       method = "selectPolicyByPolicyIdForUpdate")
   PolicyPO selectPolicyByPolicyIdForUpdate(@Param("policyId") Long policyId);
 
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at")
-  })
+  @ResultMap("policyOnlyPOResultMap")
   @SelectProvider(type = PolicyMetaSQLProviderFactory.class, method = "listPolicyPOsByPolicyIds")
   List<PolicyPO> listPolicyPOsByPolicyIds(@Param("policyIds") List<Long> policyIds);
 
@@ -199,39 +172,13 @@ public interface PolicyMetaMapper {
    * @param policyIds The policy IDs to lock.
    * @return The locked policies. Policies that are not active are absent from the result.
    */
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at")
-  })
+  @ResultMap("policyOnlyPOResultMap")
   @SelectProvider(
       type = PolicyMetaSQLProviderFactory.class,
       method = "listPolicyPOsByPolicyIdsForUpdate")
   List<PolicyPO> listPolicyPOsByPolicyIdsForUpdate(@Param("policyIds") List<Long> policyIds);
 
-  @Results({
-    @Result(property = "policyId", column = "policy_id"),
-    @Result(property = "policyName", column = "policy_name"),
-    @Result(property = "policyType", column = "policy_type"),
-    @Result(property = "metalakeId", column = "metalake_id"),
-    @Result(property = "auditInfo", column = "audit_info"),
-    @Result(property = "currentVersion", column = "current_version"),
-    @Result(property = "lastVersion", column = "last_version"),
-    @Result(property = "deletedAt", column = "deleted_at"),
-    @Result(property = "policyVersionPO.id", column = "id"),
-    @Result(property = "policyVersionPO.metalakeId", column = "version_metalake_id"),
-    @Result(property = "policyVersionPO.policyId", column = "version_policy_id"),
-    @Result(property = "policyVersionPO.version", column = "version"),
-    @Result(property = "policyVersionPO.policyComment", column = "policy_comment"),
-    @Result(property = "policyVersionPO.enabled", column = "enabled"),
-    @Result(property = "policyVersionPO.content", column = "content"),
-    @Result(property = "policyVersionPO.deletedAt", column = "version_deleted_at")
-  })
+  @ResultMap("policyPOResultMap")
   @SelectProvider(
       type = PolicyMetaSQLProviderFactory.class,
       method = "batchSelectPolicyByIdentifier")


### PR DESCRIPTION


### What changes were proposed in this pull request?

Replace seven duplicated @Results annotation blocks in PolicyMetaMapper with two named declarations (@Results(id = ...)) referenced by @ResultMap, matching the convention already used in FunctionMetaMapper and ViewMetaMapper.

policyPOResultMap: 16-column mapping (with policyVersionPO), 1 declaration + 3 references
policyOnlyPOResultMap: 8-column mapping (without policyVersionPO), 1 declaration + 2 references
A column addition or rename now requires changing only the single declaration instead of up to seven copies.

### Why are the changes needed?

Use @ResultMap in PolicyMetaMapper instead of ten repeated @Results blocks


Fix: #12970 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

|| Mapper Method | Test Method |
|---|---|
| `listPolicyPOsByMetalake` | `testCreateAndListPolicies` |
| `listPolicyPOsByMetalakeAndPolicyNames` | `testMetaLifeCycleFromCreationToDeletion` |
| `selectPolicyMetaByMetalakeAndName` | `testInsertAndGetPolicyByIdentifier`, `testUpdatePolicy` |
| `selectPolicyMetaByMetalakeIdAndName` | `testMetaLifeCycleFromCreationToDeletion` |
| `batchSelectPolicyByIdentifier` | `testAssociateAndDisassociatePoliciesWithMetadataObject` |
| `listPolicyPOsByPolicyIds` | `testAssociateAndDisassociatePoliciesWithMetadataObject` |
| `selectPolicyByPolicyId` | _(no direct caller, shares the same `policyOnlyPOResultMap` as `selectPolicyMetaByMetalakeIdAndName`)_ |

`selectPolicyByPolicyId` has no direct caller in the service layer, but it shares the same `policyOnlyPOResultMap` as `selectPolicyMetaByMetalakeIdAndName`, which is covered by `testMetaLifeCycleFromCreationToDeletion`. Both methods use the identical column mapping, so the coverage is equivalent.