### PR TITLE
[MINOR] refactor(server): Reuse the shared user and group authorization expressions

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/expression/AuthorizationExpressionConstants.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/expression/AuthorizationExpressionConstants.java
@@ -295,6 +295,12 @@ public class AuthorizationExpressionConstants {
           ((CAN_ACCESS_METADATA) && (TAG::OWNER || ANY_APPLY_TAG))
           """;
 
+  public static final String LOAD_USER_AUTHORIZATION_EXPRESSION =
+      "METALAKE::OWNER || METALAKE::MANAGE_USERS || USER::SELF";
+
+  public static final String LOAD_GROUP_AUTHORIZATION_EXPRESSION =
+      "METALAKE::OWNER || METALAKE::MANAGE_GROUPS || GROUP::SELF";
+
   public static final String LOAD_TAG_AUTHORIZATION_EXPRESSION =
       "METALAKE::OWNER || TAG::OWNER || ANY_APPLY_TAG";
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
@@ -52,6 +52,7 @@ import org.apache.gravitino.server.authorization.MetadataAuthzHelper;
 import org.apache.gravitino.server.authorization.NameBindings;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationMetadata;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
 import org.apache.gravitino.server.web.Utils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.slf4j.Logger;
@@ -64,7 +65,7 @@ public class GroupOperations {
   private static final Logger LOG = LoggerFactory.getLogger(GroupOperations.class);
 
   private static final String LOAD_GROUP_PRIVILEGE =
-      "METALAKE::OWNER || METALAKE::MANAGE_GROUPS || GROUP::SELF";
+      AuthorizationExpressionConstants.LOAD_GROUP_AUTHORIZATION_EXPRESSION;
 
   private final AccessControlDispatcher accessControlManager;
   private final OwnerDispatcher ownerDispatcher;

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
@@ -51,6 +51,7 @@ import org.apache.gravitino.server.authorization.MetadataAuthzHelper;
 import org.apache.gravitino.server.authorization.NameBindings;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationMetadata;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
 import org.apache.gravitino.server.web.Utils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.slf4j.Logger;
@@ -63,7 +64,7 @@ public class UserOperations {
   private static final Logger LOG = LoggerFactory.getLogger(UserOperations.class);
 
   private static final String LOAD_USER_PRIVILEGE =
-      "METALAKE::OWNER || METALAKE::MANAGE_USERS || USER::SELF";
+      AuthorizationExpressionConstants.LOAD_USER_AUTHORIZATION_EXPRESSION;
 
   private final AccessControlDispatcher accessControlManager;
   private final OwnerDispatcher ownerManager;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move the user and group listing authorization expressions from private literals in `UserOperations` and `GroupOperations` into `AuthorizationExpressionConstants`, and reference them from both resources.

```java
// AuthorizationExpressionConstants
public static final String LOAD_USER_AUTHORIZATION_EXPRESSION =
    "METALAKE::OWNER || METALAKE::MANAGE_USERS || USER::SELF";

public static final String LOAD_GROUP_AUTHORIZATION_EXPRESSION =
    "METALAKE::OWNER || METALAKE::MANAGE_GROUPS || GROUP::SELF";
```

### Why are the changes needed?

Every other entity type that has a load or filter expression already publishes it from `AuthorizationExpressionConstants` — role, tag, policy, table, schema and the rest. Users and groups are the two exceptions: each resource keeps its own private string literal, so any component that must authorize identities the same way has to copy the literal, and nothing signals it when the endpoint later tightens its expression. A copy that keeps the looser expression would disclose users or groups the listing endpoint refuses.

This follows the same direction as #12875, which reused the shared table expressions.

### Does this PR introduce _any_ user-facing change?

No. The expressions are byte-identical, so authorization behavior is unchanged. Two new public constants are added to `AuthorizationExpressionConstants`.

### How was this patch tested?

Existing `TestUserOperations` and `TestGroupOperations` pass (15 tests), and `:server`/`:server-common` compile with Spotless applied.

```bash
./gradlew :server:test --tests "*TestUserOperations*" --tests "*TestGroupOperations*" \
  :server-common:compileJava :server:compileJava -PskipITs -PskipWeb=true
```

https://claude.ai/code/session_013xVSteM2ZUjXRHFbHtayVK
