### PR TITLE
[#13020] fix(hive): Skip HMS stats update for property/comment-only alterTable

### DIFF
--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -740,9 +740,18 @@ public class HiveCatalogOperations
               targetDatabaseName);
 
       HiveTable finalUpdatedTable = updatedTable;
+      // For property-only or comment-only changes, skip the metastore statistics recomputation so
+      // it does not access the table's storage location. This keeps such lightweight alters from
+      // hanging when the underlying filesystem (e.g. HDFS NameNode) is slow or unavailable.
+      boolean skipStatsUpdate = canSkipStatsUpdate(changes);
       clientPool.run(
           c -> {
-            c.alterTable(catalogName, schemaIdent.name(), tableIdent.name(), finalUpdatedTable);
+            c.alterTable(
+                catalogName,
+                schemaIdent.name(),
+                tableIdent.name(),
+                finalUpdatedTable,
+                skipStatsUpdate);
             return null;
           });
 
@@ -764,6 +773,29 @@ public class HiveCatalogOperations
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Determines whether the metastore statistics recomputation can be skipped for the given table
+   * changes. Statistics are tied to the table data, so recomputation is only meaningful when the
+   * data layout may change. Property-only and comment-only alters never touch the data, so they can
+   * safely skip the recomputation (and the storage-location access it triggers). Any column change
+   * or rename falls back to the default behavior.
+   *
+   * @param changes The table changes to be applied.
+   * @return {@code true} if every change is a property or comment change; {@code false} otherwise.
+   */
+  @VisibleForTesting
+  static boolean canSkipStatsUpdate(TableChange[] changes) {
+    if (changes == null || changes.length == 0) {
+      return false;
+    }
+    return Arrays.stream(changes)
+        .allMatch(
+            change ->
+                change instanceof TableChange.SetProperty
+                    || change instanceof TableChange.RemoveProperty
+                    || change instanceof TableChange.UpdateComment);
   }
 
   private HiveTable buildAlteredHiveTable(

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -70,6 +70,7 @@ import org.apache.gravitino.hive.client.HiveClient;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewChange;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;
@@ -1677,5 +1678,48 @@ class TestHiveCatalogOperations {
 
     boolean dropped = op.dropView(NameIdentifier.of("db", "t1"));
     Assertions.assertFalse(dropped);
+  }
+
+  @Test
+  void testCanSkipStatsUpdate() {
+    // Property-only and comment-only changes can skip the metastore statistics recomputation.
+    Assertions.assertTrue(
+        HiveCatalogOperations.canSkipStatsUpdate(
+            new TableChange[] {TableChange.setProperty("k", "v")}));
+    Assertions.assertTrue(
+        HiveCatalogOperations.canSkipStatsUpdate(
+            new TableChange[] {TableChange.removeProperty("k")}));
+    Assertions.assertTrue(
+        HiveCatalogOperations.canSkipStatsUpdate(
+            new TableChange[] {TableChange.updateComment("new comment")}));
+    Assertions.assertTrue(
+        HiveCatalogOperations.canSkipStatsUpdate(
+            new TableChange[] {
+              TableChange.setProperty("k", "v"),
+              TableChange.removeProperty("k2"),
+              TableChange.updateComment("c")
+            }));
+
+    // Column changes and renames must not skip the statistics recomputation.
+    Assertions.assertFalse(
+        HiveCatalogOperations.canSkipStatsUpdate(
+            new TableChange[] {TableChange.addColumn(new String[] {"c"}, Types.StringType.get())}));
+    Assertions.assertFalse(
+        HiveCatalogOperations.canSkipStatsUpdate(
+            new TableChange[] {TableChange.deleteColumn(new String[] {"c"}, true)}));
+    Assertions.assertFalse(
+        HiveCatalogOperations.canSkipStatsUpdate(
+            new TableChange[] {TableChange.rename("newName")}));
+    // A mix that contains a column change falls back to the default behavior.
+    Assertions.assertFalse(
+        HiveCatalogOperations.canSkipStatsUpdate(
+            new TableChange[] {
+              TableChange.setProperty("k", "v"),
+              TableChange.addColumn(new String[] {"c"}, Types.StringType.get())
+            }));
+
+    // No changes: nothing to optimize, keep the default behavior.
+    Assertions.assertFalse(HiveCatalogOperations.canSkipStatsUpdate(new TableChange[] {}));
+    Assertions.assertFalse(HiveCatalogOperations.canSkipStatsUpdate(null));
   }
 }

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClient.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClient.java
@@ -51,8 +51,33 @@ public interface HiveClient extends AutoCloseable {
 
   HiveTable getTable(String catalogName, String databaseName, String tableName);
 
+  default void alterTable(
+      String catalogName, String databaseName, String tableName, HiveTable alteredHiveTable) {
+    alterTable(catalogName, databaseName, tableName, alteredHiveTable, false);
+  }
+
+  /**
+   * Alters a table in the Hive metastore.
+   *
+   * <p>When {@code skipStatsUpdate} is {@code true}, the metastore is instructed (via the {@code
+   * DO_NOT_UPDATE_STATS} environment context) not to recompute table statistics for this alter.
+   * This avoids the metastore accessing the table's storage location (for example an {@code
+   * getFileInfo} call against the NameNode), which is unnecessary for property-only or comment-only
+   * changes and can otherwise make a lightweight alter hang when the underlying filesystem is slow
+   * or unavailable.
+   *
+   * @param catalogName The Hive catalog name.
+   * @param databaseName The database name.
+   * @param tableName The table name.
+   * @param alteredHiveTable The altered table definition.
+   * @param skipStatsUpdate Whether to skip metastore statistics recomputation for this alter.
+   */
   void alterTable(
-      String catalogName, String databaseName, String tableName, HiveTable alteredHiveTable);
+      String catalogName,
+      String databaseName,
+      String tableName,
+      HiveTable alteredHiveTable,
+      boolean skipStatsUpdate);
 
   void dropTable(
       String catalogName,

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClientImpl.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClientImpl.java
@@ -100,8 +100,12 @@ public class HiveClientImpl implements HiveClient {
 
   @Override
   public void alterTable(
-      String catalogName, String databaseName, String tableName, HiveTable alteredHiveTable) {
-    shim.alterTable(catalogName, databaseName, tableName, alteredHiveTable);
+      String catalogName,
+      String databaseName,
+      String tableName,
+      HiveTable alteredHiveTable,
+      boolean skipStatsUpdate) {
+    shim.alterTable(catalogName, databaseName, tableName, alteredHiveTable, skipStatsUpdate);
   }
 
   @Override

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShim.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShim.java
@@ -79,7 +79,11 @@ public abstract class HiveShim {
   public abstract HiveTable getTable(String catalogName, String databaseName, String tableName);
 
   public abstract void alterTable(
-      String catalogName, String databaseName, String tableName, HiveTable alteredHiveTable);
+      String catalogName,
+      String databaseName,
+      String tableName,
+      HiveTable alteredHiveTable,
+      boolean skipStatsUpdate);
 
   public abstract void dropTable(
       String catalogName,

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV2.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV2.java
@@ -317,9 +317,7 @@ class HiveShimV2 extends HiveShim {
    * @return An environment context with {@code DO_NOT_UPDATE_STATS} set to {@code true}.
    */
   protected EnvironmentContext doNotUpdateStatsContext() {
-    // The value is the literal "true" instead of StatsSetupConst.TRUE because that constant does
-    // not exist in all supported Hive versions (for example, it is absent in Hive 3.1.3).
     return new EnvironmentContext(
-        Collections.singletonMap(StatsSetupConst.DO_NOT_UPDATE_STATS, "true"));
+        Collections.singletonMap(StatsSetupConst.DO_NOT_UPDATE_STATS, StatsSetupConst.TRUE));
   }
 }

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV2.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV2.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.hive.client.Util.updateConfigurationFromPrope
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.apache.gravitino.hive.HivePartition;
@@ -31,9 +32,11 @@ import org.apache.gravitino.hive.client.HiveExceptionConverter.ExceptionTarget;
 import org.apache.gravitino.hive.converter.HiveDatabaseConverter;
 import org.apache.gravitino.hive.converter.HiveTableConverter;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 
 class HiveShimV2 extends HiveShim {
 
@@ -148,10 +151,22 @@ class HiveShimV2 extends HiveShim {
 
   @Override
   public void alterTable(
-      String catalogName, String databaseName, String tableName, HiveTable alteredHiveTable) {
+      String catalogName,
+      String databaseName,
+      String tableName,
+      HiveTable alteredHiveTable,
+      boolean skipStatsUpdate) {
     try {
       var tb = HiveTableConverter.toHiveTable(alteredHiveTable);
-      client.alter_table(databaseName, tableName, tb);
+      if (skipStatsUpdate) {
+        // Instruct the metastore not to recompute statistics for this alter, so it does not access
+        // the table's storage location. Hive 2.x has no catalog-aware alter, so the database name
+        // is used directly.
+        client.alter_table_with_environmentContext(
+            databaseName, tableName, tb, doNotUpdateStatsContext());
+      } else {
+        client.alter_table(databaseName, tableName, tb);
+      }
     } catch (Exception e) {
       throw HiveExceptionConverter.toGravitinoException(e, ExceptionTarget.table(tableName));
     }
@@ -293,5 +308,19 @@ class HiveShimV2 extends HiveShim {
   @Override
   public void close() throws Exception {
     client.close();
+  }
+
+  /**
+   * Builds an {@link EnvironmentContext} that tells the metastore not to recompute table statistics
+   * during an alter, avoiding an access to the table's storage location.
+   *
+   * @return An environment context with {@code DO_NOT_UPDATE_STATS} set to {@code true}.
+   */
+  protected EnvironmentContext doNotUpdateStatsContext() {
+    // Use the literal "true" rather than StatsSetupConst.TRUE, which is not present in all
+    // supported
+    // Hive versions (e.g. Hive 3.1.3).
+    return new EnvironmentContext(
+        Collections.singletonMap(StatsSetupConst.DO_NOT_UPDATE_STATS, "true"));
   }
 }

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV2.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV2.java
@@ -317,9 +317,8 @@ class HiveShimV2 extends HiveShim {
    * @return An environment context with {@code DO_NOT_UPDATE_STATS} set to {@code true}.
    */
   protected EnvironmentContext doNotUpdateStatsContext() {
-    // Use the literal "true" rather than StatsSetupConst.TRUE, which is not present in all
-    // supported
-    // Hive versions (e.g. Hive 3.1.3).
+    // The value is the literal "true" instead of StatsSetupConst.TRUE because that constant does
+    // not exist in all supported Hive versions (for example, it is absent in Hive 3.1.3).
     return new EnvironmentContext(
         Collections.singletonMap(StatsSetupConst.DO_NOT_UPDATE_STATS, "true"));
   }

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV3.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV3.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.Table;
 
 class HiveShimV3 extends HiveShimV2 {
@@ -50,6 +51,7 @@ class HiveShimV3 extends HiveShimV2 {
   private final Method getTableMethod;
   private final Method createTableMethod;
   private final Method alterTableMethod;
+  private final Method alterTableWithEnvironmentContextMethod;
   private final Method dropTableMethod;
   private final Method getAllTablesMethod;
   private final Method getTablesByTypeMethod;
@@ -107,6 +109,14 @@ class HiveShimV3 extends HiveShimV2 {
               String.class,
               String.class,
               org.apache.hadoop.hive.metastore.api.Table.class);
+      this.alterTableWithEnvironmentContextMethod =
+          IMetaStoreClient.class.getMethod(
+              "alter_table",
+              String.class,
+              String.class,
+              String.class,
+              Table.class,
+              EnvironmentContext.class);
       this.dropTableMethod =
           IMetaStoreClient.class.getMethod(
               "dropTable", String.class, String.class, String.class, boolean.class, boolean.class);
@@ -293,17 +303,35 @@ class HiveShimV3 extends HiveShimV2 {
 
   @Override
   public void alterTable(
-      String catalogName, String databaseName, String tableName, HiveTable alteredHiveTable) {
+      String catalogName,
+      String databaseName,
+      String tableName,
+      HiveTable alteredHiveTable,
+      boolean skipStatsUpdate) {
     var tb = HiveTableConverter.toHiveTable(alteredHiveTable);
     invoke(ExceptionTarget.other(""), tb, tableSetCatalogNameMethod, catalogName);
-    invoke(
-        ExceptionTarget.table(tableName),
-        client,
-        alterTableMethod,
-        catalogName,
-        databaseName,
-        tableName,
-        tb);
+    if (skipStatsUpdate) {
+      // Instruct the metastore not to recompute statistics for this alter, so it does not access
+      // the table's storage location.
+      invoke(
+          ExceptionTarget.table(tableName),
+          client,
+          alterTableWithEnvironmentContextMethod,
+          catalogName,
+          databaseName,
+          tableName,
+          tb,
+          doNotUpdateStatsContext());
+    } else {
+      invoke(
+          ExceptionTarget.table(tableName),
+          client,
+          alterTableMethod,
+          catalogName,
+          databaseName,
+          tableName,
+          tb);
+    }
   }
 
   @Override

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestHive2HMS.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestHive2HMS.java
@@ -148,7 +148,9 @@ public class TestHive2HMS {
       Assertions.assertEquals(
           1, loadedTable.partitioning().length, "Table should have 1 partition key");
 
-      hiveClient.alterTable(catalogName, dbName, tableName, loadedTable);
+      // Use skipStatsUpdate=true so the metastore does not recompute statistics or access the
+      // table's storage location for this property-only alter.
+      hiveClient.alterTable(catalogName, dbName, tableName, loadedTable, true);
       HiveTable alteredTable = hiveClient.getTable(catalogName, dbName, tableName);
       Assertions.assertNotNull(alteredTable, "Altered table should not be null");
 

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestHiveShimAlterTable.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestHiveShimAlterTable.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.hive.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.gravitino.catalog.hive.HiveConstants;
+import org.apache.gravitino.hive.HiveTable;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.types.Types;
+import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests verifying that the Hive shims send a {@code DO_NOT_UPDATE_STATS} environment context
+ * to the metastore when {@code skipStatsUpdate} is requested, and use the plain alter otherwise.
+ */
+class TestHiveShimAlterTable {
+
+  private static final String CATALOG = "hive";
+  private static final String DB = "db";
+  private static final String TABLE = "tbl";
+
+  /**
+   * A {@link HiveShimV2} that uses a mocked metastore client instead of connecting to a real Hive
+   * Metastore. The mock is created inside {@link #createMetaStoreClient(Properties)} because that
+   * method is invoked from the superclass constructor, before any subclass field is initialized.
+   */
+  private static class MockHiveShimV2 extends HiveShimV2 {
+    MockHiveShimV2() {
+      super(new Properties());
+    }
+
+    @Override
+    public IMetaStoreClient createMetaStoreClient(Properties properties) {
+      return mock(IMetaStoreClient.class);
+    }
+
+    IMetaStoreClient metaStoreClient() {
+      return client;
+    }
+  }
+
+  private HiveTable testTable() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(HiveConstants.LOCATION, "hdfs://ns/warehouse/db.db/tbl");
+    return HiveTable.builder()
+        .withName(TABLE)
+        .withColumns(new Column[] {Column.of("id", Types.IntegerType.get())})
+        .withProperties(properties)
+        .withAuditInfo(
+            AuditInfo.builder().withCreator("tester").withCreateTime(Instant.now()).build())
+        .withCatalogName(CATALOG)
+        .withDatabaseName(DB)
+        .build();
+  }
+
+  @Test
+  void testSkipStatsUpdateSendsDoNotUpdateStats() throws Exception {
+    MockHiveShimV2 shim = new MockHiveShimV2();
+    IMetaStoreClient client = shim.metaStoreClient();
+
+    shim.alterTable(CATALOG, DB, TABLE, testTable(), true);
+
+    ArgumentCaptor<EnvironmentContext> captor = ArgumentCaptor.forClass(EnvironmentContext.class);
+    verify(client)
+        .alter_table_with_environmentContext(eq(DB), eq(TABLE), any(Table.class), captor.capture());
+    Assertions.assertEquals(
+        "true", captor.getValue().getProperties().get(StatsSetupConst.DO_NOT_UPDATE_STATS));
+    verify(client, never()).alter_table(any(), any(), any());
+  }
+
+  @Test
+  void testDefaultUsesPlainAlter() throws Exception {
+    MockHiveShimV2 shim = new MockHiveShimV2();
+    IMetaStoreClient client = shim.metaStoreClient();
+
+    shim.alterTable(CATALOG, DB, TABLE, testTable(), false);
+
+    verify(client).alter_table(eq(DB), eq(TABLE), any(Table.class));
+    verify(client, never()).alter_table_with_environmentContext(any(), any(), any(), any());
+  }
+}

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestHiveShimAlterTable.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestHiveShimAlterTable.java
@@ -97,7 +97,8 @@ class TestHiveShimAlterTable {
     verify(client)
         .alter_table_with_environmentContext(eq(DB), eq(TABLE), any(Table.class), captor.capture());
     Assertions.assertEquals(
-        "true", captor.getValue().getProperties().get(StatsSetupConst.DO_NOT_UPDATE_STATS));
+        StatsSetupConst.TRUE,
+        captor.getValue().getProperties().get(StatsSetupConst.DO_NOT_UPDATE_STATS));
     verify(client, never()).alter_table(any(), any(), any());
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

For Hive-catalog `alterTable` requests that contain only property or comment
changes, pass an `EnvironmentContext` with `DO_NOT_UPDATE_STATS=true` to the
Hive Metastore, so it does not recompute table statistics and therefore does
not access the table's storage location.

- Added an `alterTable(..., boolean skipStatsUpdate)` overload to `HiveClient`
  (the existing overload is kept as a default delegating with
  `skipStatsUpdate=false`), `HiveClientImpl`, and `HiveShim`.
- `HiveShimV2` uses `alter_table_with_environmentContext`; `HiveShimV3` uses the
  catalog-aware `alter_table(..., EnvironmentContext)`. The context is built
  internally so the shared client interface stays free of Hive-specific types.
- `HiveCatalogOperations.alterTable` sets `skipStatsUpdate=true` only when every
  change is a set/remove property or update comment. Column changes and renames
  keep the previous behavior.

### Why are the changes needed?

A property-only or comment-only alter does not change table data, so the
metastore statistics recomputation (and the storage-location access it triggers,
e.g. an HDFS `getFileInfo`) is unnecessary. When the filesystem is slow or
unavailable, such a lightweight alter can block for minutes on the server side.

Fix: #13020 

### Does this PR introduce _any_ user-facing change?

No. There is no API or property change. Property-only and comment-only alters
avoid an unnecessary metastore stats update; all other alter behavior is
unchanged.

### How was this patch tested?

- Added a unit test `TestHiveCatalogOperations#testCanSkipStatsUpdate` covering
  the decision logic (property/comment-only changes skip stats; column changes
  and renames do not; empty/null changes fall back to the default).
- Ran `./gradlew :catalogs:hive-metastore-common:test :catalogs:catalog-hive:test -PskipITs`
  and `spotlessApply`; all pass.
