### PR TITLE
[#13018] feat(spark-connector): Add Spark 4.1 support

### DIFF
--- a/.github/workflows/backend-integration-test-action.yml
+++ b/.github/workflows/backend-integration-test-action.yml
@@ -72,8 +72,8 @@ jobs:
             -x :flink-connector:flink-1.18:test -x :flink-connector:flink-runtime-1.18:test \
             -x :flink-connector:flink-1.19:test -x :flink-connector:flink-runtime-1.19:test \
             -x :flink-connector:flink-1.20:test -x :flink-connector:flink-runtime-1.20:test \
-            -x :spark-connector:spark-3.5:test -x :spark-connector:spark-4.0:test \
-            -x :spark-connector:spark-runtime-3.5:test -x :spark-connector:spark-runtime-4.0:test \
+            -x :spark-connector:spark-3.5:test -x :spark-connector:spark-4.0:test -x :spark-connector:spark-4.1:test \
+            -x :spark-connector:spark-runtime-3.5:test -x :spark-connector:spark-runtime-4.0:test -x :spark-connector:spark-runtime-4.1:test \
             -x :trino-connector:integration-test:test -x :trino-connector:trino-connector:test \
             -x :iceberg:iceberg-rest-trino-it:test \
             -x :plugins:idp-basic:test \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,10 +112,12 @@ jobs:
         run: |
           ./gradlew assemble -PskipWeb=true
 
-  # To check the spark-connector is compatible with scala2.13
+  # Compiles and unit-tests the connector module of every Spark line, and checks 3.5 against Scala
+  # 2.13. The Spark 4 modules are Scala 2.13 only and ignore -PscalaVersion. The runtime shading
+  # modules are not built here; the full build job below covers those.
   spark-connector-build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: changes
     if: needs.changes.outputs.spark_connector_changes == 'true'
     steps:
@@ -131,9 +133,9 @@ jobs:
         run: |
           dev/ci/util_free_space.sh
 
-      - name: Build with Scala2.13
+      - name: Build Spark 3.5, 4.0 and 4.1 connectors
         run: |
-          ./gradlew :spark-connector:spark-3.5:build -PscalaVersion=2.13 -PskipITs -PskipDockerTests=false -PskipWeb=true
+          ./gradlew :spark-connector:spark-3.5:build :spark-connector:spark-4.0:build :spark-connector:spark-4.1:build -PscalaVersion=2.13 -PskipITs -PskipDockerTests=false -PskipWeb=true
 
       - name: Upload unit tests report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,12 +112,10 @@ jobs:
         run: |
           ./gradlew assemble -PskipWeb=true
 
-  # Compiles and unit-tests the connector module of every Spark line, and checks 3.5 against Scala
-  # 2.13. The Spark 4 modules are Scala 2.13 only and ignore -PscalaVersion. The runtime shading
-  # modules are not built here; the full build job below covers those.
+  # To check the spark-connector is compatible with scala2.13
   spark-connector-build:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     needs: changes
     if: needs.changes.outputs.spark_connector_changes == 'true'
     steps:
@@ -133,9 +131,9 @@ jobs:
         run: |
           dev/ci/util_free_space.sh
 
-      - name: Build Spark 3.5, 4.0 and 4.1 connectors
+      - name: Build with Scala2.13
         run: |
-          ./gradlew :spark-connector:spark-3.5:build :spark-connector:spark-4.0:build :spark-connector:spark-4.1:build -PscalaVersion=2.13 -PskipITs -PskipDockerTests=false -PskipWeb=true
+          ./gradlew :spark-connector:spark-3.5:build -PscalaVersion=2.13 -PskipITs -PskipDockerTests=false -PskipWeb=true
 
       - name: Upload unit tests report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -106,5 +106,6 @@ jobs:
             distribution/**/*.log
             spark-connector/v3.5/spark/build/spark-3.5-integration-test.log
             spark-connector/v4.0/spark/build/spark-4.0-integration-test.log
+            spark-connector/v4.1/spark/build/spark-4.1-integration-test.log
             flink-connector/build/flink-connector-integration-test.log
             flink-connector/build/*.tar

--- a/.github/workflows/spark-integration-test-action.yml
+++ b/.github/workflows/spark-integration-test-action.yml
@@ -59,10 +59,11 @@ jobs:
         id: integrationTest
         run: |
           ./gradlew -PskipTests -PtestMode=${{ inputs.test-mode }} -PscalaVersion=${{ inputs.scala-version }} -PskipDockerTests=false -PskipWeb=true :spark-connector:spark-3.5:test --tests "org.apache.gravitino.spark.connector.integration.test.**"
-          # Spark 4 is Scala 2.13 only, so its module ignores -PscalaVersion. Guard on 2.12 so that
-          # adding a 2.13 entry to the matrix later does not run the Spark 4 suite twice.
+          # The Spark 4 modules are Scala 2.13 only, so they ignore -PscalaVersion. Guard on 2.12 so
+          # that adding a 2.13 entry to the matrix later does not run those suites twice.
           if [ "${{ inputs.scala-version }}" == "2.12" ]; then
             ./gradlew -PskipTests -PtestMode=${{ inputs.test-mode }} -PskipDockerTests=false -PskipWeb=true :spark-connector:spark-4.0:test --tests "org.apache.gravitino.spark.connector.integration.test.**"
+            ./gradlew -PskipTests -PtestMode=${{ inputs.test-mode }} -PskipDockerTests=false -PskipWeb=true :spark-connector:spark-4.1:test --tests "org.apache.gravitino.spark.connector.integration.test.**"
           fi
 
       - name: Upload integrate tests reports
@@ -74,5 +75,6 @@ jobs:
             build/reports
             spark-connector/v3.5/spark/build/spark-3.5-integration-test.log
             spark-connector/v4.0/spark/build/spark-4.0-integration-test.log
+            spark-connector/v4.1/spark/build/spark-4.1-integration-test.log
             distribution/package/logs/*.out
             distribution/package/logs/*.log

--- a/.github/workflows/trino-integration-test.yml
+++ b/.github/workflows/trino-integration-test.yml
@@ -87,8 +87,8 @@ jobs:
             -x :flink-connector:flink-runtime-1.19:build \
             -x :flink-connector:flink-1.20:build \
             -x :flink-connector:flink-runtime-1.20:build \
-            -x :spark-connector:spark-3.5:build -x :spark-connector:spark-4.0:build \
-            -x :spark-connector:spark-runtime-3.5:build -x :spark-connector:spark-runtime-4.0:build \
+            -x :spark-connector:spark-3.5:build -x :spark-connector:spark-4.0:build -x :spark-connector:spark-4.1:build \
+            -x :spark-connector:spark-runtime-3.5:build -x :spark-connector:spark-runtime-4.0:build -x :spark-connector:spark-runtime-4.1:build \
             -x :mcp-server:build -x :lineage:build \
             -x :maintenance:optimizer:build -x :maintenance:jobs:build \
             -x :lance:lance-common:build -x :lance:lance-rest-server:build

--- a/.github/workflows/trino-multi-version-test.yml
+++ b/.github/workflows/trino-multi-version-test.yml
@@ -33,8 +33,8 @@ jobs:
             -x :flink-connector:flink-runtime-1.19:build \
             -x :flink-connector:flink-1.20:build \
             -x :flink-connector:flink-runtime-1.20:build \
-            -x :spark-connector:spark-3.5:build -x :spark-connector:spark-4.0:build \
-            -x :spark-connector:spark-runtime-3.5:build -x :spark-connector:spark-runtime-4.0:build \
+            -x :spark-connector:spark-3.5:build -x :spark-connector:spark-4.0:build -x :spark-connector:spark-4.1:build \
+            -x :spark-connector:spark-runtime-3.5:build -x :spark-connector:spark-runtime-4.0:build -x :spark-connector:spark-runtime-4.1:build \
             -x :mcp-server:build -x :lineage:build \
             -x :maintenance:optimizer:build -x :maintenance:jobs:build \
             -x :lance:lance-common:build -x :lance:lance-rest-server:build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -398,7 +398,9 @@ subprojects {
   // though the rest of :spark-connector (3.x) stays on Java 8.
   val jdk17OnlyProjectPaths = setOf(
     ":spark-connector:spark-4.0",
-    ":spark-connector:spark-runtime-4.0"
+    ":spark-connector:spark-runtime-4.0",
+    ":spark-connector:spark-4.1",
+    ":spark-connector:spark-runtime-4.1"
   )
 
   fun compatibleWithJDK8(project: Project): Boolean {

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -79,7 +79,7 @@ Gravitino builds from source on Linux and macOS natively, and on Windows through
 
   This creates `gravitino-spark-connector-runtime-{sparkVersion}_{scalaVersion}-{version}.jar` under the `spark-connector/v3.5/spark-runtime/build/libs` directory. Replace `2.12` with `2.13` to build against a different Scala version. The default Scala version is `2.12` if `-PscalaVersion` is not specified.
 
-  Replace `spark-runtime-3.5` with `spark-runtime-4.0` for Spark 4. Spark 4 is Scala 2.13 only, so that module ignores `-PscalaVersion` and always builds against 2.13.
+  Replace `spark-runtime-3.5` with `spark-runtime-4.0` or `spark-runtime-4.1` for Spark 4. Spark 4 is Scala 2.13 only, so those modules ignore `-PscalaVersion` and always build against 2.13.
 
   :::note
   The first time you build the project, downloading the dependencies may take a while.

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -20,6 +20,7 @@ Spark clients use a different Iceberg version than the Gravitino server (1.11.0)
 |---------------|----------------|-----------------|---------------------------------------------------------|-----------------------------------------------------------------------------------|
 | 3.5           | 2.12 or 2.13   | 1.11.0          | `iceberg-spark-runtime-3.5_${scala-version}-1.11.0.jar` | `gravitino-spark-connector-runtime-3.5_${scala-version}-${gravitino-version}.jar` |
 | 4.0           | 2.13           | 1.11.0          | `iceberg-spark-runtime-4.0_2.13-1.11.0.jar`             | `gravitino-spark-connector-runtime-4.0_2.13-${gravitino-version}.jar`             |
+| 4.1           | 2.13           | 1.11.0          | `iceberg-spark-runtime-4.1_2.13-1.11.0.jar`             | `gravitino-spark-connector-runtime-4.1_2.13-${gravitino-version}.jar`             |
 
 Replace `${scala-version}` with `2.12` or `2.13`, and `${gravitino-version}` with your Gravitino release version.
 

--- a/docs/spark-connector/spark-catalog-paimon.md
+++ b/docs/spark-connector/spark-catalog-paimon.md
@@ -16,8 +16,9 @@ The Apache Gravitino Spark connector offers the capability to read and write Pai
 
 :::info
 The Paimon catalog is available on Spark 3.5 only. Paimon first published `paimon-spark-4.0` in
-Paimon 1.3.0, above the version Gravitino currently depends on, and publishes no `paimon-spark-4.1`
-at any version, so the Spark 4 connectors build without the Paimon classes.
+Paimon 1.3.0, above the version Gravitino currently depends on, and has published no
+`paimon-spark-4.1` in any release so far, so the Spark 4 connectors build without the Paimon
+classes.
 :::
 
 ## Capabilities

--- a/docs/spark-connector/spark-catalog-paimon.md
+++ b/docs/spark-connector/spark-catalog-paimon.md
@@ -16,8 +16,8 @@ The Apache Gravitino Spark connector offers the capability to read and write Pai
 
 :::info
 The Paimon catalog is available on Spark 3.5 only. Paimon first published `paimon-spark-4.0` in
-Paimon 1.3.0, above the version Gravitino currently depends on, so the Spark 4 connector builds
-without the Paimon classes.
+Paimon 1.3.0, above the version Gravitino currently depends on, and publishes no `paimon-spark-4.1`
+at any version, so the Spark 4 connectors build without the Paimon classes.
 :::
 
 ## Capabilities

--- a/docs/spark-connector/spark-connector.md
+++ b/docs/spark-connector/spark-connector.md
@@ -17,13 +17,13 @@ The Apache Gravitino Spark connector leverages the Spark DataSourceV2 interface 
 
 ## Requirement
 
-* Spark 3.5 or 4.0
+* Spark 3.5, 4.0 or 4.1
 * Scala 2.12 or 2.13 on Spark 3.5; Spark 4 is Scala 2.13 only
 * JDK 8, 11 or 17 on Spark 3.5; Spark 4 requires JDK 17
 
 ## Usage
 
-1. [Build](../how-to-build.md) or download the package matching your Spark minor version and Scala version ([gravitino-spark-connector-runtime-3.5_2.12](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-spark-connector-runtime-3.5_2.12), [gravitino-spark-connector-runtime-3.5_2.13](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-spark-connector-runtime-3.5_2.13), [gravitino-spark-connector-runtime-4.0_2.13](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-spark-connector-runtime-4.0_2.13)), and place it to the classpath of Spark.
+1. [Build](../how-to-build.md) or download the package matching your Spark minor version and Scala version ([gravitino-spark-connector-runtime-3.5_2.12](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-spark-connector-runtime-3.5_2.12), [gravitino-spark-connector-runtime-3.5_2.13](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-spark-connector-runtime-3.5_2.13), [gravitino-spark-connector-runtime-4.0_2.13](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-spark-connector-runtime-4.0_2.13), [gravitino-spark-connector-runtime-4.1_2.13](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-spark-connector-runtime-4.1_2.13)), and place it to the classpath of Spark.
 2. Configure the Spark session to use the Gravitino spark connector.
 
 | Property                                         | Type    | Default Value | Description                                                                                                                                                              | Required |

--- a/docs/spark-connector/spark-integration-test.md
+++ b/docs/spark-connector/spark-integration-test.md
@@ -17,7 +17,7 @@ Normal integration test are mainly used to test the correctness of the metadata,
 ./gradlew :spark-connector:spark-3.5:test --tests "org.apache.gravitino.spark.connector.integration.test.hive.SparkHiveCatalogIT35.testCreateHiveFormatPartitionTable"
 ```
 
-Every version module carries its own subclass of each shared IT, named after the Spark minor version, so the Spark 4.1 equivalent is `:spark-connector:spark-4.1:test --tests "...SparkHiveCatalogIT41.testCreateHiveFormatPartitionTable"`.
+Every version module carries its own subclass of each shared IT, named after the Spark minor version, so the Spark 4.0 equivalent is `:spark-connector:spark-4.0:test --tests "...SparkHiveCatalogIT40.testCreateHiveFormatPartitionTable"`.
 
 ## Golden File Integration Test
 

--- a/docs/spark-connector/spark-integration-test.md
+++ b/docs/spark-connector/spark-integration-test.md
@@ -17,7 +17,7 @@ Normal integration test are mainly used to test the correctness of the metadata,
 ./gradlew :spark-connector:spark-3.5:test --tests "org.apache.gravitino.spark.connector.integration.test.hive.SparkHiveCatalogIT35.testCreateHiveFormatPartitionTable"
 ```
 
-Every version module carries its own subclass of each shared IT, named after the Spark minor version, so the Spark 4.0 equivalent is `:spark-connector:spark-4.0:test --tests "...SparkHiveCatalogIT40.testCreateHiveFormatPartitionTable"`.
+Every version module carries its own subclass of each shared IT, named after the Spark minor version, so the Spark 4.1 equivalent is `:spark-connector:spark-4.1:test --tests "...SparkHiveCatalogIT41.testCreateHiveFormatPartitionTable"`.
 
 ## Golden File Integration Test
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ iceberg = '1.11.0'
 iceberg4spark33 = "1.8.1"
 iceberg4spark35 = "1.11.0"
 iceberg4spark40 = "1.11.0"
+iceberg4spark41 = "1.11.0"
 paimon = '1.2.0'
 # spark33 and spark34 are pinned by modules other than the Spark connector for their own tests, so
 # they stay after the connector dropped 3.3 and 3.4; they say nothing about connector support.
@@ -79,6 +80,7 @@ spark33 = "3.3.4"
 spark34 = "3.4.3"
 spark35 = "3.5.3"
 spark40 = "4.0.3"
+spark41 = "4.1.3"
 kyuubi4spark = "1.11.0"
 kyuubi4authz = "1.10.2"
 trino = '435'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -107,7 +107,7 @@ include("spark-connector:spark-3.5", "spark-connector:spark-runtime-3.5")
 project(":spark-connector:spark-3.5").projectDir = file("spark-connector/v3.5/spark")
 project(":spark-connector:spark-runtime-3.5").projectDir = file("spark-connector/v3.5/spark-runtime")
 // Spark 4.0 support (#8771). Spark 4 is Scala 2.13 only and needs JDK 17, so these modules pin
-// 2.13 rather than reading -PscalaVersion. The same holds for every later Spark 4 line.
+// 2.13 rather than reading -PscalaVersion.
 include("spark-connector:spark-4.0", "spark-connector:spark-runtime-4.0")
 project(":spark-connector:spark-4.0").projectDir = file("spark-connector/v4.0/spark")
 project(":spark-connector:spark-runtime-4.0").projectDir = file("spark-connector/v4.0/spark-runtime")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -107,10 +107,13 @@ include("spark-connector:spark-3.5", "spark-connector:spark-runtime-3.5")
 project(":spark-connector:spark-3.5").projectDir = file("spark-connector/v3.5/spark")
 project(":spark-connector:spark-runtime-3.5").projectDir = file("spark-connector/v3.5/spark-runtime")
 // Spark 4.0 support (#8771). Spark 4 is Scala 2.13 only and needs JDK 17, so these modules pin
-// 2.13 rather than reading -PscalaVersion.
+// 2.13 rather than reading -PscalaVersion. The same holds for every later Spark 4 line.
 include("spark-connector:spark-4.0", "spark-connector:spark-runtime-4.0")
 project(":spark-connector:spark-4.0").projectDir = file("spark-connector/v4.0/spark")
 project(":spark-connector:spark-runtime-4.0").projectDir = file("spark-connector/v4.0/spark-runtime")
+include("spark-connector:spark-4.1", "spark-connector:spark-runtime-4.1")
+project(":spark-connector:spark-4.1").projectDir = file("spark-connector/v4.1/spark")
+project(":spark-connector:spark-runtime-4.1").projectDir = file("spark-connector/v4.1/spark-runtime")
 include("web:web", "web:integration-test")
 include("web-v2:web", "web-v2:integration-test")
 include("docs")

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter.java
@@ -29,9 +29,6 @@ public class SparkTableChangeConverter {
     this.sparkTypeConverter = sparkTypeConverter;
   }
 
-  // Spark 4.1 deprecates UpdateColumnDefaultValue#newDefaultValue in favour of newCurrentDefault,
-  // which returns a DefaultValue type that Spark 3.5 and 4.0 do not have.
-  @SuppressWarnings("deprecation")
   public org.apache.gravitino.rel.TableChange toGravitinoTableChange(TableChange change) {
     if (change instanceof TableChange.SetProperty) {
       TableChange.SetProperty setProperty = (TableChange.SetProperty) change;
@@ -94,9 +91,13 @@ public class SparkTableChangeConverter {
     } else if (change instanceof TableChange.UpdateColumnDefaultValue) {
       TableChange.UpdateColumnDefaultValue updateColumnDefaultValue =
           (TableChange.UpdateColumnDefaultValue) change;
+      // Spark 4.1 deprecates newDefaultValue in favour of newCurrentDefault, which Spark 3.5 and
+      // 4.0's UpdateColumnDefaultValue does not declare. Scoped to this declaration so the rest of
+      // the method keeps the -Werror deprecation gate.
+      @SuppressWarnings("deprecation")
+      String newDefaultValue = updateColumnDefaultValue.newDefaultValue();
       return org.apache.gravitino.rel.TableChange.updateColumnDefaultValue(
-          updateColumnDefaultValue.fieldNames(),
-          Literals.stringLiteral(updateColumnDefaultValue.newDefaultValue()));
+          updateColumnDefaultValue.fieldNames(), Literals.stringLiteral(newDefaultValue));
     } else {
       throw new UnsupportedOperationException(
           String.format("Unsupported table change %s", change.getClass().getName()));

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter.java
@@ -29,6 +29,9 @@ public class SparkTableChangeConverter {
     this.sparkTypeConverter = sparkTypeConverter;
   }
 
+  // Spark 4.1 deprecates UpdateColumnDefaultValue#newDefaultValue in favour of newCurrentDefault,
+  // which returns a DefaultValue type that Spark 3.5 and 4.0 do not have.
+  @SuppressWarnings("deprecation")
   public org.apache.gravitino.rel.TableChange toGravitinoTableChange(TableChange change) {
     if (change instanceof TableChange.SetProperty) {
       TableChange.SetProperty setProperty = (TableChange.SetProperty) change;

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergRestOAuthConfig.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergRestOAuthConfig.java
@@ -129,6 +129,10 @@ class IcebergRestOAuthConfig {
     }
   }
 
+  // Hand-rolled rather than StringUtils.removeEnd/removeStart: commons-lang3 deprecates both in
+  // 3.19.0, which the Spark 4.1 build resolves, and -Werror makes that a compile error. Their
+  // replacement, Strings.CS, does not exist in the 3.12.0 the Spark 3.5 build resolves, so no
+  // named helper compiles on every supported line.
   private static String joinUri(String serverUri, String tokenPath) {
     String base =
         serverUri.endsWith("/") ? serverUri.substring(0, serverUri.length() - 1) : serverUri;

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergRestOAuthConfig.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergRestOAuthConfig.java
@@ -80,7 +80,7 @@ class IcebergRestOAuthConfig {
         sparkConf.getBoolean(GravitinoSparkConfig.GRAVITINO_ICEBERG_REUSE_OAUTH2, true)
             && AuthProperties.isOAuth2(authType);
     boolean hasExplicitLegacyOAuth2 =
-        StringUtils.equalsIgnoreCase(explicitAuthType, AUTH_TYPE_OAUTH2)
+        AUTH_TYPE_OAUTH2.equalsIgnoreCase(explicitAuthType)
             || result.keySet().stream().anyMatch(OAUTH2_TRIGGER_PROPERTIES::contains);
     if (!reuseOAuth2 && !hasExplicitLegacyOAuth2) {
       return result;
@@ -130,6 +130,9 @@ class IcebergRestOAuthConfig {
   }
 
   private static String joinUri(String serverUri, String tokenPath) {
-    return StringUtils.removeEnd(serverUri, "/") + "/" + StringUtils.removeStart(tokenPath, "/");
+    String base =
+        serverUri.endsWith("/") ? serverUri.substring(0, serverUri.length() - 1) : serverUri;
+    String path = tokenPath.startsWith("/") ? tokenPath.substring(1) : tokenPath;
+    return base + "/" + path;
   }
 }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTable.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTable.java
@@ -19,7 +19,6 @@
 
 package org.apache.gravitino.spark.connector.iceberg;
 
-import java.lang.reflect.Field;
 import java.util.Map;
 import org.apache.gravitino.rel.Table;
 import org.apache.gravitino.spark.connector.PropertiesConverter;
@@ -38,7 +37,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * For spark-connector in Iceberg, it explicitly uses SparkTable to identify whether it is an Apache
  * Iceberg table, so the SparkIcebergTable must extend SparkTable.
  */
-public class SparkIcebergTable extends SparkTable {
+public class SparkIcebergTable extends SparkIcebergTableBase {
 
   private GravitinoTableInfoHelper gravitinoTableInfoHelper;
   private org.apache.spark.sql.connector.catalog.Table sparkTable;
@@ -51,7 +50,7 @@ public class SparkIcebergTable extends SparkTable {
       PropertiesConverter propertiesConverter,
       SparkTransformConverter sparkTransformConverter,
       SparkTypeConverter sparkTypeConverter) {
-    super(sparkTable.table(), !isCacheEnabled(sparkCatalog));
+    super(sparkTable, sparkCatalog);
     this.gravitinoTableInfoHelper =
         new GravitinoTableInfoHelper(
             true,
@@ -91,15 +90,5 @@ public class SparkIcebergTable extends SparkTable {
   @Override
   public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
     return ((SparkTable) sparkTable).newScanBuilder(options);
-  }
-
-  private static boolean isCacheEnabled(SparkCatalog sparkCatalog) {
-    try {
-      Field cacheEnabled = sparkCatalog.getClass().getDeclaredField("cacheEnabled");
-      cacheEnabled.setAccessible(true);
-      return cacheEnabled.getBoolean(sparkCatalog);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new RuntimeException("Failed to get cacheEnabled field from SparkCatalog", e);
-    }
   }
 }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/jdbc/SparkJdbcTable.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/jdbc/SparkJdbcTable.java
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTable;
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog;
 import org.apache.spark.sql.types.StructType;
 
-public class SparkJdbcTable extends JDBCTable {
+public class SparkJdbcTable extends SparkJdbcTableBase {
 
   private GravitinoTableInfoHelper gravitinoTableInfoHelper;
 
@@ -42,7 +42,7 @@ public class SparkJdbcTable extends JDBCTable {
       PropertiesConverter propertiesConverter,
       SparkTransformConverter sparkTransformConverter,
       SparkTypeConverter sparkTypeConverter) {
-    super(identifier, jdbcTable.schema(), jdbcTable.jdbcOptions());
+    super(identifier, jdbcTable);
     this.gravitinoTableInfoHelper =
         new GravitinoTableInfoHelper(
             false,

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/HiveGravitinoOperationOperator.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/HiveGravitinoOperationOperator.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,7 +151,7 @@ public class HiveGravitinoOperationOperator {
     return new GenericInternalRow(values);
   }
 
-  private @NotNull String getHivePartitionName(
+  private String getHivePartitionName(
       String[] names, InternalRow ident, StructType partitionSchema) {
     StringBuilder partitionName = new StringBuilder();
     Preconditions.checkArgument(names != null, "Partition column names must not be null");
@@ -170,7 +169,7 @@ public class HiveGravitinoOperationOperator {
     return partitionName.toString();
   }
 
-  private @NotNull String getHivePartitionName(InternalRow ident, StructType partitionSchema) {
+  private String getHivePartitionName(InternalRow ident, StructType partitionSchema) {
     StringBuilder partitionName = new StringBuilder();
     int numFields = ident.numFields();
     for (int i = 0; i < numFields; i++) {

--- a/spark-connector/spark-common/src/main/spark35/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTableBase.java
+++ b/spark-connector/spark-common/src/main/spark35/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTableBase.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.iceberg;
+
+import java.lang.reflect.Field;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.source.SparkTable;
+
+/**
+ * Carries the Iceberg constructor call for {@link SparkIcebergTable}. Iceberg publishes one Spark
+ * module per Spark line and their {@code SparkTable} constructors differ, so each line has its own
+ * copy of this class while the table itself stays shared.
+ */
+public abstract class SparkIcebergTableBase extends SparkTable {
+
+  /**
+   * Creates the Iceberg table this wrapper stands in for.
+   *
+   * @param sparkTable the Iceberg table Spark loaded
+   * @param sparkCatalog the Iceberg catalog that loaded it, read for its cache setting
+   */
+  protected SparkIcebergTableBase(SparkTable sparkTable, SparkCatalog sparkCatalog) {
+    super(sparkTable.table(), !isCacheEnabled(sparkCatalog));
+  }
+
+  private static boolean isCacheEnabled(SparkCatalog sparkCatalog) {
+    try {
+      Field cacheEnabled = sparkCatalog.getClass().getDeclaredField("cacheEnabled");
+      cacheEnabled.setAccessible(true);
+      return cacheEnabled.getBoolean(sparkCatalog);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to get cacheEnabled field from SparkCatalog", e);
+    }
+  }
+}

--- a/spark-connector/spark-common/src/main/spark35/org/apache/gravitino/spark/connector/jdbc/SparkJdbcTableBase.java
+++ b/spark-connector/spark-common/src/main/spark35/org/apache/gravitino/spark/connector/jdbc/SparkJdbcTableBase.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.jdbc;
+
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTable;
+
+/**
+ * Carries the {@code JDBCTable} constructor call for {@link SparkJdbcTable}. Spark 4.1 added a
+ * fourth constructor parameter, so each Spark line has its own copy of this class while the table
+ * itself stays shared.
+ */
+public abstract class SparkJdbcTableBase extends JDBCTable {
+
+  /**
+   * Creates the JDBC table this wrapper stands in for.
+   *
+   * @param identifier the table identifier
+   * @param jdbcTable the JDBC table Spark loaded
+   */
+  protected SparkJdbcTableBase(Identifier identifier, JDBCTable jdbcTable) {
+    super(identifier, jdbcTable.schema(), jdbcTable.jdbcOptions());
+  }
+}

--- a/spark-connector/spark-common/src/main/spark40/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTableBase.java
+++ b/spark-connector/spark-common/src/main/spark40/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTableBase.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.iceberg;
+
+import java.lang.reflect.Field;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.source.SparkTable;
+
+/**
+ * Carries the Iceberg constructor call for {@link SparkIcebergTable}. Iceberg publishes one Spark
+ * module per Spark line and their {@code SparkTable} constructors differ, so each line has its own
+ * copy of this class while the table itself stays shared.
+ */
+public abstract class SparkIcebergTableBase extends SparkTable {
+
+  /**
+   * Creates the Iceberg table this wrapper stands in for.
+   *
+   * @param sparkTable the Iceberg table Spark loaded
+   * @param sparkCatalog the Iceberg catalog that loaded it, read for its cache setting
+   */
+  protected SparkIcebergTableBase(SparkTable sparkTable, SparkCatalog sparkCatalog) {
+    super(sparkTable.table(), !isCacheEnabled(sparkCatalog));
+  }
+
+  private static boolean isCacheEnabled(SparkCatalog sparkCatalog) {
+    try {
+      Field cacheEnabled = sparkCatalog.getClass().getDeclaredField("cacheEnabled");
+      cacheEnabled.setAccessible(true);
+      return cacheEnabled.getBoolean(sparkCatalog);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to get cacheEnabled field from SparkCatalog", e);
+    }
+  }
+}

--- a/spark-connector/spark-common/src/main/spark40/org/apache/gravitino/spark/connector/jdbc/SparkJdbcTableBase.java
+++ b/spark-connector/spark-common/src/main/spark40/org/apache/gravitino/spark/connector/jdbc/SparkJdbcTableBase.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.jdbc;
+
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTable;
+
+/**
+ * Carries the {@code JDBCTable} constructor call for {@link SparkJdbcTable}. Spark 4.1 added a
+ * fourth constructor parameter, so each Spark line has its own copy of this class while the table
+ * itself stays shared.
+ */
+public abstract class SparkJdbcTableBase extends JDBCTable {
+
+  /**
+   * Creates the JDBC table this wrapper stands in for.
+   *
+   * @param identifier the table identifier
+   * @param jdbcTable the JDBC table Spark loaded
+   */
+  protected SparkJdbcTableBase(Identifier identifier, JDBCTable jdbcTable) {
+    super(identifier, jdbcTable.schema(), jdbcTable.jdbcOptions());
+  }
+}

--- a/spark-connector/spark-common/src/main/spark41/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTableBase.java
+++ b/spark-connector/spark-common/src/main/spark41/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTableBase.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.iceberg;
+
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.source.SparkTable;
+
+/**
+ * Carries the Iceberg constructor call for {@link SparkIcebergTable}. Iceberg publishes one Spark
+ * module per Spark line and their {@code SparkTable} constructors differ, so each line has its own
+ * copy of this class while the table itself stays shared.
+ */
+public abstract class SparkIcebergTableBase extends SparkTable {
+
+  /**
+   * Creates the Iceberg table this wrapper stands in for.
+   *
+   * @param sparkTable the Iceberg table Spark loaded
+   * @param sparkCatalog the Iceberg catalog that loaded it, unused on this Spark line
+   */
+  protected SparkIcebergTableBase(SparkTable sparkTable, SparkCatalog sparkCatalog) {
+    // Iceberg's Spark 4.1 module publishes only SparkTable(Table). The earlier lines pass an
+    // eager-refresh flag derived from the catalog's cacheEnabled field; 4.1 has no such parameter.
+    super(sparkTable.table());
+  }
+}

--- a/spark-connector/spark-common/src/main/spark41/org/apache/gravitino/spark/connector/jdbc/SparkJdbcTableBase.java
+++ b/spark-connector/spark-common/src/main/spark41/org/apache/gravitino/spark/connector/jdbc/SparkJdbcTableBase.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.jdbc;
+
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTable;
+
+/**
+ * Carries the {@code JDBCTable} constructor call for {@link SparkJdbcTable}. Spark 4.1 added a
+ * fourth constructor parameter, so each Spark line has its own copy of this class while the table
+ * itself stays shared.
+ */
+public abstract class SparkJdbcTableBase extends JDBCTable {
+
+  /**
+   * Creates the JDBC table this wrapper stands in for.
+   *
+   * @param identifier the table identifier
+   * @param jdbcTable the JDBC table Spark loaded
+   */
+  protected SparkJdbcTableBase(Identifier identifier, JDBCTable jdbcTable) {
+    // Spark 4.1 added the additionalMetrics parameter; forward what the loaded table reports.
+    super(identifier, jdbcTable.schema(), jdbcTable.jdbcOptions(), jdbcTable.additionalMetrics());
+  }
+}

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/catalog/TestTransformTableChange.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/catalog/TestTransformTableChange.java
@@ -45,13 +45,14 @@ public class TestTransformTableChange {
     Assertions.assertEquals("value", gravitinoSetProperty.getValue());
   }
 
-  // Spark 4.1 deprecates the String form of updateColumnDefaultValue; the DefaultValue form that
-  // replaces it does not exist on Spark 3.5 or 4.0, and the converter still reads the String.
-  @SuppressWarnings("deprecation")
   @Test
   void testTransformUpdateColumnDefaultValue() {
     String[] fieldNames = new String[] {"col"};
     String defaultValue = "col_default_value";
+    // Spark 4.1 deprecates the String form of updateColumnDefaultValue; the DefaultValue form that
+    // replaces it does not exist on Spark 3.5 or 4.0. Scoped to this declaration so the rest of the
+    // method keeps the -Werror deprecation gate.
+    @SuppressWarnings("deprecation")
     TableChange.UpdateColumnDefaultValue sparkChange =
         (TableChange.UpdateColumnDefaultValue)
             TableChange.updateColumnDefaultValue(fieldNames, defaultValue);

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/catalog/TestTransformTableChange.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/catalog/TestTransformTableChange.java
@@ -45,6 +45,9 @@ public class TestTransformTableChange {
     Assertions.assertEquals("value", gravitinoSetProperty.getValue());
   }
 
+  // Spark 4.1 deprecates the String form of updateColumnDefaultValue; the DefaultValue form that
+  // replaces it does not exist on Spark 3.5 or 4.0, and the converter still reads the String.
+  @SuppressWarnings("deprecation")
   @Test
   void testTransformUpdateColumnDefaultValue() {
     String[] fieldNames = new String[] {"col"};

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogIT.java
@@ -903,7 +903,7 @@ public abstract class SparkIcebergCatalogIT extends SparkCommonIT {
     // drop branch
     sql(String.format("ALTER TABLE %s DROP BRANCH `%s`", tableName, branch1));
     Assertions.assertThrows(
-        ValidationException.class,
+        unknownVersionException(),
         () -> sql(String.format("SELECT * FROM %s VERSION AS OF '%s'", tableName, branch1)));
   }
 
@@ -950,7 +950,7 @@ public abstract class SparkIcebergCatalogIT extends SparkCommonIT {
     // drop tag
     sql(String.format("ALTER TABLE %s DROP TAG `%s`", tableName, tag1));
     Assertions.assertThrows(
-        ValidationException.class,
+        unknownVersionException(),
         () -> sql(String.format("SELECT * FROM %s VERSION AS OF '%s'", tableName, tag1)));
   }
 
@@ -1114,6 +1114,18 @@ public abstract class SparkIcebergCatalogIT extends SparkCommonIT {
     queryResult = getTableData(tableName);
     Assertions.assertEquals(4, queryResult.size());
     Assertions.assertEquals("1,1,1;1,1,1;1,1,1;1,1,1", String.join(";", queryResult));
+  }
+
+  /**
+   * The exception a query against a branch or tag that no longer exists raises. Iceberg makes this
+   * check with {@code ValidationException.check} in {@code SparkCatalog} up to its Spark 4.0
+   * module, and with {@code Preconditions.checkArgument} in {@code SparkTable} from its Spark 4.1
+   * one.
+   *
+   * @return the exception class this Spark line raises
+   */
+  protected Class<? extends Throwable> unknownVersionException() {
+    return ValidationException.class;
   }
 
   protected SparkMetadataColumnInfo[] getIcebergMetadataColumns() {

--- a/spark-connector/v4.0/spark/build.gradle.kts
+++ b/spark-connector/v4.0/spark/build.gradle.kts
@@ -45,8 +45,9 @@ val jakartaValidationVersion: String = "2.0.2"
 val artifactName = "${rootProject.name}-spark-${sparkMajorVersion}_$scalaVersion"
 
 // The connector's shared sources are compiled here rather than consumed as a jar, so that every
-// supported Spark version builds them against its own API. Everything a Spark 4 build needs its own
-// copy of lives in this module's own src/main/java, so no flavor directory is composed in.
+// supported Spark version builds them against its own API. The spark40 directory holds the shared
+// classes whose superclass constructor differs on this line; everything else this build needs its
+// own copy of lives in src/main/java.
 val sparkCommonDir = project(":spark-connector").projectDir.resolve("spark-common")
 
 sourceSets {
@@ -55,6 +56,7 @@ sourceSets {
       setSrcDirs(
         listOf(
           "$sparkCommonDir/src/main/java",
+          "$sparkCommonDir/src/main/spark40",
           "src/main/java"
         )
       )

--- a/spark-connector/v4.1/spark-runtime/build.gradle.kts
+++ b/spark-connector/v4.1/spark-runtime/build.gradle.kts
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+plugins {
+  `maven-publish`
+  id("java")
+  alias(libs.plugins.shadow)
+}
+
+// Spark 4 is Scala 2.13 only.
+val scalaVersion: String = "2.13"
+val sparkVersion: String = libs.versions.spark41.get()
+val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
+val kyuubiVersion: String = libs.versions.kyuubi4spark.get()
+val baseName = "${rootProject.name}-spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
+
+dependencies {
+  implementation(project(":clients:client-java-runtime", configuration = "shadow"))
+  implementation(project(":spark-connector:spark-4.1"))
+  implementation("org.apache.kyuubi:kyuubi-spark-connector-hive_$scalaVersion:$kyuubiVersion")
+}
+
+tasks.withType<ShadowJar>(ShadowJar::class.java) {
+  isZip64 = true
+  configurations = listOf(project.configurations.runtimeClasspath.get())
+  archiveFileName.set("$baseName-$version.jar")
+  archiveClassifier.set("")
+
+  exclude("org/slf4j/**")
+
+  // Relocate dependencies to avoid conflicts
+  relocate("com.google", "org.apache.gravitino.shaded.com.google")
+  relocate("google", "org.apache.gravitino.shaded.google")
+  relocate("org.apache.hc", "org.apache.gravitino.shaded.org.apache.hc")
+  relocate("com.github.benmanes.caffeine", "org.apache.gravitino.shaded.com.github.benmanes.caffeine")
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = baseName
+    }
+  }
+}
+
+tasks.jar {
+  dependsOn(tasks.named("shadowJar"))
+  archiveClassifier.set("empty")
+}

--- a/spark-connector/v4.1/spark/build.gradle.kts
+++ b/spark-connector/v4.1/spark/build.gradle.kts
@@ -80,10 +80,11 @@ sourceSets {
   }
 }
 
-// Paimon publishes no paimon-spark-4.1 artifact at any version, so the Paimon classes stay out of
-// this build. They live in spark-common/src/main/spark35 and are not on this module's source path;
-// the shared tests that exercise them are excluded here. The two shared test utilities that mention
-// Paimon reach it by simple class name and provider string, so they need no exclusion.
+// Paimon publishes no paimon-spark-4.1 artifact at the versions released so far, so the Paimon
+// classes stay out of this build. They live in spark-common/src/main/spark35 and are not on this
+// module's source path; the shared tests that exercise them are excluded here. The two shared test
+// utilities that mention Paimon reach it by simple class name and provider string, so they need no
+// exclusion.
 sourceSets {
   named("test") {
     java {

--- a/spark-connector/v4.1/spark/build.gradle.kts
+++ b/spark-connector/v4.1/spark/build.gradle.kts
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import com.diffplug.gradle.spotless.SpotlessExtension
+
+plugins {
+  `maven-publish`
+  id("java")
+  id("idea")
+  alias(libs.plugins.shadow)
+}
+
+repositories {
+  mavenCentral()
+}
+
+// Spark 4 is Scala 2.13 only.
+val scalaVersion: String = "2.13"
+val sparkVersion: String = libs.versions.spark41.get()
+val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
+val icebergVersion: String = libs.versions.iceberg4spark41.get()
+val kyuubiVersion: String = libs.versions.kyuubi4spark.get()
+val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
+val jerseyVersion: String = libs.versions.jersey.get()
+val javaxWsRsVersion: String = libs.versions.javax.ws.rs.api.get()
+// The HK2 line that Jersey 2.x is built against (javax.inject annotations).
+val hk2Version: String = "2.6.1"
+// jakarta.validation-api 2.x still ships the javax.validation packages; 3.x renames them.
+val jakartaValidationVersion: String = "2.0.2"
+val artifactName = "${rootProject.name}-spark-${sparkMajorVersion}_$scalaVersion"
+
+// The connector's shared sources are compiled here rather than consumed as a jar, so that every
+// supported Spark version builds them against its own API. The spark41 directory holds the shared
+// classes whose superclass constructor differs on this line; everything else this build needs its
+// own copy of lives in src/main/java.
+val sparkCommonDir = project(":spark-connector").projectDir.resolve("spark-common")
+
+sourceSets {
+  named("main") {
+    java {
+      setSrcDirs(
+        listOf(
+          "$sparkCommonDir/src/main/java",
+          "$sparkCommonDir/src/main/spark41",
+          "src/main/java"
+        )
+      )
+    }
+    resources {
+      setSrcDirs(listOf("src/main/resources"))
+    }
+  }
+  named("test") {
+    java {
+      setSrcDirs(
+        listOf(
+          "$sparkCommonDir/src/test/java",
+          "src/test/java"
+        )
+      )
+    }
+    resources {
+      setSrcDirs(listOf("src/test/resources"))
+    }
+  }
+}
+
+// Paimon publishes no paimon-spark-4.1 artifact at any version, so the Paimon classes stay out of
+// this build. They live in spark-common/src/main/spark35 and are not on this module's source path;
+// the shared tests that exercise them are excluded here. The two shared test utilities that mention
+// Paimon reach it by simple class name and provider string, so they need no exclusion.
+sourceSets {
+  named("test") {
+    java {
+      exclude("org/apache/gravitino/spark/connector/paimon/**")
+      exclude("org/apache/gravitino/spark/connector/integration/test/paimon/**")
+    }
+  }
+}
+
+// The source dirs above reach outside this project, and Spotless rejects cross-project targets.
+// The shared tree is formatted by the :spark-connector project that owns it, so scope Spotless here
+// to this module's own sources.
+plugins.withId("com.diffplug.spotless") {
+  configure<SpotlessExtension> {
+    java {
+      target(project.fileTree("src") { include("**/*.java") })
+    }
+  }
+}
+
+// The ITs run an embedded Gravitino server, which serves REST on Jetty 9 (javax.servlet) with
+// Jersey 2 (javax.ws.rs) and HK2 2.x (javax.inject). Spark 4 brings the jakarta flavor of these
+// transitively via spark-hive, and Gradle's conflict resolution upgrades the server's copies:
+// Jersey 2.41 -> 3.0.x (Jetty 9 then rejects the ServletContainer: "is not a javax.servlet.Servlet"),
+// HK2 2.6.1 -> 3.0.x (HK2 3 reads jakarta.inject annotations, so Jersey 2's javax.inject-annotated
+// RequestContext is no longer seen as a singleton), and jakarta.validation-api 2.0.2 -> 3.0.x
+// (the 2.x jar still holds the javax.validation packages Jersey 2 looks up). Pin the test classpath
+// back to the javax flavor. Tests only: the Spark 4 connector runtime jar bundles neither Jersey
+// nor the Gravitino server.
+configurations.testRuntimeClasspath {
+  resolutionStrategy {
+    force("javax.ws.rs:javax.ws.rs-api:$javaxWsRsVersion")
+    force("org.glassfish.jersey.core:jersey-server:$jerseyVersion")
+    force("org.glassfish.jersey.core:jersey-common:$jerseyVersion")
+    force("org.glassfish.jersey.core:jersey-client:$jerseyVersion")
+    force("org.glassfish.jersey.containers:jersey-container-servlet:$jerseyVersion")
+    force("org.glassfish.jersey.containers:jersey-container-servlet-core:$jerseyVersion")
+    force("org.glassfish.jersey.containers:jersey-container-jetty-http:$jerseyVersion")
+    force("org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion")
+    force("org.glassfish.hk2:hk2-api:$hk2Version")
+    force("org.glassfish.hk2:hk2-locator:$hk2Version")
+    force("org.glassfish.hk2:hk2-utils:$hk2Version")
+    force("org.glassfish.hk2.external:aopalliance-repackaged:$hk2Version")
+    force("org.glassfish.hk2.external:jakarta.inject:$hk2Version")
+    force("jakarta.validation:jakarta.validation-api:$jakartaValidationVersion")
+  }
+}
+
+dependencies {
+  implementation(project(":catalogs:catalog-common")) {
+    exclude("org.apache.logging.log4j")
+  }
+  implementation(libs.guava)
+  implementation(libs.caffeine)
+
+  compileOnly("org.apache.kyuubi:kyuubi-spark-connector-hive_$scalaVersion:$kyuubiVersion")
+  compileOnly("org.apache.spark:spark-catalyst_$scalaVersion:$sparkVersion") {
+    exclude("com.fasterxml.jackson")
+  }
+  compileOnly("org.apache.spark:spark-core_$scalaVersion:$sparkVersion")
+  compileOnly("org.apache.spark:spark-sql_$scalaVersion:$sparkVersion")
+  compileOnly(project(":clients:client-java-runtime", configuration = "shadow"))
+  compileOnly("org.apache.iceberg:iceberg-spark-runtime-${sparkMajorVersion}_$scalaVersion:$icebergVersion")
+  compileOnly(libs.aws.glue)
+
+  annotationProcessor(libs.lombok)
+  compileOnly(libs.lombok)
+
+  testAnnotationProcessor(libs.lombok)
+  testCompileOnly(libs.lombok)
+
+  testImplementation(project(":api")) {
+    exclude("org.apache.logging.log4j")
+  }
+  testImplementation(project(":catalogs:catalog-glue")) {
+    exclude("org.apache.logging.log4j")
+  }
+  testImplementation(project(":catalogs:catalog-jdbc-common")) {
+    exclude("org.apache.logging.log4j")
+  }
+  testImplementation(project(":catalogs:hive-metastore-common")) {
+    exclude("*")
+  }
+  testImplementation(project(":clients:client-java")) {
+    exclude("org.apache.logging.log4j")
+    exclude("org.slf4j")
+  }
+  testImplementation(project(":core")) {
+    exclude("org.apache.logging.log4j")
+    exclude("org.slf4j")
+  }
+  testImplementation(project(":common")) {
+    exclude("org.apache.logging.log4j")
+    exclude("org.slf4j")
+  }
+  testImplementation(project(":integration-test-common", "testArtifacts")) {
+    exclude("org.apache.logging.log4j")
+    exclude("org.slf4j")
+  }
+  testImplementation(project(":server")) {
+    exclude("org.apache.logging.log4j")
+    exclude("org.slf4j")
+  }
+  testImplementation(project(":server-common")) {
+    exclude("org.apache.logging.log4j")
+    exclude("org.slf4j")
+  }
+
+  testImplementation(libs.awaitility)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.mockito.inline)
+  testImplementation(libs.nimbus.jose.jwt)
+  // Spark 3.x pulled javax.ws.rs transitively via spark-hive; Spark 4 no longer does, so the
+  // embedded MiniGravitino server started by the ITs needs the JAX-RS API added explicitly.
+  testImplementation(libs.javax.ws.rs.api)
+  // Iceberg's GlueCatalog references several AWS SDK modules at runtime; must be on test classpath
+  testImplementation(libs.aws.dynamodb)
+  testImplementation(libs.aws.glue)
+  testImplementation(libs.aws.kms)
+  testImplementation(libs.aws.s3)
+  testImplementation(libs.aws.sts)
+  testImplementation(libs.hadoop3.aws)
+  // hadoop-aws declares hadoop-client-api as provided; add it explicitly so S3AFileSystem can load
+  // org.apache.hadoop.fs.impl.prefetch.PrefetchingStatistics (added in 3.3.5) at runtime.
+  testImplementation(libs.hadoop3.client.api)
+  testImplementation(libs.hive2.common) {
+    exclude("com.sun.jersey")
+    exclude("org.apache.curator")
+    exclude("org.apache.logging.log4j")
+    // use hadoop from Spark
+    exclude("org.apache.hadoop")
+    exclude("org.eclipse.jetty.aggregate", "jetty-all")
+    exclude("org.eclipse.jetty.orbit", "javax.servlet")
+  }
+  testImplementation(libs.hive2.metastore) {
+    exclude("co.cask.tephra")
+    exclude("com.github.joshelser")
+    exclude("com.google.code.findbugs", "jsr305")
+    exclude("com.google.code.findbugs", "sr305")
+    exclude("com.tdunning", "json")
+    exclude("com.zaxxer", "HikariCP")
+    exclude("com.sun.jersey")
+    exclude("io.dropwizard.metrics")
+    exclude("javax.transaction", "transaction-api")
+    exclude("org.apache.avro")
+    exclude("org.apache.curator")
+    exclude("org.apache.hbase")
+    exclude("org.apache.hadoop")
+    exclude("org.apache.hive", "hive-common")
+    exclude("org.apache.hive", "hive-shims")
+    exclude("org.apache.logging.log4j")
+    exclude("org.apache.parquet", "parquet-hadoop-bundle")
+    exclude("org.apache.zookeeper")
+    exclude("org.eclipse.jetty.aggregate", "jetty-all")
+    exclude("org.eclipse.jetty.orbit", "javax.servlet")
+    exclude("org.slf4j")
+  }
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.mysql.driver)
+  testImplementation(libs.postgresql.driver)
+  testImplementation(libs.testcontainers)
+
+  // iceberg-core must precede iceberg-spark-runtime: RESTSerializers#registerAll has a different
+  // signature in each, and the MiniGravitino server needs the iceberg-core one.
+  testImplementation("org.apache.iceberg:iceberg-core:$icebergVersion")
+  testImplementation("org.apache.iceberg:iceberg-spark-runtime-${sparkMajorVersion}_$scalaVersion:$icebergVersion")
+  testImplementation("org.apache.iceberg:iceberg-hive-metastore:$icebergVersion")
+  testImplementation("org.apache.kyuubi:kyuubi-spark-connector-hive_$scalaVersion:$kyuubiVersion")
+  testImplementation("org.apache.spark:spark-hive_$scalaVersion:$sparkVersion") {
+    // conflict with Gravitino server jersey
+    exclude("org.glassfish.jersey.core")
+    exclude("org.glassfish.jersey.containers")
+    exclude("org.glassfish.jersey.inject")
+    exclude("com.sun.jersey")
+    exclude("com.fasterxml.jackson")
+    exclude("com.fasterxml.jackson.core")
+  }
+  testImplementation("org.scala-lang.modules:scala-collection-compat_$scalaVersion:$scalaCollectionCompatVersion")
+  testImplementation("org.apache.spark:spark-catalyst_$scalaVersion:$sparkVersion")
+  testImplementation("org.apache.spark:spark-core_$scalaVersion:$sparkVersion")
+  testImplementation("org.apache.spark:spark-sql_$scalaVersion:$sparkVersion")
+
+  testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+tasks.test {
+  val skipITs = project.hasProperty("skipITs")
+  val enableSparkSQLITs = project.hasProperty("enableSparkSQLITs")
+  if (!enableSparkSQLITs) {
+    exclude("**/integration/test/sql/**")
+  }
+  if (skipITs) {
+    exclude("**/integration/test/**")
+  } else {
+    dependsOn(tasks.jar)
+    dependsOn(":catalogs:catalog-lakehouse-iceberg:jar")
+    dependsOn(":catalogs:catalog-hive:jar")
+    dependsOn(":iceberg:iceberg-rest-server:jar")
+    dependsOn(":lance:lance-rest-server:jar")
+    dependsOn(":catalogs:catalog-jdbc-mysql:jar")
+    dependsOn(":catalogs:catalog-jdbc-postgresql:jar")
+
+    // Spark 4's web UI serves its REST API with Jersey 3 (jakarta.servlet) on its shaded Jetty,
+    // while the embedded Gravitino server needs Jersey 2 (javax.servlet) on Jetty 9 -- the two
+    // cannot coexist on one classpath, and the block above pins Jersey to 2.x for the server. The
+    // ITs never look at the UI, so turn it off. SparkConf loads defaults from "spark.*" system
+    // properties, so this reaches the session without touching the shared SparkEnvIT.
+    systemProperty("spark.ui.enabled", "false")
+  }
+}
+
+tasks.withType<Jar> {
+  archiveBaseName.set(artifactName)
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = artifactName
+    }
+  }
+}
+
+tasks.clean {
+  delete("derby.log")
+  delete("metastore_db")
+  delete("spark-warehouse")
+}
+
+tasks.named<Jar>("sourcesJar") {
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}

--- a/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/authorization/GravitinoAuthorizationSparkSessionExtensions.java
+++ b/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/authorization/GravitinoAuthorizationSparkSessionExtensions.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.authorization;
+
+import org.apache.spark.sql.SparkSessionExtensions;
+import org.apache.spark.sql.catalyst.FunctionIdentifier;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.parser.ParameterContext;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructType;
+import scala.Function1;
+import scala.collection.immutable.Seq;
+
+/**
+ * Registers Gravitino authorization checks with a Spark session.
+ *
+ * <p>This is the Spark 4.1 copy. Each version module carries one at this name, because the parser
+ * can implement only one Spark version's {@code ParserInterface}: Spark 4 added the abstract {@code
+ * parseRoutineParam}, and Spark 4.1 added {@code parsePlanWithParameters}. Everything else here
+ * matches the Spark 4.0 copy in {@code v4.0/spark}.
+ */
+public class GravitinoAuthorizationSparkSessionExtensions
+    implements Function1<SparkSessionExtensions, Void> {
+
+  @Override
+  public Void apply(SparkSessionExtensions extensions) {
+    // Post-hoc resolution runs after every relation is resolved but before checkAnalysis, so all
+    // denied tables are reported together rather than failing on the first resolution error.
+    extensions.injectPostHocResolutionRule(session -> new RequiredPrivilegesCheck());
+    extensions.injectParser((session, parser) -> new AuthorizationParser(parser));
+    return null;
+  }
+
+  private static class AuthorizationParser implements ParserInterface {
+    private final ParserInterface delegate;
+
+    private AuthorizationParser(ParserInterface delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public LogicalPlan parsePlan(String sqlText) throws ParseException {
+      AuthorizationTable.clear();
+      return delegate.parsePlan(sqlText);
+    }
+
+    // Spark 4.1 routes SparkSession.sql through this method, and the interface default drops the
+    // parameter context by falling back to parsePlan, which leaves parameter markers unbound.
+    @Override
+    public LogicalPlan parsePlanWithParameters(String sqlText, ParameterContext parameterContext)
+        throws ParseException {
+      AuthorizationTable.clear();
+      return delegate.parsePlanWithParameters(sqlText, parameterContext);
+    }
+
+    @Override
+    public Expression parseExpression(String sqlText) throws ParseException {
+      return delegate.parseExpression(sqlText);
+    }
+
+    @Override
+    public TableIdentifier parseTableIdentifier(String sqlText) throws ParseException {
+      return delegate.parseTableIdentifier(sqlText);
+    }
+
+    @Override
+    public FunctionIdentifier parseFunctionIdentifier(String sqlText) throws ParseException {
+      return delegate.parseFunctionIdentifier(sqlText);
+    }
+
+    @Override
+    public Seq<String> parseMultipartIdentifier(String sqlText) throws ParseException {
+      return delegate.parseMultipartIdentifier(sqlText).toList();
+    }
+
+    @Override
+    public LogicalPlan parseQuery(String sqlText) throws ParseException {
+      AuthorizationTable.clear();
+      return delegate.parseQuery(sqlText);
+    }
+
+    @Override
+    public StructType parseTableSchema(String sqlText) throws ParseException {
+      return delegate.parseTableSchema(sqlText);
+    }
+
+    @Override
+    public DataType parseDataType(String sqlText) throws ParseException {
+      return delegate.parseDataType(sqlText);
+    }
+
+    @Override
+    public StructType parseRoutineParam(String sqlText) throws ParseException {
+      return delegate.parseRoutineParam(sqlText);
+    }
+  }
+}

--- a/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/glue/GravitinoGlueCatalogSpark41.java
+++ b/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/glue/GravitinoGlueCatalogSpark41.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.glue;
+
+/** Spark 4.1 specific Gravitino Glue catalog implementation. */
+public class GravitinoGlueCatalogSpark41 extends GravitinoGlueCatalog {}

--- a/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalogSpark41.java
+++ b/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalogSpark41.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.hive;
+
+/** Spark 4.1 specific Gravitino Hive catalog implementation. */
+public class GravitinoHiveCatalogSpark41 extends GravitinoHiveCatalog {}

--- a/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/iceberg/GravitinoIcebergCatalogSpark41.java
+++ b/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/iceberg/GravitinoIcebergCatalogSpark41.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.iceberg;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import org.apache.iceberg.spark.procedures.SparkProcedures;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.ProcedureCatalog;
+import org.apache.spark.sql.connector.catalog.procedures.UnboundProcedure;
+
+/**
+ * Spark 4.1 specific Gravitino Iceberg catalog implementation. {@link ProcedureCatalog} is declared
+ * here rather than in the shared base because Spark 4 moved the procedure types out of Iceberg's
+ * package into its own and changed {@code loadProcedure} to return {@link UnboundProcedure}.
+ */
+public class GravitinoIcebergCatalogSpark41 extends GravitinoIcebergCatalog
+    implements ProcedureCatalog {
+
+  /**
+   * Procedures validate that the catalog registered with Spark's catalogManager is the same one
+   * passed to the {@code ProcedureBuilder} that invokes loadProcedure(). Pass this catalog rather
+   * than the internal Spark catalog to satisfy that check.
+   */
+  @Override
+  public UnboundProcedure loadProcedure(Identifier identifier) {
+    String[] namespace = identifier.namespace();
+    String name = identifier.name();
+
+    try {
+      if (isSystemNamespace(namespace)) {
+        SparkProcedures.ProcedureBuilder builder = SparkProcedures.newBuilder(name);
+        if (builder != null) {
+          return builder.withTableCatalog(this).build();
+        }
+      }
+    } catch (NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException
+        | ClassNotFoundException e) {
+      throw new RuntimeException("Failed to load Iceberg Procedure " + identifier, e);
+    }
+
+    // Spark 4 ships no NoSuchProcedureException: it wraps whatever loadProcedure throws in
+    // FAILED_TO_LOAD_ROUTINE unless the exception is already a SparkThrowable. Iceberg's own
+    // BaseCatalog throws a plain RuntimeException here for the same reason, so match it.
+    throw new RuntimeException("Procedure does not exist: " + identifier);
+  }
+
+  /** Spark 4.1 added this method to {@code ProcedureCatalog}; Spark 4.0 has no equivalent. */
+  @Override
+  public Identifier[] listProcedures(String[] namespace) {
+    try {
+      if (isSystemNamespace(namespace)) {
+        return SparkProcedures.names().stream()
+            .map(name -> Identifier.of(namespace, name))
+            .toArray(Identifier[]::new);
+      }
+    } catch (NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException
+        | ClassNotFoundException e) {
+      throw new RuntimeException(
+          "Failed to list Iceberg Procedures under " + Arrays.toString(namespace), e);
+    }
+    return new Identifier[0];
+  }
+}

--- a/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/jdbc/GravitinoJdbcCatalogSpark41.java
+++ b/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/jdbc/GravitinoJdbcCatalogSpark41.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.jdbc;
+
+/** Spark 4.1 specific Gravitino JDBC catalog implementation. */
+public class GravitinoJdbcCatalogSpark41 extends GravitinoJdbcCatalog {}

--- a/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/jdbc/postgresql/GravitinoPostgreSqlCatalogSpark41.java
+++ b/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/jdbc/postgresql/GravitinoPostgreSqlCatalogSpark41.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.jdbc.postgresql;
+
+import org.apache.gravitino.spark.connector.PropertiesConverter;
+import org.apache.gravitino.spark.connector.jdbc.GravitinoJdbcCatalog;
+import org.apache.gravitino.spark.connector.jdbc.JdbcPropertiesConverter;
+
+/** Spark 4.1 specific Gravitino PostgreSQL catalog implementation. */
+public class GravitinoPostgreSqlCatalogSpark41 extends GravitinoJdbcCatalog {
+  @Override
+  protected PropertiesConverter getPropertiesConverter() {
+    return JdbcPropertiesConverter.getNoTablePropertiesInstance();
+  }
+}

--- a/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoSparkPlugin.java
+++ b/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoSparkPlugin.java
@@ -38,8 +38,8 @@ import org.apache.spark.api.plugin.SparkPlugin;
  * compile-time class references, so a renamed or missing class fails the build rather than the
  * session, and a jar can only bind classes it actually contains.
  *
- * <p>No Paimon catalog is bound: Paimon publishes no {@code paimon-spark-4.1} artifact at any
- * version, so the Spark 4.1 build has no Paimon catalog to name.
+ * <p>No Paimon catalog is bound: Paimon publishes no {@code paimon-spark-4.1} artifact at the
+ * versions released so far, so the Spark 4.1 build has no Paimon catalog to name.
  */
 public class GravitinoSparkPlugin implements SparkPlugin {
 

--- a/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoSparkPlugin.java
+++ b/spark-connector/v4.1/spark/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoSparkPlugin.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.plugin;
+
+import org.apache.gravitino.spark.connector.authorization.GravitinoAuthorizationSparkSessionExtensions;
+import org.apache.gravitino.spark.connector.catalog.SparkCatalogKind;
+import org.apache.gravitino.spark.connector.glue.GravitinoGlueCatalogSpark41;
+import org.apache.gravitino.spark.connector.hive.GravitinoHiveCatalogSpark41;
+import org.apache.gravitino.spark.connector.iceberg.GravitinoIcebergCatalogSpark41;
+import org.apache.gravitino.spark.connector.jdbc.GravitinoJdbcCatalogSpark41;
+import org.apache.gravitino.spark.connector.jdbc.postgresql.GravitinoPostgreSqlCatalogSpark41;
+import org.apache.spark.api.plugin.DriverPlugin;
+import org.apache.spark.api.plugin.ExecutorPlugin;
+import org.apache.spark.api.plugin.SparkPlugin;
+
+/**
+ * The entrypoint for Apache Gravitino Spark connector on Spark 4.1.
+ *
+ * <p>Every supported Spark version has a class of this name in this package, which is what users
+ * name in {@code spark.plugins}. Each one binds the classes its own Spark version needs, as
+ * compile-time class references, so a renamed or missing class fails the build rather than the
+ * session, and a jar can only bind classes it actually contains.
+ *
+ * <p>No Paimon catalog is bound: Paimon publishes no {@code paimon-spark-4.1} artifact at any
+ * version, so the Spark 4.1 build has no Paimon catalog to name.
+ */
+public class GravitinoSparkPlugin implements SparkPlugin {
+
+  @Override
+  public DriverPlugin driverPlugin() {
+    return new GravitinoDriverPlugin(bindings());
+  }
+
+  @Override
+  public ExecutorPlugin executorPlugin() {
+    return null;
+  }
+
+  private static SparkBindings bindings() {
+    return SparkBindings.builder()
+        .authorizationExtension(GravitinoAuthorizationSparkSessionExtensions.class)
+        .catalog(SparkCatalogKind.HIVE, GravitinoHiveCatalogSpark41.class)
+        .catalog(SparkCatalogKind.LAKEHOUSE_ICEBERG, GravitinoIcebergCatalogSpark41.class)
+        .catalog(SparkCatalogKind.GLUE, GravitinoGlueCatalogSpark41.class)
+        .catalog(SparkCatalogKind.JDBC, GravitinoJdbcCatalogSpark41.class)
+        .catalog(SparkCatalogKind.JDBC_POSTGRESQL, GravitinoPostgreSqlCatalogSpark41.class)
+        .build();
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/authorization/TestGravitinoAuthorizationSparkSessionExtensions.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/authorization/TestGravitinoAuthorizationSparkSessionExtensions.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.authorization;
+
+import java.util.Collections;
+import org.apache.gravitino.authorization.Privilege;
+import org.apache.gravitino.exceptions.ForbiddenException;
+import org.apache.spark.sql.SparkSessionExtensions;
+import org.apache.spark.sql.catalyst.parser.ParameterContext;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests the parser this module injects. Spark 4.1 added {@code parsePlanWithParameters} to {@code
+ * ParserInterface} and gave it a default body, so a wrapper that forgets to forward it compiles and
+ * then silently drops the parameter context that {@code SparkSession.sql} passes.
+ */
+public class TestGravitinoAuthorizationSparkSessionExtensions {
+
+  @AfterEach
+  void clearDeniedTables() {
+    AuthorizationTable.clear();
+  }
+
+  @Test
+  void testParsePlanWithParametersForwardsTheParameterContext() throws ParseException {
+    ParserInterface delegate = Mockito.mock(ParserInterface.class);
+    ParameterContext parameterContext = Mockito.mock(ParameterContext.class);
+
+    injectedParser(delegate).parsePlanWithParameters("SELECT ?", parameterContext);
+
+    Mockito.verify(delegate).parsePlanWithParameters("SELECT ?", parameterContext);
+    // The inherited default would come through parsePlan and lose the context, which leaves the
+    // parameter markers unbound outside legacy parameter substitution.
+    Mockito.verify(delegate, Mockito.never()).parsePlan(Mockito.anyString());
+  }
+
+  @Test
+  void testParsePlanWithParametersClearsTheDeniedTablesFirst() throws ParseException {
+    ParserInterface parser = injectedParser(Mockito.mock(ParserInterface.class));
+    AuthorizationTable.deny(
+        "t",
+        "metalake.catalog.schema.t",
+        Collections.singleton(Privilege.Name.SELECT_TABLE),
+        new ForbiddenException("denied"));
+
+    parser.parsePlanWithParameters("SELECT ?", Mockito.mock(ParameterContext.class));
+
+    Assertions.assertFalse(
+        AuthorizationTable.drainFailure().isPresent(),
+        "a denial recorded before the parse must not carry into the plan parsed after it");
+  }
+
+  private static ParserInterface injectedParser(ParserInterface delegate) {
+    SparkSessionExtensions extensions = new SparkSessionExtensions();
+    new GravitinoAuthorizationSparkSessionExtensions().apply(extensions);
+    // The injected builder ignores the session, so a null one is enough to reach the wrapper.
+    return extensions.buildParser(null, delegate);
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/authorization/TestGravitinoAuthorizationSparkSessionExtensions.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/authorization/TestGravitinoAuthorizationSparkSessionExtensions.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.spark.connector.authorization;
 
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.spark.sql.SparkSessionExtensions;
@@ -57,19 +58,34 @@ public class TestGravitinoAuthorizationSparkSessionExtensions {
   }
 
   @Test
-  void testParsePlanWithParametersClearsTheDeniedTablesFirst() throws ParseException {
-    ParserInterface parser = injectedParser(Mockito.mock(ParserInterface.class));
+  void testParsePlanWithParametersClearsTheDeniedTablesBeforeDelegating() throws ParseException {
+    ParserInterface delegate = Mockito.mock(ParserInterface.class);
+    ParameterContext parameterContext = Mockito.mock(ParameterContext.class);
+    // Read the denied tables from inside the delegate rather than after the call: the wrapper's own
+    // parsePlan clears them too, so a check made afterwards passes whether or not this method
+    // forwards. Both the ThreadLocal and the answer run on this thread.
+    AtomicBoolean denialReachedTheDelegate = new AtomicBoolean(true);
+    Mockito.when(delegate.parsePlanWithParameters(Mockito.anyString(), Mockito.any()))
+        .thenAnswer(
+            invocation -> {
+              denialReachedTheDelegate.set(AuthorizationTable.drainFailure().isPresent());
+              return null;
+            });
+    ParserInterface parser = injectedParser(delegate);
     AuthorizationTable.deny(
         "t",
         "metalake.catalog.schema.t",
         Collections.singleton(Privilege.Name.SELECT_TABLE),
         new ForbiddenException("denied"));
 
-    parser.parsePlanWithParameters("SELECT ?", Mockito.mock(ParameterContext.class));
+    parser.parsePlanWithParameters("SELECT ?", parameterContext);
 
+    // Verify the delegation separately: without it, a wrapper that never forwarded would fail below
+    // with a message about clearing rather than about forwarding.
+    Mockito.verify(delegate).parsePlanWithParameters("SELECT ?", parameterContext);
     Assertions.assertFalse(
-        AuthorizationTable.drainFailure().isPresent(),
-        "a denial recorded before the parse must not carry into the plan parsed after it");
+        denialReachedTheDelegate.get(),
+        "a denial recorded before the parse must be cleared before this method delegates");
   }
 
   private static ParserInterface injectedParser(ParserInterface delegate) {

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/authorization/SparkAuthorizationIT41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/authorization/SparkAuthorizationIT41.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.authorization;
+
+/** Spark 4.1 authorization integration tests. */
+public class SparkAuthorizationIT41 extends SparkAuthorizationIT {}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/authorization/SparkJwksAuthorizationIT41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/authorization/SparkJwksAuthorizationIT41.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.authorization;
+
+/** Spark 4.1 authorization integration tests against a JWKS-backed Gravitino server. */
+public class SparkJwksAuthorizationIT41 extends SparkJwksAuthorizationIT {}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT41.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.hive;
+
+import org.apache.gravitino.spark.connector.hive.GravitinoHiveCatalogSpark41;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SparkHiveCatalogIT41 extends SparkHiveCatalogIT {
+  @Test
+  void testCatalogClassName() {
+    String catalogClass =
+        getSparkSession()
+            .sessionState()
+            .conf()
+            .getConfString("spark.sql.catalog." + getCatalogName());
+    Assertions.assertEquals(GravitinoHiveCatalogSpark41.class.getName(), catalogClass);
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/IcebergMetadataColumnsSpark41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/IcebergMetadataColumnsSpark41.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.iceberg;
+
+import org.apache.gravitino.spark.connector.integration.test.util.SparkMetadataColumnInfo;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+
+/**
+ * The metadata columns Iceberg reports from its Spark 4.1 module, which differ from its 3.5 one.
+ *
+ * <p>The row-lineage columns ({@code _row_id}, {@code _last_updated_sequence_number}) only show up
+ * for tables that support row lineage, meaning format version 3 and above, while the 3.5 module
+ * reports them unconditionally; these ITs create format version 2 tables, Iceberg's default. {@code
+ * _spec_id} is also nullable here and non-nullable on 3.5.
+ *
+ * <p>Every Iceberg IT on this line needs the same answer, and the two backends inherit from
+ * different shared bases, so it lives here rather than being overridden twice.
+ */
+final class IcebergMetadataColumnsSpark41 {
+
+  private IcebergMetadataColumnsSpark41() {}
+
+  /** Returns a fresh array each call: the shared ITs mutate entries of it in place. */
+  static SparkMetadataColumnInfo[] newMetadataColumns() {
+    return new SparkMetadataColumnInfo[] {
+      new SparkMetadataColumnInfo("_spec_id", DataTypes.IntegerType, true),
+      new SparkMetadataColumnInfo(
+          "_partition",
+          DataTypes.createStructType(
+              new StructField[] {DataTypes.createStructField("name", DataTypes.StringType, true)}),
+          true),
+      new SparkMetadataColumnInfo("_file", DataTypes.StringType, false),
+      new SparkMetadataColumnInfo("_pos", DataTypes.LongType, false),
+      new SparkMetadataColumnInfo("_deleted", DataTypes.BooleanType, false)
+    };
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogHiveBackendIT41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogHiveBackendIT41.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.iceberg;
+
+import org.apache.gravitino.spark.connector.iceberg.GravitinoIcebergCatalogSpark41;
+import org.apache.gravitino.spark.connector.integration.test.util.SparkMetadataColumnInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SparkIcebergCatalogHiveBackendIT41 extends SparkIcebergCatalogHiveBackendIT {
+
+  @Test
+  void testCatalogClassName() {
+    String catalogClass =
+        getSparkSession()
+            .sessionState()
+            .conf()
+            .getConfString("spark.sql.catalog." + getCatalogName());
+    Assertions.assertEquals(GravitinoIcebergCatalogSpark41.class.getName(), catalogClass);
+  }
+
+  @Override
+  protected SparkMetadataColumnInfo[] getIcebergMetadataColumns() {
+    return IcebergMetadataColumnsSpark41.newMetadataColumns();
+  }
+
+  @Override
+  protected Class<? extends Throwable> unknownVersionException() {
+    return IllegalArgumentException.class;
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogRestBackendIT41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogRestBackendIT41.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.iceberg;
+
+import org.apache.gravitino.spark.connector.integration.test.util.SparkMetadataColumnInfo;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+/**
+ * Runs the shared Iceberg suite against the Iceberg REST backend on Spark 4.1. The base is disabled
+ * in embedded mode; repeating the condition here matches what the 3.5 subclass does.
+ */
+@DisabledIf("org.apache.gravitino.integration.test.util.ITUtils#isEmbedded")
+public class SparkIcebergCatalogRestBackendIT41 extends SparkIcebergCatalogRestBackendIT {
+
+  @Override
+  protected SparkMetadataColumnInfo[] getIcebergMetadataColumns() {
+    return IcebergMetadataColumnsSpark41.newMetadataColumns();
+  }
+
+  @Override
+  protected Class<? extends Throwable> unknownVersionException() {
+    return IllegalArgumentException.class;
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogRestRoutingIT41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogRestRoutingIT41.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.iceberg;
+
+import org.apache.gravitino.spark.connector.integration.test.util.SparkMetadataColumnInfo;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+/**
+ * Runs the shared Iceberg suite against a Hive-backed catalog routed through the Iceberg REST
+ * server on Spark 4.1. The base is disabled in embedded mode; repeating the condition here matches
+ * what the 3.5 subclass does.
+ */
+@DisabledIf("org.apache.gravitino.integration.test.util.ITUtils#isEmbedded")
+public class SparkIcebergCatalogRestRoutingIT41 extends SparkIcebergCatalogRestRoutingIT {
+
+  @Override
+  protected SparkMetadataColumnInfo[] getIcebergMetadataColumns() {
+    return IcebergMetadataColumnsSpark41.newMetadataColumns();
+  }
+
+  @Override
+  protected Class<? extends Throwable> unknownVersionException() {
+    return IllegalArgumentException.class;
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/jdbc/SparkJdbcMysqlCatalogIT41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/jdbc/SparkJdbcMysqlCatalogIT41.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.jdbc;
+
+import org.apache.gravitino.spark.connector.jdbc.GravitinoJdbcCatalogSpark41;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SparkJdbcMysqlCatalogIT41 extends SparkJdbcMysqlCatalogIT {
+  @Test
+  void testCatalogClassName() {
+    String catalogClass =
+        getSparkSession()
+            .sessionState()
+            .conf()
+            .getConfString("spark.sql.catalog." + getCatalogName());
+    Assertions.assertEquals(GravitinoJdbcCatalogSpark41.class.getName(), catalogClass);
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/jdbc/SparkJdbcPostgreSqlCatalogIT41.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/jdbc/SparkJdbcPostgreSqlCatalogIT41.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.jdbc;
+
+import org.apache.gravitino.spark.connector.jdbc.postgresql.GravitinoPostgreSqlCatalogSpark41;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SparkJdbcPostgreSqlCatalogIT41 extends SparkJdbcPostgreSqlCatalogIT {
+  @Test
+  void testCatalogClassName() {
+    String catalogClass =
+        getSparkSession()
+            .sessionState()
+            .conf()
+            .getConfString("spark.sql.catalog." + getCatalogName());
+    Assertions.assertEquals(GravitinoPostgreSqlCatalogSpark41.class.getName(), catalogClass);
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/plugin/TestGravitinoSparkPlugin.java
+++ b/spark-connector/v4.1/spark/src/test/java/org/apache/gravitino/spark/connector/plugin/TestGravitinoSparkPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.plugin;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that this module's bindings are complete. Constructing the driver plugin runs {@code
+ * SparkBindings.build()}, whose Preconditions reject a missing binding, so a catalog this module
+ * forgot to bind fails here rather than at session startup.
+ */
+public class TestGravitinoSparkPlugin {
+
+  @Test
+  void testTheBindingsThisModuleDeclaresAreComplete() {
+    Assertions.assertNotNull(new GravitinoSparkPlugin().driverPlugin());
+  }
+}

--- a/spark-connector/v4.1/spark/src/test/resources/log4j2.properties
+++ b/spark-connector/v4.1/spark/src/test/resources/log4j2.properties
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Set to debug or trace if log4j initialization is failing
+status = info
+
+# Name of the configuration
+name = ConsoleLogConfig
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+# Log files location
+property.logPath = ${sys:gravitino.log.path:-integration-test/build/integration-test.log}
+
+# File appender configuration
+appender.file.type = File
+appender.file.name = fileLogger
+appender.file.fileName = ${logPath}
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+# Root logger level
+rootLogger.level = info
+
+# Root logger referring to console and file appenders
+rootLogger.appenderRef.stdout.ref = consoleLogger
+rootLogger.appenderRef.file.ref = fileLogger


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a `spark-connector/v4.1` module mirroring `v4.0`, published as `gravitino-spark-4.1_2.13` and `gravitino-spark-connector-runtime-4.1_2.13`, pinned to Spark 4.1.3 and the same Iceberg 1.11.0 the other lines use.

Four Spark 4.1 API changes needed more than a copy:

- `ParserInterface.parsePlanWithParameters` is new in 4.1 with a default body, and `SparkSession.sql` calls it for every query. The authorization parser forwards it explicitly; inheriting the default routes through `parsePlan` and drops the parameter context, which leaves parameter markers unbound outside legacy parameter substitution.
- Iceberg's Spark 4.1 module publishes only `SparkTable(Table)`, and Spark 4.1's `JDBCTable` takes a fourth constructor argument. The superclass constructor call for the two shared table classes now comes from a per-line base class under `spark-common/src/main/spark35`, `spark40` and `spark41`, so the table bodies stay shared.
- `ProcedureCatalog.listProcedures` is abstract in 4.1, implemented the way Iceberg's own `BaseCatalog` does it.
- Iceberg raises a different exception for a version reference that no longer exists: up to its Spark 4.0 module the check lives in `SparkCatalog` and throws `ValidationException`, and from its Spark 4.1 one it lives in `SparkTable` and throws `IllegalArgumentException`. The shared Iceberg IT asks the subclass for the expected type rather than hardcoding it.

Paimon stays out of the build: no released Paimon version publishes `paimon-spark-4.1`.

The 4.1 compile also forced two changes in the shared tree. An unused `org.jetbrains.annotations.NotNull` import had to go, since it resolved only because ORC leaked that jar onto the 4.0 compile classpath and 4.1 no longer does. Two commons-lang3 helpers that the newer commons-lang3 deprecates are now plain Java: `-Xlint:deprecation -Werror` applies to every module, and 4.1 resolves commons-lang3 3.19.0 where 3.5 resolves 3.12.0. `UpdateColumnDefaultValue#newDefaultValue` needs a suppression for the same reason, scoped to that one declaration so the other nine branches of the method keep the gate.

Everything outside `spark-connector/v4.1` is there because 4.1 cannot build or be tested without it. The only touch on an existing line is the `v4.0` build file composing its own copy of the two base classes, since one class name cannot be shadowed per Spark line. None of it changes 3.5 or 4.0 behavior.

### Why are the changes needed?

Spark 4.1 is released and users on it have no connector build. Iceberg 1.11.0 publishes an `iceberg-spark-runtime` for 4.1 and none for 4.2, so 4.1 is the newest line the connector can support.

Fix: #13018

### Does this PR introduce _any_ user-facing change?

Two new published artifacts, `gravitino-spark-4.1_2.13` and `gravitino-spark-connector-runtime-4.1_2.13`. No property or API changes. Paimon is unavailable on 4.1, as it is on 4.0.

### How was this patch tested?

A new unit test pins the parser forwarding. Delete the override and it fails twice: on the `verify` that the delegate received `parsePlanWithParameters`, and on the assertion that the denied-table state was cleared before delegating. The shared integration suite runs against the new module in CI in both embedded and deploy mode, alongside 3.5 and 4.0.
