### PR TITLE
[#13024] fix(catalog-jdbc-postgresql): Quote table name in ALTER statements for mixed-case tables

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -563,7 +563,8 @@ public class PostgreSqlTableOperations extends JdbcTableOperations
       throw new NoSuchColumnException("Column %s does not exist.", col);
     }
 
-    StringBuilder sqlBuilder = new StringBuilder(ALTER_TABLE + jdbcTable.name());
+    StringBuilder sqlBuilder =
+        new StringBuilder(ALTER_TABLE + PG_QUOTE + jdbcTable.name() + PG_QUOTE);
     sqlBuilder
         .append("\n")
         .append(ALTER_COLUMN)
@@ -592,7 +593,8 @@ public class PostgreSqlTableOperations extends JdbcTableOperations
     if (null == column) {
       throw new NoSuchColumnException("Column %s does not exist.", col);
     }
-    StringBuilder sqlBuilder = new StringBuilder(ALTER_TABLE + jdbcTable.name());
+    StringBuilder sqlBuilder =
+        new StringBuilder(ALTER_TABLE + PG_QUOTE + jdbcTable.name() + PG_QUOTE);
     sqlBuilder
         .append("\n")
         .append(ALTER_COLUMN)
@@ -619,7 +621,9 @@ public class PostgreSqlTableOperations extends JdbcTableOperations
       throw new UnsupportedOperationException(POSTGRESQL_NOT_SUPPORT_NESTED_COLUMN_MSG);
     }
     return ALTER_TABLE
+        + PG_QUOTE
         + tableName
+        + PG_QUOTE
         + " RENAME COLUMN "
         + PG_QUOTE
         + renameColumn.fieldName()[0]
@@ -644,7 +648,9 @@ public class PostgreSqlTableOperations extends JdbcTableOperations
     StringBuilder columnDefinition = new StringBuilder();
     columnDefinition
         .append(ALTER_TABLE)
+        .append(PG_QUOTE)
         .append(lazyLoadTable.name())
+        .append(PG_QUOTE)
         .append(SPACE)
         .append("ADD COLUMN ")
         .append(PG_QUOTE)

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperationsSqlGeneration.java
@@ -64,7 +64,17 @@ public class TestPostgreSqlTableOperationsSqlGeneration {
     @Override
     protected JdbcTable getOrCreateTable(
         String databaseName, String tableName, JdbcTable lazyLoadCreateTable) {
-      return JdbcTable.builder().withName(tableName).build();
+      return JdbcTable.builder()
+          .withName(tableName)
+          .withColumns(
+              new JdbcColumn[] {
+                JdbcColumn.builder()
+                    .withName("col1")
+                    .withType(Types.VarCharType.of(255))
+                    .withNullable(true)
+                    .build()
+              })
+          .build();
     }
   }
 
@@ -145,5 +155,43 @@ public class TestPostgreSqlTableOperationsSqlGeneration {
         alterSql.contains(
             "COMMENT ON COLUMN \"test_table\".\"col2\" IS E'owner\\\\''s \"comment\"; --';"),
         alterSql);
+  }
+
+  @Test
+  public void testMixedCaseTableNameIsQuotedOnAddColumn() {
+    TestablePostgreSqlTableOperations ops = new TestablePostgreSqlTableOperations();
+    String alterSql =
+        ops.alterTableSql(
+            "MixedCaseTbl", TableChange.addColumn(new String[] {"extra"}, Types.IntegerType.get()));
+    Assertions.assertTrue(alterSql.contains("ALTER TABLE \"MixedCaseTbl\""), alterSql);
+  }
+
+  @Test
+  public void testMixedCaseTableNameIsQuotedOnUpdateColumnDefaultValue() {
+    TestablePostgreSqlTableOperations ops = new TestablePostgreSqlTableOperations();
+    String alterSql =
+        ops.alterTableSql(
+            "MixedCaseTbl",
+            TableChange.updateColumnDefaultValue(
+                new String[] {"col1"}, Literals.of("abc", Types.VarCharType.of(255))));
+    Assertions.assertTrue(alterSql.contains("ALTER TABLE \"MixedCaseTbl\""), alterSql);
+  }
+
+  @Test
+  public void testMixedCaseTableNameIsQuotedOnUpdateColumnType() {
+    TestablePostgreSqlTableOperations ops = new TestablePostgreSqlTableOperations();
+    String alterSql =
+        ops.alterTableSql(
+            "MixedCaseTbl",
+            TableChange.updateColumnType(new String[] {"col1"}, Types.VarCharType.of(255)));
+    Assertions.assertTrue(alterSql.contains("ALTER TABLE \"MixedCaseTbl\""), alterSql);
+  }
+
+  @Test
+  public void testMixedCaseTableNameIsQuotedOnRenameColumn() {
+    TestablePostgreSqlTableOperations ops = new TestablePostgreSqlTableOperations();
+    String alterSql =
+        ops.alterTableSql("MixedCaseTbl", TableChange.renameColumn(new String[] {"col1"}, "col2"));
+    Assertions.assertTrue(alterSql.contains("ALTER TABLE \"MixedCaseTbl\""), alterSql);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Quote the table name in four ALTER-statement builders in
PostgreSqlTableOperations.java that previously emitted it unquoted:
addColumn, updateColumnDefaultValue, updateColumnType, renameColumn.

### Why are the changes needed?

Mixed-case PostgreSQL table names (e.g. "MixedCaseTbl") fail to
alter because the unquoted identifier gets folded to lower case by
PostgreSQL, so the statement targets a non-existent relation.

Fix: #13024

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Added regression tests covering the four alter paths with a
mixed-case table name in TestPostgreSqlTableOperationsSqlGeneration.
