### PR TITLE
[#13043] fix(job): report deleted jobs to listeners

### DIFF
--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -95,6 +95,8 @@ import org.apache.gravitino.listener.TableEventDispatcher;
 import org.apache.gravitino.listener.TagEventDispatcher;
 import org.apache.gravitino.listener.TopicEventDispatcher;
 import org.apache.gravitino.listener.ViewEventDispatcher;
+import org.apache.gravitino.listener.api.event.job.DeleteJobEvent;
+import org.apache.gravitino.listener.api.info.JobInfo;
 import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.metalake.MetalakeDispatcher;
 import org.apache.gravitino.metalake.MetalakeManager;
@@ -1029,7 +1031,19 @@ public class GravitinoEnv {
     PolicyHookDispatcher policyHookDispatcher = new PolicyHookDispatcher(policyManager);
     this.policyDispatcher = new PolicyEventDispatcher(eventBus, policyHookDispatcher);
 
-    JobManager jobManager = new JobManager(config, entityStore, idGenerator);
+    // The staging directory cleanup deletes jobs on its own schedule, below the dispatcher chain
+    // that turns operations into events, so it reports them here instead.
+    JobManager jobManager =
+        new JobManager(
+            config,
+            entityStore,
+            idGenerator,
+            job ->
+                eventBus.dispatchEvent(
+                    new DeleteJobEvent(
+                        DeleteJobEvent.SYSTEM_USER,
+                        job.namespace().level(0),
+                        JobInfo.fromJobEntity(job))));
     JobTemplateValidationDispatcher validationDispatcher =
         new JobTemplateValidationDispatcher(jobManager);
     this.internalJobOperationDispatcher = validationDispatcher;

--- a/core/src/main/java/org/apache/gravitino/audit/AuditLog.java
+++ b/core/src/main/java/org/apache/gravitino/audit/AuditLog.java
@@ -470,6 +470,8 @@ public interface AuditLog {
 
     CANCEL_JOB,
 
+    DELETE_JOB,
+
     LIST_STATISTICS,
 
     LIST_PARTITION_STATISTICS,

--- a/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
+++ b/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
@@ -168,6 +168,7 @@ public class CompatibilityUtils {
           .put(OperationType.RUN_JOB, Operation.RUN_JOB)
           .put(OperationType.GET_JOB, Operation.GET_JOB)
           .put(OperationType.CANCEL_JOB, Operation.CANCEL_JOB)
+          .put(OperationType.DELETE_JOB, Operation.DELETE_JOB)
           .put(OperationType.LIST_STATISTICS, Operation.LIST_STATISTICS)
           .put(OperationType.LIST_PARTITION_STATISTICS, Operation.LIST_PARTITION_STATISTICS)
           .put(OperationType.DROP_STATISTICS, Operation.DROP_STATISTICS)

--- a/core/src/main/java/org/apache/gravitino/job/JobManager.java
+++ b/core/src/main/java/org/apache/gravitino/job/JobManager.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -103,17 +104,52 @@ public class JobManager implements JobOperationDispatcher {
 
   private final long jobStagingDirKeepTimeInMs;
 
+  private final Consumer<JobEntity> jobDeletionListener;
+
   @VisibleForTesting final ScheduledExecutorService cleanUpExecutor;
 
   @VisibleForTesting final ScheduledExecutorService statusPullExecutor;
 
   public JobManager(Config config, EntityStore entityStore, IdGenerator idGenerator) {
-    this(config, entityStore, idGenerator, JobExecutorFactory.create(config));
+    this(config, entityStore, idGenerator, job -> {});
+  }
+
+  /**
+   * Creates a job manager that reports the jobs its staging directory cleanup deletes.
+   *
+   * <p>That cleanup is the only path that removes a job, and it runs on a scheduler rather than for
+   * a request, so it never passes through the dispatcher chain that turns operations into events.
+   * The listener is how an observer, such as an event bus, learns that a job is gone.
+   *
+   * @param config The configuration to read the staging directory settings from.
+   * @param entityStore The entity store holding the jobs.
+   * @param idGenerator The generator for new job identifiers.
+   * @param jobDeletionListener Called once per job the cleanup deletes, after the deletion. It is
+   *     called on the cleanup thread, so it should return promptly, and a failure in it is logged
+   *     and does not stop the cleanup.
+   */
+  public JobManager(
+      Config config,
+      EntityStore entityStore,
+      IdGenerator idGenerator,
+      Consumer<JobEntity> jobDeletionListener) {
+    this(config, entityStore, idGenerator, JobExecutorFactory.create(config), jobDeletionListener);
   }
 
   @VisibleForTesting
   JobManager(
       Config config, EntityStore entityStore, IdGenerator idGenerator, JobExecutor jobExecutor) {
+    this(config, entityStore, idGenerator, jobExecutor, job -> {});
+  }
+
+  @VisibleForTesting
+  JobManager(
+      Config config,
+      EntityStore entityStore,
+      IdGenerator idGenerator,
+      JobExecutor jobExecutor,
+      Consumer<JobEntity> jobDeletionListener) {
+    this.jobDeletionListener = jobDeletionListener;
     this.entityStore = entityStore;
     this.jobExecutor = jobExecutor;
     this.idGenerator = idGenerator;
@@ -784,6 +820,7 @@ public class JobManager implements JobOperationDispatcher {
             try {
               entityStore.delete(
                   NameIdentifierUtil.ofJob(metalake, job.name()), Entity.EntityType.JOB);
+              notifyJobDeleted(job);
 
               String jobStagingPath =
                   stagingDir.getAbsolutePath()
@@ -797,6 +834,18 @@ public class JobManager implements JobOperationDispatcher {
               LOG.error("Failed to delete job and staging directory for job {}", job.name(), e);
             }
           });
+    }
+  }
+
+  /**
+   * Reports one deleted job to the listener. The job is already gone from the store by this point,
+   * so a listener that fails must not stop the cleanup from reaching the remaining jobs.
+   */
+  private void notifyJobDeleted(JobEntity job) {
+    try {
+      jobDeletionListener.accept(job);
+    } catch (RuntimeException e) {
+      LOG.warn("Job deletion listener failed for job {}", job.name(), e);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
@@ -185,6 +185,7 @@ public enum OperationType {
   RUN_JOB,
   GET_JOB,
   CANCEL_JOB,
+  DELETE_JOB,
 
   // Statistics operations
   LIST_STATISTICS,

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/job/DeleteJobEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/job/DeleteJobEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event.job;
+
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.listener.api.event.OperationType;
+import org.apache.gravitino.listener.api.info.JobInfo;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+
+/**
+ * Represents an event triggered when a job has been deleted.
+ *
+ * <p>Jobs are deleted by the staging directory cleanup, which runs on the server's own schedule
+ * rather than for a request. That makes this event the only signal a listener receives that a job
+ * is gone, so a listener keeping a projection of jobs needs it to avoid serving jobs that no longer
+ * exist.
+ */
+@DeveloperApi
+public class DeleteJobEvent extends JobEvent {
+
+  /**
+   * The user reported for a deletion the server performs on its own schedule, where no request and
+   * therefore no caller exists.
+   */
+  public static final String SYSTEM_USER = "system";
+
+  private final JobInfo jobInfo;
+
+  /**
+   * Constructs a new {@code DeleteJobEvent} instance.
+   *
+   * @param user The user who initiated the deletion, or {@link #SYSTEM_USER} when the server
+   *     deleted the job on its own schedule.
+   * @param metalake The metalake name where the job resided.
+   * @param jobInfo The information of the job that has been deleted.
+   */
+  public DeleteJobEvent(String user, String metalake, JobInfo jobInfo) {
+    super(user, NameIdentifierUtil.ofJob(metalake, jobInfo.jobId()));
+    this.jobInfo = jobInfo;
+  }
+
+  /**
+   * Returns the information of the job that has been deleted.
+   *
+   * @return the job information.
+   */
+  public JobInfo deletedJobInfo() {
+    return jobInfo;
+  }
+
+  /**
+   * Returns the type of operation.
+   *
+   * @return the operation type.
+   */
+  @Override
+  public OperationType operationType() {
+    return OperationType.DELETE_JOB;
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/job/TestJobManager.java
+++ b/core/src/test/java/org/apache/gravitino/job/TestJobManager.java
@@ -1186,6 +1186,42 @@ public class TestJobManager {
   }
 
   @Test
+  public void testCleanUpStagingDirsNotifiesDeletionListener() throws IOException {
+    // The reaper is the only path that deletes a job, and it runs on a scheduler rather than for a
+    // request, so a listener is the only way an observer can learn the job is gone.
+    List<JobEntity> deleted = Lists.newArrayList();
+    JobManager manager =
+        Mockito.spy(new JobManager(config, entityStore, idGenerator, jobExecutor, deleted::add));
+
+    BaseMetalake mockMetalake =
+        BaseMetalake.builder()
+            .withName(metalake)
+            .withId(idGenerator.nextId())
+            .withVersion(SchemaVersion.V_0_1)
+            .withAuditInfo(AuditInfo.EMPTY)
+            .build();
+    when(entityStore.list(Namespace.empty(), BaseMetalake.class, Entity.EntityType.METALAKE))
+        .thenReturn(ImmutableList.of(mockMetalake));
+    mockedMetalake
+        .when(() -> MetalakeManager.listInUseMetalakes(entityStore))
+        .thenReturn(ImmutableList.of(metalake));
+
+    JobEntity finishedJob = newJobEntity("shell_job", JobHandle.Status.SUCCEEDED);
+    when(manager.listJobs(metalake, Optional.empty())).thenReturn(ImmutableList.of(finishedJob));
+
+    Awaitility.await()
+        .atMost(3, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              Assertions.assertDoesNotThrow(() -> manager.cleanUpStagingDirs());
+              return !deleted.isEmpty();
+            });
+
+    Assertions.assertEquals(1, deleted.size());
+    Assertions.assertEquals(finishedJob.name(), deleted.get(0).name());
+  }
+
+  @Test
   public void testUpdateShellJobTemplateEntity() {
     String jobTemplateName = "old_shell_job";
     String jobTemplateComment = "An old shell job template";

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestDeleteJobEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestDeleteJobEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import java.time.Instant;
+import org.apache.gravitino.job.JobHandle;
+import org.apache.gravitino.listener.api.event.job.DeleteJobEvent;
+import org.apache.gravitino.listener.api.info.JobInfo;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.JobEntity;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+import org.apache.gravitino.utils.NamespaceUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The staging directory cleanup is the only path that deletes a job, and it runs on the server's
+ * own schedule rather than for a request, so this event is the only signal a listener gets that a
+ * job is gone.
+ */
+class TestDeleteJobEvent {
+
+  @Test
+  void testEventCarriesTheDeletedJob() {
+    JobEntity job =
+        JobEntity.builder()
+            .withId(9001L)
+            .withJobExecutionId("exec-1")
+            .withNamespace(NamespaceUtil.ofJob("metalake"))
+            .withJobTemplateName("daily-etl")
+            .withStatus(JobHandle.Status.SUCCEEDED)
+            .withStartedAt(System.currentTimeMillis())
+            .withFinishedAt(System.currentTimeMillis())
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("tester").withCreateTime(Instant.now()).build())
+            .build();
+    JobInfo jobInfo = JobInfo.fromJobEntity(job);
+
+    DeleteJobEvent event = new DeleteJobEvent(DeleteJobEvent.SYSTEM_USER, "metalake", jobInfo);
+
+    Assertions.assertEquals(NameIdentifierUtil.ofJob("metalake", job.name()), event.identifier());
+    Assertions.assertEquals(OperationType.DELETE_JOB, event.operationType());
+    Assertions.assertEquals(OperationStatus.SUCCESS, event.operationStatus());
+    Assertions.assertSame(jobInfo, event.deletedJobInfo());
+    Assertions.assertEquals(DeleteJobEvent.SYSTEM_USER, event.user());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add `DeleteJobEvent`, so a listener can learn that a job is gone. Job templates already had `Register`, `Alter` and `Delete` events, while jobs had only `Run`, `Cancel`, `Get` and `List`.
- Give `JobManager` a listener, injected through the constructor, that it calls once per job its staging directory cleanup deletes. `GravitinoEnv` passes one that dispatches `DeleteJobEvent` on the event bus.
- Register `DELETE_JOB` in `AuditLog.Operation` and in the v2 `CompatibilityUtils` mapping, without which the audit log records it as `UNKNOWN_OPERATION`.

Constructor injection keeps `JobManager` free of a dependency on the event bus and keeps the field final. A listener that throws is logged and does not stop the cleanup from reaching the remaining jobs, which are already deleted from the store by that point.

### Why are the changes needed?

`JobManager.cleanUpStagingDirs()` is the only path that deletes a job. It runs on a scheduler inside `JobManager`, which sits at the bottom of the chain assembled in `GravitinoEnv`:

```
JobHookDispatcher -> JobEventDispatcher(eventBus) -> JobTemplateValidationDispatcher -> JobManager
```

The deletion therefore never passes through `JobEventDispatcher`, and no listener observes it. A listener that keeps a projection of jobs serves jobs that no longer exist, and its store grows without bound, because the one path that removes a job is invisible to it.

Fix: #13043

### Does this PR introduce _any_ user-facing change?

Yes, all additive:

- New event `DeleteJobEvent`, with `deletedJobInfo()` and operation type `DELETE_JOB`.
- New `OperationType.DELETE_JOB` and `AuditLog.Operation.DELETE_JOB`. Job deletions now appear in the audit log rather than being absent.
- New `JobManager` constructor taking the deletion listener. The existing constructors keep working and default to doing nothing, so no caller has to change.

One point I would like reviewers' opinion on: the cleanup runs on the server's own schedule, so no caller exists to attribute the deletion to, and `Event` requires a user. I added `DeleteJobEvent.SYSTEM_USER` for that case rather than reusing the anonymous user, which means an unauthenticated caller and would be misleading here. Happy to switch to another convention if the project has one.

### How was this patch tested?

- `TestJobManager.testCleanUpStagingDirsNotifiesDeletionListener` covers that the cleanup reports each job it deletes. Written first: it failed to compile against the old API, which is what proves it exercises the new path.
- `TestDeleteJobEvent` covers the event's identifier, operation type, operation status and payload.
- `./gradlew :core:test :core:javadoc -PskipITs`

The full `:core` suite is what caught the missing audit mapping: `TestCompatibilityUtils.testAllKnownOperationTypesMapToConcreteAuditOperation` fails for any `OperationType` that has no concrete audit operation, and the targeted job tests were all green while that was still broken.
