### PR TITLE
[#13029] fix(lance): Correct the Lance Spark Catalog class in the integration guide

### DIFF
--- a/docs/lance-rest-integration.md
+++ b/docs/lance-rest-integration.md
@@ -138,7 +138,7 @@ os.environ["PYSPARK_SUBMIT_ARGS"] = (
 # it via Lance REST API `CreateNamespace` or Gravitino REST API `CreateCatalog`.
 spark = SparkSession.builder \
     .appName("lance_rest_integration") \
-    .config("spark.sql.catalog.lance", "com.lancedb.lance.spark.LanceNamespaceSparkCatalog") \
+    .config("spark.sql.catalog.lance", "org.lance.spark.LanceNamespaceSparkCatalog") \
     .config("spark.sql.catalog.lance.impl", "rest") \
     .config("spark.sql.catalog.lance.uri", "http://localhost:9101/lance") \
     .config("spark.sql.catalog.lance.parent", "lance_catalog") \

--- a/lance/lance-rest-server/build.gradle.kts
+++ b/lance/lance-rest-server/build.gradle.kts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import java.util.jar.JarFile
-
 description = "lance-rest-server"
 
 plugins {
@@ -42,9 +40,6 @@ if (lanceSparkBundleVersions.isEmpty()) {
 }
 val primaryLanceSparkBundleVersion: String = lanceSparkBundleVersions.first()
 val lanceSparkBundleJarPathProperty = "gravitino.lance.spark.bundle.jar"
-val lanceSparkIntegrationDoc = rootProject.file("docs/lance-rest-integration.md")
-val lanceSparkCatalogClassPattern =
-  Regex("spark\\.sql\\.catalog\\.lance\"\\s*,\\s*\"([A-Za-z_][A-Za-z0-9_.]*)\"")
 
 fun lanceSparkBundleConfigName(version: String): String =
   "lanceSparkBundle_" + version.replace(".", "_").replace("-", "_")
@@ -163,56 +158,6 @@ tasks {
     }
   }
 
-  val checkLanceSparkCatalogDocumentation =
-    register("checkLanceSparkCatalogDocumentation") {
-      group = "verification"
-      description =
-        "Verify that the Lance Spark Catalog class documented for Spark is present in every " +
-        "prepared Lance Spark bundle"
-      dependsOn(
-        lanceSparkBundleVersions.map { named(lanceSparkPrepareTaskName(it)) }
-      )
-      doLast {
-        if (!lanceSparkIntegrationDoc.isFile) {
-          throw GradleException("Missing Lance Spark integration documentation: $lanceSparkIntegrationDoc")
-        }
-
-        val matches =
-          lanceSparkCatalogClassPattern.findAll(lanceSparkIntegrationDoc.readText()).toList()
-        if (matches.size != 1) {
-          throw GradleException(
-            "Expected exactly one Spark Lance Catalog class in $lanceSparkIntegrationDoc, " +
-              "but found ${matches.size}"
-          )
-        }
-
-        val catalogClass = matches.single().groupValues[1]
-        val classEntry = catalogClass.replace('.', '/') + ".class"
-        lanceSparkBundleVersions.forEach { version ->
-          val bundleDir = lanceSparkBundleDirFor(version).get().asFile
-          val bundleJar =
-            bundleDir.listFiles()?.singleOrNull { it.extension == "jar" }
-              ?: throw GradleException(
-                "Expected exactly one Lance Spark bundle JAR for version $version in $bundleDir"
-              )
-
-          JarFile(bundleJar).use { jarFile ->
-            if (jarFile.getEntry(classEntry) == null) {
-              throw GradleException(
-                "Lance Spark bundle $version ($bundleJar) does not contain documented " +
-                  "Catalog class $catalogClass"
-              )
-            }
-          }
-        }
-
-        println(
-          "[lance-spark-doc-check] $catalogClass is present in " +
-            "${lanceSparkBundleVersions.joinToString(", ")}"
-        )
-      }
-    }
-
   val primaryPrepareLanceSparkBundle =
     named(lanceSparkPrepareTaskName(primaryLanceSparkBundleVersion))
 
@@ -246,7 +191,6 @@ tasks {
 
   test {
     dependsOn(primaryPrepareLanceSparkBundle)
-    dependsOn(checkLanceSparkCatalogDocumentation)
 
     val primaryBundleDir = lanceSparkBundleDirFor(primaryLanceSparkBundleVersion)
     doFirst {
@@ -318,7 +262,6 @@ tasks {
       "(default: $primaryLanceSparkBundleVersion). Reports land under " +
       "build/reports/lance-spark-matrix/<version>/."
     dependsOn(
-      checkLanceSparkCatalogDocumentation,
       lanceSparkBundleVersions.map { named(lanceSparkTestTaskName(it)) }
     )
   }

--- a/lance/lance-rest-server/build.gradle.kts
+++ b/lance/lance-rest-server/build.gradle.kts
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import java.util.jar.JarFile
+
 description = "lance-rest-server"
 
 plugins {
@@ -40,6 +42,9 @@ if (lanceSparkBundleVersions.isEmpty()) {
 }
 val primaryLanceSparkBundleVersion: String = lanceSparkBundleVersions.first()
 val lanceSparkBundleJarPathProperty = "gravitino.lance.spark.bundle.jar"
+val lanceSparkIntegrationDoc = rootProject.file("docs/lance-rest-integration.md")
+val lanceSparkCatalogClassPattern =
+  Regex("spark\\.sql\\.catalog\\.lance\"\\s*,\\s*\"([A-Za-z_][A-Za-z0-9_.]*)\"")
 
 fun lanceSparkBundleConfigName(version: String): String =
   "lanceSparkBundle_" + version.replace(".", "_").replace("-", "_")
@@ -157,6 +162,57 @@ tasks {
       into(lanceSparkBundleDirFor(version))
     }
   }
+
+  val checkLanceSparkCatalogDocumentation =
+    register("checkLanceSparkCatalogDocumentation") {
+      group = "verification"
+      description =
+        "Verify that the Lance Spark Catalog class documented for Spark is present in every " +
+        "prepared Lance Spark bundle"
+      dependsOn(
+        lanceSparkBundleVersions.map { named(lanceSparkPrepareTaskName(it)) }
+      )
+      doLast {
+        if (!lanceSparkIntegrationDoc.isFile) {
+          throw GradleException("Missing Lance Spark integration documentation: $lanceSparkIntegrationDoc")
+        }
+
+        val matches =
+          lanceSparkCatalogClassPattern.findAll(lanceSparkIntegrationDoc.readText()).toList()
+        if (matches.size != 1) {
+          throw GradleException(
+            "Expected exactly one Spark Lance Catalog class in $lanceSparkIntegrationDoc, " +
+              "but found ${matches.size}"
+          )
+        }
+
+        val catalogClass = matches.single().groupValues[1]
+        val classEntry = catalogClass.replace('.', '/') + ".class"
+        lanceSparkBundleVersions.forEach { version ->
+          val bundleDir = lanceSparkBundleDirFor(version).get().asFile
+          val bundleJar =
+            bundleDir.listFiles()?.singleOrNull { it.extension == "jar" }
+              ?: throw GradleException(
+                "Expected exactly one Lance Spark bundle JAR for version $version in $bundleDir"
+              )
+
+          JarFile(bundleJar).use { jarFile ->
+            if (jarFile.getEntry(classEntry) == null) {
+              throw GradleException(
+                "Lance Spark bundle $version ($bundleJar) does not contain documented " +
+                  "Catalog class $catalogClass"
+              )
+            }
+          }
+        }
+
+        println(
+          "[lance-spark-doc-check] $catalogClass is present in " +
+            "${lanceSparkBundleVersions.joinToString(", ")}"
+        )
+      }
+    }
+
   val primaryPrepareLanceSparkBundle =
     named(lanceSparkPrepareTaskName(primaryLanceSparkBundleVersion))
 
@@ -190,6 +246,7 @@ tasks {
 
   test {
     dependsOn(primaryPrepareLanceSparkBundle)
+    dependsOn(checkLanceSparkCatalogDocumentation)
 
     val primaryBundleDir = lanceSparkBundleDirFor(primaryLanceSparkBundleVersion)
     doFirst {
@@ -261,6 +318,7 @@ tasks {
       "(default: $primaryLanceSparkBundleVersion). Reports land under " +
       "build/reports/lance-spark-matrix/<version>/."
     dependsOn(
+      checkLanceSparkCatalogDocumentation,
       lanceSparkBundleVersions.map { named(lanceSparkTestTaskName(it)) }
     )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the Lance Spark integration guide to use `org.lance.spark.LanceNamespaceSparkCatalog`, which is the Catalog implementation shipped by the supported `lance-spark-bundle-3.5_2.12:0.4.0` bundle.

Add `checkLanceSparkCatalogDocumentation` to the Lance REST server Gradle build. The check extracts the Catalog class from the documentation example, verifies that exactly one class is documented, and checks that the corresponding `.class` entry exists in every prepared Lance Spark bundle. The check is attached to the normal `test` task and the existing `lanceSparkMatrixTest` task.

### Why are the changes needed?

The integration guide referenced `com.lancedb.lance.spark.LanceNamespaceSparkCatalog`, which is absent from the supported 0.4.0 bundle. Following the guide fails with `ClassNotFoundException` while Spark loads the Catalog, before Spark contacts the Gravitino Lance REST endpoint. The existing `LanceSparkRESTServiceIT` already uses the correct `org.lance` class, so this change aligns the documentation with the runtime test configuration and adds a guard against future documentation-to-bundle drift.

Fix: #13029

### Does this PR introduce _any_ user-facing change?

Yes. Users following the Lance Spark integration guide can load the documented Catalog with the supported 0.4.0 bundle. No public API, REST protocol, storage configuration, Docker default, or vector computation behavior is changed.

### How was this patch tested?

- `./gradlew :lance:lance-rest-server:checkLanceSparkCatalogDocumentation -PskipWeb=true -PskipDockerTests=true --no-daemon --console=plain`: passed for the default 0.4.0 bundle.
- `./gradlew :lance:lance-rest-server:checkLanceSparkCatalogDocumentation -PlanceSparkBundleVersions=0.2.0,0.4.0 -PskipWeb=true -PskipDockerTests=true --no-daemon --console=plain`: passed for both configured bundles.
- `./gradlew :lance:lance-rest-server:test -PskipITs -PskipDockerTests=true -PskipWeb=true --no-daemon --console=plain`: passed; the normal test task executed the documentation check.
- `./gradlew :lance:lance-rest-server:spotlessKotlinGradleCheck -PskipWeb=true -PskipDockerTests=true --no-daemon --console=plain`: passed.
- `./gradlew :lance:lance-rest-server:lanceSparkMatrixTest -PlanceSparkBundleVersions=0.2.0,0.4.0 -PskipDockerTests=true -PskipWeb=true --no-daemon --console=plain`: passed; both per-version `LanceSparkRESTServiceIT` tasks passed.

The known 0.5.1 error-path assertion failure was not changed and did not gate this documentation-focused PR.
