### PR TITLE
[#12544] feat(ci): run pull request tests with contributor fork resources

### DIFF
--- a/.github/actions/checkout-and-sync/action.yml
+++ b/.github/actions/checkout-and-sync/action.yml
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Checkout and sync
+description: Check out the upstream base branch and merge the contributor branch for fork CI.
+
+outputs:
+  base-ref:
+    description: Upstream branch used as the comparison base.
+    value: ${{ steps.base.outputs.base_ref }}
+  base-sha:
+    description: Upstream commit checked out before merging contributor changes.
+    value: ${{ steps.upstream.outputs.base_sha }}
+  head-sha:
+    description: Commit tested after contributor changes are merged.
+    value: ${{ steps.head.outputs.head_sha }}
+  synced:
+    description: Whether contributor changes were merged onto the upstream base.
+    value: ${{ steps.base.outputs.should_sync }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve pull request base branch
+      id: base
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        HEAD_OWNER: ${{ github.repository_owner }}
+        HEAD_BRANCH: ${{ github.ref_name }}
+        HEAD_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        if [[ "${GITHUB_REPOSITORY}" == "apache/gravitino" && \
+          ("${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_REF}" == refs/heads/branch-*) ]]; then
+          echo "base_ref=${GITHUB_REF_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "should_sync=false" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        response="$(curl --fail-with-body --silent --show-error \
+          --header "Accept: application/vnd.github+json" \
+          --header "Authorization: Bearer ${GH_TOKEN}" \
+          --header "X-GitHub-Api-Version: 2022-11-28" \
+          --get \
+          --data-urlencode "state=open" \
+          --data-urlencode "head=${HEAD_OWNER}:${HEAD_BRANCH}" \
+          --data-urlencode "per_page=10" \
+          "https://api.github.com/repos/apache/gravitino/pulls")"
+
+        base_ref="$(jq -r \
+          --arg head_sha "${HEAD_SHA}" \
+          '[.[] | select(.head.sha == $head_sha) | .base.ref]
+           | if length == 1 then .[0] else "main" end' \
+          <<< "${response}")"
+
+        echo "base_ref=${base_ref}" >> "${GITHUB_OUTPUT}"
+        echo "should_sync=true" >> "${GITHUB_OUTPUT}"
+
+    - name: Checkout upstream base branch
+      if: steps.base.outputs.should_sync == 'true'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        repository: apache/gravitino
+        ref: ${{ steps.base.outputs.base_ref }}
+
+    - name: Resolve upstream base commit
+      id: upstream
+      shell: bash
+      run: echo "base_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+    - name: Merge contributor branch
+      if: steps.base.outputs.should_sync == 'true'
+      shell: bash
+      env:
+        HEAD_REPOSITORY: ${{ github.repository }}
+        HEAD_BRANCH: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+
+        git fetch "https://github.com/${HEAD_REPOSITORY}.git" \
+          "+refs/heads/${HEAD_BRANCH}:refs/remotes/contributor/${HEAD_BRANCH}"
+        git \
+          -c user.name='Apache Gravitino CI' \
+          -c user.email='dev@gravitino.apache.org' \
+          merge --no-commit --no-ff "refs/remotes/contributor/${HEAD_BRANCH}"
+        git \
+          -c user.name='Apache Gravitino CI' \
+          -c user.email='dev@gravitino.apache.org' \
+          commit --allow-empty -m 'Merge contributor branch for CI'
+
+    - name: Resolve tested commit
+      id: head
+      shell: bash
+      run: echo "head_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/access-control-integration-test-action.yml
+++ b/.github/workflows/access-control-integration-test-action.yml
@@ -21,6 +21,7 @@ jobs:
       PLATFORM: ${{ inputs.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/access-control-integration-test.yml
+++ b/.github/workflows/access-control-integration-test.yml
@@ -2,14 +2,11 @@ name: Access Control Integration Test
 
 # Controls when the workflow will run
 on:
+  workflow_call:
   # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-access-control-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -17,11 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -20,15 +20,8 @@
 name: "ASF Allowlist Check"
 
 on:
+  workflow_call:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".github/**"
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/**"
 
 permissions:
   contents: read
@@ -40,6 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: ./.github/actions/checkout-and-sync
       - uses: apache/infrastructure-actions/allowlist-check@main
         with:
           scan-glob: ".github/**/*.y*ml"

--- a/.github/workflows/backend-integration-test-action.yml
+++ b/.github/workflows/backend-integration-test-action.yml
@@ -25,11 +25,12 @@ jobs:
   start-runner:
     name: JDK${{ inputs.java-version }}-${{ inputs.test-mode }}-${{ inputs.backend }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       PLATFORM: ${{ inputs.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -2,13 +2,10 @@ name: Backend Integration Test
 
 # Controls when the workflow will run
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-backend-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -18,11 +15,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,20 +2,10 @@ name: build
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: [ "main", "branch-*" ]
-    paths-ignore:
-      - 'docs/assets/**'
-      - 'web-v2/**'
-  pull_request:
-    branches: [ "main", "branch-*" ]
-    paths-ignore:
-      - 'docs/assets/**'
-      - 'web-v2/**'
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-build-${{ github.ref }}
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -24,11 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           list-files: shell
           filters: |
             source_changes:
@@ -103,6 +97,7 @@ jobs:
     if: needs.changes.outputs.source_changes != 'true'
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: ./.github/actions/setup-java-toolchains
         with:
@@ -120,6 +115,7 @@ jobs:
     if: needs.changes.outputs.spark_connector_changes == 'true'
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:
@@ -157,6 +153,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: build-checkout
 
       - uses: ./.github/actions/setup-java-toolchains
         with:
@@ -216,36 +214,30 @@ jobs:
           ./gradlew "${gradle_args[@]}"
 
       - name: Fetch base branch for coverage diff
-        if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }} --depth=1
+        if: steps.build-checkout.outputs.synced == 'true'
+        run: git fetch origin ${{ steps.build-checkout.outputs.base-ref }} --depth=1
 
       - name: Generate Coverage Report
         id: coverage
-        if: github.event_name == 'pull_request'
+        if: steps.build-checkout.outputs.synced == 'true'
         run: |
           python3 dev/ci/jacoco_report.py \
-            --base-ref "${{ github.base_ref }}" \
-            --head-sha "${{ github.event.pull_request.head.sha }}" \
-            --repo-url "${{ github.event.pull_request.head.repo.html_url }}" \
+            --base-ref "${{ steps.build-checkout.outputs.base-ref }}" \
+            --head-sha "${{ github.sha }}" \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}" \
             --min-overall 40 \
             --min-changed 60 \
             --output coverage-report.md
 
-      - name: Save PR number
-        if: github.event_name == 'pull_request' && steps.coverage.outputs.has_reports == 'true'
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
-
       - name: Upload Coverage Report
-        if: github.event_name == 'pull_request' && steps.coverage.outputs.has_reports == 'true'
+        if: steps.build-checkout.outputs.synced == 'true' && steps.coverage.outputs.has_reports == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report
-          path: |
-            coverage-report.md
-            pr-number.txt
+          path: coverage-report.md
 
       - name: Output Coverage Info
-        if: github.event_name == 'pull_request' && steps.coverage.outputs.has_reports == 'true'
+        if: steps.build-checkout.outputs.synced == 'true' && steps.coverage.outputs.has_reports == 'true'
         run: |
           echo "Total coverage ${{ steps.coverage.outputs.coverage-overall }}"
           echo "Changed Files coverage ${{ steps.coverage.outputs.coverage-changed-files }}"

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -2,11 +2,10 @@ name: Test Charts
 
 # Controls when the workflow will run
 on:
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-charts-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -14,11 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/workflows/**
@@ -34,6 +37,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
 
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310
@@ -92,7 +97,7 @@ jobs:
       - name: List changed
         id: list-changed
         run: |
-          changed=$(ct list-changed --chart-dirs=dev/charts --target-branch ${{ github.event.pull_request.base.ref }})
+          changed=$(ct list-changed --chart-dirs=dev/charts --target-branch ${{ steps.checkout.outputs.base-ref }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -101,7 +106,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          ct lint --chart-dirs=dev/charts --chart-yaml-schema=dev/ci/chart_schema.yaml --lint-conf=dev/ci/lintconf.yaml --target-branch ${{ github.event.pull_request.base.ref }} --check-version-increment=false
+          ct lint --chart-dirs=dev/charts --chart-yaml-schema=dev/ci/chart_schema.yaml --lint-conf=dev/ci/lintconf.yaml --target-branch ${{ steps.checkout.outputs.base-ref }} --check-version-increment=false
 
       - name: Set up helm-unittest
         if: steps.list-changed.outputs.changed == 'true'
@@ -172,19 +177,19 @@ jobs:
 
       - name: Run chart-testing (install default,gravitino)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --charts dev/charts/gravitino --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args "--set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino"
+        run: ct install --charts dev/charts/gravitino --target-branch ${{ steps.checkout.outputs.base-ref }} --helm-extra-set-args "--set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino"
 
       - name: Run chart-testing (install default,gravitino-iceberg-rest-server)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --charts dev/charts/gravitino-iceberg-rest-server --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args "--set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino-iceberg-rest"
+        run: ct install --charts dev/charts/gravitino-iceberg-rest-server --target-branch ${{ steps.checkout.outputs.base-ref }} --helm-extra-set-args "--set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino-iceberg-rest"
 
       - name: Run chart-testing (install gravitino with mysql enable,replicas 2)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --charts=dev/charts/gravitino --helm-extra-set-args "--values dev/charts/gravitino/resources/scenarios/ci-values.yaml --set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino" --target-branch ${{ github.event.pull_request.base.ref }}
+        run: ct install --charts=dev/charts/gravitino --helm-extra-set-args "--values dev/charts/gravitino/resources/scenarios/ci-values.yaml --set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino" --target-branch ${{ steps.checkout.outputs.base-ref }}
 
       - name: Run chart-testing (install gravitino with postgresql enable)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --charts=dev/charts/gravitino --helm-extra-set-args "--values dev/charts/gravitino/resources/scenarios/pg-values.yaml --set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino" --target-branch ${{ github.event.pull_request.base.ref }}
+        run: ct install --charts=dev/charts/gravitino --helm-extra-set-args "--values dev/charts/gravitino/resources/scenarios/pg-values.yaml --set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino" --target-branch ${{ steps.checkout.outputs.base-ref }}
 
       - name: Run chart-testing (install default,gravitino-lance-rest-server)
         if: steps.list-changed.outputs.changed == 'true'
@@ -196,4 +201,4 @@ jobs:
           -H "Accept: application/vnd.gravitino.v1+json" \
           -d '{"name":"lrs_test","comment":"Quick setup"}' \
           http://gravitino.test:8090/api/metalakes
-          ct install --charts dev/charts/gravitino-lance-rest-server --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args "--set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino-lance-rest --set lanceRest.gravitinoUri=http://gravitino.test:8090 --set lanceRest.gravitinoMetalake=lrs_test"
+          ct install --charts dev/charts/gravitino-lance-rest-server --target-branch ${{ steps.checkout.outputs.base-ref }} --helm-extra-set-args "--set image.registry="" --set image.repository=${KIND_REGISTRY}/gravitino-lance-rest --set lanceRest.gravitinoUri=http://gravitino.test:8090 --set lanceRest.gravitinoMetalake=lrs_test"

--- a/.github/workflows/contrib-catalog-test.yml
+++ b/.github/workflows/contrib-catalog-test.yml
@@ -1,14 +1,11 @@
 name: Contrib Catalog Test
 
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-contrib-catalog-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -18,11 +15,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/workflows/contrib-catalog-test.yml
@@ -39,9 +40,9 @@ jobs:
       - name: Detect changed catalogs-contrib modules
         id: contrib
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ "${{ steps.checkout.outputs.synced }}" = "true" ]; then
+            BASE_SHA="${{ steps.checkout.outputs.base-sha }}"
+            HEAD_SHA="$(git rev-parse HEAD)"
           else
             BASE_SHA="${{ github.event.before }}"
             HEAD_SHA="${{ github.sha }}"
@@ -75,6 +76,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/flink-integration-test-action.yml
+++ b/.github/workflows/flink-integration-test-action.yml
@@ -22,6 +22,7 @@ jobs:
       PLATFORM: ${{ inputs.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/flink-integration-test.yml
+++ b/.github/workflows/flink-integration-test.yml
@@ -2,13 +2,10 @@ name: Flink Integration Test
 
 # Controls when the workflow will run
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-flink-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,11 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**

--- a/.github/workflows/fork-ci-status-update.yml
+++ b/.github/workflows/fork-ci-status-update.yml
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.
+#
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Update Fork CI Status
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+
+permissions:
+  actions: read
+  checks: write
+  pull-requests: read
+
+jobs:
+  update:
+    name: Update fork CI checks
+    runs-on: ubuntu-slim
+    steps:
+      - name: Synchronize fork CI checks
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prs = await github.paginate(
+              'GET /repos/{owner}/{repo}/pulls',
+              { owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100 });
+
+            for (const pr of prs) {
+              if (!pr.head.repo) continue;
+              const owner = pr.head.repo.owner.login;
+              const repo = pr.head.repo.name;
+              let runs;
+              try {
+                runs = await github.paginate(
+                  'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs',
+                  { owner, repo, workflow_id: 'fork-ci.yml', branch: pr.head.ref, per_page: 100 });
+              } catch (error) {
+                core.warning(`Unable to read ${owner}/${repo}: ${error.message}`);
+                continue;
+              }
+
+              const run = runs.find(candidate => candidate.head_sha === pr.head.sha);
+              const checks = await github.paginate(
+                'GET /repos/{owner}/{repo}/commits/{ref}/check-runs',
+                { owner: context.repo.owner, repo: context.repo.repo, ref: pr.head.sha, per_page: 100 });
+              const forkChecks = checks.filter(check => check.name === 'Fork CI');
+
+              const detailsUrl = run
+                ? `https://github.com/${owner}/${repo}/actions/runs/${run.id}`
+                : `https://github.com/${owner}/${repo}/actions/workflows/fork-ci.yml`;
+              if (!forkChecks.length) {
+                const status = !run || run.status === 'completed' ? 'completed' : 'queued';
+                const conclusion = run && run.status === 'completed'
+                  ? run.conclusion
+                  : (run ? undefined : 'action_required');
+                const output = run
+                  ? {
+                      title: 'Fork CI results',
+                      summary: `[See fork CI results](${detailsUrl})`,
+                      text: JSON.stringify({ owner, repo, run_id: run.id })
+                    }
+                  : {
+                      title: 'Fork CI is not available',
+                      summary: 'Enable GitHub Actions in the fork and push the PR branch again.',
+                      text: JSON.stringify({ owner, repo, workflow: 'fork-ci.yml' })
+                    };
+                await github.rest.checks.create({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  name: 'Fork CI', head_sha: pr.head.sha, status,
+                  ...(conclusion ? { conclusion } : {}),
+                  details_url: detailsUrl, output
+                });
+              }
+
+              for (const check of forkChecks) {
+                if (!run) {
+                  await github.rest.checks.update({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    check_run_id: check.id, status: 'completed', conclusion: 'action_required',
+                    details_url: detailsUrl, output: check.output
+                  });
+                  continue;
+                }
+                const status = run.status === 'completed' ? 'completed' :
+                  (run.status === 'in_progress' ? 'in_progress' : 'queued');
+                const params = {
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  check_run_id: check.id, status, details_url: detailsUrl,
+                  output: check.output
+                };
+                if (status === 'completed') params.conclusion = run.conclusion;
+                await github.rest.checks.update(params);
+              }
+
+            }

--- a/.github/workflows/fork-ci-status.yml
+++ b/.github/workflows/fork-ci-status.yml
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.
+#
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Fork CI Status
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: read
+  checks: write
+
+jobs:
+  notify:
+    name: Notify fork CI
+    runs-on: ubuntu-slim
+    steps:
+      - name: Create fork CI check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = pr.head.repo.owner.login;
+            const repo = pr.head.repo.name;
+            const branch = pr.head.ref;
+            const headSha = pr.head.sha;
+            const workflow = 'fork-ci.yml';
+
+            let run;
+            for (let attempt = 0; attempt < 3 && !run; attempt++) {
+              if (attempt > 0) {
+                await new Promise(resolve => setTimeout(resolve, 3000));
+              }
+              try {
+                const runs = await github.paginate(
+                  'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs',
+                  { owner, repo, workflow_id: workflow, branch, per_page: 100 });
+                run = runs.find(candidate => candidate.head_sha === headSha);
+              } catch (error) {
+                core.warning(`Unable to read fork Actions: ${error.message}`);
+              }
+            }
+
+            const detailsUrl = run
+              ? `https://github.com/${owner}/${repo}/actions/runs/${run.id}`
+              : `https://github.com/${owner}/${repo}/actions/workflows/${workflow}`;
+            const status = !run || run.status === 'completed' ? 'completed' : 'queued';
+            const conclusion = run && run.status === 'completed'
+              ? run.conclusion
+              : (run ? undefined : 'action_required');
+
+            const output = run
+              ? {
+                  title: 'Fork CI results',
+                  summary: `[See fork CI results](${detailsUrl})`,
+                  text: JSON.stringify({ owner, repo, run_id: run.id })
+                }
+              : {
+                  title: 'Fork CI is not available',
+                  summary: 'Enable GitHub Actions in the fork and push the PR branch again.',
+                  text: JSON.stringify({ owner, repo, workflow })
+                };
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Fork CI',
+              head_sha: headSha,
+              status,
+              ...(conclusion ? { conclusion } : {}),
+              output,
+              details_url: detailsUrl
+            });

--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Run the complete CI entry point from branch pushes in the contributor's repository.
+name: Fork CI
+
+on:
+  push:
+    branches: ['**']
+
+concurrency:
+  group: fork-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  backend:
+    uses: ./.github/workflows/backend-integration-test.yml
+
+  spark:
+    uses: ./.github/workflows/spark-integration-test.yml
+
+  flink:
+    uses: ./.github/workflows/flink-integration-test.yml
+
+  trino:
+    uses: ./.github/workflows/trino-integration-test.yml
+
+  iceberg_rest_trino:
+    uses: ./.github/workflows/iceberg-rest-trino-integration-test.yml
+
+  python:
+    uses: ./.github/workflows/python-integration-test.yml
+
+  frontend:
+    uses: ./.github/workflows/frontend-integration-test.yml
+
+  access_control:
+    uses: ./.github/workflows/access-control-integration-test.yml
+
+  idp_basic:
+    uses: ./.github/workflows/idp-basic-test.yml
+
+  mcp:
+    uses: ./.github/workflows/mcp-integration-test.yml
+
+  maintenance:
+    uses: ./.github/workflows/maintenance-integration-test.yml
+
+  web_ui:
+    uses: ./.github/workflows/web-ui-tests.yml
+
+  charts:
+    uses: ./.github/workflows/chart-test.yaml
+
+  contrib_catalog:
+    uses: ./.github/workflows/contrib-catalog-test.yml
+
+  asf_allowlist:
+    uses: ./.github/workflows/asf-allowlist-check.yml
+
+  required_ci:
+    name: Required CI
+    if: always()
+    needs:
+      - build
+      - backend
+      - spark
+      - flink
+      - trino
+      - iceberg_rest_trino
+      - python
+      - frontend
+      - access_control
+      - idp_basic
+      - mcp
+      - maintenance
+      - web_ui
+      - charts
+      - contrib_catalog
+      - asf_allowlist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required CI suites
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "Required CI suite results:"
+          jq -r 'to_entries[] | "\(.key)=\(.value.result)"' <<< "${RESULTS}"
+          failures="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success" and .value.result != "skipped")
+              | "\(.key)=\(.value.result)"
+            ' <<< "${RESULTS}"
+          )"
+          if [ -n "${failures}" ]; then
+            echo "::error::One or more required CI suites did not succeed."
+            echo "${failures}"
+            exit 1
+          fi

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -2,13 +2,10 @@ name: Frontend Integration Test
 
 # Controls when the workflow will run
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-frontend-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,11 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**
@@ -69,6 +70,7 @@ jobs:
       PLATFORM: ${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: ./.github/actions/setup-java-toolchains
         with:

--- a/.github/workflows/iceberg-rest-trino-integration-test-action.yml
+++ b/.github/workflows/iceberg-rest-trino-integration-test-action.yml
@@ -21,6 +21,7 @@ jobs:
       PLATFORM: ${{ inputs.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       # Installs the primary JDK plus JDK 24 and registers JDK 24 with the Gradle
       # toolchain, which the trino-iceberg-rest module requires.

--- a/.github/workflows/iceberg-rest-trino-integration-test.yml
+++ b/.github/workflows/iceberg-rest-trino-integration-test.yml
@@ -5,13 +5,10 @@ name: Iceberg REST Trino Integration Test
 # The module uses a Java 24 toolchain (Trino 478) and runs in deploy mode against
 # the built distribution, so it needs its own job rather than the catch-all backend IT.
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-iceberg-rest-trino-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -19,11 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**

--- a/.github/workflows/idp-basic-test-action.yml
+++ b/.github/workflows/idp-basic-test-action.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/idp-basic-test.yml
+++ b/.github/workflows/idp-basic-test.yml
@@ -1,14 +1,11 @@
 name: IdP Basic Test
 
 on:
-  push:
-    branches: ["main", "branch-*"]
-  pull_request:
-    branches: ["main", "branch-*"]
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-idp-basic-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,11 +13,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - plugins/idp-basic/**

--- a/.github/workflows/maintenance-integration-test-action.yml
+++ b/.github/workflows/maintenance-integration-test-action.yml
@@ -22,6 +22,7 @@ jobs:
       PLATFORM: ${{ inputs.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/maintenance-integration-test.yml
+++ b/.github/workflows/maintenance-integration-test.yml
@@ -2,13 +2,10 @@ name: Maintenance Integration Test
 
 # Controls when the workflow will run
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-maintenance-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,11 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**

--- a/.github/workflows/mcp-integration-test-action.yml
+++ b/.github/workflows/mcp-integration-test-action.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: ./.github/actions/setup-java-toolchains
         with:

--- a/.github/workflows/mcp-integration-test.yml
+++ b/.github/workflows/mcp-integration-test.yml
@@ -19,13 +19,10 @@
 name: mcp-integration-test
 
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-mcp-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -35,11 +32,15 @@ jobs:
       mcp_or_authz_changes: ${{ steps.filter.outputs.mcp_or_authz_changes }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             mcp_or_authz_changes:
               - 'mcp-server/**'

--- a/.github/workflows/python-integration-test-action.yml
+++ b/.github/workflows/python-integration-test-action.yml
@@ -21,6 +21,7 @@ jobs:
       PLATFORM: ${{ inputs.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -2,13 +2,10 @@ name: Python Client Integration Test
 
 # Controls when the workflow will run
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-python-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,11 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**

--- a/.github/workflows/spark-integration-test-action.yml
+++ b/.github/workflows/spark-integration-test-action.yml
@@ -32,6 +32,7 @@ jobs:
       PLATFORM: ${{ inputs.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/spark-integration-test.yml
+++ b/.github/workflows/spark-integration-test.yml
@@ -2,13 +2,10 @@ name: Spark Integration Test
 
 # Controls when the workflow will run
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-spark-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,11 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**

--- a/.github/workflows/trino-integration-test-action.yml
+++ b/.github/workflows/trino-integration-test-action.yml
@@ -21,6 +21,7 @@ jobs:
       PLATFORM: ${{ inputs.architecture }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
 
       - uses: ./.github/actions/setup-java-toolchains
         with:

--- a/.github/workflows/trino-integration-test.yml
+++ b/.github/workflows/trino-integration-test.yml
@@ -2,13 +2,10 @@ name: Trino Integration Test
 
 # Controls when the workflow will run
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fork-ci-trino-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,11 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
       - name: Disable Git automatic maintenance
         run: git config --local maintenance.auto false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
           filters: |
             source_changes:
               - .github/**

--- a/.github/workflows/web-ui-tests.yml
+++ b/.github/workflows/web-ui-tests.yml
@@ -1,24 +1,42 @@
 name: Web UI Tests
 
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-    paths:
-      - 'web/web/**'
-      - '.github/workflows/web-ui-tests.yml'
-  pull_request:
-    branches: [ "main", "branch-*" ]
-    paths:
-      - 'web/web/**'
-      - '.github/workflows/web-ui-tests.yml'
+  workflow_call:
+
+concurrency:
+  group: fork-ci-web-ui-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      source_changes: ${{ steps.filter.outputs.source_changes }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-and-sync
+        id: checkout
+      - name: Disable Git automatic maintenance
+        run: git config --local maintenance.auto false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
+        id: filter
+        with:
+          base: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.base-sha || steps.checkout.outputs.base-ref }}
+          ref: ${{ steps.checkout.outputs.synced == 'true' && steps.checkout.outputs.head-sha || github.ref }}
+          filters: |
+            source_changes:
+              - 'web/web/**'
+              - '.github/**'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.source_changes == 'true'
     runs-on: ubuntu-latest
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+    - uses: ./.github/actions/checkout-and-sync
     
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10


### PR DESCRIPTION
### What changes were proposed in this pull request?

Run pull request CI from the contributor fork on branch pushes, following the Apache Spark model:

- Check out the resolved Apache Gravitino base branch and merge the contributor branch before testing.
- Convert the migrated suites to reusable workflows and fan them out from one Fork CI entry point.
- Aggregate suite results into one Required CI result.
- Mirror the fork workflow result to the upstream pull request through trusted status workflows.
- Preserve changed-path filtering, release-branch bases, chart testing, and contrib catalog testing.

### Why are the changes needed?

Pull request tests currently consume Apache-hosted Actions resources. Running untrusted pull request code in the contributor fork moves that workload to contributor-owned Actions resources while the upstream repository only reads and reports the result.

Fix: #12544

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. Contributors must enable GitHub Actions in their fork and push the pull request branch to run Fork CI.

### How was this patch tested?

- actionlint v1.7.12 on all workflow YAML files.
- Live fork run 34355192254: checkout/sync and changed-path detection passed; it exposed an empty chart base in push mode and a cold-cache Backend MySQL run reaching the 120-minute timeout.
- Live fork run 34431409678 after the chart fix: completed successfully, including all suites and Required CI.
- Raised the shared Backend IT timeout to 180 minutes for cold fork caches; the resulting workflow files pass actionlint.
