### PR TITLE
[MINOR] docs(open-api): Document job list filter combination and missing-timestamp sorting

### DIFF
--- a/docs/open-api/jobs.yaml
+++ b/docs/open-api/jobs.yaml
@@ -361,7 +361,9 @@ components:
       name: queuedAfter
       in: query
       description: >-
-        Only return jobs queued at or after this ISO-8601 instant (e.g. 2026-08-18T00:00:00Z)
+        Only return jobs queued at or after this ISO-8601 instant (e.g. 2026-08-18T00:00:00Z).
+        When combined with startedAfter or finishedAfter, all supplied time filters must match
+        (AND semantics)
       required: false
       schema:
         type: string
@@ -371,7 +373,8 @@ components:
       in: query
       description: >-
         Only return jobs started at or after this ISO-8601 instant (e.g. 2026-08-18T00:00:00Z).
-        Jobs that have not started yet are excluded
+        Jobs that have not started yet are excluded. When combined with queuedAfter or
+        finishedAfter, all supplied time filters must match (AND semantics)
       required: false
       schema:
         type: string
@@ -381,7 +384,8 @@ components:
       in: query
       description: >-
         Only return jobs finished at or after this ISO-8601 instant (e.g. 2026-08-18T00:00:00Z).
-        Jobs that have not finished yet are excluded
+        Jobs that have not finished yet are excluded. When combined with queuedAfter or
+        startedAfter, all supplied time filters must match (AND semantics)
       required: false
       schema:
         type: string
@@ -389,7 +393,10 @@ components:
     sortBy:
       name: sortBy
       in: query
-      description: The field to sort the returned jobs by
+      description: >-
+        The field to sort the returned jobs by. Jobs with no value for the selected field
+        (e.g. jobs that have not started or finished yet) always sort last, for both the asc
+        and desc sort orders
       required: false
       schema:
         type: string
@@ -401,7 +408,9 @@ components:
     sortOrder:
       name: sortOrder
       in: query
-      description: The sort order for the returned jobs
+      description: >-
+        The sort order for the returned jobs. It only orders the jobs that have a value for the
+        selected sortBy field; jobs missing that value always sort last in both orders
       required: false
       schema:
         type: string

--- a/docs/open-api/jobs.yaml
+++ b/docs/open-api/jobs.yaml
@@ -362,8 +362,8 @@ components:
       in: query
       description: >-
         Only return jobs queued at or after this ISO-8601 instant (e.g. 2026-08-18T00:00:00Z).
-        When combined with startedAfter or finishedAfter, all supplied time filters must match
-        (AND semantics)
+        A job must satisfy all supplied time filters (AND semantics), so this combines with
+        one or more of startedAfter and finishedAfter
       required: false
       schema:
         type: string
@@ -373,8 +373,9 @@ components:
       in: query
       description: >-
         Only return jobs started at or after this ISO-8601 instant (e.g. 2026-08-18T00:00:00Z).
-        Jobs that have not started yet are excluded. When combined with queuedAfter or
-        finishedAfter, all supplied time filters must match (AND semantics)
+        Jobs that have not started yet are excluded. A job must satisfy all supplied time
+        filters (AND semantics), so this combines with one or more of queuedAfter and
+        finishedAfter
       required: false
       schema:
         type: string
@@ -384,8 +385,9 @@ components:
       in: query
       description: >-
         Only return jobs finished at or after this ISO-8601 instant (e.g. 2026-08-18T00:00:00Z).
-        Jobs that have not finished yet are excluded. When combined with queuedAfter or
-        startedAfter, all supplied time filters must match (AND semantics)
+        Jobs that have not finished yet are excluded. A job must satisfy all supplied time
+        filters (AND semantics), so this combines with one or more of queuedAfter and
+        startedAfter
       required: false
       schema:
         type: string
@@ -395,8 +397,8 @@ components:
       in: query
       description: >-
         The field to sort the returned jobs by. Jobs with no value for the selected field
-        (e.g. jobs that have not started or finished yet) always sort last, for both the asc
-        and desc sort orders
+        (e.g. jobs that have not started or finished yet) always sort last, for both the "asc"
+        and "desc" sort orders
       required: false
       schema:
         type: string
@@ -410,7 +412,8 @@ components:
       in: query
       description: >-
         The sort order for the returned jobs. It only orders the jobs that have a value for the
-        selected sortBy field; jobs missing that value always sort last in both orders
+        selected sortBy field; jobs missing that value always sort last in both "asc" and "desc"
+        order
       required: false
       schema:
         type: string


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clarify the `GET /metalakes/{metalake}/jobs/runs` query-parameter docs in
`docs/open-api/jobs.yaml`:

- `queuedAfter`, `startedAfter` and `finishedAfter` combine with AND semantics
  when more than one is supplied.
- Jobs with no value for the selected `sortBy` timestamp always sort last, for
  both the `asc` and `desc` sort orders.

### Why are the changes needed?

Clients need these rules to correctly construct requests and interpret sorted
job-list responses. Both rules already match the server behaviour in
`JobOperations`, but were not stated in the specification.

### Does this PR introduce _any_ user-facing change?

No behaviour change; OpenAPI documentation only.

### How was this patch tested?

`./gradlew :docs:build` (Redocly validation passes).
