### PR TITLE
[#13041] fix(server): Add @ResponseMetered to JobOperations#cancelJob

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
@@ -442,6 +442,7 @@ public class JobOperations {
   @Path("runs/{jobId}")
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "cancel-job." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "cancel-job", absolute = true)
   @AuthorizationExpression(expression = "METALAKE::OWNER || JOB::OWNER")
   public Response cancelJob(
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestJobOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestJobOperations.java
@@ -28,9 +28,12 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -1213,6 +1216,20 @@ public class TestJobOperations extends JerseyTest {
     Assertions.assertEquals(0, jobResp.getCode());
     Assertions.assertEquals(JobHandle.Status.CANCELLED, jobResp.getJob().status());
     Assertions.assertNull(jobResp.getJob().runtimeJobTemplate());
+  }
+
+  @Test
+  public void testCancelJobIsResponseMetered() throws Exception {
+    Method cancelJob = JobOperations.class.getMethod("cancelJob", String.class, String.class);
+    ResponseMetered metered = cancelJob.getAnnotation(ResponseMetered.class);
+    Assertions.assertNotNull(metered);
+    Assertions.assertEquals("cancel-job", metered.name());
+    Assertions.assertTrue(metered.absolute());
+
+    Timed timed = cancelJob.getAnnotation(Timed.class);
+    Assertions.assertNotNull(timed);
+    Assertions.assertTrue(timed.name().startsWith("cancel-job."));
+    Assertions.assertTrue(timed.absolute());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

I added `@ResponseMetered(name = "cancel-job", absolute = true)` on `JobOperations#cancelJob`, next to the existing `@Timed`, same as the other eight endpoints in that class.

### Why are the changes needed?

`cancelJob` only had `@Timed`. Without `@ResponseMetered`, the Jersey listener never registers `gravitino-server.cancel-job.2xx-responses` (or 4xx/5xx), so `/metrics` shows cancel latency but not outcome.

Fix: #13041

### Does this PR introduce _any_ user-facing change?

No API or property changes. Cancel responses start showing up on `/metrics` like the sibling endpoints.

### How was this patch tested?

```
./gradlew :server:test --tests org.apache.gravitino.server.web.rest.TestJobOperations.testCancelJobIsResponseMetered -PskipITs
```
