### PR TITLE
[#13033] fix(iceberg): Map PostgreSQL JDBC auth failures to ConnectionFailedException

### DIFF
--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
@@ -186,10 +186,7 @@ public class IcebergCatalogUtil {
       jdbcCatalog.setConf(hdfsConfiguration);
       jdbcCatalog.initialize(icebergCatalogName, properties);
     } catch (UncheckedSQLException e) {
-      Throwable cause = e.getCause();
-      if (cause instanceof SQLException
-          && cause.getMessage() != null
-          && cause.getMessage().contains("Access denied")) {
+      if (isJdbcAuthorizationFailure(e.getCause())) {
         throw new ConnectionFailedException(e, e.getMessage());
       }
       if (!isConcurrentViewMigrationConflict(e)) {
@@ -212,6 +209,38 @@ public class IcebergCatalogUtil {
       jdbcCatalog.initialize(icebergCatalogName, properties);
     }
     return jdbcCatalog;
+  }
+
+  /**
+   * Whether a JDBC failure from {@code JdbcCatalog.initialize} is an authorization / credential
+   * error that should surface as {@link ConnectionFailedException}.
+   *
+   * <p>MySQL reports SQLState {@code 28000} with message {@code Access denied for user ...};
+   * PostgreSQL uses SQLState class {@code 28} ({@code 28P01}, {@code 28000}) with messages such as
+   * {@code password authentication failed} or {@code role "..." does not exist}. Prefer SQLState
+   * class {@code 28}; fall back to known message fragments when the driver omits SQLState.
+   *
+   * @param cause the cause of an {@link UncheckedSQLException}, may be null
+   * @return {@code true} if the failure is an invalid-authorization error
+   */
+  @VisibleForTesting
+  static boolean isJdbcAuthorizationFailure(Throwable cause) {
+    if (!(cause instanceof SQLException)) {
+      return false;
+    }
+    SQLException sqlException = (SQLException) cause;
+    String sqlState = sqlException.getSQLState();
+    if (sqlState != null && sqlState.regionMatches(true, 0, "28", 0, 2)) {
+      return true;
+    }
+    String message = sqlException.getMessage();
+    if (message == null) {
+      return false;
+    }
+    String lower = message.toLowerCase(Locale.ROOT);
+    return lower.contains("access denied")
+        || lower.contains("password authentication failed")
+        || (lower.contains("role ") && lower.contains("does not exist"));
   }
 
   /**

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
@@ -65,6 +65,12 @@ public class IcebergCatalogUtil {
    */
   private static final String ICEBERG_TYPE_COLUMN = "iceberg_type";
 
+  /**
+   * SQLSTATE class {@code 28} = invalid authorization specification. Covers MySQL 1045 ({@code
+   * 28000}), PostgreSQL {@code 28P01}/{@code 28000}, and H2 wrong user/password ({@code 28000}).
+   */
+  private static final String INVALID_AUTHORIZATION_SQLSTATE_CLASS = "28";
+
   private static final ConcurrentHashMap<String, InMemoryCatalog> MEMORY_CATALOGS =
       new ConcurrentHashMap<>();
 
@@ -187,11 +193,9 @@ public class IcebergCatalogUtil {
       jdbcCatalog.initialize(icebergCatalogName, properties);
     } catch (UncheckedSQLException e) {
       Throwable cause = e.getCause();
-      // SQLState class 28 = invalid authorization (MySQL 1045 -> 28000; PostgreSQL 28P01/28000;
-      // H2 wrong user/password -> 28000).
       if (cause instanceof SQLException) {
         String sqlState = ((SQLException) cause).getSQLState();
-        if (sqlState != null && sqlState.regionMatches(true, 0, "28", 0, 2)) {
+        if (sqlState != null && sqlState.startsWith(INVALID_AUTHORIZATION_SQLSTATE_CLASS)) {
           throw new ConnectionFailedException(e, e.getMessage());
         }
       }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
@@ -187,7 +187,8 @@ public class IcebergCatalogUtil {
       jdbcCatalog.initialize(icebergCatalogName, properties);
     } catch (UncheckedSQLException e) {
       Throwable cause = e.getCause();
-      // SQLState class 28 = invalid authorization (MySQL 1045 -> 28000; PostgreSQL 28P01/28000).
+      // SQLState class 28 = invalid authorization (MySQL 1045 -> 28000; PostgreSQL 28P01/28000;
+      // H2 wrong user/password -> 28000).
       if (cause instanceof SQLException) {
         String sqlState = ((SQLException) cause).getSQLState();
         if (sqlState != null && sqlState.regionMatches(true, 0, "28", 0, 2)) {

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
@@ -66,10 +66,13 @@ public class IcebergCatalogUtil {
   private static final String ICEBERG_TYPE_COLUMN = "iceberg_type";
 
   /**
-   * SQLSTATE class {@code 28} = invalid authorization specification. Covers MySQL 1045 ({@code
-   * 28000}), PostgreSQL {@code 28P01}/{@code 28000}, and H2 wrong user/password ({@code 28000}).
+   * SQLSTATE {@code 28000}: MySQL error 1045 (Access denied), H2 wrong user/password, and
+   * PostgreSQL {@code invalid_authorization_specification} (for example unknown role).
    */
-  private static final String INVALID_AUTHORIZATION_SQLSTATE_CLASS = "28";
+  private static final String SQLSTATE_INVALID_AUTHORIZATION = "28000";
+
+  /** SQLSTATE {@code 28P01}: PostgreSQL {@code invalid_password}. */
+  private static final String SQLSTATE_INVALID_PASSWORD = "28P01";
 
   private static final ConcurrentHashMap<String, InMemoryCatalog> MEMORY_CATALOGS =
       new ConcurrentHashMap<>();
@@ -195,7 +198,8 @@ public class IcebergCatalogUtil {
       Throwable cause = e.getCause();
       if (cause instanceof SQLException) {
         String sqlState = ((SQLException) cause).getSQLState();
-        if (sqlState != null && sqlState.startsWith(INVALID_AUTHORIZATION_SQLSTATE_CLASS)) {
+        if (SQLSTATE_INVALID_AUTHORIZATION.equals(sqlState)
+            || SQLSTATE_INVALID_PASSWORD.equals(sqlState)) {
           throw new ConnectionFailedException(e, e.getMessage());
         }
       }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
@@ -186,8 +186,13 @@ public class IcebergCatalogUtil {
       jdbcCatalog.setConf(hdfsConfiguration);
       jdbcCatalog.initialize(icebergCatalogName, properties);
     } catch (UncheckedSQLException e) {
-      if (isJdbcAuthorizationFailure(e.getCause())) {
-        throw new ConnectionFailedException(e, e.getMessage());
+      Throwable cause = e.getCause();
+      // SQLState class 28 = invalid authorization (MySQL 1045 -> 28000; PostgreSQL 28P01/28000).
+      if (cause instanceof SQLException) {
+        String sqlState = ((SQLException) cause).getSQLState();
+        if (sqlState != null && sqlState.regionMatches(true, 0, "28", 0, 2)) {
+          throw new ConnectionFailedException(e, e.getMessage());
+        }
       }
       if (!isConcurrentViewMigrationConflict(e)) {
         throw e;
@@ -209,38 +214,6 @@ public class IcebergCatalogUtil {
       jdbcCatalog.initialize(icebergCatalogName, properties);
     }
     return jdbcCatalog;
-  }
-
-  /**
-   * Whether a JDBC failure from {@code JdbcCatalog.initialize} is an authorization / credential
-   * error that should surface as {@link ConnectionFailedException}.
-   *
-   * <p>MySQL reports SQLState {@code 28000} with message {@code Access denied for user ...};
-   * PostgreSQL uses SQLState class {@code 28} ({@code 28P01}, {@code 28000}) with messages such as
-   * {@code password authentication failed} or {@code role "..." does not exist}. Prefer SQLState
-   * class {@code 28}; fall back to known message fragments when the driver omits SQLState.
-   *
-   * @param cause the cause of an {@link UncheckedSQLException}, may be null
-   * @return {@code true} if the failure is an invalid-authorization error
-   */
-  @VisibleForTesting
-  static boolean isJdbcAuthorizationFailure(Throwable cause) {
-    if (!(cause instanceof SQLException)) {
-      return false;
-    }
-    SQLException sqlException = (SQLException) cause;
-    String sqlState = sqlException.getSQLState();
-    if (sqlState != null && sqlState.regionMatches(true, 0, "28", 0, 2)) {
-      return true;
-    }
-    String message = sqlException.getMessage();
-    if (message == null) {
-      return false;
-    }
-    String lower = message.toLowerCase(Locale.ROOT);
-    return lower.contains("access denied")
-        || lower.contains("password authentication failed")
-        || (lower.contains("role ") && lower.contains("does not exist"));
   }
 
   /**

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/utils/TestIcebergCatalogUtil.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/utils/TestIcebergCatalogUtil.java
@@ -381,6 +381,43 @@ public class TestIcebergCatalogUtil {
   }
 
   @Test
+  void testIsJdbcAuthorizationFailureRecognizesMysqlAndPostgres() {
+    Assertions.assertTrue(
+        IcebergCatalogUtil.isJdbcAuthorizationFailure(
+            new SQLException(
+                "Access denied for user 'gravitino'@'%' (using password: YES)", "28000", 1045)),
+        "MySQL 1045 should be treated as an authorization failure");
+    Assertions.assertTrue(
+        IcebergCatalogUtil.isJdbcAuthorizationFailure(
+            new SQLException(
+                "FATAL: password authentication failed for user \"gravitino\"", "28P01")),
+        "PostgreSQL 28P01 should be treated as an authorization failure");
+    Assertions.assertTrue(
+        IcebergCatalogUtil.isJdbcAuthorizationFailure(
+            new SQLException("FATAL: role \"missing\" does not exist", "28000")),
+        "PostgreSQL unknown-role 28000 should be treated as an authorization failure");
+    // Drivers that omit SQLState still need message fallbacks.
+    Assertions.assertTrue(
+        IcebergCatalogUtil.isJdbcAuthorizationFailure(
+            new SQLException("Access denied for user 'gravitino'@'%'")));
+    Assertions.assertTrue(
+        IcebergCatalogUtil.isJdbcAuthorizationFailure(
+            new SQLException("FATAL: password authentication failed for user \"gravitino\"")));
+  }
+
+  @Test
+  void testIsJdbcAuthorizationFailureRejectsUnrelatedErrors() {
+    Assertions.assertFalse(
+        IcebergCatalogUtil.isJdbcAuthorizationFailure(
+            new SQLException("Communications link failure", "08S01")));
+    Assertions.assertFalse(
+        IcebergCatalogUtil.isJdbcAuthorizationFailure(new SQLException((String) null)));
+    Assertions.assertFalse(
+        IcebergCatalogUtil.isJdbcAuthorizationFailure(new RuntimeException("Access denied")));
+    Assertions.assertFalse(IcebergCatalogUtil.isJdbcAuthorizationFailure(null));
+  }
+
+  @Test
   void testIsConcurrentViewMigrationConflictAcrossDatabases() {
     // The duplicate `iceberg_type` column error wording differs per backend database; each of these
     // means another Iceberg JDBC catalog on the same `uri` already ran the V1 view migration.

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/utils/TestIcebergCatalogUtil.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/utils/TestIcebergCatalogUtil.java
@@ -381,43 +381,6 @@ public class TestIcebergCatalogUtil {
   }
 
   @Test
-  void testIsJdbcAuthorizationFailureRecognizesMysqlAndPostgres() {
-    Assertions.assertTrue(
-        IcebergCatalogUtil.isJdbcAuthorizationFailure(
-            new SQLException(
-                "Access denied for user 'gravitino'@'%' (using password: YES)", "28000", 1045)),
-        "MySQL 1045 should be treated as an authorization failure");
-    Assertions.assertTrue(
-        IcebergCatalogUtil.isJdbcAuthorizationFailure(
-            new SQLException(
-                "FATAL: password authentication failed for user \"gravitino\"", "28P01")),
-        "PostgreSQL 28P01 should be treated as an authorization failure");
-    Assertions.assertTrue(
-        IcebergCatalogUtil.isJdbcAuthorizationFailure(
-            new SQLException("FATAL: role \"missing\" does not exist", "28000")),
-        "PostgreSQL unknown-role 28000 should be treated as an authorization failure");
-    // Drivers that omit SQLState still need message fallbacks.
-    Assertions.assertTrue(
-        IcebergCatalogUtil.isJdbcAuthorizationFailure(
-            new SQLException("Access denied for user 'gravitino'@'%'")));
-    Assertions.assertTrue(
-        IcebergCatalogUtil.isJdbcAuthorizationFailure(
-            new SQLException("FATAL: password authentication failed for user \"gravitino\"")));
-  }
-
-  @Test
-  void testIsJdbcAuthorizationFailureRejectsUnrelatedErrors() {
-    Assertions.assertFalse(
-        IcebergCatalogUtil.isJdbcAuthorizationFailure(
-            new SQLException("Communications link failure", "08S01")));
-    Assertions.assertFalse(
-        IcebergCatalogUtil.isJdbcAuthorizationFailure(new SQLException((String) null)));
-    Assertions.assertFalse(
-        IcebergCatalogUtil.isJdbcAuthorizationFailure(new RuntimeException("Access denied")));
-    Assertions.assertFalse(IcebergCatalogUtil.isJdbcAuthorizationFailure(null));
-  }
-
-  @Test
   void testIsConcurrentViewMigrationConflictAcrossDatabases() {
     // The duplicate `iceberg_type` column error wording differs per backend database; each of these
     // means another Iceberg JDBC catalog on the same `uri` already ran the V1 view migration.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Classify Iceberg JDBC catalog authorization failures via SQLState class `28` (plus MySQL/PostgreSQL message fallbacks), so PostgreSQL bad-credential errors become `ConnectionFailedException` like MySQL `Access denied`.

### Why are the changes needed?

Previously only the literal `Access denied` was matched. PostgreSQL reports `password authentication failed` / `role ... does not exist` (`28P01` / `28000`), so failures escaped as raw `UncheckedSQLException`.

Fix: #13033

### Does this PR introduce _any_ user-facing change?

- PostgreSQL Iceberg JDBC catalogs with bad credentials now surface `ConnectionFailedException` instead of a generic internal error.
- No new APIs or property keys.

### How was this patch tested?

```
./gradlew :iceberg:iceberg-common:test --tests org.apache.gravitino.iceberg.common.utils.TestIcebergCatalogUtil -PskipITs
```

