### PR TITLE
[#12957] fix(lance): Prevent stale schema repair writes

### DIFF
--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
@@ -88,10 +89,10 @@ public class LanceTableOperations extends ManagedTableOperations {
    */
   private static final int REPAIR_UPDATE_MAX_ATTEMPTS = 5;
 
-  /** Lower bound (inclusive) of the randomized backoff slept between lost-CAS retries. */
+  /** Lower bound (inclusive) of the randomized backoff slept between repair retries. */
   private static final long REPAIR_RETRY_MIN_BACKOFF_MS = 10;
 
-  /** Upper bound (inclusive) of the randomized backoff slept between lost-CAS retries. */
+  /** Upper bound (inclusive) of the randomized backoff slept between repair retries. */
   private static final long REPAIR_RETRY_MAX_BACKOFF_MS = 100;
 
   public enum CreationMode {
@@ -449,7 +450,39 @@ public class LanceTableOperations extends ManagedTableOperations {
   }
 
   private Table loadTableInternal(NameIdentifier ident, boolean forAlter) {
-    Table table = super.loadTable(ident);
+    OptimisticLockException lastConflict = null;
+    for (int attempt = 1; attempt <= REPAIR_UPDATE_MAX_ATTEMPTS; attempt++) {
+      try {
+        return loadTableInternalOnce(ident, forAlter);
+      } catch (OptimisticLockException e) {
+        lastConflict = e;
+        LOG.debug(
+            "Table {} changed while reading its Lance schema (attempt {}/{}), {}",
+            ident,
+            attempt,
+            REPAIR_UPDATE_MAX_ATTEMPTS,
+            attempt < REPAIR_UPDATE_MAX_ATTEMPTS ? "reloading repair inputs" : "retries exhausted",
+            e);
+
+        if (attempt < REPAIR_UPDATE_MAX_ATTEMPTS) {
+          try {
+            backoffBeforeRetry(ident);
+          } catch (IOException ioe) {
+            throw new RuntimeException("Failed to retry schema repair for table " + ident, ioe);
+          }
+        }
+      }
+    }
+    throw new OptimisticLockException(
+        lastConflict,
+        "Failed to repair table %s after %d optimistic-lock attempts",
+        ident,
+        REPAIR_UPDATE_MAX_ATTEMPTS);
+  }
+
+  private Table loadTableInternalOnce(NameIdentifier ident, boolean forAlter) {
+    TableEntity observedTable = loadTableEntity(ident);
+    Table table = toGenericTable(observedTable);
     // Spark staged create can write the actual schema only to the Lance dataset path. Refresh
     // Gravitino metadata when the stored table is declared-only, empty, or configured to track
     // Lance dataset versions.
@@ -506,12 +539,22 @@ public class LanceTableOperations extends ManagedTableOperations {
       // can skip the dataset open (see the early-return above). Declared tables are excluded
       // because their lance.declared flag is the authoritative "not yet written" signal.
       if (!declaredOnly) {
-        return recordCheckedEmptyVersion(ident, datasetVersion);
+        return recordCheckedEmptyVersion(ident, observedTable, datasetVersion);
       }
       return table;
     }
 
-    return repairTableMetadata(ident, columns, datasetVersion);
+    return repairTableMetadata(ident, observedTable, columns, datasetVersion);
+  }
+
+  private TableEntity loadTableEntity(NameIdentifier ident) {
+    try {
+      return store.get(ident, Entity.EntityType.TABLE, TableEntity.class);
+    } catch (NoSuchEntityException e) {
+      throw new NoSuchTableException(e, "Table %s does not exist", ident);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load table " + ident, e);
+    }
   }
 
   private SchemaRefreshMode schemaRefreshMode() {
@@ -562,11 +605,13 @@ public class LanceTableOperations extends ManagedTableOperations {
         .toArray(Column[]::new);
   }
 
-  private Table repairTableMetadata(NameIdentifier ident, Column[] columns, long datasetVersion) {
+  private Table repairTableMetadata(
+      NameIdentifier ident, TableEntity observedTable, Column[] columns, long datasetVersion) {
     try {
       TableEntity tableEntity =
-          updateTableWithCasRetry(
+          updateTableIfObservationCurrent(
               ident,
+              observedTable,
               current -> {
                 if (!needsSchemaRefresh(current, datasetVersion)) {
                   return current;
@@ -584,46 +629,39 @@ public class LanceTableOperations extends ManagedTableOperations {
   }
 
   /**
-   * Repairs stored table metadata and retries only when another repair wins the same race.
-   *
-   * <p>Two concurrent loads can both read the old metadata. The first update wins; the second gets
-   * {@link OptimisticLockException}. Repair is safe to run more than once, so the loser waits
-   * briefly, reads the winner's latest row, and tries again. Ordinary IO failures are not safe to
-   * retry here and are returned immediately.
+   * Updates stored table metadata only if the dataset observation still belongs to the same table
+   * state.
    */
-  private TableEntity updateTableWithCasRetry(
-      NameIdentifier ident, Function<TableEntity, TableEntity> updater) throws IOException {
-    OptimisticLockException lastConflict = null;
-    for (int attempt = 1; attempt <= REPAIR_UPDATE_MAX_ATTEMPTS; attempt++) {
-      try {
-        return store.update(ident, TableEntity.class, Entity.EntityType.TABLE, updater);
-      } catch (OptimisticLockException e) {
-        lastConflict = e;
-        LOG.debug(
-            "Optimistic-lock conflict updating table {} metadata (attempt {}/{}), {}",
-            ident,
-            attempt,
-            REPAIR_UPDATE_MAX_ATTEMPTS,
-            attempt < REPAIR_UPDATE_MAX_ATTEMPTS ? "retrying" : "retries exhausted",
-            e);
-
-        if (attempt < REPAIR_UPDATE_MAX_ATTEMPTS) {
-          backoffBeforeRetry(ident);
-        }
-      }
-    }
-    // Reaching here means every attempt lost to another writer. Keep the exception type so the
-    // caller still knows this is an OCC conflict, and add the attempt count for diagnosis.
-    throw new OptimisticLockException(
-        lastConflict,
-        "Failed to repair table %s after %d optimistic-lock attempts",
+  private TableEntity updateTableIfObservationCurrent(
+      NameIdentifier ident, TableEntity observedTable, Function<TableEntity, TableEntity> updater)
+      throws IOException {
+    return store.update(
         ident,
-        REPAIR_UPDATE_MAX_ATTEMPTS);
+        TableEntity.class,
+        Entity.EntityType.TABLE,
+        current -> {
+          validateRepairObservation(ident, observedTable, current);
+          return updater.apply(current);
+        });
+  }
+
+  private void validateRepairObservation(
+      NameIdentifier ident, TableEntity observedTable, TableEntity currentTable) {
+    String observedLocation = observedTable.properties().get(Table.PROPERTY_LOCATION);
+    String currentLocation = currentTable.properties().get(Table.PROPERTY_LOCATION);
+    String observedVersion = observedTable.properties().get(LanceConstants.LANCE_TABLE_VERSION);
+    String currentVersion = currentTable.properties().get(LanceConstants.LANCE_TABLE_VERSION);
+    if (!Objects.equals(observedTable.id(), currentTable.id())
+        || !Objects.equals(observedLocation, currentLocation)
+        || !Objects.equals(observedVersion, currentVersion)) {
+      throw new OptimisticLockException(
+          "Table %s changed after its Lance dataset schema was read", ident);
+    }
   }
 
   /**
-   * Sleeps a short randomized backoff between two lost-CAS retries so that racing loads de-sync
-   * instead of immediately colliding again. Package-private so tests can neutralize the sleep.
+   * Sleeps a short randomized backoff between repair retries so racing loads de-sync instead of
+   * immediately colliding again. Package-private so tests can neutralize the sleep.
    *
    * @param ident the table being updated, used only for the interrupt error message
    * @throws IOException if the thread is interrupted while backing off
@@ -640,11 +678,13 @@ public class LanceTableOperations extends ManagedTableOperations {
     }
   }
 
-  private Table recordCheckedEmptyVersion(NameIdentifier ident, long datasetVersion) {
+  private Table recordCheckedEmptyVersion(
+      NameIdentifier ident, TableEntity observedTable, long datasetVersion) {
     try {
       TableEntity tableEntity =
-          updateTableWithCasRetry(
+          updateTableIfObservationCurrent(
               ident,
+              observedTable,
               current -> {
                 if (!isDatasetVersionChanged(current.properties(), datasetVersion)) {
                   return current;

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -219,20 +219,14 @@ public class TestLanceTableOperations {
                     .build()),
             Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "8"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
-        .thenReturn(tableEntity);
+        .thenReturn(tableEntity, alreadyRepairedTableEntity);
     when(idGenerator.nextId()).thenReturn(10L, 11L);
 
     // First repair attempt loses the optimistic-lock CAS (a concurrent load already bumped the
-    // version). The retry re-reads the winner's already-repaired entity, against which the
-    // idempotent updater succeeds.
+    // version). The retry re-reads the winner's already-repaired entity before deciding whether
+    // another dataset observation and metadata update are needed.
     when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
-        .thenThrow(new OptimisticLockException("mock conflict"))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Function<TableEntity, TableEntity> updater = invocation.getArgument(3);
-              return updater.apply(alreadyRepairedTableEntity);
-            });
+        .thenThrow(new OptimisticLockException("mock conflict"));
 
     Dataset dataset = mock(Dataset.class);
     when(dataset.getSchema())
@@ -257,6 +251,103 @@ public class TestLanceTableOperations {
     Assertions.assertEquals(2, loadedTable.columns().length);
     Assertions.assertEquals("id", loadedTable.columns()[0].name());
     Assertions.assertEquals("name", loadedTable.columns()[1].name());
+  }
+
+  @Test
+  public void testRepairDoesNotOverwriteNewerDatasetVersion() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String location = tempDir.resolve("stale-version-observation").toString();
+    TableEntity observedTable =
+        tableEntity(
+            ident,
+            List.of(),
+            Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_DECLARED, "true"));
+    TableEntity newerTable =
+        tableEntity(
+            ident,
+            List.of(columnEntity(20L, "new_column")),
+            Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "9"));
+    AtomicReference<TableEntity> storedTable = new AtomicReference<>(observedTable);
+    stubMutableTable(ident, storedTable);
+    when(idGenerator.nextId()).thenReturn(10L);
+
+    Dataset dataset = mock(Dataset.class);
+    when(dataset.getSchema())
+        .thenAnswer(
+            invocation -> {
+              storedTable.set(newerTable);
+              return new Schema(List.of(Field.nullable("old_column", new ArrowType.Utf8())));
+            });
+    when(dataset.version()).thenReturn(8L);
+    Mockito.doReturn(dataset).when(lanceTableOps).openDataset(location, Map.of());
+
+    Table loaded =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+
+    Assertions.assertEquals("9", loaded.properties().get(LANCE_TABLE_VERSION));
+    Assertions.assertEquals("new_column", loaded.columns()[0].name());
+    Assertions.assertSame(newerTable, storedTable.get());
+  }
+
+  @ParameterizedTest(name = "changeTableId={0}")
+  @ValueSource(booleans = {false, true})
+  public void testRepairDoesNotCrossTableIdentityOrLocationChange(boolean changeTableId)
+      throws Exception {
+    NameIdentifier ident = NameIdentifier.of("schema", "table");
+    String oldLocation = tempDir.resolve("replaced-table-old").toString();
+    String newLocation = tempDir.resolve("replaced-table-new").toString();
+    TableEntity observedTable =
+        tableEntity(
+            1L,
+            ident,
+            List.of(),
+            Map.of(Table.PROPERTY_LOCATION, oldLocation, LANCE_TABLE_DECLARED, "true"));
+    TableEntity replacement =
+        tableEntity(
+            changeTableId ? 2L : 1L,
+            ident,
+            List.of(),
+            Map.of(
+                Table.PROPERTY_LOCATION,
+                changeTableId ? oldLocation : newLocation,
+                LANCE_TABLE_DECLARED,
+                "true"));
+    AtomicReference<TableEntity> storedTable = new AtomicReference<>(observedTable);
+    stubMutableTable(ident, storedTable);
+    when(idGenerator.nextId()).thenReturn(10L, 20L);
+
+    Dataset oldDataset = mock(Dataset.class);
+    when(oldDataset.getSchema())
+        .thenAnswer(
+            invocation -> {
+              storedTable.set(replacement);
+              return new Schema(List.of(Field.nullable("old_column", new ArrowType.Utf8())));
+            });
+    when(oldDataset.version()).thenReturn(8L);
+    Dataset replacementDataset = mock(Dataset.class);
+    when(replacementDataset.getSchema())
+        .thenReturn(
+            new Schema(List.of(Field.nullable("replacement_column", new ArrowType.Utf8()))));
+    when(replacementDataset.version()).thenReturn(9L);
+    if (changeTableId) {
+      Mockito.doReturn(oldDataset, replacementDataset)
+          .when(lanceTableOps)
+          .openDataset(oldLocation, Map.of());
+    } else {
+      Mockito.doReturn(oldDataset).when(lanceTableOps).openDataset(oldLocation, Map.of());
+      Mockito.doReturn(replacementDataset).when(lanceTableOps).openDataset(newLocation, Map.of());
+    }
+
+    Table loaded =
+        PrincipalUtils.doAs(new UserPrincipal("tester"), () -> lanceTableOps.loadTable(ident));
+
+    Assertions.assertEquals(
+        changeTableId ? oldLocation : newLocation,
+        loaded.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertEquals("9", loaded.properties().get(LANCE_TABLE_VERSION));
+    Assertions.assertEquals("replacement_column", loaded.columns()[0].name());
+    Assertions.assertEquals(changeTableId ? 2L : 1L, storedTable.get().id());
+    Assertions.assertEquals("replacement_column", storedTable.get().columns().get(0).name());
   }
 
   @Test
@@ -455,7 +546,7 @@ public class TestLanceTableOperations {
                     .build()),
             Map.of(Table.PROPERTY_LOCATION, location, LANCE_TABLE_VERSION, "9"));
     when(store.get(eq(ident), eq(Entity.EntityType.TABLE), eq(TableEntity.class)))
-        .thenReturn(staleTableEntity);
+        .thenReturn(staleTableEntity, alreadyRepairedTableEntity);
     when(store.update(eq(ident), eq(TableEntity.class), eq(Entity.EntityType.TABLE), any()))
         .thenAnswer(
             invocation -> {
@@ -1104,8 +1195,13 @@ public class TestLanceTableOperations {
 
   private static TableEntity tableEntity(
       NameIdentifier ident, List<ColumnEntity> columns, Map<String, String> properties) {
+    return tableEntity(1L, ident, columns, properties);
+  }
+
+  private static TableEntity tableEntity(
+      long id, NameIdentifier ident, List<ColumnEntity> columns, Map<String, String> properties) {
     return TableEntity.builder()
-        .withId(1L)
+        .withId(id)
         .withName(ident.name())
         .withNamespace(ident.namespace())
         .withComment("comment")
@@ -1113,6 +1209,16 @@ public class TestLanceTableOperations {
         .withProperties(properties)
         .withAuditInfo(
             AuditInfo.builder().withCreator("creator").withCreateTime(Instant.EPOCH).build())
+        .build();
+  }
+
+  private static ColumnEntity columnEntity(long id, String name) {
+    return ColumnEntity.builder()
+        .withId(id)
+        .withName(name)
+        .withDataType(Types.StringType.get())
+        .withPosition(0)
+        .withAuditInfo(AuditInfo.EMPTY)
         .build();
   }
 

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -19,9 +19,11 @@
 package org.apache.gravitino.catalog.lakehouse.lance.integration.test;
 
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_CREATION_MODE;
+import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_SCHEMA_REFRESH_MODE;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_DECLARED;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_FORMAT;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_REGISTER;
+import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_VERSION;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
@@ -511,6 +513,62 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
       }
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testVersionCheckPersistsLatestDatasetSchema() {
+    String testCatalogName = GravitinoITUtils.genRandomName("lance_version_check_catalog");
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(LANCE_SCHEMA_REFRESH_MODE, "VERSION_CHECK");
+    metalake.createCatalog(
+        testCatalogName, Catalog.Type.RELATIONAL, provider, "comment", catalogProperties);
+
+    try {
+      Catalog versionCheckCatalog = metalake.loadCatalog(testCatalogName);
+      String testSchemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
+      versionCheckCatalog
+          .asSchemas()
+          .createSchema(testSchemaName, "comment", createSchemaProperties());
+      NameIdentifier ident =
+          NameIdentifier.of(
+              testSchemaName, GravitinoITUtils.genRandomName("lance_version_check_table"));
+      String location = String.format("%s/%s/%s", tempDirectory, testSchemaName, ident.name());
+      Map<String, String> tableProperties = createProperties();
+      tableProperties.put(Table.PROPERTY_LOCATION, location);
+      tableProperties.put(Table.PROPERTY_TABLE_FORMAT, LANCE_TABLE_FORMAT);
+
+      Table created =
+          versionCheckCatalog
+              .asTableCatalog()
+              .createTable(
+                  ident,
+                  createColumns(),
+                  TABLE_COMMENT,
+                  tableProperties,
+                  Transforms.EMPTY_TRANSFORM,
+                  null,
+                  null);
+      long createdVersion = Long.parseLong(created.properties().get(LANCE_TABLE_VERSION));
+
+      long latestVersion;
+      try (Dataset dataset = Dataset.open().uri(location).build()) {
+        dataset.dropColumns(List.of(LANCE_COL_NAME3));
+        latestVersion = dataset.getVersion().getId();
+      }
+      Assertions.assertTrue(latestVersion > createdVersion);
+
+      Table repaired = versionCheckCatalog.asTableCatalog().loadTable(ident);
+      Assertions.assertEquals(2, repaired.columns().length);
+      Assertions.assertEquals(
+          String.valueOf(latestVersion), repaired.properties().get(LANCE_TABLE_VERSION));
+
+      Table reloaded = versionCheckCatalog.asTableCatalog().loadTable(ident);
+      Assertions.assertEquals(2, reloaded.columns().length);
+      Assertions.assertEquals(
+          String.valueOf(latestVersion), reloaded.properties().get(LANCE_TABLE_VERSION));
+    } finally {
+      metalake.dropCatalog(testCatalogName, true);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reload the complete Lance table repair observation after an optimistic lock conflict instead of retrying with previously read schema data. Before updating metadata, verify that the observed table ID, location, and Lance version still match the current table.

Add deterministic regression tests for concurrent metadata updates and table identity or location changes, plus integration coverage for persisting a newer Lance dataset schema through the catalog API.

### Why are the changes needed?

A schema repair can read an older Lance dataset version and later overwrite metadata that already points to a newer version. A version check alone is also insufficient when a table is replaced or its location changes.

Fix: #12957

### Does this PR introduce _any_ user-facing change?

No API or property changes. Lance schema repair no longer writes schema metadata from a stale table observation.

### How was this patch tested?

- Reproduced the regression against the original implementation, where a version 8 observation overwrote metadata at version 9.
- Added deterministic interleaving tests that change stored metadata while the old dataset schema is being read, then verify the newer stored schema is preserved for version, table identity, and location changes.
- Added an integration test that advances a real Lance dataset schema, loads it through Gravitino, and verifies the updated schema and `lance.version` remain persisted on a second read.
- Ran the module unit checks and the new integration test on Linux: https://github.com/IcebreakerSA/gravitino/actions/runs/34242053525
- Ran compile and Spotless checks locally with JDK 17.
