### PR TITLE
[#12955] improvement(lance): Authorize existing metadata returned by exist_ok mode

### DIFF
--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceAuthorizationExpressions.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceAuthorizationExpressions.java
@@ -130,6 +130,29 @@ public final class LanceAuthorizationExpressions {
           + ")";
 
   /**
+   * Authorizes reading an existing object when a create request uses {@code exist_ok} mode and the
+   * object already exists. The response returns the existing object's metadata, so the caller must
+   * hold the same read privilege that a describe would require. Without this check, a caller with
+   * only {@code CREATE_TABLE} or {@code CREATE_SCHEMA} could obtain metadata that describe would
+   * deny.
+   *
+   * <p>For tables, the expression requires the table read privilege. For namespaces, it requires
+   * catalog access (at catalog level) or schema read (at schema level); the entity type is already
+   * resolved by the interceptor, so only the matching branch is evaluated.
+   */
+  public static final String EXIST_OK_TABLE_AUTHORIZATION_EXPRESSION =
+      "entityType == 'TABLE' && (" + LOAD_TABLE_AUTHORIZATION_EXPRESSION + ")";
+
+  /** See {@link #EXIST_OK_TABLE_AUTHORIZATION_EXPRESSION}; same logic for namespace reads. */
+  public static final String EXIST_OK_NAMESPACE_AUTHORIZATION_EXPRESSION =
+      "(entityType == 'CATALOG' && ("
+          + CAN_ACCESS_METADATA
+          + ")) || "
+          + "(entityType == 'SCHEMA' && ("
+          + LOAD_SCHEMA_AUTHORIZATION_EXPRESSION
+          + "))";
+
+  /**
    * Authorizes removing a table, whether the storage is deleted with it or only the Gravitino
    * metadata is. Both require ownership of the table or of one of its ancestors, matching the
    * Gravitino and Iceberg REST surfaces: MODIFY_TABLE alters a table but never removes it.

--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceMetadataAuthorizationMethodInterceptor.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/authorization/LanceMetadataAuthorizationMethodInterceptor.java
@@ -151,14 +151,16 @@ public class LanceMetadataAuthorizationMethodInterceptor
   }
 
   /**
-   * Returns the handler that authorizes an overwrite of an existing object. The mode of a Lance
-   * create request travels in the request body or in a query parameter rather than in the request
-   * path, so which privileges a create needs cannot be expressed by the method annotation alone.
+   * Returns the handler that authorizes a create request whose mode affects an existing object.
+   *
+   * <p>The mode of a Lance create request travels in the request body or in a query parameter
+   * rather than in the request path, so which privileges a create needs cannot be expressed by the
+   * method annotation alone.
    *
    * @param method invoked protocol method
    * @param parameters invoked method parameters
    * @param args invoked method arguments
-   * @return the overwrite handler for a create request, empty for every other operation
+   * @return the handler for a create request, empty for every other operation
    */
   @Override
   protected Optional<AuthorizationHandler> createAuthorizationHandler(
@@ -167,8 +169,12 @@ public class LanceMetadataAuthorizationMethodInterceptor
         isTableOperation(method)
             ? LanceAuthorizationExpressions.MODIFY_TABLE_AUTHORIZATION_EXPRESSION
             : LanceAuthorizationExpressions.MODIFY_NAMESPACE_AUTHORIZATION_EXPRESSION;
+    String existOkExpression =
+        isTableOperation(method)
+            ? LanceAuthorizationExpressions.EXIST_OK_TABLE_AUTHORIZATION_EXPRESSION
+            : LanceAuthorizationExpressions.EXIST_OK_NAMESPACE_AUTHORIZATION_EXPRESSION;
     return createMode(parameters, args)
-        .map(mode -> new OverwriteAuthzHandler(mode, overwriteExpression));
+        .map(mode -> new CreateModeAuthzHandler(mode, overwriteExpression, existOkExpression));
   }
 
   @Override
@@ -200,60 +206,82 @@ public class LanceMetadataAuthorizationMethodInterceptor
   }
 
   /**
-   * Authorizes a create request whose mode overwrites an object that already exists.
+   * Authorizes a create request whose mode affects an existing object.
    *
    * <p>An overwrite replaces an existing namespace or table, so it is a modification rather than a
    * creation and is authorized against the modification expression for the invoked resource instead
    * of the create expression on the method. Without this, CREATE_CATALOG, CREATE_SCHEMA, or
    * CREATE_TABLE would escalate into permission to replace an object the caller does not own.
    *
+   * <p>The {@code exist_ok} mode returns the existing object's metadata (location, properties,
+   * schema) when the object already exists. That is a read of the object, so the caller must hold
+   * the same read privilege that a describe/probe would require. Without this check, a caller with
+   * only CREATE_TABLE could obtain metadata that DescribeTable would deny.
+   *
    * <p>The mode alone decides this, without probing whether the object exists: an existence probe
    * at authorization time would race with the create that follows it, and the required privilege
    * would then depend on that race.
    */
-  private static final class OverwriteAuthzHandler implements AuthorizationHandler {
+  private static final class CreateModeAuthzHandler implements AuthorizationHandler {
 
     private static final String OVERWRITE_MODE = "OVERWRITE";
+    private static final String EXIST_OK_MODE = "EXIST_OK";
 
     private final boolean overwrite;
-    private final String authorizationExpression;
+    private final boolean existOk;
+    private final String overwriteExpression;
+    private final String existOkExpression;
 
-    private OverwriteAuthzHandler(String mode, String authorizationExpression) {
+    private CreateModeAuthzHandler(
+        String mode, String overwriteExpression, String existOkExpression) {
       // Read the mode through the same normalization the create operation applies, so a token the
-      // operation will act on as an overwrite cannot be authorized as a plain create. Comparing the
-      // raw string here would leave a gap: " overwrite " reaches the operation as OVERWRITE but
-      // would not match, and a caller holding only a create privilege could replace an object owned
-      // by somebody else.
-      this.overwrite = OVERWRITE_MODE.equals(CommonUtil.normalizeToken(mode));
-      this.authorizationExpression = authorizationExpression;
+      // operation will act on as an overwrite or exist_ok cannot be authorized as a plain create.
+      String normalized = CommonUtil.normalizeToken(mode);
+      this.overwrite = OVERWRITE_MODE.equals(normalized);
+      this.existOk = EXIST_OK_MODE.equals(normalized);
+      this.overwriteExpression = overwriteExpression;
+      this.existOkExpression = existOkExpression;
     }
 
     @Override
     public void process(Map<Entity.EntityType, NameIdentifier> nameIdentifierMap) {
-      if (!overwrite) {
-        return;
-      }
-
       Entity.EntityType entityType = deepestEntityType(nameIdentifierMap);
-      boolean authorized =
-          new AuthorizationExpressionEvaluator(authorizationExpression)
-              .evaluate(
-                  nameIdentifierMap,
-                  new HashMap<>(),
-                  new AuthorizationRequestContext(),
-                  Optional.of(entityType.name()));
-      if (!authorized) {
-        throw new ForbiddenException(
-            "User '%s' is not authorized to overwrite '%s'",
-            PrincipalUtils.getCurrentUserName(), nameIdentifierMap.get(entityType));
+      if (overwrite) {
+        boolean authorized =
+            new AuthorizationExpressionEvaluator(overwriteExpression)
+                .evaluate(
+                    nameIdentifierMap,
+                    new HashMap<>(),
+                    new AuthorizationRequestContext(),
+                    Optional.of(entityType.name()));
+        if (!authorized) {
+          throw new ForbiddenException(
+              "User '%s' is not authorized to overwrite '%s'",
+              PrincipalUtils.getCurrentUserName(), nameIdentifierMap.get(entityType));
+        }
+      }
+      if (existOk) {
+        boolean authorized =
+            new AuthorizationExpressionEvaluator(existOkExpression)
+                .evaluate(
+                    nameIdentifierMap,
+                    new HashMap<>(),
+                    new AuthorizationRequestContext(),
+                    Optional.of(entityType.name()));
+        if (!authorized) {
+          throw new ForbiddenException(
+              "User '%s' is not authorized to read existing metadata for '%s' in exist_ok mode",
+              PrincipalUtils.getCurrentUserName(), nameIdentifierMap.get(entityType));
+        }
       }
     }
 
     @Override
     public boolean authorizationCompleted() {
-      // An overwrite is fully authorized here, so the create expression on the method must not be
-      // evaluated afterwards. A create that does not overwrite falls through to it unchanged.
-      return overwrite;
+      // Both overwrite and exist_ok are fully authorized here, so the create expression on the
+      // method must not be evaluated afterwards. A plain create (neither flag set) falls through
+      // to it unchanged.
+      return overwrite || existOk;
     }
 
     private static Entity.EntityType deepestEntityType(

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceNamespaceAuthorizationIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceNamespaceAuthorizationIT.java
@@ -165,9 +165,13 @@ public class LanceNamespaceAuthorizationIT extends BaseIT {
     Assertions.assertFalse(
         properties(ADMIN, id(VISIBLE_CATALOG, VISIBLE_SCHEMA)).containsKey(MARKER_PROPERTY));
 
-    // exist_ok is a create, not a modification, so the create privilege is enough for it.
+    // exist_ok returns the existing object's metadata, so the caller needs read privileges.
+    // WRITER has UseCatalog so catalog-level exist_ok is allowed.
     assertStatus(200, create(WRITER, VISIBLE_CATALOG, "exist_ok", Map.of()));
     Assertions.assertFalse(properties(ADMIN, VISIBLE_CATALOG).containsKey(MARKER_PROPERTY));
+
+    // WRITER lacks UseSchema on VISIBLE_SCHEMA, so schema-level exist_ok is denied.
+    assertStatus(403, create(WRITER, id(VISIBLE_CATALOG, VISIBLE_SCHEMA), "exist_ok", Map.of()));
 
     assertStatus(403, drop(WRITER, id(VISIBLE_CATALOG, HIDDEN_SCHEMA), null, null));
     assertStatus(200, post(ADMIN, id(VISIBLE_CATALOG, HIDDEN_SCHEMA), "exists"));

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/authorization/TestLanceMetadataAuthorizationMethodInterceptor.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/authorization/TestLanceMetadataAuthorizationMethodInterceptor.java
@@ -190,6 +190,9 @@ class TestLanceMetadataAuthorizationMethodInterceptor {
 
     // The same privileges that authorize a create must not authorize an overwrite, which replaces
     // the properties of a namespace the caller does not own.
+    // exist_ok now requires read privileges; CREATE_CATALOG alone is not enough.
+    // WRITER has both CREATE_CATALOG and USE_CATALOG, so catalog-level exist_ok is allowed
+    // because USE_CATALOG satisfies the CAN_ACCESS_METADATA expression.
     assertEquals(PROCEEDED, interceptor.invoke(createInvocation(CATALOG, "$", "exist_ok")));
     assertErrorResponse(
         interceptor.invoke(createInvocation(CATALOG, "$", "overwrite")), Response.Status.FORBIDDEN);
@@ -346,12 +349,74 @@ class TestLanceMetadataAuthorizationMethodInterceptor {
   void testCreateTablePrivilegeCannotOverwriteAnExistingTable() throws Throwable {
     allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.CREATE_TABLE);
 
-    assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "exist_ok")));
+    // exist_ok now requires read privileges (SELECT_TABLE or ownership) because it returns
+    // the existing table's metadata when the table already exists. CREATE_TABLE alone is
+    // no longer enough — a caller who can create but not read must not learn the table's
+    // location and properties through this path.
+    MethodInvocation existOk = createTableInvocation(tableId(), "exist_ok");
+    assertErrorResponse(interceptor.invoke(existOk), Response.Status.FORBIDDEN);
+    verify(existOk, never()).proceed();
+
     MethodInvocation overwrite = createTableInvocation(tableId(), "overwrite");
     assertErrorResponse(interceptor.invoke(overwrite), Response.Status.FORBIDDEN);
     verify(overwrite, never()).proceed();
     assertErrorResponse(
         interceptor.invoke(registerTableInvocation(tableId(), "OVERWRITE")),
+        Response.Status.FORBIDDEN);
+  }
+
+  @Test
+  void testExistOkRequiresReadPrivilegeForTables() throws Throwable {
+    // A caller with only CREATE_TABLE must not obtain existing table metadata via exist_ok.
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.CREATE_TABLE);
+    MethodInvocation existOk = createTableInvocation(tableId(), "exist_ok");
+    assertErrorResponse(interceptor.invoke(existOk), Response.Status.FORBIDDEN);
+    verify(existOk, never()).proceed();
+
+    // A caller with SELECT_TABLE (read privilege) may use exist_ok to obtain metadata.
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.SELECT_TABLE);
+    assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "exist_ok")));
+
+    // MODIFY_TABLE also satisfies the read check (it implies table access).
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA, Privilege.Name.MODIFY_TABLE);
+    assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "exist_ok")));
+
+    // Ownership satisfies the read check.
+    when(authorizer.isOwner(any(), any(), any(), any())).thenReturn(true);
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA);
+    assertEquals(PROCEEDED, interceptor.invoke(createTableInvocation(tableId(), "exist_ok")));
+  }
+
+  @Test
+  void testExistOkRequiresReadPrivilegeForNamespaces() throws Throwable {
+    // A caller with only CREATE_SCHEMA (no USE_SCHEMA) must not obtain existing schema metadata.
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.CREATE_SCHEMA);
+    MethodInvocation existOk = createInvocation(CATALOG + "$" + SCHEMA, "$", "exist_ok");
+    assertErrorResponse(interceptor.invoke(existOk), Response.Status.FORBIDDEN);
+    verify(existOk, never()).proceed();
+
+    // A caller with USE_SCHEMA (read privilege) may use exist_ok for a schema.
+    allow(Privilege.Name.USE_CATALOG, Privilege.Name.USE_SCHEMA);
+    assertEquals(
+        PROCEEDED, interceptor.invoke(createInvocation(CATALOG + "$" + SCHEMA, "$", "exist_ok")));
+
+    // Ownership satisfies the read check.
+    when(authorizer.isOwner(any(), any(), any(), any())).thenReturn(true);
+    allow(Privilege.Name.USE_CATALOG);
+    assertEquals(
+        PROCEEDED, interceptor.invoke(createInvocation(CATALOG + "$" + SCHEMA, "$", "exist_ok")));
+  }
+
+  @Test
+  void testExistOkRejectsIdentifiersOfTheWrongDepth() throws Throwable {
+    when(authorizer.isOwner(any(), any(), any(), any())).thenReturn(true);
+    allow(Privilege.Name.values());
+
+    // A catalog or schema identifier must not be authorized as a table exist_ok.
+    assertErrorResponse(
+        interceptor.invoke(createTableInvocation(CATALOG, "exist_ok")), Response.Status.FORBIDDEN);
+    assertErrorResponse(
+        interceptor.invoke(createTableInvocation(CATALOG + "$" + SCHEMA, "exist_ok")),
         Response.Status.FORBIDDEN);
   }
 


### PR DESCRIPTION



<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

CreateTable(mode=exist_ok) and CreateNamespace(mode=exist_ok) return the existing object's metadata (location, properties, schema) when the object already exists, but the authorization interceptor only checked CREATE_TABLE / CREATE_SCHEMA privileges. A caller without read privileges could therefore obtain metadata that DescribeTable or DescribeNamespace would deny.

Add EXIST_OK_TABLE_AUTHORIZATION_EXPRESSION and
EXIST_OK_NAMESPACE_AUTHORIZATION_EXPRESSION that require the same read privilege as a describe request. Extend OverwriteAuthzHandler to CreateModeAuthzHandler so that exist_ok mode is authorized against the read expression before the method proceeds, in addition to the existing overwrite handling.

The mode alone decides the authorization path, without probing whether the object exists, avoiding the TOCTOU race that an existence probe at authorization time would introduce.

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #12955 

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
