### PR TITLE
[MINOR] fix(release): abort when a required config is missing in force mode

### DIFF
--- a/dev/release/release-util.sh
+++ b/dev/release/release-util.sh
@@ -27,7 +27,7 @@ ASF_REPO_WEBUI="https://raw.githubusercontent.com/apache/gravitino"
 ASF_GRAVITINO_REPO="gitbox.apache.org/repos/asf/gravitino.git"
 
 function error {
-  echo "$*"
+  echo "$*" >&2
   exit 1
 }
 
@@ -105,7 +105,10 @@ function get_release_info {
       cut -d/ -f3)
   fi
 
-  export GIT_BRANCH=$(read_config "Branch" "$GIT_BRANCH" GIT_BRANCH)
+  # Assign before exporting: `export VAR=$(...)` would mask a failure in the
+  # substitution, since the exit status seen by `set -e` is export's own.
+  GIT_BRANCH=$(read_config "Branch" "$GIT_BRANCH" GIT_BRANCH)
+  export GIT_BRANCH
 
   # Find the current version for the branch.
   local VERSION=$(curl -s "$ASF_REPO_WEBUI/$GIT_BRANCH/gradle.properties" |
@@ -145,7 +148,8 @@ function get_release_info {
   fi
 
   export NEXT_VERSION
-  export RELEASE_VERSION=$(read_config "Release" "$RELEASE_VERSION" RELEASE_VERSION)
+  RELEASE_VERSION=$(read_config "Release" "$RELEASE_VERSION" RELEASE_VERSION)
+  export RELEASE_VERSION
 
   # If -r was explicitly provided (non-zero), override the auto-detected NRC_COUNT
   if [ "${RC_COUNT:-0}" -gt 0 ]; then
@@ -185,16 +189,19 @@ function get_release_info {
 
   # Gather some user information.
   if [ -z "${ASF_USERNAME:-}" ]; then
-    export ASF_USERNAME=$(read_config "ASF user" "$LOGNAME" ASF_USERNAME)
+    ASF_USERNAME=$(read_config "ASF user" "$LOGNAME" ASF_USERNAME)
+    export ASF_USERNAME
   fi
 
   if [ -z "${GIT_NAME:-}" ]; then
     GIT_NAME=$(git config user.name || echo "")
-    export GIT_NAME=$(read_config "Full name" "$GIT_NAME" GIT_NAME)
+    GIT_NAME=$(read_config "Full name" "$GIT_NAME" GIT_NAME)
+    export GIT_NAME
   fi
 
   export GIT_EMAIL="$ASF_USERNAME@apache.org"
-  export GPG_KEY=$(read_config "GPG key" "$GIT_EMAIL" GPG_KEY)
+  GPG_KEY=$(read_config "GPG key" "$GIT_EMAIL" GPG_KEY)
+  export GPG_KEY
 
   cat <<EOF
 ================


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `dev/release/release-util.sh`:

- `error` now writes to stderr. `read_config` returns its value on stdout, and every call site captures it with `$(...)`, so a fatal message written to stdout became the variable's value instead of being displayed.
- The five `export VAR=$(read_config ...)` call sites are split into an assignment followed by `export`. `exit 1` inside a command substitution only ends the subshell, and `export` reports its own exit status (always 0), so `set -e` in `do-release.sh` never saw the failure. A bare assignment propagates it.

`RC_COUNT` and `GIT_REF` already used the two-line form and were unaffected.

### Why are the changes needed?

With `-y` and a required variable unset, the release script printed the error text as configuration and continued:

```
ASF USER:   Force mode requires 'ASF user' to be set via environment variable ASF_USERNAME.
GPG KEY:    Force mode requires 'GPG key' to be set via environment variable GPG_KEY.
FULL NAME:  Force mode requires 'Full name' to be set via environment variable GIT_NAME.
E-MAIL:     Force mode requires 'ASF user' to be set via environment variable ASF_USERNAME.@apache.org
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran `dev/release/mock/do-release.sh -b branch-1.3 -r 1 -y` with `ASF_USERNAME`, `GIT_NAME` and `GPG_KEY` unset. Before the change the run reached the interactive password prompt with all four identity fields holding the error text; after it, the message is printed once on stderr and the script exits with status 1.
