### PR TITLE
[#12429] feat(catalog-lakehouse-generic): Pluggable table location provider

### DIFF
--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/DefaultTableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/DefaultTableLocationProvider.java
@@ -34,12 +34,16 @@ import org.apache.gravitino.rel.Table;
  * levels:
  *
  * <ol>
- *   <li>the table's own {@code location} property, used as-is;
+ *   <li>the table's own {@code location} property, with a trailing slash added;
  *   <li>the schema's {@code location} property, with the table name appended;
  *   <li>the catalog's {@code location} property, with the schema and table names appended.
  * </ol>
  *
  * If none of them is set, provisioning fails with an {@link IllegalArgumentException}.
+ *
+ * <p>The first level is unreachable through the catalog, which keeps a caller-supplied location
+ * without consulting any provider. It is kept so that the three levels still read as one rule, and
+ * so that calling this provider directly behaves as it always has.
  */
 public class DefaultTableLocationProvider implements TableLocationProvider {
 
@@ -48,7 +52,7 @@ public class DefaultTableLocationProvider implements TableLocationProvider {
 
   private static final String SLASH = "/";
 
-  private Optional<String> catalogLocation = Optional.empty();
+  private volatile Optional<String> catalogLocation = Optional.empty();
 
   @Override
   public String name() {
@@ -57,8 +61,7 @@ public class DefaultTableLocationProvider implements TableLocationProvider {
 
   @Override
   public void initialize(Map<String, String> catalogProperties) {
-    String location =
-        catalogProperties == null ? null : catalogProperties.get(Catalog.PROPERTY_LOCATION);
+    String location = catalogProperties.get(Catalog.PROPERTY_LOCATION);
     this.catalogLocation =
         StringUtils.isNotBlank(location)
             ? Optional.of(location).map(DefaultTableLocationProvider::ensureTrailingSlash)
@@ -95,7 +98,7 @@ public class DefaultTableLocationProvider implements TableLocationProvider {
     }
 
     return ensureTrailingSlash(catalogLocation.get())
-        + tableIdent.namespace().level(2)
+        + schema.name()
         + SLASH
         + tableIdent.name()
         + SLASH;
@@ -111,7 +114,29 @@ public class DefaultTableLocationProvider implements TableLocationProvider {
   @Override
   public void unprovisionTableLocation(TableLocationContext context) {}
 
-  private static String ensureTrailingSlash(String path) {
+  /**
+   * Does nothing, for the same reason as {@link #unprovisionTableLocation(TableLocationContext)}: a
+   * composed location was never allocated anywhere, so a location the table did not use costs
+   * nothing and there is nothing to release. Written out rather than inherited so that the two
+   * callbacks are visibly deliberate here, not overlooked.
+   *
+   * @param context the table that was created, unused
+   */
+  @Override
+  public void releaseUnusedLocation(TableLocationContext context) {}
+
+  /**
+   * Appends a trailing slash to the given path unless it already ends with one.
+   *
+   * <p>Package-private rather than private so that {@link GenericCatalogOperations} can apply the
+   * very same normalization to a caller-supplied location, which bypasses this provider, and when
+   * comparing a provisioned location against the one the created table reports. Sharing the method
+   * is what keeps those and this provider from drifting apart.
+   *
+   * @param path the path to normalize
+   * @return the path, ending with a slash
+   */
+  static String ensureTrailingSlash(String path) {
     return path.endsWith(SLASH) ? path : path + SLASH;
   }
 }

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/DefaultTableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/DefaultTableLocationProvider.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Schema;
+import org.apache.gravitino.rel.Table;
+
+/**
+ * The built-in {@link TableLocationProvider}, used when the {@code table-location-provider} catalog
+ * property is not set.
+ *
+ * <p>It derives the table location from the {@code location} property, falling back through three
+ * levels:
+ *
+ * <ol>
+ *   <li>the table's own {@code location} property, used as-is;
+ *   <li>the schema's {@code location} property, with the table name appended;
+ *   <li>the catalog's {@code location} property, with the schema and table names appended.
+ * </ol>
+ *
+ * If none of them is set, provisioning fails with an {@link IllegalArgumentException}.
+ */
+public class DefaultTableLocationProvider implements TableLocationProvider {
+
+  /** The name under which this provider is registered. */
+  public static final String NAME = "default";
+
+  private static final String SLASH = "/";
+
+  private Optional<String> catalogLocation = Optional.empty();
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public void initialize(Map<String, String> catalogProperties) {
+    String location =
+        catalogProperties == null ? null : catalogProperties.get(Catalog.PROPERTY_LOCATION);
+    this.catalogLocation =
+        StringUtils.isNotBlank(location)
+            ? Optional.of(location).map(DefaultTableLocationProvider::ensureTrailingSlash)
+            : Optional.empty();
+  }
+
+  @Override
+  public String provisionTableLocation(TableLocationContext context) {
+    NameIdentifier tableIdent = context.tableIdentifier();
+    Schema schema = context.schema();
+
+    String tableLocation = context.tableProperties().get(Table.PROPERTY_LOCATION);
+    if (StringUtils.isNotBlank(tableLocation)) {
+      return ensureTrailingSlash(tableLocation);
+    }
+
+    String schemaLocation =
+        schema.properties() == null ? null : schema.properties().get(Schema.PROPERTY_LOCATION);
+
+    // If we do not set location in table properties, and schema location is set, use schema
+    // location as the base path.
+    if (StringUtils.isNotBlank(schemaLocation)) {
+      return ensureTrailingSlash(schemaLocation) + tableIdent.name() + SLASH;
+    }
+
+    // If the schema location is not set, use catalog lakehouse dir as the base path. Or else, throw
+    // an exception.
+    if (catalogLocation.isEmpty()) {
+      throw new IllegalArgumentException(
+          "'location' property is neither set in table properties "
+              + "nor in schema properties, and no location is set in catalog properties either. "
+              + "Please set the 'location' in either of them to create the table "
+              + tableIdent);
+    }
+
+    return ensureTrailingSlash(catalogLocation.get())
+        + tableIdent.namespace().level(2)
+        + SLASH
+        + tableIdent.name()
+        + SLASH;
+  }
+
+  /**
+   * Does nothing: this provider composes the location from the table, schema and catalog {@code
+   * location} properties and registers it nowhere, so there is nothing to hand back. Deleting the
+   * data itself stays the responsibility of the table format.
+   *
+   * @param context the table that was dropped, unused
+   */
+  @Override
+  public void unprovisionTableLocation(TableLocationContext context) {}
+
+  private static String ensureTrailingSlash(String path) {
+    return path.endsWith(SLASH) ? path : path + SLASH;
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/GenericCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/GenericCatalogOperations.java
@@ -32,8 +32,10 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
@@ -78,9 +80,11 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
 
   private final Map<String, Supplier<ManagedTableOperations>> tableOpsCache;
 
-  private TableLocationProvider tableLocationProvider;
+  private volatile TableLocationProvider tableLocationProvider;
 
-  private Map<String, String> catalogProperties = Map.of();
+  private volatile Map<String, String> catalogProperties = Map.of();
+
+  private final AtomicBoolean closed = new AtomicBoolean();
 
   private final Cache<NameIdentifier, String> tableFormatCache;
 
@@ -128,7 +132,13 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
   public void initialize(
       Map<String, String> conf, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
       throws RuntimeException {
-    this.catalogProperties = conf == null ? Map.of() : Maps.newHashMap(conf);
+    // A defensive copy that tolerates null values, for the same reason as
+    // TableLocationContext.Builder#withTableProperties: nothing upstream rejects a catalog
+    // property whose value is null, and ImmutableMap.copyOf would turn one into a
+    // NullPointerException. Here it would fail the creation of the whole catalog rather than a
+    // single request.
+    this.catalogProperties =
+        conf == null ? Map.of() : Collections.unmodifiableMap(Maps.newHashMap(conf));
 
     String providerName =
         (String)
@@ -142,8 +152,14 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
   @Override
   public void close() throws IOException {
     tableFormatCache.cleanUp();
-    if (tableLocationProvider != null) {
-      tableLocationProvider.close();
+
+    // A flag rather than clearing the field: closing the catalog twice must not close the provider
+    // twice, but a drop in flight while the catalog shuts down must not meet a null provider
+    // either. The contract asks a provider to tolerate close after a failed initialize, not
+    // repeated closes from its owner.
+    TableLocationProvider provider = tableLocationProvider;
+    if (provider != null && closed.compareAndSet(false, true)) {
+      provider.close();
     }
   }
 
@@ -207,11 +223,14 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
           "Schema %s is not empty, cannot drop it without cascade", ident);
     }
 
-    // Drop all tables under the schema first if cascade is true. This goes through the catalog
-    // level dropTable, so that the location of each table is unprovisioned and its cached format
-    // invalidated.
+    // Drop all tables under the schema first if cascade is true. This goes through the same path
+    // as the catalog level dropTable, so that the location of each table is unprovisioned and its
+    // cached format invalidated. The schema is resolved once for the whole cascade rather than
+    // once per table: every table here has the same parent, and the provider may not ask for it at
+    // all.
+    Schema cascadedSchema = loadSchema(ident);
     for (NameIdentifier tableIdent : tableIdents) {
-      dropTable(tableIdent);
+      dropOrPurgeTable(tableIdent, false /* purge */, cascadedSchema);
     }
 
     return schemaOps.dropSchema(ident, cascade);
@@ -250,34 +269,38 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
     Schema schema = loadSchema(NameIdentifier.of(ident.namespace().levels()));
-    String tableLocation =
-        validateProvisionedLocation(
-            tableLocationProvider.provisionTableLocation(
-                TableLocationContext.builder()
-                    .withTableIdentifier(ident)
-                    .withTableProperties(properties)
-                    .withSchema(schema)
-                    .build()),
-            tableLocationProvider.name(),
-            ident);
 
     String format = properties.getOrDefault(Table.PROPERTY_TABLE_FORMAT, null);
     Preconditions.checkArgument(
         format != null, "Table format must be specified in table properties");
     format = format.toLowerCase(Locale.ROOT);
 
-    Map<String, String> newProperties = Maps.newHashMap(properties);
-    newProperties.put(Table.PROPERTY_LOCATION, tableLocation);
-    newProperties.put(Table.PROPERTY_TABLE_FORMAT, format);
-
     // Get the table operations for the specified table format.
     Supplier<ManagedTableOperations> tableOpsSupplier = tableOpsCache.get(format);
     Preconditions.checkArgument(tableOpsSupplier != null, "Unsupported table format: %s", format);
     ManagedTableOperations tableOps = configureTableOps(tableOpsSupplier.get());
 
+    // The provider is consulted only once the request is known to be one this catalog can serve,
+    // and only when the catalog is the one choosing the location. A provider that allocates real
+    // storage has no compensating callback, so every check that can be made before asking it for a
+    // location is one reservation it does not have to reclaim later.
+    String suppliedLocation = properties.get(Table.PROPERTY_LOCATION);
+    boolean provisioned = StringUtils.isBlank(suppliedLocation);
+    String tableLocation =
+        provisioned
+            ? provisionTableLocation(ident, properties, schema)
+            : DefaultTableLocationProvider.ensureTrailingSlash(suppliedLocation);
+
+    Map<String, String> newProperties = Maps.newHashMap(properties);
+    newProperties.put(Table.PROPERTY_LOCATION, tableLocation);
+    newProperties.put(Table.PROPERTY_TABLE_FORMAT, format);
+
     Table createdTable =
         tableOps.createTable(
             ident, columns, comment, newProperties, partitions, distribution, sortOrders, indexes);
+    if (provisioned) {
+      releaseLocationIfUnused(ident, schema, newProperties, tableLocation, createdTable);
+    }
     // Cache the table format for future use.
     tableFormatCache.put(ident, format);
     return createdTable;
@@ -308,6 +331,17 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
   }
 
   /**
+   * Returns the cache mapping a table to its format, so that tests can assert it is kept in step
+   * with the tables that exist.
+   *
+   * @return the table format cache
+   */
+  @VisibleForTesting
+  Cache<NameIdentifier, String> tableFormatCache() {
+    return tableFormatCache;
+  }
+
+  /**
    * Drops or purges a table, and hands its location back to the {@link TableLocationProvider}
    * afterwards.
    *
@@ -323,6 +357,25 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
    * @return true if the table was dropped, false if it did not exist
    */
   private boolean dropOrPurgeTable(NameIdentifier ident, boolean purge) {
+    return dropOrPurgeTable(
+        ident, purge, loadSchema(NameIdentifier.of(ident.namespace().levels())));
+  }
+
+  /**
+   * Drops or purges a table, resolving its parent schema through the given supplier.
+   *
+   * <p>The schema is passed in rather than loaded here so that a cascading schema drop, where every
+   * table shares one parent, loads it once instead of once per table. It stays eager: the context
+   * is built in full before the table is removed, so that a store read failing fails the request
+   * while the table is still there, rather than from inside a callback where it could only be
+   * reported as a provider failure it is not.
+   *
+   * @param ident the identifier of the table to drop
+   * @param purge whether to purge the table instead of dropping it
+   * @param schema the table's parent schema
+   * @return true if the table was dropped, false if it did not exist
+   */
+  private boolean dropOrPurgeTable(NameIdentifier ident, boolean purge, Schema schema) {
     Map<String, String> tableProperties;
     try {
       tableProperties = store.get(ident, TABLE, TableEntity.class).properties();
@@ -340,49 +393,67 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
         TableLocationContext.builder()
             .withTableIdentifier(ident)
             .withTableProperties(tableProperties)
-            .withSchema(loadSchema(NameIdentifier.of(ident.namespace().levels())))
+            .withSchema(schema)
             .build();
 
-    boolean dropped = purge ? tableOps(ident).purgeTable(ident) : tableOps(ident).dropTable(ident);
+    // The properties just read are handed on rather than left to be read again: resolving the
+    // table format is a second store read for the very same entity whenever the format cache is
+    // cold, which for a drop it usually is.
+    ManagedTableOperations tableOps = tableOps(ident, tableProperties);
+    boolean dropped = purge ? tableOps.purgeTable(ident) : tableOps.dropTable(ident);
     tableFormatCache.invalidate(ident);
 
-    if (dropped) {
+    if (dropped && !context.isExternal()) {
+      TableLocationProvider provider = tableLocationProvider;
       try {
-        tableLocationProvider.unprovisionTableLocation(context);
+        provider.unprovisionTableLocation(context);
       } catch (Exception e) {
         LOG.warn(
             "Table {} was already {}, but table location provider '{}' failed to unprovision its "
                 + "location '{}'. The storage may be leaked and needs to be reclaimed manually.",
             ident,
             purge ? "purged" : "dropped",
-            tableLocationProvider.name(),
+            provider.name(),
             context.tableProperties().get(Table.PROPERTY_LOCATION),
             e);
       }
+    } else if (dropped) {
+      LOG.debug(
+          "Table {} is external, so its location '{}' is left alone rather than handed back to "
+              + "table location provider '{}': the catalog does not own that data.",
+          ident,
+          context.tableProperties().get(Table.PROPERTY_LOCATION),
+          tableLocationProvider.name());
     }
 
     return dropped;
   }
 
-  /**
-   * Returns the cache mapping a table to its format, so that tests can assert it is kept in step
-   * with the tables that exist.
-   *
-   * @return the table format cache
-   */
-  @VisibleForTesting
-  Cache<NameIdentifier, String> tableFormatCache() {
-    return tableFormatCache;
+  private ManagedTableOperations tableOps(NameIdentifier tableIdent) {
+    return tableOps(tableIdent, null);
   }
 
-  private ManagedTableOperations tableOps(NameIdentifier tableIdent) {
+  /**
+   * Returns the table operations for the format of the given table.
+   *
+   * @param tableIdent the identifier of the table
+   * @param knownProperties the table's properties if the caller has already read them, null to have
+   *     them read from the store when the format cache misses. Passing them in only saves a store
+   *     read; it does not let a caller override the format of a table that is already cached.
+   * @return the table operations for the table's format
+   */
+  private ManagedTableOperations tableOps(
+      NameIdentifier tableIdent, @Nullable Map<String, String> knownProperties) {
     try {
       String tableFormat =
           tableFormatCache.get(
               tableIdent,
               () -> {
-                TableEntity table = store.get(tableIdent, TABLE, TableEntity.class);
-                String format = table.properties().getOrDefault(Table.PROPERTY_TABLE_FORMAT, null);
+                Map<String, String> properties =
+                    knownProperties != null
+                        ? knownProperties
+                        : store.get(tableIdent, TABLE, TableEntity.class).properties();
+                String format = properties.getOrDefault(Table.PROPERTY_TABLE_FORMAT, null);
                 Preconditions.checkArgument(
                     format != null, "Table format for %s is null, this is unexpected", tableIdent);
 
@@ -418,29 +489,147 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
   }
 
   /**
-   * Validates the location returned by a {@link TableLocationProvider} before it is stored in the
-   * table properties, so that a misbehaving provider fails the table creation instead of silently
-   * producing a broken location.
+   * Asks the {@link TableLocationProvider} where the table being created should live.
    *
-   * <p>Only blankness is checked. The shape of the path belongs to the provider: nothing downstream
-   * appends to the location, and the value is stored verbatim so that a provider unprovisioning it
-   * later sees exactly the string it returned.
+   * <p>Called only when the request does not carry a location of its own. A caller that supplies a
+   * location has already decided where the data goes, and in this catalog it usually does so
+   * because the data is already there: an external Delta table, or a Lance registration, both of
+   * which point at a dataset that exists. Handing such a request to a provider that allocates
+   * storage would do two wrong things at once -- repoint the table at a freshly allocated empty
+   * path, leaving the caller's data orphaned while the creation still reports success, and leave
+   * behind an allocation that is never written to and never handed back.
    *
-   * @param location the location returned by the provider
-   * @param providerName the name of the provider that returned it
-   * @param tableIdent the identifier of the table being created
-   * @return the validated location
-   * @throws IllegalArgumentException if the location is blank
+   * <p>The catalog cannot tell those requests apart from a caller merely overriding placement, and
+   * a rule each provider has to re-derive for itself is a rule most of them will get wrong. So the
+   * provider is consulted only when the catalog is the one choosing, which is also what this
+   * catalog has always done with a supplied location. A deployment that wants allocation to be
+   * mandatory has to reject a caller-supplied location before it reaches the catalog.
+   *
+   * @param ident the identifier of the table being created
+   * @param properties the table properties the caller supplied
+   * @param schema the schema the table is created in
+   * @return the provisioned location, never blank
    */
-  @VisibleForTesting
-  static String validateProvisionedLocation(
-      String location, String providerName, NameIdentifier tableIdent) {
+  private String provisionTableLocation(
+      NameIdentifier ident, Map<String, String> properties, Schema schema) {
+    TableLocationProvider provider = tableLocationProvider;
+    String location =
+        provider.provisionTableLocation(
+            TableLocationContext.builder()
+                .withTableIdentifier(ident)
+                .withTableProperties(properties)
+                .withSchema(schema)
+                .build());
+
+    // Only blankness is checked. The shape of the path belongs to the provider: nothing downstream
+    // appends to the location, and the value is stored verbatim so that a provider unprovisioning
+    // it later sees exactly the string it returned.
     Preconditions.checkArgument(
         StringUtils.isNotBlank(location),
         "Table location provider '%s' returned a null or blank location for table %s",
-        providerName,
-        tableIdent);
+        provider.name(),
+        ident);
 
     return location;
+  }
+
+  /**
+   * Hands back a location that was provisioned for this creation and that the created table does
+   * not point at.
+   *
+   * <p>A format may decline the location it was given and still report success. Lance's {@code
+   * EXIST_OK} creation mode returns the table that already exists, at the location that table
+   * already had, and a client retrying a create is the ordinary way to reach that path. Without
+   * this, every such call would leak one allocation with nothing in the logs to show for it.
+   *
+   * <p>This is {@link TableLocationProvider#releaseUnusedLocation(TableLocationContext)} and not
+   * {@link TableLocationProvider#unprovisionTableLocation(TableLocationContext)}, even though for
+   * the built-in provider the two do the same nothing. The table here is alive and is about to be
+   * returned to the caller; a provider that reclaims by table identity rather than by path would
+   * read the drop callback literally and delete the registration of a table that exists. Releasing
+   * defaults to doing nothing for exactly that reason, so a provider opts in to it knowingly.
+   *
+   * <p>Releasing is safe here in a way it is not on the creation failure path: nothing can have
+   * been written to a location the created table does not point at. A failure to release is logged
+   * and otherwise ignored, as it is on drop -- the table was created, and reporting the creation as
+   * failed would be the worse answer.
+   *
+   * <p>The two locations are compared with a trailing slash added to both, since that is the one
+   * rewrite this catalog performs itself. A format that rewrites the location further -- collapsing
+   * a duplicated separator, or normalizing a URI scheme -- is indistinguishable from here from a
+   * format that declined the location outright, which the contract warns providers about.
+   *
+   * @param ident the identifier of the table that was created
+   * @param schema the schema the table was created in
+   * @param properties the properties the format was given, carrying the provisioned location
+   * @param provisionedLocation the location the provider handed out
+   * @param createdTable the table the format returned, which may be null
+   */
+  private void releaseLocationIfUnused(
+      NameIdentifier ident,
+      Schema schema,
+      Map<String, String> properties,
+      String provisionedLocation,
+      Table createdTable) {
+    // Neither built-in delegator returns null, but a third-party one that did would otherwise
+    // fail a creation that has already succeeded, and only on this path: the same delegator would
+    // serve a request that carried its own location without complaint. An asymmetry like that is
+    // far harder to diagnose than the leaked location that returning here may cost.
+    if (createdTable == null) {
+      return;
+    }
+
+    Map<String, String> createdProperties = createdTable.properties();
+    String storedLocation =
+        createdProperties == null ? null : createdProperties.get(Table.PROPERTY_LOCATION);
+
+    // Only a location that is visibly different is released. A format reporting no location at all
+    // may still be using the one it was handed, and leaking it is the safer reading of that.
+    if (StringUtils.isBlank(storedLocation)
+        || DefaultTableLocationProvider.ensureTrailingSlash(provisionedLocation)
+            .equals(DefaultTableLocationProvider.ensureTrailingSlash(storedLocation))) {
+      return;
+    }
+
+    TableLocationProvider provider = tableLocationProvider;
+    // The exact class, not instanceof: the built-in provider composes its location from
+    // configuration and registers it nowhere, so nothing was allocated and nothing can leak. A
+    // subclass of it may well allocate, and silencing that one would be the same lie in the other
+    // direction. Warning unconditionally would be the more common lie, since a client retrying a
+    // create reaches this path routinely on a default deployment.
+    if (provider.getClass() == DefaultTableLocationProvider.class) {
+      LOG.debug(
+          "Table {} was created at '{}' rather than at the composed location '{}'. The composed "
+              + "location was never allocated anywhere, so there is nothing to release.",
+          ident,
+          storedLocation,
+          provisionedLocation);
+    } else {
+      LOG.warn(
+          "Table {} was created at '{}' rather than at the provisioned location '{}'. Asking "
+              + "table location provider '{}' to release the unused location; a provider that "
+              + "does not implement the release callback leaves it allocated.",
+          ident,
+          storedLocation,
+          provisionedLocation,
+          provider.name());
+    }
+
+    try {
+      provider.releaseUnusedLocation(
+          TableLocationContext.builder()
+              .withTableIdentifier(ident)
+              .withTableProperties(properties)
+              .withSchema(schema)
+              .build());
+    } catch (Exception e) {
+      LOG.warn(
+          "Table location provider '{}' failed to release the unused location '{}' provisioned for "
+              + "table {}. The storage may be leaked and needs to be reclaimed manually.",
+          provider.name(),
+          provisionedLocation,
+          ident,
+          e);
+    }
   }
 }

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/GenericCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/GenericCatalogOperations.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.Catalog;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
@@ -67,21 +66,21 @@ import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.ExceptionMessages;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Operations for interacting with a generic lakehouse catalog in Apache Gravitino. */
 public class GenericCatalogOperations implements CatalogOperations, SupportsSchemas, TableCatalog {
 
-  private static final String SLASH = "/";
+  private static final Logger LOG = LoggerFactory.getLogger(GenericCatalogOperations.class);
 
   private final ManagedSchemaOperations schemaOps;
 
   private final Map<String, Supplier<ManagedTableOperations>> tableOpsCache;
 
-  private Optional<String> catalogLocation;
+  private TableLocationProvider tableLocationProvider;
 
   private Map<String, String> catalogProperties = Map.of();
-
-  private HasPropertyMetadata propertiesMetadata;
 
   private final Cache<NameIdentifier, String> tableFormatCache;
 
@@ -130,21 +129,22 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
       Map<String, String> conf, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
       throws RuntimeException {
     this.catalogProperties = conf == null ? Map.of() : Maps.newHashMap(conf);
-    String location =
+
+    String providerName =
         (String)
             propertiesMetadata
                 .catalogPropertiesMetadata()
-                .getOrDefault(conf, Catalog.PROPERTY_LOCATION);
-    this.catalogLocation =
-        StringUtils.isNotBlank(location)
-            ? Optional.of(location).map(this::ensureTrailingSlash)
-            : Optional.empty();
-    this.propertiesMetadata = propertiesMetadata;
+                .getOrDefault(conf, GenericCatalogPropertiesMetadata.TABLE_LOCATION_PROVIDER);
+    this.tableLocationProvider =
+        TableLocationProviderFactory.create(providerName, catalogProperties);
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     tableFormatCache.cleanUp();
+    if (tableLocationProvider != null) {
+      tableLocationProvider.close();
+    }
   }
 
   @Override
@@ -175,6 +175,21 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
     return schemaOps.alterSchema(ident, changes);
   }
 
+  /**
+   * Drops a schema, dropping every table it contains first when cascade is set.
+   *
+   * <p>The cascaded tables go through {@link #dropTable(NameIdentifier)} rather than straight to
+   * the table operations, so that the location of each of them is unprovisioned and its cached
+   * format invalidated. A table failing to drop aborts the cascade: the tables handled so far are
+   * gone, the remaining ones and the schema itself are untouched, and the call can safely be
+   * retried. A {@link TableLocationProvider} failing to unprovision a location does not abort it,
+   * because the table it belongs to is already gone.
+   *
+   * @param ident the identifier of the schema to drop
+   * @param cascade whether to drop the tables contained in the schema
+   * @return true if the schema was dropped, false if it did not exist
+   * @throws NonEmptySchemaException if the schema contains tables and cascade is not set
+   */
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
     Namespace tableNs =
@@ -192,9 +207,11 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
           "Schema %s is not empty, cannot drop it without cascade", ident);
     }
 
-    // Drop all tables under the schema first if cascade is true.
+    // Drop all tables under the schema first if cascade is true. This goes through the catalog
+    // level dropTable, so that the location of each table is unprovisioned and its cached format
+    // invalidated.
     for (NameIdentifier tableIdent : tableIdents) {
-      tableOps(tableIdent).dropTable(tableIdent);
+      dropTable(tableIdent);
     }
 
     return schemaOps.dropSchema(ident, cascade);
@@ -233,7 +250,16 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
     Schema schema = loadSchema(NameIdentifier.of(ident.namespace().levels()));
-    String tableLocation = calculateTableLocation(schema, ident, properties);
+    String tableLocation =
+        validateProvisionedLocation(
+            tableLocationProvider.provisionTableLocation(
+                TableLocationContext.builder()
+                    .withTableIdentifier(ident)
+                    .withTableProperties(properties)
+                    .withSchema(schema)
+                    .build()),
+            tableLocationProvider.name(),
+            ident);
 
     String format = properties.getOrDefault(Table.PROPERTY_TABLE_FORMAT, null);
     Preconditions.checkArgument(
@@ -273,57 +299,80 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
 
   @Override
   public boolean purgeTable(NameIdentifier ident) {
-    boolean purged = tableOps(ident).purgeTable(ident);
-    tableFormatCache.invalidate(ident);
-    return purged;
+    return dropOrPurgeTable(ident, true /* purge */);
   }
 
   @Override
   public boolean dropTable(NameIdentifier ident) throws UnsupportedOperationException {
-    boolean dropped = tableOps(ident).dropTable(ident);
+    return dropOrPurgeTable(ident, false /* purge */);
+  }
+
+  /**
+   * Drops or purges a table, and hands its location back to the {@link TableLocationProvider}
+   * afterwards.
+   *
+   * <p>The table properties are read before the removal, because they carry the location the
+   * provider has to hand back, and the unprovisioning itself happens after the removal so that a
+   * provider never reclaims the storage of a table that is still there. A provider failing to
+   * unprovision is logged at WARN rather than propagated: the table is already gone at that point,
+   * so failing the request would report a drop that did in fact happen as unsuccessful and invite a
+   * retry that cannot undo anything.
+   *
+   * @param ident the identifier of the table to drop
+   * @param purge whether to purge the table instead of dropping it
+   * @return true if the table was dropped, false if it did not exist
+   */
+  private boolean dropOrPurgeTable(NameIdentifier ident, boolean purge) {
+    Map<String, String> tableProperties;
+    try {
+      tableProperties = store.get(ident, TABLE, TableEntity.class).properties();
+    } catch (NoSuchEntityException e) {
+      return false;
+    } catch (IOException e) {
+      throw new RuntimeException(
+          String.format("Failed to load table %s before dropping it", ident), e);
+    }
+
+    // Built entirely before the drop, so that a store read failing here fails the request while
+    // the table is still there, rather than after it is gone where it could only be reported as a
+    // provider failure it is not.
+    TableLocationContext context =
+        TableLocationContext.builder()
+            .withTableIdentifier(ident)
+            .withTableProperties(tableProperties)
+            .withSchema(loadSchema(NameIdentifier.of(ident.namespace().levels())))
+            .build();
+
+    boolean dropped = purge ? tableOps(ident).purgeTable(ident) : tableOps(ident).dropTable(ident);
     tableFormatCache.invalidate(ident);
+
+    if (dropped) {
+      try {
+        tableLocationProvider.unprovisionTableLocation(context);
+      } catch (Exception e) {
+        LOG.warn(
+            "Table {} was already {}, but table location provider '{}' failed to unprovision its "
+                + "location '{}'. The storage may be leaked and needs to be reclaimed manually.",
+            ident,
+            purge ? "purged" : "dropped",
+            tableLocationProvider.name(),
+            context.tableProperties().get(Table.PROPERTY_LOCATION),
+            e);
+      }
+    }
+
     return dropped;
   }
 
-  private String calculateTableLocation(
-      Schema schema, NameIdentifier tableIdent, Map<String, String> tableProperties) {
-    String tableLocation =
-        (String)
-            propertiesMetadata
-                .tablePropertiesMetadata()
-                .getOrDefault(tableProperties, Table.PROPERTY_LOCATION);
-    if (StringUtils.isNotBlank(tableLocation)) {
-      return ensureTrailingSlash(tableLocation);
-    }
-
-    String schemaLocation =
-        schema.properties() == null ? null : schema.properties().get(Schema.PROPERTY_LOCATION);
-
-    // If we do not set location in table properties, and schema location is set, use schema
-    // location as the base path.
-    if (StringUtils.isNotBlank(schemaLocation)) {
-      return ensureTrailingSlash(schemaLocation) + tableIdent.name() + SLASH;
-    }
-
-    // If the schema location is not set, use catalog lakehouse dir as the base path. Or else, throw
-    // an exception.
-    if (catalogLocation.isEmpty()) {
-      throw new IllegalArgumentException(
-          "'location' property is neither set in table properties "
-              + "nor in schema properties, and no location is set in catalog properties either. "
-              + "Please set the 'location' in either of them to create the table "
-              + tableIdent);
-    }
-
-    return ensureTrailingSlash(catalogLocation.get())
-        + tableIdent.namespace().level(2)
-        + SLASH
-        + tableIdent.name()
-        + SLASH;
-  }
-
-  private String ensureTrailingSlash(String path) {
-    return path.endsWith(SLASH) ? path : path + SLASH;
+  /**
+   * Returns the cache mapping a table to its format, so that tests can assert it is kept in step
+   * with the tables that exist.
+   *
+   * @return the table format cache
+   */
+  @VisibleForTesting
+  Cache<NameIdentifier, String> tableFormatCache() {
+    return tableFormatCache;
   }
 
   private ManagedTableOperations tableOps(NameIdentifier tableIdent) {
@@ -366,5 +415,32 @@ public class GenericCatalogOperations implements CatalogOperations, SupportsSche
     }
 
     return ops;
+  }
+
+  /**
+   * Validates the location returned by a {@link TableLocationProvider} before it is stored in the
+   * table properties, so that a misbehaving provider fails the table creation instead of silently
+   * producing a broken location.
+   *
+   * <p>Only blankness is checked. The shape of the path belongs to the provider: nothing downstream
+   * appends to the location, and the value is stored verbatim so that a provider unprovisioning it
+   * later sees exactly the string it returned.
+   *
+   * @param location the location returned by the provider
+   * @param providerName the name of the provider that returned it
+   * @param tableIdent the identifier of the table being created
+   * @return the validated location
+   * @throws IllegalArgumentException if the location is blank
+   */
+  @VisibleForTesting
+  static String validateProvisionedLocation(
+      String location, String providerName, NameIdentifier tableIdent) {
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(location),
+        "Table location provider '%s' returned a null or blank location for table %s",
+        providerName,
+        tableIdent);
+
+    return location;
   }
 }

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/GenericCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/GenericCatalogPropertiesMetadata.java
@@ -36,6 +36,13 @@ import org.apache.gravitino.connector.PropertyEntry;
 
 public class GenericCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata {
 
+  /**
+   * The name of the {@link TableLocationProvider} that provisions and unprovisions the locations of
+   * this catalog's tables. Defaults to {@link DefaultTableLocationProvider#NAME} and is immutable
+   * once the catalog is created.
+   */
+  public static final String TABLE_LOCATION_PROVIDER = "table-location-provider";
+
   private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA;
 
   static {
@@ -54,6 +61,15 @@ public class GenericCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
                 null, /* defaultValue */
                 false /* hidden */,
                 false /* reserved */),
+            stringOptionalPropertyEntry(
+                TABLE_LOCATION_PROVIDER,
+                "The name of the table location provider that provisions and unprovisions the"
+                    + " locations of this catalog's tables. It is fixed when the catalog is"
+                    + " created, because switching it would leave the tables of a single catalog"
+                    + " spread over two different location schemes.",
+                true /* immutable */,
+                DefaultTableLocationProvider.NAME, /* defaultValue */
+                false /* hidden */),
             enumPropertyEntry(
                 LANCE_SCHEMA_REFRESH_MODE,
                 "Controls when Lance table schemas are refreshed from the underlying dataset.",

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationContext.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationContext.java
@@ -20,19 +20,24 @@ package org.apache.gravitino.catalog.lakehouse.generic;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import java.util.Collections;
 import java.util.Map;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;
+import org.apache.gravitino.rel.Table;
 
 /**
- * The context passed to a {@link TableLocationProvider}, both when the location of a table that is
- * being created has to be provisioned and when the location of a table that has been dropped has to
- * be unprovisioned.
+ * The context passed to a {@link TableLocationProvider} on each of its three callbacks: when a
+ * table is being created and its location has to be provisioned, when a location that was
+ * provisioned turns out not to be the one the table ended up at and has to be released, and when a
+ * table has been dropped and its location has to be unprovisioned.
  *
- * <p>The same type is used for both operations so that a new input becomes an additional accessor
- * rather than a signature change: providers written against an older version keep compiling and
- * running. For that reason implementations should not rely on the constructor signature and should
- * build instances through {@link #builder()}.
+ * <p>The same type is used for all three so that a new input becomes an additional accessor rather
+ * than a signature change: providers written against an older version keep compiling and running.
+ * For that reason implementations should not rely on the constructor signature and should build
+ * instances through {@link #builder()}.
  */
 public class TableLocationContext {
 
@@ -60,11 +65,27 @@ public class TableLocationContext {
   }
 
   /**
-   * Returns the properties of the table this context is about. On provisioning, these are the
-   * properties of the creation request, before the location is filled in. On unprovisioning, these
-   * are the stored properties of the table being dropped, read right before it was removed, so they
-   * carry the {@code location} that was provisioned for it under {@link
-   * org.apache.gravitino.rel.Table#PROPERTY_LOCATION}.
+   * Returns the properties of the table this context is about. Which properties those are, and in
+   * particular whether the {@code location} entry ({@link
+   * org.apache.gravitino.rel.Table#PROPERTY_LOCATION}) is filled in, depends on the callback being
+   * served:
+   *
+   * <ul>
+   *   <li>{@link TableLocationProvider#provisionTableLocation(TableLocationContext)} gets the
+   *       properties of the creation request. There is no location worth reading here: the provider
+   *       is consulted only when the request did not carry a non-blank one, so the entry is either
+   *       absent or blank.
+   *   <li>{@link TableLocationProvider#releaseUnusedLocation(TableLocationContext)} gets the
+   *       properties the table was created with, so the location entry is filled in, and it holds
+   *       exactly the provisioned location that is to be released.
+   *   <li>{@link TableLocationProvider#unprovisionTableLocation(TableLocationContext)} gets the
+   *       stored properties of the table being dropped, read right before it was removed, so the
+   *       location entry holds the location that was provisioned for it.
+   * </ul>
+   *
+   * <p>Values are carried through as they were given, null ones included: the catalog accepts a
+   * property whose value is null, and this context is not the layer that starts to reject it. Read
+   * a property with {@code get} rather than assuming that a key which is present has a value.
    *
    * @return the table properties, never null but possibly empty
    */
@@ -79,6 +100,22 @@ public class TableLocationContext {
    */
   public Schema schema() {
     return schema;
+  }
+
+  /**
+   * Returns whether the table this context is about is an external table, that is, one whose data
+   * the catalog does not own and only points at.
+   *
+   * <p>This is the {@code external} entry of {@link #tableProperties()}, read as a boolean, and is
+   * false when the entry is absent, null or not parseable. It is offered as an accessor because it
+   * changes what a provider should do: the catalog does not ask a provider to unprovision the
+   * location of an external table, and a provider asked to provision one is being asked for a path
+   * for data that may already exist elsewhere.
+   *
+   * @return true if the table is marked external
+   */
+  public boolean isExternal() {
+    return BooleanUtils.toBoolean(tableProperties.get(Table.PROPERTY_EXTERNAL));
   }
 
   /**
@@ -113,15 +150,20 @@ public class TableLocationContext {
     }
 
     /**
-     * Sets the properties of the table this context is about. A null value is treated as an empty
-     * map.
+     * Sets the properties of the table this context is about. A null map is treated as an empty
+     * one; a null value under a key is kept as it is.
      *
      * @param tableProperties the table properties
      * @return this builder
      */
     public Builder withTableProperties(Map<String, String> tableProperties) {
+      // A defensive copy that tolerates null values, which ImmutableMap.copyOf would reject. The
+      // catalog itself accepts a property whose value is null, and building this context must not
+      // be what turns such a request into a failure.
       this.tableProperties =
-          tableProperties == null ? ImmutableMap.of() : ImmutableMap.copyOf(tableProperties);
+          tableProperties == null
+              ? ImmutableMap.of()
+              : Collections.unmodifiableMap(Maps.newHashMap(tableProperties));
       return this;
     }
 

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationContext.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationContext.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.Map;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.rel.Table;
@@ -106,16 +105,20 @@ public class TableLocationContext {
    * Returns whether the table this context is about is an external table, that is, one whose data
    * the catalog does not own and only points at.
    *
-   * <p>This is the {@code external} entry of {@link #tableProperties()}, read as a boolean, and is
-   * false when the entry is absent, null or not parseable. It is offered as an accessor because it
-   * changes what a provider should do: the catalog does not ask a provider to unprovision the
-   * location of an external table, and a provider asked to provision one is being asked for a path
-   * for data that may already exist elsewhere.
+   * <p>This is the {@code external} entry of {@link #tableProperties()}, read with {@link
+   * Boolean#parseBoolean(String)}, so only {@code "true"} ignoring case is true and anything else,
+   * absent or null included, is false. That is deliberately the same reading the table formats and
+   * the property metadata use: a provider that saw {@code external} differently from the format
+   * that owns the data would skip reclaiming a location the format had just deleted the data under,
+   * or reclaim one it had left alone. It is offered as an accessor because it changes what a
+   * provider should do: the catalog does not ask a provider to unprovision the location of an
+   * external table, and a provider asked to provision one is being asked for a path for data that
+   * may already exist elsewhere.
    *
    * @return true if the table is marked external
    */
   public boolean isExternal() {
-    return BooleanUtils.toBoolean(tableProperties.get(Table.PROPERTY_EXTERNAL));
+    return Boolean.parseBoolean(tableProperties.get(Table.PROPERTY_EXTERNAL));
   }
 
   /**

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationContext.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationContext.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Schema;
+
+/**
+ * The context passed to a {@link TableLocationProvider}, both when the location of a table that is
+ * being created has to be provisioned and when the location of a table that has been dropped has to
+ * be unprovisioned.
+ *
+ * <p>The same type is used for both operations so that a new input becomes an additional accessor
+ * rather than a signature change: providers written against an older version keep compiling and
+ * running. For that reason implementations should not rely on the constructor signature and should
+ * build instances through {@link #builder()}.
+ */
+public class TableLocationContext {
+
+  private final NameIdentifier tableIdentifier;
+
+  private final Map<String, String> tableProperties;
+
+  private final Schema schema;
+
+  private TableLocationContext(
+      NameIdentifier tableIdentifier, Map<String, String> tableProperties, Schema schema) {
+    this.tableIdentifier = tableIdentifier;
+    this.tableProperties = tableProperties;
+    this.schema = schema;
+  }
+
+  /**
+   * Returns the identifier of the table this context is about, in the form of {@code
+   * metalake.catalog.schema.table}.
+   *
+   * @return the table identifier, never null
+   */
+  public NameIdentifier tableIdentifier() {
+    return tableIdentifier;
+  }
+
+  /**
+   * Returns the properties of the table this context is about. On provisioning, these are the
+   * properties of the creation request, before the location is filled in. On unprovisioning, these
+   * are the stored properties of the table being dropped, read right before it was removed, so they
+   * carry the {@code location} that was provisioned for it under {@link
+   * org.apache.gravitino.rel.Table#PROPERTY_LOCATION}.
+   *
+   * @return the table properties, never null but possibly empty
+   */
+  public Map<String, String> tableProperties() {
+    return tableProperties;
+  }
+
+  /**
+   * Returns the schema the table belongs to, including its properties.
+   *
+   * @return the parent schema, never null
+   */
+  public Schema schema() {
+    return schema;
+  }
+
+  /**
+   * Creates a builder for {@link TableLocationContext}.
+   *
+   * @return a new builder
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** A builder for {@link TableLocationContext}. */
+  public static class Builder {
+
+    private NameIdentifier tableIdentifier;
+
+    private Map<String, String> tableProperties = ImmutableMap.of();
+
+    private Schema schema;
+
+    private Builder() {}
+
+    /**
+     * Sets the identifier of the table this context is about.
+     *
+     * @param tableIdentifier the table identifier
+     * @return this builder
+     */
+    public Builder withTableIdentifier(NameIdentifier tableIdentifier) {
+      this.tableIdentifier = tableIdentifier;
+      return this;
+    }
+
+    /**
+     * Sets the properties of the table this context is about. A null value is treated as an empty
+     * map.
+     *
+     * @param tableProperties the table properties
+     * @return this builder
+     */
+    public Builder withTableProperties(Map<String, String> tableProperties) {
+      this.tableProperties =
+          tableProperties == null ? ImmutableMap.of() : ImmutableMap.copyOf(tableProperties);
+      return this;
+    }
+
+    /**
+     * Sets the schema the table belongs to.
+     *
+     * @param schema the parent schema
+     * @return this builder
+     */
+    public Builder withSchema(Schema schema) {
+      this.schema = schema;
+      return this;
+    }
+
+    /**
+     * Builds the {@link TableLocationContext}.
+     *
+     * @return the built context
+     */
+    public TableLocationContext build() {
+      Preconditions.checkArgument(tableIdentifier != null, "tableIdentifier must not be null");
+      Preconditions.checkArgument(schema != null, "schema must not be null");
+      return new TableLocationContext(tableIdentifier, tableProperties, schema);
+    }
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProvider.java
@@ -60,9 +60,10 @@ import java.util.Map;
  *   <li>{@link #name()} must be unique across the classpath, and must not be {@value
  *       DefaultTableLocationProvider#NAME}, which is reserved by {@link
  *       DefaultTableLocationProvider}. If two providers share a name, every catalog selecting that
- *       name fails to initialize. A provider that cannot be instantiated at all is logged and
- *       skipped rather than failing the lookup, so one broken jar does not stop every catalog from
- *       starting.
+ *       name fails to initialize. A provider whose constructor or {@link #name()} throws is logged
+ *       and skipped rather than failing the lookup, so a provider that is broken at runtime does
+ *       not stop catalogs that named a different one from starting. A services file naming a class
+ *       that cannot be loaded at all still fails the lookup.
  * </ul>
  *
  * <p><b>Known limitations.</b> Four of them, and they all point the same way: a provider that

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProvider.java
@@ -32,25 +32,70 @@ import java.util.Map;
  * their own implementation instead.
  *
  * <p>An instance is created per catalog, {@link #initialize(Map)} is called once before any
- * provisioning, and {@link #close()} is called when the catalog is closed. Neither {@link
- * #provisionTableLocation(TableLocationContext)} nor {@link
- * #unprovisionTableLocation(TableLocationContext)} is supported after {@link #close()}.
- * Implementations must be thread-safe, because both of them are called concurrently by table
- * requests.
+ * provisioning, and {@link #close()} is called when the catalog is closed. Implementations must be
+ * thread-safe: {@link #provisionTableLocation(TableLocationContext)}, {@link
+ * #unprovisionTableLocation(TableLocationContext)} and {@link
+ * #releaseUnusedLocation(TableLocationContext)} are all called concurrently by table requests.
+ *
+ * <p>The catalog does not fence in-flight requests against {@link #close()}, so a request that
+ * started before the catalog was closed can reach any of the three callbacks afterwards. An
+ * implementation is not asked to keep working across a close; it is asked to fail cleanly rather
+ * than corrupt anything, which is what a closed client throwing does on its own. On the drop and
+ * release paths the failure is logged at WARN and nothing else happens; on the provisioning path it
+ * fails the table creation, which is the right answer for a catalog that is shutting down.
  *
  * <p>Implementations must satisfy two constraints imposed by the {@link java.util.ServiceLoader}
  * based discovery:
  *
  * <ul>
- *   <li>They must have a public no-argument constructor that is cheap and does not throw. Every
- *       provider registered on the classpath is instantiated before the one matching the catalog
- *       property is selected, so a heavy or failing constructor breaks the initialization of every
- *       catalog, including those using the built-in provider. Connection pools, remote clients and
- *       any other expensive setup belong in {@link #initialize(Map)}.
+ *   <li>They must have a public no-argument constructor that is cheap, does not throw and acquires
+ *       nothing. Every provider registered on the classpath is instantiated before the one matching
+ *       the catalog property is selected, so a heavy constructor slows the initialization of every
+ *       catalog, including those using the built-in provider. One that throws is logged and skipped
+ *       rather than failing the lookup, which costs that provider the ability to be selected at
+ *       all. The instances that were not selected are then discarded without {@link #close()} being
+ *       called on them, so anything a constructor acquires is leaked once per catalog creation.
+ *       Connection pools, remote clients and any other expensive setup belong in {@link
+ *       #initialize(Map)}.
  *   <li>{@link #name()} must be unique across the classpath, and must not be {@value
  *       DefaultTableLocationProvider#NAME}, which is reserved by {@link
- *       DefaultTableLocationProvider}. Two providers sharing a name make every catalog selecting
- *       that name fail to initialize.
+ *       DefaultTableLocationProvider}. If two providers share a name, every catalog selecting that
+ *       name fails to initialize. A provider that cannot be instantiated at all is logged and
+ *       skipped rather than failing the lookup, so one broken jar does not stop every catalog from
+ *       starting.
+ * </ul>
+ *
+ * <p><b>Known limitations.</b> Four of them, and they all point the same way: a provider that
+ * manages real storage needs its own reconciliation against the catalog and cannot treat the
+ * callbacks here as a complete record of what it handed out.
+ *
+ * <ul>
+ *   <li>{@code location} is a mutable table property, so {@code alterTable(setProperty("location",
+ *       ...))} repoints a table without this provider being told. The old location is never
+ *       unprovisioned and the new one never went through this provider.
+ *   <li>{@link #provisionTableLocation(TableLocationContext)} is called before the table is
+ *       actually created, so a creation that fails afterwards -- a table that already exists, or a
+ *       failure inside the table format itself -- leaves a location provisioned for a table that
+ *       does not exist. There is no compensating unprovision, deliberately: a table format that
+ *       fails partway through creation may already have written to the location, and calling {@link
+ *       #unprovisionTableLocation(TableLocationContext)} would then tell the provider it is free to
+ *       reclaim a path that has data on it. Leaking an unused path is the safer of the two
+ *       failures, and doing better would need the format to report whether it touched storage
+ *       before failing, which this interface cannot express. Every check this catalog can make on
+ *       its own is made before the provider is consulted, so the cases that remain are the ones
+ *       only the table format can detect.
+ *   <li>A table format that drops a table through its own internals, rather than through the
+ *       catalog, does not trigger {@link #unprovisionTableLocation(TableLocationContext)}. Lance's
+ *       {@code OVERWRITE} creation mode does this: it drops the existing table and creates a new
+ *       one, so the old location is never handed back. A format-internal drop is not visible to the
+ *       catalog, so this cannot be closed from here.
+ *   <li>{@code alterTable(rename(...))} changes a table's identity without telling this provider,
+ *       and without moving any data. A provider deriving the path from the table name is left with
+ *       a path that no longer matches the name, which is cosmetic. A provider that books
+ *       allocations against {@code (schema, table)} loses the table altogether: the drop that
+ *       follows arrives under the new name, and the allocation booked under the old one is never
+ *       handed back. Such a provider has to reconcile renames out of band, or the deployment has to
+ *       forbid renaming tables in this catalog.
  * </ul>
  */
 public interface TableLocationProvider extends Closeable {
@@ -72,7 +117,12 @@ public interface TableLocationProvider extends Closeable {
    * a connection or any state that must outlive a single table creation must override it, and
    * release those resources in {@link #close()}.
    *
-   * @param catalogProperties the properties of the catalog owning this provider
+   * <p>Throwing from here fails the initialization of the catalog. The instance is closed before
+   * the failure propagates, so a provider that acquired part of its resources before giving up
+   * still gets to release them in {@link #close()}.
+   *
+   * @param catalogProperties the properties of the catalog owning this provider, never null and
+   *     never modified after this call
    */
   default void initialize(Map<String, String> catalogProperties) {}
 
@@ -85,9 +135,19 @@ public interface TableLocationProvider extends Closeable {
    * nothing downstream appends to the location, and storing it unchanged is what lets a provider
    * unprovisioning it later match the string it handed out.
    *
-   * <p>A user-supplied {@code location} is visible in {@link
-   * TableLocationContext#tableProperties()} and the provider is free to honour or ignore it; the
-   * value returned here always wins.
+   * <p>A request that carries its own {@code location} never reaches this method; the supplied
+   * value is stored, normalized only with a trailing slash. In this catalog a caller supplies a
+   * location mostly because the data is already there -- an external Delta table, or a Lance
+   * registration -- and allocating a fresh empty path for one of those would orphan the caller's
+   * data while still reporting success. The catalog cannot tell those requests apart from a caller
+   * merely overriding placement, so it keeps the supplied location in both cases, which is also
+   * what it has always done. A deployment that wants allocation to be mandatory has to reject a
+   * caller-supplied location before it reaches the catalog; a provider cannot enforce it, because
+   * it is not called.
+   *
+   * <p>Everything else reaches this method, including an external table that carries no location.
+   * Whether a table is external can be read from the {@code external} entry of {@link
+   * TableLocationContext#tableProperties()}.
    *
    * @param context the table being created and the context needed to derive its location
    * @return the provisioned table location, never null or blank
@@ -110,15 +170,88 @@ public interface TableLocationProvider extends Closeable {
    * failure is logged at WARN and the drop still reports success. Dropping a schema with cascade
    * unprovisions the location of every table it contains, one by one.
    *
-   * <p>It is called at most once per dropped table, but a server crash between the removal and this
-   * call means it may not be called at all, so an implementation reclaiming real storage needs its
-   * own reconciliation to catch those. It must also tolerate being called for a location that is
-   * already released. Like {@link #provisionTableLocation(TableLocationContext)}, it is called
-   * concurrently and must be thread-safe.
+   * <p>It is <em>not</em> called for external tables. The catalog does not own their data -- the
+   * table formats leave the dataset in place on drop -- so asking a provider to hand the location
+   * back would invite it to delete exactly the data the catalog just promised not to touch. A leak
+   * is recoverable and a deletion is not, so the callback is skipped. {@link
+   * TableLocationContext#isExternal()} reports the same flag on the paths where it is called.
+   *
+   * <p>The external flag is an approximation of the rule this callback actually wants, which is
+   * "hand back only what was handed out", and two cases stay asymmetric under it. An external table
+   * created without a location <em>does</em> get one provisioned -- both table formats check the
+   * location after the catalog has filled it in -- and skipping leaks that one. A table that is not
+   * external but whose creation carried its own location was never provisioned, yet is still
+   * unprovisioned here, so the provider is asked about a path it never issued. Distinguishing them
+   * exactly would need the catalog to record, per table, whether it provisioned the location, which
+   * it does not do today. Both cases are why an implementation reclaiming real storage needs its
+   * own reconciliation, and why this method must tolerate a location it does not recognize.
+   *
+   * <p>There is no purge flag in the context, because for the tables this catalog manages there is
+   * nothing to distinguish: {@code ManagedTableOperations.purgeTable} delegates straight to {@code
+   * dropTable}, so the two paths remove exactly the same things. The signal that matters is {@code
+   * external}, which is already available.
+   *
+   * <p>This method is only ever called for a table that is gone. A location provisioned for a table
+   * that then went on to exist somewhere else is handed back through {@link
+   * #releaseUnusedLocation(TableLocationContext)} instead, which is a separate method precisely so
+   * that an implementation deleting by table identity does not delete a live table.
+   *
+   * <p>It is called once per dropped table, but it is not guaranteed to be called at all. A crash
+   * between the removal and this call skips it, and so does a failure raised inside the drop after
+   * the metadata is already gone, which takes no crash and leaves the server running normally. An
+   * implementation reclaiming real storage needs its own reconciliation to catch both. It must also
+   * tolerate being called for a location that is already released. Like {@link
+   * #provisionTableLocation(TableLocationContext)}, it is called concurrently and must be
+   * thread-safe.
    *
    * @param context the table that was dropped and the context needed to release its location
    */
   void unprovisionTableLocation(TableLocationContext context);
+
+  /**
+   * Hands back a location that was provisioned for a table creation the table format did not use,
+   * so that it is not leaked. The location to release is the {@code location} entry of {@link
+   * TableLocationContext#tableProperties()}.
+   *
+   * <p><b>The table is alive.</b> This is the one callback here that does not mean the table went
+   * away: the creation succeeded, the caller is about to be handed the table, and only the location
+   * this provider issued for that call went unused, because the format answered with a table living
+   * somewhere else. An {@code EXIST_OK}-style creation mode reaching a table that already exists is
+   * the ordinary way to get here. An implementation must therefore release <em>the location</em>
+   * and must not delete anything keyed by the table identity in the context, because that identity
+   * belongs to a table that exists. This is why the callback is not {@link
+   * #unprovisionTableLocation(TableLocationContext)}: for a provider deriving paths from
+   * configuration the two are the same operation, but for one that books allocations against {@code
+   * (schema, table)} they are opposites, and no runtime flag would have made that difference as
+   * hard to overlook as two methods do.
+   *
+   * <p>For the same reason the {@code external} entry of the properties is not a signal to skip
+   * here, though it is on the drop path. The location being released was allocated by this provider
+   * moments ago, on request, so nobody else's data can be under it.
+   *
+   * <p>The default implementation does nothing, which leaks the unused location. That is the
+   * deliberate default: not releasing is what this catalog did before the callback existed and
+   * costs one stray allocation, whereas releasing something the implementation has misidentified
+   * costs live data. A provider that allocates real storage should implement it.
+   *
+   * <p>This is deliberately the opposite call from {@link
+   * #unprovisionTableLocation(TableLocationContext)}, which has no default so that no provider can
+   * stay silent about drops by accident. The two differ because the cost of silence differs: there,
+   * silence leaks a location on every drop, on the ordinary path, forever; here it leaks one
+   * location in the uncommon case that a format declined the one it was given. A provider that
+   * cannot release by path -- because the service behind it only deletes by table identity --
+   * should leave this method alone and reclaim through its own reconciliation, which the default
+   * lets it do without writing a body that would be wrong.
+   *
+   * <p>The catalog decides that a location went unused by comparing the location it handed the
+   * format with the one the created table reports, ignoring a trailing slash. A format that
+   * rewrites the location it was given -- normalizing a URI scheme, say -- looks from here like a
+   * format that declined it, so a provider whose paths may come back rewritten should verify before
+   * reclaiming. Throwing is logged at WARN and does not fail the creation, which already succeeded.
+   *
+   * @param context the table that was created and the unused location provisioned for it
+   */
+  default void releaseUnusedLocation(TableLocationContext context) {}
 
   /**
    * Releases the resources held by this provider. The default implementation does nothing.

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProvider.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A pluggable strategy for deciding where the data of a newly created table lives.
+ *
+ * <p>Implementations are discovered through Java's {@link java.util.ServiceLoader} and selected by
+ * {@link #name()} using the {@code table-location-provider} catalog property. The built-in {@link
+ * DefaultTableLocationProvider} derives the location from the table, schema and catalog {@code
+ * location} properties; deployments that allocate storage through an external service can register
+ * their own implementation instead.
+ *
+ * <p>An instance is created per catalog, {@link #initialize(Map)} is called once before any
+ * provisioning, and {@link #close()} is called when the catalog is closed. Neither {@link
+ * #provisionTableLocation(TableLocationContext)} nor {@link
+ * #unprovisionTableLocation(TableLocationContext)} is supported after {@link #close()}.
+ * Implementations must be thread-safe, because both of them are called concurrently by table
+ * requests.
+ *
+ * <p>Implementations must satisfy two constraints imposed by the {@link java.util.ServiceLoader}
+ * based discovery:
+ *
+ * <ul>
+ *   <li>They must have a public no-argument constructor that is cheap and does not throw. Every
+ *       provider registered on the classpath is instantiated before the one matching the catalog
+ *       property is selected, so a heavy or failing constructor breaks the initialization of every
+ *       catalog, including those using the built-in provider. Connection pools, remote clients and
+ *       any other expensive setup belong in {@link #initialize(Map)}.
+ *   <li>{@link #name()} must be unique across the classpath, and must not be {@value
+ *       DefaultTableLocationProvider#NAME}, which is reserved by {@link
+ *       DefaultTableLocationProvider}. Two providers sharing a name make every catalog selecting
+ *       that name fail to initialize.
+ * </ul>
+ */
+public interface TableLocationProvider extends Closeable {
+
+  /**
+   * Returns the name identifying this provider. The value is matched case-insensitively against the
+   * {@code table-location-provider} catalog property to select a provider.
+   *
+   * @return the provider name, never null or blank
+   */
+  String name();
+
+  /**
+   * Initializes the provider with the properties of the catalog it belongs to. Called exactly once,
+   * before any call to {@link #provisionTableLocation(TableLocationContext)}.
+   *
+   * <p>The default implementation does nothing, because a provider that derives the location purely
+   * from {@link TableLocationContext} has nothing to prepare. Providers that hold a remote client,
+   * a connection or any state that must outlive a single table creation must override it, and
+   * release those resources in {@link #close()}.
+   *
+   * @param catalogProperties the properties of the catalog owning this provider
+   */
+  default void initialize(Map<String, String> catalogProperties) {}
+
+  /**
+   * Provisions the location for the table that is being created.
+   *
+   * <p>The returned location is stored verbatim in the table's {@code location} property. It must
+   * be non-blank; the caller rejects the table creation with an {@link IllegalArgumentException}
+   * otherwise. Nothing else is required of it: the shape of the path belongs to the provider,
+   * nothing downstream appends to the location, and storing it unchanged is what lets a provider
+   * unprovisioning it later match the string it handed out.
+   *
+   * <p>A user-supplied {@code location} is visible in {@link
+   * TableLocationContext#tableProperties()} and the provider is free to honour or ignore it; the
+   * value returned here always wins.
+   *
+   * @param context the table being created and the context needed to derive its location
+   * @return the provisioned table location, never null or blank
+   * @throws IllegalArgumentException if no location can be derived from the given context
+   */
+  String provisionTableLocation(TableLocationContext context);
+
+  /**
+   * Unprovisions the location of a table that has been dropped, so that a provider allocating
+   * storage through an external service can hand it back instead of leaking it. The location to
+   * hand back is the {@code location} entry of {@link TableLocationContext#tableProperties()}.
+   *
+   * <p>There is deliberately no default implementation. A provider allocating from an external
+   * system has to state what happens when the table goes away, and a provider deriving the path
+   * from configuration writes an empty body and says so; an inherited empty body would let the
+   * second answer be given by accident.
+   *
+   * <p>It is called <em>after</em> the table metadata, and the underlying data of a managed table,
+   * have been removed, so throwing does not roll the drop back: the table is gone either way. The
+   * failure is logged at WARN and the drop still reports success. Dropping a schema with cascade
+   * unprovisions the location of every table it contains, one by one.
+   *
+   * <p>It is called at most once per dropped table, but a server crash between the removal and this
+   * call means it may not be called at all, so an implementation reclaiming real storage needs its
+   * own reconciliation to catch those. It must also tolerate being called for a location that is
+   * already released. Like {@link #provisionTableLocation(TableLocationContext)}, it is called
+   * concurrently and must be thread-safe.
+   *
+   * @param context the table that was dropped and the context needed to release its location
+   */
+  void unprovisionTableLocation(TableLocationContext context);
+
+  /**
+   * Releases the resources held by this provider. The default implementation does nothing.
+   *
+   * @throws IOException if closing the underlying resources fails
+   */
+  @Override
+  default void close() throws IOException {}
+}

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProviderFactory.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProviderFactory.java
@@ -150,11 +150,16 @@ public class TableLocationProviderFactory {
    * Instantiates every registered provider once to learn its name, and remembers the resulting
    * name-to-class mapping.
    *
-   * <p>A candidate that cannot be instantiated, or that cannot report its name, is logged and
-   * skipped rather than allowed to fail the scan: one broken third-party jar on the classpath must
-   * not stop every catalog from starting, including the ones on the built-in provider. A services
-   * file that is itself malformed still fails the scan; that error is raised while the loader is
-   * being iterated, before any candidate is reached.
+   * <p>A candidate whose constructor or {@link TableLocationProvider#name()} throws is logged and
+   * skipped rather than allowed to fail the scan, so a provider that is merely broken at runtime
+   * does not stop catalogs that named a different one from starting.
+   *
+   * <p>That does not cover every broken jar. A services file naming a class that cannot be loaded
+   * at all fails the whole scan with a {@link ServiceConfigurationError}, raised while the loader
+   * is being iterated and before any candidate is reached, which is out of reach of the handling
+   * here. Catching it per candidate would mean driving the loader's iterator by hand and risking a
+   * loop that never terminates, which is the worse trade for a case an operator can see in the
+   * failure it produces.
    *
    * <p>A name claimed by more than one provider is recorded rather than thrown here, and fails only
    * the catalogs that actually ask for that name. Throwing during the scan would let two unrelated

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProviderFactory.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProviderFactory.java
@@ -18,20 +18,52 @@
  */
 package org.apache.gravitino.catalog.lakehouse.generic;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A factory that discovers {@link TableLocationProvider}s through {@link ServiceLoader}. */
+/**
+ * A factory that discovers {@link TableLocationProvider}s through {@link ServiceLoader}.
+ *
+ * <p>Discovery is done once per class loader and remembered, because it is the expensive half:
+ * selecting by name requires every registered provider to be instantiated so that {@link
+ * TableLocationProvider#name()} can be called on it, and {@code name()} is an instance method, so
+ * there is no way to learn the names without doing that at least once. What the cache removes is
+ * repeating it for every catalog; it cannot remove the first pass. Creating a catalog after the
+ * first then instantiates only the provider it selected.
+ *
+ * <p>The remembered index holds classes, and a class keeps its class loader alive, so the entries
+ * are weak on both sides: the map is keyed weakly by class loader and holds each class through a
+ * {@link WeakReference}. A strong value would pin the loader of a dropped catalog through the very
+ * map meant to speed the next one up, which is the leak {@code [#12986]} removed elsewhere. A
+ * collected entry simply causes the next lookup to scan again.
+ */
 public class TableLocationProviderFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(TableLocationProviderFactory.class);
+
+  /**
+   * Provider classes by lower-cased name, per class loader. Weak on both sides; see the class
+   * javadoc. Guarded by synchronization on the map itself rather than by a concurrent map, because
+   * {@link WeakHashMap} is not thread-safe and the map is touched once per catalog creation.
+   */
+  private static final Map<ClassLoader, Index> INDEXES =
+      Collections.synchronizedMap(new WeakHashMap<>());
 
   private TableLocationProviderFactory() {}
 
@@ -39,14 +71,20 @@ public class TableLocationProviderFactory {
    * Creates and initializes the {@link TableLocationProvider} registered under the given name.
    *
    * <p>A new instance is returned on every call, so the caller owns its lifecycle and is
-   * responsible for closing it.
+   * responsible for closing it. Only the selected provider is instantiated once the class loader
+   * has been scanned; the instances made during that first scan are discarded without {@link
+   * TableLocationProvider#close()} being called on them, which is safe only because the interface
+   * requires a constructor that acquires nothing. Everything worth closing is acquired in {@link
+   * TableLocationProvider#initialize(Map)}, which only the selected provider ever reaches.
    *
    * @param name the provider name to look up, matched case-insensitively against {@link
    *     TableLocationProvider#name()}
    * @param catalogProperties the properties of the catalog the provider belongs to
    * @return the initialized provider
    * @throws IllegalArgumentException if no provider, or more than one provider, is registered under
-   *     the given name
+   *     the given name, or if the selected provider cannot be instantiated
+   * @throws ServiceConfigurationError if a {@code META-INF/services} file for this interface is
+   *     itself malformed, which fails the scan before any candidate is reached
    */
   public static TableLocationProvider create(String name, Map<String, String> catalogProperties) {
     Preconditions.checkArgument(
@@ -55,31 +93,177 @@ public class TableLocationProviderFactory {
     ClassLoader cl =
         Optional.ofNullable(Thread.currentThread().getContextClassLoader())
             .orElse(TableLocationProvider.class.getClassLoader());
-    ServiceLoader<TableLocationProvider> loader =
-        ServiceLoader.load(TableLocationProvider.class, cl);
+    String key = name.toLowerCase(Locale.ROOT);
 
-    List<TableLocationProvider> providers =
-        loader.stream()
-            .map(ServiceLoader.Provider::get)
-            .filter(provider -> name.equalsIgnoreCase(provider.name()))
-            .collect(Collectors.toList());
-
-    if (providers.isEmpty()) {
-      throw new IllegalArgumentException(
-          String.format("No TableLocationProvider found for name '%s'", name));
-    } else if (providers.size() > 1) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Multiple TableLocationProviders found for name '%s': %s",
-              name,
-              providers.stream()
-                  .map(provider -> provider.getClass().getName())
-                  .collect(Collectors.joining(", "))));
+    Index index = index(cl);
+    Class<? extends TableLocationProvider> type = index.get(key);
+    if (type == null) {
+      // Either never seen, or the entry was collected along with its class loader. Scanning again
+      // is the correct answer to both, and tells a caller asking for a provider added since the
+      // last scan about it.
+      index = rescan(cl);
+      type = index.get(key);
     }
 
-    TableLocationProvider provider = providers.get(0);
-    provider.initialize(catalogProperties);
-    LOG.info("Loaded TableLocationProvider '{}': {}", name, provider.getClass().getName());
+    Preconditions.checkArgument(
+        !index.isDuplicated(key),
+        "Multiple TableLocationProviders are registered under the name '%s'. Provider names must "
+            + "be unique across the classpath.",
+        name);
+    Preconditions.checkArgument(type != null, "No TableLocationProvider found for name '%s'", name);
+
+    TableLocationProvider provider = instantiate(type);
+    try {
+      // Passed on as given rather than copied again. The caller hands over a map it already
+      // made unmodifiable, and copying it here would only re-introduce the rejection of a null
+      // property value that the caller deliberately tolerates.
+      provider.initialize(catalogProperties == null ? Map.of() : catalogProperties);
+    } catch (RuntimeException | Error e) {
+      // initialize is where a provider opens its clients and connections, so one that fails
+      // halfway has resources to release. Nobody else can do it: the instance never reaches the
+      // caller that would have owned its lifecycle. Error is caught alongside RuntimeException
+      // because a plugin loaded through its own classloader fails with NoClassDefFoundError as
+      // readily as with an exception, and it is rethrown either way.
+      closeQuietly(provider, name);
+      throw e;
+    }
+
+    LOG.info("Loaded TableLocationProvider '{}': {}", name, type.getName());
     return provider;
+  }
+
+  /**
+   * Forgets everything discovered so far, so that the next lookup scans again. For tests, which
+   * register providers through class loaders they build themselves.
+   */
+  @VisibleForTesting
+  static void invalidateCache() {
+    INDEXES.clear();
+  }
+
+  private static Index index(ClassLoader cl) {
+    Index index = INDEXES.get(cl);
+    return index == null ? rescan(cl) : index;
+  }
+
+  /**
+   * Instantiates every registered provider once to learn its name, and remembers the resulting
+   * name-to-class mapping.
+   *
+   * <p>A candidate that cannot be instantiated, or that cannot report its name, is logged and
+   * skipped rather than allowed to fail the scan: one broken third-party jar on the classpath must
+   * not stop every catalog from starting, including the ones on the built-in provider. A services
+   * file that is itself malformed still fails the scan; that error is raised while the loader is
+   * being iterated, before any candidate is reached.
+   *
+   * <p>A name claimed by more than one provider is recorded rather than thrown here, and fails only
+   * the catalogs that actually ask for that name. Throwing during the scan would let two unrelated
+   * third-party jars break every catalog, which is the same failure the paragraph above avoids.
+   *
+   * @param cl the class loader to scan
+   * @return the index for that class loader
+   */
+  private static Index rescan(ClassLoader cl) {
+    Map<String, WeakReference<Class<? extends TableLocationProvider>>> byName = new HashMap<>();
+    Set<String> duplicated = new HashSet<>();
+
+    List<ServiceLoader.Provider<TableLocationProvider>> candidates =
+        ServiceLoader.load(TableLocationProvider.class, cl).stream().collect(Collectors.toList());
+
+    for (ServiceLoader.Provider<TableLocationProvider> candidate : candidates) {
+      Class<? extends TableLocationProvider> type = candidate.type();
+      String name;
+      try {
+        name = candidate.get().name();
+      } catch (RuntimeException | Error e) {
+        // Error, not just ServiceConfigurationError: the loader wraps a failing constructor for
+        // us, but name() is called here rather than by the loader, so whatever it throws arrives
+        // unwrapped. A plugin loaded through its own class loader reaches a missing class with a
+        // NoClassDefFoundError, which is an Error, and letting it through would fail the whole
+        // scan.
+        LOG.warn(
+            "Skipping TableLocationProvider {}, which could not be instantiated or could not "
+                + "report its name. It cannot be selected by any catalog until this is fixed.",
+            type.getName(),
+            e);
+        continue;
+      }
+
+      if (StringUtils.isBlank(name)) {
+        LOG.warn(
+            "Skipping TableLocationProvider {}, which reported a null or blank name.",
+            type.getName());
+        continue;
+      }
+
+      String key = name.toLowerCase(Locale.ROOT);
+      WeakReference<Class<? extends TableLocationProvider>> previous =
+          byName.put(key, new WeakReference<>(type));
+      if (previous != null && previous.get() != type) {
+        duplicated.add(key);
+        LOG.warn(
+            "TableLocationProvider name '{}' is claimed by more than one implementation, including "
+                + "{} and {}. Catalogs selecting that name will fail to initialize.",
+            name,
+            previous.get() == null ? "an unloaded class" : previous.get().getName(),
+            type.getName());
+      }
+    }
+
+    Index index = new Index(byName, duplicated);
+    INDEXES.put(cl, index);
+    LOG.info("Discovered TableLocationProviders: {}", byName.keySet());
+    return index;
+  }
+
+  private static TableLocationProvider instantiate(Class<? extends TableLocationProvider> type) {
+    try {
+      return type.getDeclaredConstructor().newInstance();
+    } catch (ReflectiveOperationException | RuntimeException | Error e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Failed to instantiate TableLocationProvider %s. It must have a public no-argument "
+                  + "constructor that does not throw.",
+              type.getName()),
+          e);
+    }
+  }
+
+  private static void closeQuietly(TableLocationProvider provider, String name) {
+    try {
+      provider.close();
+    } catch (Exception | Error e) {
+      // Error too: this runs while the initialize failure is being unwound, and a close that threw
+      // one would replace the failure the caller actually needs to see.
+      LOG.warn(
+          "Failed to close TableLocationProvider '{}' after it failed to initialize. Any resource "
+              + "it acquired before failing may be leaked.",
+          name,
+          e);
+    }
+  }
+
+  /** The providers discovered under one class loader, held weakly. */
+  private static final class Index {
+
+    private final Map<String, WeakReference<Class<? extends TableLocationProvider>>> byName;
+
+    private final Set<String> duplicated;
+
+    private Index(
+        Map<String, WeakReference<Class<? extends TableLocationProvider>>> byName,
+        Set<String> duplicated) {
+      this.byName = byName;
+      this.duplicated = duplicated;
+    }
+
+    private Class<? extends TableLocationProvider> get(String key) {
+      WeakReference<Class<? extends TableLocationProvider>> ref = byName.get(key);
+      return ref == null ? null : ref.get();
+    }
+
+    private boolean isDuplicated(String key) {
+      return duplicated.contains(key);
+    }
   }
 }

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProviderFactory.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/generic/TableLocationProviderFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A factory that discovers {@link TableLocationProvider}s through {@link ServiceLoader}. */
+public class TableLocationProviderFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TableLocationProviderFactory.class);
+
+  private TableLocationProviderFactory() {}
+
+  /**
+   * Creates and initializes the {@link TableLocationProvider} registered under the given name.
+   *
+   * <p>A new instance is returned on every call, so the caller owns its lifecycle and is
+   * responsible for closing it.
+   *
+   * @param name the provider name to look up, matched case-insensitively against {@link
+   *     TableLocationProvider#name()}
+   * @param catalogProperties the properties of the catalog the provider belongs to
+   * @return the initialized provider
+   * @throws IllegalArgumentException if no provider, or more than one provider, is registered under
+   *     the given name
+   */
+  public static TableLocationProvider create(String name, Map<String, String> catalogProperties) {
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(name), "Table location provider name must not be blank");
+
+    ClassLoader cl =
+        Optional.ofNullable(Thread.currentThread().getContextClassLoader())
+            .orElse(TableLocationProvider.class.getClassLoader());
+    ServiceLoader<TableLocationProvider> loader =
+        ServiceLoader.load(TableLocationProvider.class, cl);
+
+    List<TableLocationProvider> providers =
+        loader.stream()
+            .map(ServiceLoader.Provider::get)
+            .filter(provider -> name.equalsIgnoreCase(provider.name()))
+            .collect(Collectors.toList());
+
+    if (providers.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format("No TableLocationProvider found for name '%s'", name));
+    } else if (providers.size() > 1) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Multiple TableLocationProviders found for name '%s': %s",
+              name,
+              providers.stream()
+                  .map(provider -> provider.getClass().getName())
+                  .collect(Collectors.joining(", "))));
+    }
+
+    TableLocationProvider provider = providers.get(0);
+    provider.initialize(catalogProperties);
+    LOG.info("Loaded TableLocationProvider '{}': {}", name, provider.getClass().getName());
+    return provider;
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/main/resources/META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider
+++ b/catalogs/catalog-lakehouse-generic/src/main/resources/META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.catalog.lakehouse.generic.DefaultTableLocationProvider

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/BrokenTableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/BrokenTableLocationProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+/**
+ * A provider that stands in for a broken third-party jar on the classpath. It is registered in the
+ * test {@code META-INF/services} file alongside the working one, so every factory lookup in this
+ * module has to get past it.
+ *
+ * <p>It fails from {@link #name()} with an {@link Error} rather than an exception, which is the way
+ * a plugin loaded through its own classloader fails when a class it needs is missing. The factory
+ * calls {@code name()} itself rather than going through the loader, so nothing wraps this into a
+ * {@link java.util.ServiceConfigurationError} on the way out.
+ */
+public class BrokenTableLocationProvider implements TableLocationProvider {
+
+  @Override
+  public String name() {
+    throw new NoClassDefFoundError("com/example/a/class/this/plugin/was/built/against");
+  }
+
+  @Override
+  public String provisionTableLocation(TableLocationContext context) {
+    throw new UnsupportedOperationException("This provider can never be selected");
+  }
+
+  @Override
+  public void unprovisionTableLocation(TableLocationContext context) {
+    throw new UnsupportedOperationException("This provider can never be selected");
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableDelegator.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableDelegator.java
@@ -19,12 +19,21 @@
 package org.apache.gravitino.catalog.lakehouse.generic;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import java.util.List;
+import java.util.Map;
 import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.catalog.ManagedSchemaOperations;
 import org.apache.gravitino.catalog.ManagedTableOperations;
 import org.apache.gravitino.connector.PropertyEntry;
 import org.apache.gravitino.connector.SupportsSchemas;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.expressions.distributions.Distribution;
+import org.apache.gravitino.rel.expressions.sorts.SortOrder;
+import org.apache.gravitino.rel.expressions.transforms.Transform;
+import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.storage.IdGenerator;
 
 /**
@@ -37,6 +46,26 @@ public class FakeTableDelegator implements LakehouseTableDelegator {
 
   /** The table format handled by this delegator. */
   public static final String TABLE_FORMAT = "testing";
+
+  // Set by a test to make createTable behave like a format that declines the location it was
+  // given: Lance's EXIST_OK mode returns the table that already exists, at the location that table
+  // already had. Static because the catalog builds its own table operations through ServiceLoader.
+  private static volatile String locationToUseInstead;
+
+  /**
+   * Makes every subsequent creation store the given location instead of the one the catalog
+   * provisioned, the way a format returning an already existing table does.
+   *
+   * @param location the location the created table will report, null to create normally
+   */
+  public static void useLocationInstead(String location) {
+    locationToUseInstead = location;
+  }
+
+  /** Stops overriding the location of created tables. */
+  public static void reset() {
+    locationToUseInstead = null;
+  }
 
   @Override
   public String tableFormat() {
@@ -65,6 +94,34 @@ public class FakeTableDelegator implements LakehouseTableDelegator {
       @Override
       protected IdGenerator idGenerator() {
         return idGenerator;
+      }
+
+      @Override
+      public Table createTable(
+          NameIdentifier ident,
+          Column[] columns,
+          String comment,
+          Map<String, String> properties,
+          Transform[] partitions,
+          Distribution distribution,
+          SortOrder[] sortOrders,
+          Index[] indexes) {
+        String override = locationToUseInstead;
+        Map<String, String> storedProperties = properties;
+        if (override != null) {
+          storedProperties = Maps.newHashMap(properties);
+          storedProperties.put(Table.PROPERTY_LOCATION, override);
+        }
+
+        return super.createTable(
+            ident,
+            columns,
+            comment,
+            storedProperties,
+            partitions,
+            distribution,
+            sortOrders,
+            indexes);
       }
     };
   }

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableDelegator.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableDelegator.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.catalog.ManagedSchemaOperations;
+import org.apache.gravitino.catalog.ManagedTableOperations;
+import org.apache.gravitino.connector.PropertyEntry;
+import org.apache.gravitino.connector.SupportsSchemas;
+import org.apache.gravitino.storage.IdGenerator;
+
+/**
+ * A {@link LakehouseTableDelegator} registered only in the test classpath, whose table operations
+ * touch nothing but the entity store. It lets the tests drive the catalog level table operations,
+ * and the {@link TableLocationProvider} callbacks hanging off them, without a real table format
+ * behind them.
+ */
+public class FakeTableDelegator implements LakehouseTableDelegator {
+
+  /** The table format handled by this delegator. */
+  public static final String TABLE_FORMAT = "testing";
+
+  @Override
+  public String tableFormat() {
+    return TABLE_FORMAT;
+  }
+
+  @Override
+  public List<PropertyEntry<?>> tablePropertyEntries() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public ManagedTableOperations createTableOps(
+      EntityStore store, ManagedSchemaOperations schemaOps, IdGenerator idGenerator) {
+    return new ManagedTableOperations() {
+      @Override
+      protected EntityStore store() {
+        return store;
+      }
+
+      @Override
+      protected SupportsSchemas schemas() {
+        return schemaOps;
+      }
+
+      @Override
+      protected IdGenerator idGenerator() {
+        return idGenerator;
+      }
+    };
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableLocationProvider.java
@@ -49,6 +49,10 @@ public class FakeTableLocationProvider implements TableLocationProvider {
 
   private static final AtomicInteger CLOSED = new AtomicInteger();
 
+  // Selection has to construct every registered provider to ask it its name, so counting
+  // constructions is how a test observes whether a lookup scanned or answered from the index.
+  private static final AtomicInteger CONSTRUCTED = new AtomicInteger();
+
   private static volatile boolean failOnUnprovision;
 
   private static volatile boolean failOnInitialize;
@@ -60,6 +64,11 @@ public class FakeTableLocationProvider implements TableLocationProvider {
   private Map<String, String> catalogProperties;
 
   private boolean closed;
+
+  /** Public and no-argument, as the SPI requires; it acquires nothing. */
+  public FakeTableLocationProvider() {
+    CONSTRUCTED.incrementAndGet();
+  }
 
   /**
    * Returns the contexts this provider was asked to provision, in the order the calls came in, so
@@ -122,6 +131,16 @@ public class FakeTableLocationProvider implements TableLocationProvider {
   }
 
   /**
+   * Returns how many instances have been constructed since the last {@link #reset()}, so that a
+   * test can tell a lookup that scanned the classpath from one answered out of the cached index.
+   *
+   * @return the number of constructions
+   */
+  public static int constructedCount() {
+    return CONSTRUCTED.get();
+  }
+
+  /**
    * Makes every subsequent provision call return the given location instead of the composed one, so
    * that a test can drive the catalog with a location a real provider should never return.
    *
@@ -140,6 +159,7 @@ public class FakeTableLocationProvider implements TableLocationProvider {
     UNPROVISIONED.clear();
     RELEASED.clear();
     CLOSED.set(0);
+    CONSTRUCTED.set(0);
     failOnUnprovision = false;
     failOnInitialize = false;
   }

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableLocationProvider.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+import com.google.common.collect.Lists;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link TableLocationProvider} registered only in the test classpath, used to verify that a
+ * custom provider is discovered, initialized and closed by the generic catalog.
+ */
+public class FakeTableLocationProvider implements TableLocationProvider {
+
+  /** The name under which this provider is registered. */
+  public static final String NAME = "testing";
+
+  /** The prefix of every location allocated by this provider. */
+  public static final String LOCATION_PREFIX = "testing://bucket/";
+
+  // The provider instance used by a catalog is created by the ServiceLoader and not reachable from
+  // the test, so the unprovision calls are recorded statically.
+  private static final List<TableLocationContext> UNPROVISIONED =
+      Collections.synchronizedList(Lists.newArrayList());
+
+  private static volatile boolean failOnUnprovision;
+
+  private Map<String, String> catalogProperties;
+
+  private boolean closed;
+
+  /**
+   * Returns the contexts this provider was asked to unprovision, in the order the calls came in.
+   *
+   * @return the recorded unprovision contexts
+   */
+  public static List<TableLocationContext> unprovisioned() {
+    return Lists.newArrayList(UNPROVISIONED);
+  }
+
+  /**
+   * Makes every subsequent unprovision call fail, to verify how the catalog reports a provider that
+   * cannot reclaim a location.
+   *
+   * @param fail whether unprovisioning should throw
+   */
+  public static void failOnUnprovision(boolean fail) {
+    failOnUnprovision = fail;
+  }
+
+  /** Clears the recorded unprovision calls and stops unprovisioning from failing. */
+  public static void reset() {
+    UNPROVISIONED.clear();
+    failOnUnprovision = false;
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public void initialize(Map<String, String> catalogProperties) {
+    this.catalogProperties = catalogProperties;
+  }
+
+  @Override
+  public String provisionTableLocation(TableLocationContext context) {
+    return LOCATION_PREFIX + context.tableIdentifier().name() + "/";
+  }
+
+  @Override
+  public void unprovisionTableLocation(TableLocationContext context) {
+    UNPROVISIONED.add(context);
+    if (failOnUnprovision) {
+      throw new IllegalStateException("The path allocation service is unavailable");
+    }
+  }
+
+  @Override
+  public void close() {
+    this.closed = true;
+  }
+
+  /**
+   * Returns the catalog properties this provider was initialized with, or null if {@link
+   * #initialize(Map)} was never called.
+   *
+   * @return the catalog properties seen at initialization time
+   */
+  public Map<String, String> catalogProperties() {
+    return catalogProperties;
+  }
+
+  /**
+   * Returns whether {@link #close()} has been called on this instance.
+   *
+   * @return true if this provider was closed
+   */
+  public boolean isClosed() {
+    return closed;
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/FakeTableLocationProvider.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A {@link TableLocationProvider} registered only in the test classpath, used to verify that a
@@ -36,15 +37,39 @@ public class FakeTableLocationProvider implements TableLocationProvider {
   public static final String LOCATION_PREFIX = "testing://bucket/";
 
   // The provider instance used by a catalog is created by the ServiceLoader and not reachable from
-  // the test, so the unprovision calls are recorded statically.
+  // the test, so the provision and unprovision calls are recorded statically.
+  private static final List<TableLocationContext> PROVISIONED =
+      Collections.synchronizedList(Lists.newArrayList());
+
   private static final List<TableLocationContext> UNPROVISIONED =
       Collections.synchronizedList(Lists.newArrayList());
 
+  private static final List<TableLocationContext> RELEASED =
+      Collections.synchronizedList(Lists.newArrayList());
+
+  private static final AtomicInteger CLOSED = new AtomicInteger();
+
   private static volatile boolean failOnUnprovision;
+
+  private static volatile boolean failOnInitialize;
+
+  private static volatile boolean overrideLocation;
+
+  private static volatile String locationOverride;
 
   private Map<String, String> catalogProperties;
 
   private boolean closed;
+
+  /**
+   * Returns the contexts this provider was asked to provision, in the order the calls came in, so
+   * that a test can assert the provider was or was not consulted for a given table.
+   *
+   * @return the recorded provision contexts
+   */
+  public static List<TableLocationContext> provisioned() {
+    return Lists.newArrayList(PROVISIONED);
+  }
 
   /**
    * Returns the contexts this provider was asked to unprovision, in the order the calls came in.
@@ -53,6 +78,17 @@ public class FakeTableLocationProvider implements TableLocationProvider {
    */
   public static List<TableLocationContext> unprovisioned() {
     return Lists.newArrayList(UNPROVISIONED);
+  }
+
+  /**
+   * Returns the contexts this provider was asked to release as unused, in the order the calls came
+   * in. Kept apart from {@link #unprovisioned()} so that a test can tell the drop callback from the
+   * creation-path one, which a provider reclaiming by table identity has to tell apart too.
+   *
+   * @return the recorded release contexts
+   */
+  public static List<TableLocationContext> released() {
+    return Lists.newArrayList(RELEASED);
   }
 
   /**
@@ -65,10 +101,47 @@ public class FakeTableLocationProvider implements TableLocationProvider {
     failOnUnprovision = fail;
   }
 
-  /** Clears the recorded unprovision calls and stops unprovisioning from failing. */
+  /**
+   * Makes every subsequent initialization fail, to verify that a provider failing halfway through
+   * {@link #initialize(Map)} is still closed.
+   *
+   * @param fail whether initialization should throw
+   */
+  public static void failOnInitialize(boolean fail) {
+    failOnInitialize = fail;
+  }
+
+  /**
+   * Returns how many instances of this provider have been closed since the last {@link #reset()},
+   * so that a test can observe an instance it never gets a reference to.
+   *
+   * @return the number of recorded close calls
+   */
+  public static int closedCount() {
+    return CLOSED.get();
+  }
+
+  /**
+   * Makes every subsequent provision call return the given location instead of the composed one, so
+   * that a test can drive the catalog with a location a real provider should never return.
+   *
+   * @param location the location to return, null included
+   */
+  public static void provisionLocation(String location) {
+    overrideLocation = true;
+    locationOverride = location;
+  }
+
+  /** Clears the recorded calls and stops initialization and unprovisioning from failing. */
   public static void reset() {
+    overrideLocation = false;
+    locationOverride = null;
+    PROVISIONED.clear();
     UNPROVISIONED.clear();
+    RELEASED.clear();
+    CLOSED.set(0);
     failOnUnprovision = false;
+    failOnInitialize = false;
   }
 
   @Override
@@ -79,11 +152,17 @@ public class FakeTableLocationProvider implements TableLocationProvider {
   @Override
   public void initialize(Map<String, String> catalogProperties) {
     this.catalogProperties = catalogProperties;
+    if (failOnInitialize) {
+      throw new IllegalStateException("The path allocation service is unreachable");
+    }
   }
 
   @Override
   public String provisionTableLocation(TableLocationContext context) {
-    return LOCATION_PREFIX + context.tableIdentifier().name() + "/";
+    PROVISIONED.add(context);
+    return overrideLocation
+        ? locationOverride
+        : LOCATION_PREFIX + context.tableIdentifier().name() + "/";
   }
 
   @Override
@@ -95,8 +174,14 @@ public class FakeTableLocationProvider implements TableLocationProvider {
   }
 
   @Override
+  public void releaseUnusedLocation(TableLocationContext context) {
+    RELEASED.add(context);
+  }
+
+  @Override
   public void close() {
     this.closed = true;
+    CLOSED.incrementAndGet();
   }
 
   /**

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestDefaultTableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestDefaultTableLocationProvider.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Schema;
+import org.apache.gravitino.rel.Table;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestDefaultTableLocationProvider {
+
+  private static final NameIdentifier TABLE_IDENT =
+      NameIdentifier.of("metalake", "catalog", "schema1", "table1");
+
+  @Test
+  void testTableLocationWins() {
+    DefaultTableLocationProvider provider =
+        newProvider(ImmutableMap.of("location", "/tmp/catalog"));
+    Schema schema = mockSchema(ImmutableMap.of(Schema.PROPERTY_LOCATION, "/tmp/schema"));
+
+    String location =
+        provider.provisionTableLocation(
+            context(schema, ImmutableMap.of(Table.PROPERTY_LOCATION, "/tmp/explicit")));
+
+    // The table's own location is used as-is, the table name is not appended.
+    Assertions.assertEquals("/tmp/explicit/", location);
+  }
+
+  @Test
+  void testFallBackToSchemaLocation() {
+    DefaultTableLocationProvider provider =
+        newProvider(ImmutableMap.of("location", "/tmp/catalog"));
+    Schema schema = mockSchema(ImmutableMap.of(Schema.PROPERTY_LOCATION, "/tmp/schema"));
+
+    String location = provider.provisionTableLocation(context(schema, ImmutableMap.of()));
+
+    Assertions.assertEquals("/tmp/schema/table1/", location);
+  }
+
+  @Test
+  void testFallBackToCatalogLocation() {
+    DefaultTableLocationProvider provider =
+        newProvider(ImmutableMap.of("location", "/tmp/catalog"));
+    Schema schema = mockSchema(ImmutableMap.of());
+
+    String location = provider.provisionTableLocation(context(schema, ImmutableMap.of()));
+
+    // The schema name is taken from the table identifier's namespace.
+    Assertions.assertEquals("/tmp/catalog/schema1/table1/", location);
+  }
+
+  @Test
+  void testTrailingSlashIsNotDuplicated() {
+    DefaultTableLocationProvider provider =
+        newProvider(ImmutableMap.of("location", "/tmp/catalog/"));
+    Schema schema = mockSchema(ImmutableMap.of(Schema.PROPERTY_LOCATION, "/tmp/schema/"));
+
+    Assertions.assertEquals(
+        "/tmp/schema/table1/", provider.provisionTableLocation(context(schema, ImmutableMap.of())));
+    Assertions.assertEquals(
+        "/tmp/explicit/",
+        provider.provisionTableLocation(
+            context(schema, ImmutableMap.of(Table.PROPERTY_LOCATION, "/tmp/explicit/"))));
+  }
+
+  @Test
+  void testNullSchemaPropertiesFallsBackToCatalogLocation() {
+    DefaultTableLocationProvider provider =
+        newProvider(ImmutableMap.of("location", "/tmp/catalog"));
+    Schema schema = mockSchema(null);
+
+    Assertions.assertEquals(
+        "/tmp/catalog/schema1/table1/",
+        provider.provisionTableLocation(context(schema, ImmutableMap.of())));
+  }
+
+  @Test
+  void testNoLocationAnywhereThrows() {
+    DefaultTableLocationProvider provider = newProvider(ImmutableMap.of());
+    Schema schema = mockSchema(ImmutableMap.of());
+
+    IllegalArgumentException e =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> provider.provisionTableLocation(context(schema, ImmutableMap.of())));
+    Assertions.assertTrue(
+        e.getMessage().contains("'location' property is neither set in table properties"),
+        "Unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  void testProviderName() {
+    Assertions.assertEquals("default", new DefaultTableLocationProvider().name());
+  }
+
+  @Test
+  void testUnprovisionIsANoOp() {
+    // The built-in provider derives locations from properties and has nothing to reclaim, so
+    // unprovisioning one has to be harmless rather than unsupported.
+    Assertions.assertDoesNotThrow(
+        () ->
+            newProvider(ImmutableMap.of())
+                .unprovisionTableLocation(
+                    context(
+                        mockSchema(ImmutableMap.of()),
+                        ImmutableMap.of(Table.PROPERTY_LOCATION, "/tmp/schema/table1/"))));
+  }
+
+  private static DefaultTableLocationProvider newProvider(Map<String, String> catalogProperties) {
+    DefaultTableLocationProvider provider = new DefaultTableLocationProvider();
+    provider.initialize(catalogProperties);
+    return provider;
+  }
+
+  private static Schema mockSchema(Map<String, String> properties) {
+    Schema schema = Mockito.mock(Schema.class);
+    Mockito.when(schema.properties()).thenReturn(properties);
+    return schema;
+  }
+
+  private static TableLocationContext context(Schema schema, Map<String, String> tableProperties) {
+    return TableLocationContext.builder()
+        .withTableIdentifier(TABLE_IDENT)
+        .withTableProperties(tableProperties)
+        .withSchema(schema)
+        .build();
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestDefaultTableLocationProvider.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestDefaultTableLocationProvider.java
@@ -134,6 +134,9 @@ public class TestDefaultTableLocationProvider {
 
   private static Schema mockSchema(Map<String, String> properties) {
     Schema schema = Mockito.mock(Schema.class);
+    // The context is always built from the schema the table is being created in, so the schema
+    // name matches the second level of the table identifier by construction.
+    Mockito.when(schema.name()).thenReturn(TABLE_IDENT.namespace().level(2));
     Mockito.when(schema.properties()).thenReturn(properties);
     return schema;
   }

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
@@ -37,10 +37,12 @@ import static org.apache.gravitino.Configs.STORE_TRANSACTION_MAX_SKEW_TIME;
 import static org.apache.gravitino.Configs.VERSION_RETENTION_COUNT;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -59,17 +61,21 @@ import org.apache.gravitino.Schema;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.SchemaVersion;
+import org.apache.gravitino.meta.TableEntity;
+import org.apache.gravitino.rel.Table;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -82,6 +88,7 @@ public class TestGenericCatalogOperations {
   private static EntityStore store;
   private static IdGenerator idGenerator;
   private static GenericCatalogOperations ops;
+  private static GenericCatalogOperations opsWithFakeProvider;
 
   @BeforeAll
   public static void setUp() throws IOException, IllegalAccessException {
@@ -143,11 +150,27 @@ public class TestGenericCatalogOperations {
     FieldUtils.writeField(GravitinoEnv.getInstance(), "config", config, true);
 
     ops = new GenericCatalogOperations(store, idGenerator);
+
+    // A second instance, initialized so that it uses the test provider, to exercise the location
+    // release callbacks. The shared instance above is never initialized and has no provider.
+    opsWithFakeProvider = new GenericCatalogOperations(store, idGenerator);
+    opsWithFakeProvider.initialize(
+        ImmutableMap.of(
+            GenericCatalogPropertiesMetadata.TABLE_LOCATION_PROVIDER,
+            FakeTableLocationProvider.NAME),
+        null /* CatalogInfo, unused */,
+        new GenericCatalog());
+  }
+
+  @BeforeEach
+  public void resetProvider() {
+    FakeTableLocationProvider.reset();
   }
 
   @AfterAll
   public static void tearDown() throws IOException {
     ops.close();
+    opsWithFakeProvider.close();
     store.close();
     FileUtils.deleteDirectory(new File(STORE_PATH));
   }
@@ -241,6 +264,184 @@ public class TestGenericCatalogOperations {
         ops.dropSchema(
             NameIdentifierUtil.ofSchema(METALAKE_NAME, "non-existent-catalog", schemaName2),
             false));
+  }
+
+  @Test
+  public void testValidateProvisionedLocationAcceptsDirectoryPath() {
+    NameIdentifier tableIdent = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "schema1", "table1");
+
+    Assertions.assertEquals(
+        "s3://bucket/db/table/",
+        GenericCatalogOperations.validateProvisionedLocation(
+            "s3://bucket/db/table/", "default", tableIdent));
+  }
+
+  @Test
+  public void testValidateProvisionedLocationRejectsBlank() {
+    NameIdentifier tableIdent = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "schema1", "table1");
+
+    for (String location : Arrays.asList(null, "", "   ")) {
+      IllegalArgumentException e =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  GenericCatalogOperations.validateProvisionedLocation(
+                      location, "custom", tableIdent));
+      Assertions.assertTrue(
+          e.getMessage().contains("returned a null or blank location"), e.getMessage());
+      Assertions.assertTrue(e.getMessage().contains("custom"), e.getMessage());
+    }
+  }
+
+  @Test
+  public void testValidateProvisionedLocationKeepsPathVerbatim() {
+    NameIdentifier tableIdent = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "schema1", "table1");
+
+    // The shape of the path belongs to the provider: a location without a trailing slash is
+    // accepted and stored exactly as returned, so that the provider unprovisioning it later sees
+    // the same string it handed out.
+    Assertions.assertEquals(
+        "s3://bucket/db/9f1c2e04-6b3a-4a17-bd6e-1c0a5f2d8e77",
+        GenericCatalogOperations.validateProvisionedLocation(
+            "s3://bucket/db/9f1c2e04-6b3a-4a17-bd6e-1c0a5f2d8e77", "custom", tableIdent));
+  }
+
+  @Test
+  public void testDropTableUnprovisionsItsLocation() {
+    NameIdentifier schemaIdent = createSchema();
+    NameIdentifier tableIdent = createTable(schemaIdent, "table1");
+
+    Assertions.assertTrue(opsWithFakeProvider.dropTable(tableIdent));
+
+    List<TableLocationContext> unprovisioned = FakeTableLocationProvider.unprovisioned();
+    Assertions.assertEquals(1, unprovisioned.size());
+    TableLocationContext context = unprovisioned.get(0);
+    Assertions.assertEquals(tableIdent, context.tableIdentifier());
+    // The location the provider has to hand back reaches it through the stored table properties,
+    // which are read before the table is removed.
+    Assertions.assertEquals(
+        locationOf("table1"), context.tableProperties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertEquals(
+        FakeTableDelegator.TABLE_FORMAT,
+        context.tableProperties().get(Table.PROPERTY_TABLE_FORMAT));
+    Assertions.assertEquals(schemaIdent.name(), context.schema().name());
+  }
+
+  @Test
+  public void testPurgeTableUnprovisionsItsLocation() {
+    NameIdentifier schemaIdent = createSchema();
+    NameIdentifier tableIdent = createTable(schemaIdent, "table1");
+
+    Assertions.assertTrue(opsWithFakeProvider.purgeTable(tableIdent));
+
+    List<TableLocationContext> unprovisioned = FakeTableLocationProvider.unprovisioned();
+    Assertions.assertEquals(1, unprovisioned.size());
+    Assertions.assertEquals(tableIdent, unprovisioned.get(0).tableIdentifier());
+    Assertions.assertEquals(
+        locationOf("table1"), unprovisioned.get(0).tableProperties().get(Table.PROPERTY_LOCATION));
+  }
+
+  @Test
+  public void testDropNonExistentTableDoesNotUnprovision() {
+    NameIdentifier schemaIdent = createSchema();
+    NameIdentifier tableIdent =
+        NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaIdent.name(), "no-such-table");
+
+    Assertions.assertFalse(opsWithFakeProvider.dropTable(tableIdent));
+    Assertions.assertTrue(FakeTableLocationProvider.unprovisioned().isEmpty());
+  }
+
+  @Test
+  public void testDropSchemaWithCascadeUnprovisionsEveryTableLocation() {
+    NameIdentifier schemaIdent = createSchema();
+    NameIdentifier tableIdent1 = createTable(schemaIdent, "table1");
+    NameIdentifier tableIdent2 = createTable(schemaIdent, "table2");
+
+    // Load both tables so that their format is cached, to tell an invalidated cache apart from a
+    // cache that was never populated.
+    opsWithFakeProvider.loadTable(tableIdent1);
+    opsWithFakeProvider.loadTable(tableIdent2);
+    Assertions.assertNotNull(opsWithFakeProvider.tableFormatCache().getIfPresent(tableIdent1));
+    Assertions.assertNotNull(opsWithFakeProvider.tableFormatCache().getIfPresent(tableIdent2));
+
+    Assertions.assertTrue(opsWithFakeProvider.dropSchema(schemaIdent, true /* cascade */));
+
+    Set<NameIdentifier> unprovisionedIdents =
+        FakeTableLocationProvider.unprovisioned().stream()
+            .map(TableLocationContext::tableIdentifier)
+            .collect(Collectors.toSet());
+    Assertions.assertEquals(Set.of(tableIdent1, tableIdent2), unprovisionedIdents);
+
+    // The cascade also has to clear the cached table formats, which it only does when it goes
+    // through the catalog level dropTable.
+    Assertions.assertNull(opsWithFakeProvider.tableFormatCache().getIfPresent(tableIdent1));
+    Assertions.assertNull(opsWithFakeProvider.tableFormatCache().getIfPresent(tableIdent2));
+  }
+
+  @Test
+  public void testFailedUnprovisionStillReportsTheDropAsSuccessful() {
+    NameIdentifier schemaIdent = createSchema();
+    NameIdentifier tableIdent = createTable(schemaIdent, "table1");
+    FakeTableLocationProvider.failOnUnprovision(true);
+
+    // The table is already gone by the time the provider is called, so failing the request would
+    // report a drop that did happen as unsuccessful. The failure is logged instead.
+    Assertions.assertTrue(opsWithFakeProvider.dropTable(tableIdent));
+    Assertions.assertEquals(1, FakeTableLocationProvider.unprovisioned().size());
+    Assertions.assertThrows(
+        NoSuchTableException.class, () -> opsWithFakeProvider.loadTable(tableIdent));
+  }
+
+  @Test
+  public void testFailedUnprovisionDoesNotAbortACascadingSchemaDrop() {
+    NameIdentifier schemaIdent = createSchema();
+    createTable(schemaIdent, "table1");
+    createTable(schemaIdent, "table2");
+    FakeTableLocationProvider.failOnUnprovision(true);
+
+    Assertions.assertTrue(opsWithFakeProvider.dropSchema(schemaIdent, true /* cascade */));
+
+    // Both tables are attempted, rather than the first failure leaving the second one behind.
+    Assertions.assertEquals(2, FakeTableLocationProvider.unprovisioned().size());
+    Assertions.assertThrows(
+        NoSuchSchemaException.class, () -> opsWithFakeProvider.loadSchema(schemaIdent));
+  }
+
+  private NameIdentifier createSchema() {
+    String schemaName = randomSchemaName();
+    NameIdentifier schemaIdent =
+        NameIdentifierUtil.ofSchema(METALAKE_NAME, CATALOG_NAME, schemaName);
+    StringIdentifier stringId = StringIdentifier.fromId(idGenerator.nextId());
+    opsWithFakeProvider.createSchema(
+        schemaIdent, "schema comment", StringIdentifier.newPropertiesWithId(stringId, null));
+    return schemaIdent;
+  }
+
+  /**
+   * Puts a table entity straight into the entity store, instead of going through createTable, so
+   * that the drop paths can be exercised without a real table format behind them.
+   */
+  private NameIdentifier createTable(NameIdentifier schemaIdent, String tableName) {
+    TableEntity table =
+        TableEntity.builder()
+            .withId(idGenerator.nextId())
+            .withName(tableName)
+            .withNamespace(Namespace.of(METALAKE_NAME, CATALOG_NAME, schemaIdent.name()))
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
+            .withProperties(
+                ImmutableMap.of(
+                    Table.PROPERTY_TABLE_FORMAT,
+                    FakeTableDelegator.TABLE_FORMAT,
+                    Table.PROPERTY_LOCATION,
+                    locationOf(tableName)))
+            .build();
+    Assertions.assertDoesNotThrow(() -> store.put(table, false));
+    return NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaIdent.name(), tableName);
+  }
+
+  private static String locationOf(String tableName) {
+    return FakeTableLocationProvider.LOCATION_PREFIX + tableName + "/";
   }
 
   private String randomSchemaName() {

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
@@ -35,9 +35,11 @@ import static org.apache.gravitino.Configs.RELATIONAL_ENTITY_STORE;
 import static org.apache.gravitino.Configs.STORE_DELETE_AFTER_TIME;
 import static org.apache.gravitino.Configs.STORE_TRANSACTION_MAX_SKEW_TIME;
 import static org.apache.gravitino.Configs.VERSION_RETENTION_COUNT;
+import static org.apache.gravitino.Entity.EntityType.TABLE;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
@@ -47,6 +49,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Catalog;
@@ -68,7 +71,11 @@ import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.meta.TableEntity;
+import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.expressions.sorts.SortOrder;
+import org.apache.gravitino.rel.expressions.transforms.Transform;
+import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -89,6 +96,7 @@ public class TestGenericCatalogOperations {
   private static IdGenerator idGenerator;
   private static GenericCatalogOperations ops;
   private static GenericCatalogOperations opsWithFakeProvider;
+  private static GenericCatalogOperations opsWithDefaultProvider;
 
   @BeforeAll
   public static void setUp() throws IOException, IllegalAccessException {
@@ -160,17 +168,25 @@ public class TestGenericCatalogOperations {
             FakeTableLocationProvider.NAME),
         null /* CatalogInfo, unused */,
         new GenericCatalog());
+
+    // A third instance left on the built-in provider, to show that an external table carrying its
+    // own location is resolved the same way whichever provider a catalog is configured with.
+    opsWithDefaultProvider = new GenericCatalogOperations(store, idGenerator);
+    opsWithDefaultProvider.initialize(
+        ImmutableMap.of(), null /* CatalogInfo, unused */, new GenericCatalog());
   }
 
   @BeforeEach
   public void resetProvider() {
     FakeTableLocationProvider.reset();
+    FakeTableDelegator.reset();
   }
 
   @AfterAll
   public static void tearDown() throws IOException {
     ops.close();
     opsWithFakeProvider.close();
+    opsWithDefaultProvider.close();
     store.close();
     FileUtils.deleteDirectory(new File(STORE_PATH));
   }
@@ -267,46 +283,6 @@ public class TestGenericCatalogOperations {
   }
 
   @Test
-  public void testValidateProvisionedLocationAcceptsDirectoryPath() {
-    NameIdentifier tableIdent = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "schema1", "table1");
-
-    Assertions.assertEquals(
-        "s3://bucket/db/table/",
-        GenericCatalogOperations.validateProvisionedLocation(
-            "s3://bucket/db/table/", "default", tableIdent));
-  }
-
-  @Test
-  public void testValidateProvisionedLocationRejectsBlank() {
-    NameIdentifier tableIdent = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "schema1", "table1");
-
-    for (String location : Arrays.asList(null, "", "   ")) {
-      IllegalArgumentException e =
-          Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                  GenericCatalogOperations.validateProvisionedLocation(
-                      location, "custom", tableIdent));
-      Assertions.assertTrue(
-          e.getMessage().contains("returned a null or blank location"), e.getMessage());
-      Assertions.assertTrue(e.getMessage().contains("custom"), e.getMessage());
-    }
-  }
-
-  @Test
-  public void testValidateProvisionedLocationKeepsPathVerbatim() {
-    NameIdentifier tableIdent = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "schema1", "table1");
-
-    // The shape of the path belongs to the provider: a location without a trailing slash is
-    // accepted and stored exactly as returned, so that the provider unprovisioning it later sees
-    // the same string it handed out.
-    Assertions.assertEquals(
-        "s3://bucket/db/9f1c2e04-6b3a-4a17-bd6e-1c0a5f2d8e77",
-        GenericCatalogOperations.validateProvisionedLocation(
-            "s3://bucket/db/9f1c2e04-6b3a-4a17-bd6e-1c0a5f2d8e77", "custom", tableIdent));
-  }
-
-  @Test
   public void testDropTableUnprovisionsItsLocation() {
     NameIdentifier schemaIdent = createSchema();
     NameIdentifier tableIdent = createTable(schemaIdent, "table1");
@@ -339,6 +315,54 @@ public class TestGenericCatalogOperations {
     Assertions.assertEquals(tableIdent, unprovisioned.get(0).tableIdentifier());
     Assertions.assertEquals(
         locationOf("table1"), unprovisioned.get(0).tableProperties().get(Table.PROPERTY_LOCATION));
+  }
+
+  @Test
+  public void testACatalogPropertyWithANullValueDoesNotFailInitialization() throws IOException {
+    Map<String, String> conf = Maps.newHashMap();
+    conf.put(
+        GenericCatalogPropertiesMetadata.TABLE_LOCATION_PROVIDER, FakeTableLocationProvider.NAME);
+    conf.put("a-property-with-no-value", null);
+
+    // A null property value must not be able to fail the creation of a whole catalog. This is the
+    // catalog-level counterpart of testAPropertyWithANullValueReachesTheProvider.
+    GenericCatalogOperations catalogOps = new GenericCatalogOperations(store, idGenerator);
+    catalogOps.initialize(conf, null /* CatalogInfo, unused */, new GenericCatalog());
+
+    try {
+      NameIdentifier schemaIdent = createSchema();
+      Table created =
+          createTableThroughCatalog(catalogOps, schemaIdent, "table1", ImmutableMap.of());
+      Assertions.assertEquals(
+          locationOf("table1"), created.properties().get(Table.PROPERTY_LOCATION));
+    } finally {
+      catalogOps.close();
+    }
+  }
+
+  @Test
+  public void testDroppingATableReadsItsEntityOnlyOnce() throws IOException {
+    NameIdentifier schemaIdent = createSchema();
+    NameIdentifier tableIdent = createTable(schemaIdent, "table1");
+
+    EntityStore spiedStore = Mockito.spy(store);
+    GenericCatalogOperations catalogOps = new GenericCatalogOperations(spiedStore, idGenerator);
+    catalogOps.initialize(
+        ImmutableMap.of(
+            GenericCatalogPropertiesMetadata.TABLE_LOCATION_PROVIDER,
+            FakeTableLocationProvider.NAME),
+        null /* CatalogInfo, unused */,
+        new GenericCatalog());
+
+    try {
+      Assertions.assertTrue(catalogOps.dropTable(tableIdent));
+
+      // The properties read to build the unprovision context already carry the table format, so
+      // resolving the operations to drop with must not go back to the store for the same entity.
+      Mockito.verify(spiedStore, Mockito.times(1)).get(tableIdent, TABLE, TableEntity.class);
+    } finally {
+      catalogOps.close();
+    }
   }
 
   @Test
@@ -407,13 +431,302 @@ public class TestGenericCatalogOperations {
         NoSuchSchemaException.class, () -> opsWithFakeProvider.loadSchema(schemaIdent));
   }
 
+  @Test
+  public void testExternalTableWithLocationSkipsProvider() {
+    NameIdentifier schemaIdent = createSchema();
+    // Deliberately without a trailing slash, so that the only normalization the stored value may
+    // have gone through is the one the built-in provider applies to a table-level location.
+    String suppliedLocation = "s3://caller-owned-bucket/existing/data";
+
+    Table created =
+        createTableThroughCatalog(
+            opsWithFakeProvider,
+            schemaIdent,
+            "external_table",
+            ImmutableMap.of(
+                Table.PROPERTY_EXTERNAL, "true", Table.PROPERTY_LOCATION, suppliedLocation));
+
+    // An external table registers data that already exists. Handing it a freshly allocated path
+    // would orphan that data while still reporting the creation as successful.
+    Assertions.assertEquals(
+        suppliedLocation + "/", created.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertTrue(
+        FakeTableLocationProvider.provisioned().isEmpty(),
+        "The provider must not be consulted for an external table carrying its own location");
+  }
+
+  @Test
+  public void testExternalTableLocationIsIdenticalUnderDefaultProvider() {
+    NameIdentifier schemaIdent = createSchema();
+    // Without a trailing slash on purpose: with one, the bypass and the built-in provider agree
+    // trivially and this test would prove nothing about the normalization the bypass has to keep.
+    String suppliedLocation = "s3://caller-owned-bucket/existing/data";
+    Map<String, String> properties =
+        ImmutableMap.of(Table.PROPERTY_EXTERNAL, "true", Table.PROPERTY_LOCATION, suppliedLocation);
+
+    Table underFakeProvider =
+        createTableThroughCatalog(opsWithFakeProvider, schemaIdent, "external1", properties);
+    Table underDefaultProvider =
+        createTableThroughCatalog(opsWithDefaultProvider, schemaIdent, "external2", properties);
+
+    // The bypass is not a behaviour change for deployments on the built-in provider: it honoured
+    // the supplied location already, and still resolves to the same value, trailing slash included.
+    Assertions.assertEquals(
+        underDefaultProvider.properties().get(Table.PROPERTY_LOCATION),
+        underFakeProvider.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertEquals(
+        suppliedLocation + "/", underDefaultProvider.properties().get(Table.PROPERTY_LOCATION));
+  }
+
+  @Test
+  public void testCallerSuppliedLocationSkipsProviderEvenForAManagedTable() {
+    NameIdentifier schemaIdent = createSchema();
+    String suppliedLocation = "s3://caller-owned-bucket/managed";
+
+    Table created =
+        createTableThroughCatalog(
+            opsWithFakeProvider,
+            schemaIdent,
+            "managed_table",
+            ImmutableMap.of(Table.PROPERTY_LOCATION, suppliedLocation));
+
+    // The provider is consulted only when the catalog is the one choosing the location. A caller
+    // that supplies one is usually pointing at data that is already there -- a Lance registration
+    // carries no external flag -- and the catalog cannot tell that apart from an override, so it
+    // keeps the supplied value in both cases, exactly as it did before the provider existed.
+    Assertions.assertEquals(
+        suppliedLocation + "/", created.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertTrue(
+        FakeTableLocationProvider.provisioned().isEmpty(),
+        "The provider must not be consulted for a request that carries its own location");
+  }
+
+  @Test
+  public void testProvisionedLocationIsHandedBackWhenTheFormatDoesNotUseIt() {
+    NameIdentifier schemaIdent = createSchema();
+    String preExistingLocation = "s3://already-there/exist-ok-table/";
+    FakeTableDelegator.useLocationInstead(preExistingLocation);
+
+    Table created =
+        createTableThroughCatalog(
+            opsWithFakeProvider, schemaIdent, "exist_ok_table", ImmutableMap.of());
+
+    // A format may decline the location it was given and still report success: an EXIST_OK
+    // creation mode returns the table that already exists, at the location it already had. Nothing
+    // can have been written to the location provisioned for this call, so it goes back rather than
+    // leaking once per retried create.
+    Assertions.assertEquals(preExistingLocation, created.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertEquals(1, FakeTableLocationProvider.provisioned().size());
+    Assertions.assertEquals(1, FakeTableLocationProvider.released().size());
+    Assertions.assertEquals(
+        locationOf("exist_ok_table"),
+        FakeTableLocationProvider.released().get(0).tableProperties().get(Table.PROPERTY_LOCATION));
+
+    // The table this was called for is alive. A provider that reclaims by table identity rather
+    // than by path would delete a live registration if the drop callback were reused here, so the
+    // drop callback must not fire on the creation path at all.
+    Assertions.assertTrue(
+        FakeTableLocationProvider.unprovisioned().isEmpty(),
+        "The drop callback must not be used to release a location of a table that exists");
+  }
+
+  @Test
+  public void testUnusedLocationIsNotReleasedByDefault() {
+    // The built-in provider derives the location, so this schema has to carry one.
+    NameIdentifier schemaIdent = createSchema("s3://schema-owned/");
+    FakeTableDelegator.useLocationInstead("s3://already-there/exist-ok-table/");
+
+    // The built-in provider inherits the default body of releaseUnusedLocation, which does nothing.
+    // Leaking a stray allocation is the deliberate default; a provider that reclaims real storage
+    // opts in.
+    Table created =
+        createTableThroughCatalog(
+            opsWithDefaultProvider, schemaIdent, "exist_ok_default", ImmutableMap.of());
+
+    Assertions.assertEquals(
+        "s3://already-there/exist-ok-table/", created.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertTrue(FakeTableLocationProvider.released().isEmpty());
+    Assertions.assertTrue(FakeTableLocationProvider.unprovisioned().isEmpty());
+  }
+
+  @Test
+  public void testATrailingSlashAloneDoesNotMakeALocationLookUnused() {
+    NameIdentifier schemaIdent = createSchema();
+    String provisioned = locationOf("slash_table");
+    String withoutSlash = provisioned.substring(0, provisioned.length() - 1);
+    FakeTableDelegator.useLocationInstead(withoutSlash);
+
+    Table created =
+        createTableThroughCatalog(
+            opsWithFakeProvider, schemaIdent, "slash_table", ImmutableMap.of());
+
+    // The catalog adds the trailing slash itself, so a format storing the location without one is
+    // using the location it was given, not declining it.
+    Assertions.assertEquals(withoutSlash, created.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertTrue(
+        FakeTableLocationProvider.released().isEmpty(),
+        "A location differing only by a trailing slash is the same location");
+  }
+
+  @Test
+  public void testAPropertyWithANullValueReachesTheProvider() {
+    NameIdentifier schemaIdent = createSchema();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("a-property-with-no-value", null);
+
+    // The catalog accepts a null property value, so building the context must not be what turns
+    // such a request into a failure.
+    Table created =
+        createTableThroughCatalog(opsWithFakeProvider, schemaIdent, "null_value_table", properties);
+
+    Assertions.assertEquals(
+        locationOf("null_value_table"), created.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertEquals(1, FakeTableLocationProvider.provisioned().size());
+    Map<String, String> seen = FakeTableLocationProvider.provisioned().get(0).tableProperties();
+    Assertions.assertTrue(seen.containsKey("a-property-with-no-value"));
+    Assertions.assertNull(seen.get("a-property-with-no-value"));
+  }
+
+  @Test
+  public void testProvisionedLocationIsKeptWhenTheFormatUsesIt() {
+    NameIdentifier schemaIdent = createSchema();
+
+    Table created =
+        createTableThroughCatalog(
+            opsWithFakeProvider, schemaIdent, "normal_table", ImmutableMap.of());
+
+    Assertions.assertEquals(
+        locationOf("normal_table"), created.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertEquals(1, FakeTableLocationProvider.provisioned().size());
+    Assertions.assertTrue(
+        FakeTableLocationProvider.released().isEmpty(),
+        "A location the format actually used must not be handed back");
+  }
+
+  @Test
+  public void testExternalTableWithoutLocationStillConsultsProvider() {
+    NameIdentifier schemaIdent = createSchema();
+
+    Table created =
+        createTableThroughCatalog(
+            opsWithFakeProvider,
+            schemaIdent,
+            "external_no_location",
+            ImmutableMap.of(Table.PROPERTY_EXTERNAL, "true"));
+
+    // There is no existing location to preserve here, so this case is left as it was: the table
+    // format decides whether an external table without a location is valid at all.
+    Assertions.assertEquals(
+        locationOf("external_no_location"), created.properties().get(Table.PROPERTY_LOCATION));
+    Assertions.assertEquals(1, FakeTableLocationProvider.provisioned().size());
+  }
+
+  @Test
+  public void testDroppingExternalTableSkipsUnprovision() {
+    NameIdentifier schemaIdent = createSchema();
+    String suppliedLocation = "s3://caller-owned-bucket/existing/data/";
+    createTableThroughCatalog(
+        opsWithFakeProvider,
+        schemaIdent,
+        "external_table",
+        ImmutableMap.of(
+            Table.PROPERTY_EXTERNAL, "true", Table.PROPERTY_LOCATION, suppliedLocation));
+    NameIdentifier tableIdent =
+        NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaIdent.name(), "external_table");
+
+    Assertions.assertTrue(opsWithFakeProvider.dropTable(tableIdent));
+
+    // The data under an external table's location is not the catalog's to reclaim: the table
+    // formats leave it in place on drop, and asking a provider to hand the location back would
+    // invite it to delete exactly that data. Leaking beats deleting, so the callback is skipped.
+    Assertions.assertTrue(FakeTableLocationProvider.unprovisioned().isEmpty());
+  }
+
+  @Test
+  public void testDroppingExternalTableSkipsUnprovisionInACascade() {
+    NameIdentifier schemaIdent = createSchema();
+    createTableThroughCatalog(
+        opsWithFakeProvider,
+        schemaIdent,
+        "external_table",
+        ImmutableMap.of(
+            Table.PROPERTY_EXTERNAL,
+            "true",
+            Table.PROPERTY_LOCATION,
+            "s3://caller-owned-bucket/existing/data/"));
+    createTableThroughCatalog(opsWithFakeProvider, schemaIdent, "managed_table", ImmutableMap.of());
+
+    Assertions.assertTrue(opsWithFakeProvider.dropSchema(schemaIdent, true /* cascade */));
+
+    // Only the managed table's location comes back; the external one is left alone, exactly as on
+    // a single drop.
+    List<TableLocationContext> unprovisioned = FakeTableLocationProvider.unprovisioned();
+    Assertions.assertEquals(1, unprovisioned.size());
+    Assertions.assertEquals("managed_table", unprovisioned.get(0).tableIdentifier().name());
+  }
+
+  @Test
+  public void testContextReportsWhetherTheTableIsExternal() {
+    Assertions.assertTrue(
+        TableLocationContext.builder()
+            .withTableIdentifier(NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "s", "t"))
+            .withTableProperties(ImmutableMap.of(Table.PROPERTY_EXTERNAL, "TRUE"))
+            .withSchema(Mockito.mock(Schema.class))
+            .build()
+            .isExternal());
+
+    // Absent, and unparseable, both mean "not external" rather than an error.
+    Assertions.assertFalse(
+        TableLocationContext.builder()
+            .withTableIdentifier(NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "s", "t"))
+            .withTableProperties(ImmutableMap.of())
+            .withSchema(Mockito.mock(Schema.class))
+            .build()
+            .isExternal());
+    Assertions.assertFalse(
+        TableLocationContext.builder()
+            .withTableIdentifier(NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "s", "t"))
+            .withTableProperties(ImmutableMap.of(Table.PROPERTY_EXTERNAL, "not-a-boolean"))
+            .withSchema(Mockito.mock(Schema.class))
+            .build()
+            .isExternal());
+  }
+
+  @Test
+  public void testACascadeResolvesTheSchemaOnlyOnce() {
+    NameIdentifier schemaIdent = createSchema();
+    createTableThroughCatalog(opsWithFakeProvider, schemaIdent, "t1", ImmutableMap.of());
+    createTableThroughCatalog(opsWithFakeProvider, schemaIdent, "t2", ImmutableMap.of());
+    createTableThroughCatalog(opsWithFakeProvider, schemaIdent, "t3", ImmutableMap.of());
+
+    Assertions.assertTrue(opsWithFakeProvider.dropSchema(schemaIdent, true /* cascade */));
+
+    // Three tables, one parent schema. Every context hands back the very same Schema instance,
+    // which it could only do if the cascade resolved it once and shared it.
+    List<TableLocationContext> unprovisioned = FakeTableLocationProvider.unprovisioned();
+    Assertions.assertEquals(3, unprovisioned.size());
+    Schema resolvedOnce = unprovisioned.get(0).schema();
+    Assertions.assertSame(resolvedOnce, unprovisioned.get(1).schema());
+    Assertions.assertSame(resolvedOnce, unprovisioned.get(2).schema());
+  }
+
   private NameIdentifier createSchema() {
+    return createSchema(null);
+  }
+
+  /**
+   * Creates a schema, optionally carrying a {@code location} of its own so that the built-in
+   * provider has a level to derive a table location from.
+   */
+  private NameIdentifier createSchema(@Nullable String location) {
     String schemaName = randomSchemaName();
     NameIdentifier schemaIdent =
         NameIdentifierUtil.ofSchema(METALAKE_NAME, CATALOG_NAME, schemaName);
     StringIdentifier stringId = StringIdentifier.fromId(idGenerator.nextId());
+    Map<String, String> properties =
+        location == null ? null : ImmutableMap.of(Table.PROPERTY_LOCATION, location);
     opsWithFakeProvider.createSchema(
-        schemaIdent, "schema comment", StringIdentifier.newPropertiesWithId(stringId, null));
+        schemaIdent, "schema comment", StringIdentifier.newPropertiesWithId(stringId, properties));
     return schemaIdent;
   }
 
@@ -440,11 +753,75 @@ public class TestGenericCatalogOperations {
     return NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaIdent.name(), tableName);
   }
 
+  /**
+   * Creates a table through the catalog level createTable, so that the location resolution under
+   * test actually runs, unlike {@link #createTable(NameIdentifier, String)} which bypasses it.
+   */
+  private Table createTableThroughCatalog(
+      GenericCatalogOperations catalogOps,
+      NameIdentifier schemaIdent,
+      String tableName,
+      Map<String, String> properties) {
+    NameIdentifier tableIdent =
+        NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaIdent.name(), tableName);
+    // A plain map rather than an ImmutableMap: a creation request may carry a property whose
+    // value is null, and the test helper must be able to pass one through.
+    Map<String, String> allProperties = Maps.newHashMap(properties);
+    allProperties.put(Table.PROPERTY_TABLE_FORMAT, FakeTableDelegator.TABLE_FORMAT);
+    allProperties.putAll(
+        StringIdentifier.newPropertiesWithId(StringIdentifier.fromId(idGenerator.nextId()), null));
+
+    return catalogOps.createTable(
+        tableIdent,
+        new Column[0],
+        "table comment",
+        allProperties,
+        new Transform[0],
+        null /* distribution */,
+        new SortOrder[0],
+        new Index[0]);
+  }
+
   private static String locationOf(String tableName) {
     return FakeTableLocationProvider.LOCATION_PREFIX + tableName + "/";
   }
 
   private String randomSchemaName() {
     return "schema_" + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  @Test
+  public void testABlankProvisionedLocationFailsTheCreation() {
+    NameIdentifier schemaIdent = createSchema();
+
+    for (String location : Arrays.asList(null, "", "   ")) {
+      FakeTableLocationProvider.provisionLocation(location);
+      IllegalArgumentException e =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  createTableThroughCatalog(
+                      opsWithFakeProvider, schemaIdent, "blank_location", ImmutableMap.of()));
+      Assertions.assertTrue(
+          e.getMessage().contains("returned a null or blank location"), e.getMessage());
+      Assertions.assertTrue(
+          e.getMessage().contains(FakeTableLocationProvider.NAME), e.getMessage());
+    }
+  }
+
+  @Test
+  public void testAProvisionedLocationIsStoredVerbatim() {
+    NameIdentifier schemaIdent = createSchema();
+    // No trailing slash: the shape of the path belongs to the provider, so the catalog stores it
+    // exactly as returned rather than normalizing it, and the provider unprovisioning it later
+    // sees the same string it handed out.
+    String opaque = "testing://bucket/9f1c2e04-6b3a-4a17-bd6e-1c0a5f2d8e77";
+    FakeTableLocationProvider.provisionLocation(opaque);
+
+    Table created =
+        createTableThroughCatalog(
+            opsWithFakeProvider, schemaIdent, "verbatim_location", ImmutableMap.of());
+
+    Assertions.assertEquals(opaque, created.properties().get(Table.PROPERTY_LOCATION));
   }
 }

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
@@ -823,6 +823,20 @@ public class TestGenericCatalogOperations {
             opsWithFakeProvider, schemaIdent, "verbatim_location", ImmutableMap.of());
 
     Assertions.assertEquals(opaque, created.properties().get(Table.PROPERTY_LOCATION));
+
+    // A trailing slash is left alone for the same reason. The catalog does append one when it
+    // compares the location it handed out with the one the created table reports, so that a
+    // provider is not told its location was declined over a slash; that normalization belongs to
+    // the comparison and must not reach the stored property.
+    String directory = "testing://bucket/9f1c2e04-6b3a-4a17-bd6e-1c0a5f2d8e77/";
+    FakeTableLocationProvider.provisionLocation(directory);
+
+    Table createdInDirectory =
+        createTableThroughCatalog(
+            opsWithFakeProvider, schemaIdent, "verbatim_directory", ImmutableMap.of());
+
+    Assertions.assertEquals(
+        directory, createdInDirectory.properties().get(Table.PROPERTY_LOCATION));
   }
 
   @Test

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestGenericCatalogOperations.java
@@ -824,4 +824,49 @@ public class TestGenericCatalogOperations {
 
     Assertions.assertEquals(opaque, created.properties().get(Table.PROPERTY_LOCATION));
   }
+
+  @Test
+  public void testANonCanonicalExternalValueIsReadTheSameWayTheFormatsReadIt() {
+    // `external` is stored as the string the caller sent, and the property metadata decodes it
+    // with Boolean::valueOf, so a value like "yes" is accepted and means false. Both table formats
+    // read it with Boolean.parseBoolean or an equalsIgnoreCase("true"), so they see false too and
+    // treat the table as managed -- deleting its data on drop. If this context disagreed and
+    // reported true, the catalog would skip handing the location back for a table whose data was
+    // just deleted: the data lost and the allocation leaked at once.
+    NameIdentifier ident = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "s", "t");
+    Schema schema = Mockito.mock(Schema.class);
+
+    for (String notTrue : Arrays.asList("yes", "on", "y", "t", "1")) {
+      Assertions.assertFalse(
+          TableLocationContext.builder()
+              .withTableIdentifier(ident)
+              .withTableProperties(ImmutableMap.of(Table.PROPERTY_EXTERNAL, notTrue))
+              .withSchema(schema)
+              .build()
+              .isExternal(),
+          notTrue + " must not be read as external, because the table formats do not read it so");
+    }
+
+    Assertions.assertTrue(
+        TableLocationContext.builder()
+            .withTableIdentifier(ident)
+            .withTableProperties(ImmutableMap.of(Table.PROPERTY_EXTERNAL, "TrUe"))
+            .withSchema(schema)
+            .build()
+            .isExternal());
+  }
+
+  @Test
+  public void testManagedTableWithoutLocationConsultsProvider() {
+    NameIdentifier schemaIdent = createSchema();
+
+    createTableThroughCatalog(opsWithFakeProvider, schemaIdent, "managed_table", ImmutableMap.of());
+
+    // The fourth cell of the external x supplied-location matrix: no location and not external is
+    // the ordinary case the provider exists for.
+    List<TableLocationContext> provisioned = FakeTableLocationProvider.provisioned();
+    Assertions.assertEquals(1, provisioned.size());
+    Assertions.assertEquals("managed_table", provisioned.get(0).tableIdentifier().name());
+    Assertions.assertFalse(provisioned.get(0).isExternal());
+  }
 }

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestPropertiesMetadata.java
@@ -38,6 +38,22 @@ public class TestPropertiesMetadata {
   }
 
   @Test
+  void testTableLocationProviderPropertyIsImmutableWithDefault() {
+    PropertiesMetadata catalogPropertiesMetadata = genericCatalog.catalogPropertiesMetadata();
+
+    Assertions.assertTrue(
+        catalogPropertiesMetadata.containsProperty(
+            GenericCatalogPropertiesMetadata.TABLE_LOCATION_PROVIDER));
+    Assertions.assertEquals(
+        DefaultTableLocationProvider.NAME,
+        catalogPropertiesMetadata.getOrDefault(
+            ImmutableMap.of(), GenericCatalogPropertiesMetadata.TABLE_LOCATION_PROVIDER));
+    Assertions.assertTrue(
+        catalogPropertiesMetadata.isImmutableProperty(
+            GenericCatalogPropertiesMetadata.TABLE_LOCATION_PROVIDER));
+  }
+
+  @Test
   void testCatalogPropertiesMetadata() {
     PropertiesMetadata catalogPropertiesMetadata = genericCatalog.catalogPropertiesMetadata();
     Assertions.assertNotNull(catalogPropertiesMetadata);

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestTableLocationProviderFactory.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestTableLocationProviderFactory.java
@@ -23,12 +23,21 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TestTableLocationProviderFactory {
 
   private static final Map<String, String> CATALOG_PROPERTIES =
       ImmutableMap.of("location", "/tmp/catalog");
+
+  @BeforeEach
+  void forgetDiscoveredProviders() {
+    // The index is remembered per class loader and every test here shares one, so without this
+    // only the first test would exercise a real ServiceLoader scan and the rest would be reading
+    // back what it found.
+    TableLocationProviderFactory.invalidateCache();
+  }
 
   @Test
   void testCreateDefaultProvider() throws IOException {
@@ -126,6 +135,42 @@ public class TestTableLocationProviderFactory {
   void testBlankProviderNameThrows() {
     Assertions.assertThrows(IllegalArgumentException.class, () -> create(" "));
     Assertions.assertThrows(IllegalArgumentException.class, () -> create(null));
+  }
+
+  @Test
+  void testTheIndexIsReusedRatherThanRescanned() throws IOException {
+    FakeTableLocationProvider.reset();
+
+    try (TableLocationProvider ignored = create(DefaultTableLocationProvider.NAME)) {
+      // The first lookup has to construct every registered provider, including this one, because
+      // name() is an instance method and there is no other way to learn what a candidate answers
+      // to.
+      Assertions.assertTrue(FakeTableLocationProvider.constructedCount() >= 1);
+    }
+    int afterFirstScan = FakeTableLocationProvider.constructedCount();
+
+    try (TableLocationProvider ignored = create(DefaultTableLocationProvider.NAME)) {
+      // The second lookup reads the index, so no candidate other than the selected one is
+      // constructed. That is the whole benefit of the cache, and it is the part worth pinning.
+      Assertions.assertEquals(afterFirstScan, FakeTableLocationProvider.constructedCount());
+    }
+  }
+
+  @Test
+  void testInvalidatingTheIndexForcesARescan() throws IOException {
+    FakeTableLocationProvider.reset();
+
+    try (TableLocationProvider ignored = create(DefaultTableLocationProvider.NAME)) {
+      Assertions.assertTrue(FakeTableLocationProvider.constructedCount() >= 1);
+    }
+    int afterFirstScan = FakeTableLocationProvider.constructedCount();
+
+    TableLocationProviderFactory.invalidateCache();
+    try (TableLocationProvider ignored = create(DefaultTableLocationProvider.NAME)) {
+      // A dropped index is what a collected class loader leaves behind, and the next lookup has to
+      // survive it by scanning again rather than reporting the provider as missing.
+      Assertions.assertTrue(FakeTableLocationProvider.constructedCount() > afterFirstScan);
+    }
   }
 
   private static TableLocationProvider create(String name) {

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestTableLocationProviderFactory.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestTableLocationProviderFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.generic;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestTableLocationProviderFactory {
+
+  private static final Map<String, String> CATALOG_PROPERTIES =
+      ImmutableMap.of("location", "/tmp/catalog");
+
+  @Test
+  void testCreateDefaultProvider() throws IOException {
+    try (TableLocationProvider provider = create(DefaultTableLocationProvider.NAME)) {
+      Assertions.assertInstanceOf(DefaultTableLocationProvider.class, provider);
+      Assertions.assertEquals(DefaultTableLocationProvider.NAME, provider.name());
+    }
+  }
+
+  @Test
+  void testProviderNameIsCaseInsensitive() throws IOException {
+    try (TableLocationProvider provider = create("DeFaUlT")) {
+      Assertions.assertInstanceOf(DefaultTableLocationProvider.class, provider);
+    }
+  }
+
+  @Test
+  void testCreateCustomProviderDiscoveredViaServiceLoader() throws IOException {
+    try (TableLocationProvider provider = create(FakeTableLocationProvider.NAME)) {
+      FakeTableLocationProvider fake =
+          Assertions.assertInstanceOf(FakeTableLocationProvider.class, provider);
+      // The provider is initialized with the catalog properties before it is handed back.
+      Assertions.assertEquals(CATALOG_PROPERTIES, fake.catalogProperties());
+      Assertions.assertFalse(fake.isClosed());
+    }
+  }
+
+  @Test
+  void testEachCallReturnsANewInstance() throws IOException {
+    try (TableLocationProvider first = create(DefaultTableLocationProvider.NAME);
+        TableLocationProvider second = create(DefaultTableLocationProvider.NAME)) {
+      Assertions.assertNotSame(first, second);
+    }
+  }
+
+  @Test
+  void testUnknownProviderThrows() {
+    IllegalArgumentException e =
+        Assertions.assertThrows(IllegalArgumentException.class, () -> create("no-such-provider"));
+    Assertions.assertTrue(
+        e.getMessage().contains("No TableLocationProvider found for name 'no-such-provider'"),
+        "Unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  void testBlankProviderNameThrows() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> create(" "));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> create(null));
+  }
+
+  private static TableLocationProvider create(String name) {
+    return TableLocationProviderFactory.create(name, CATALOG_PROPERTIES);
+  }
+}

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestTableLocationProviderFactory.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/generic/TestTableLocationProviderFactory.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.lakehouse.generic;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -64,12 +65,61 @@ public class TestTableLocationProviderFactory {
   }
 
   @Test
+  void testProviderIsClosedWhenInitializeThrows() {
+    FakeTableLocationProvider.reset();
+    FakeTableLocationProvider.failOnInitialize(true);
+    try {
+      Assertions.assertThrows(
+          IllegalStateException.class, () -> create(FakeTableLocationProvider.NAME));
+
+      // A provider that failed halfway through initialize holds whatever it managed to acquire,
+      // and never reaches the caller that would have owned its lifecycle, so the factory has to
+      // close it.
+      Assertions.assertEquals(1, FakeTableLocationProvider.closedCount());
+    } finally {
+      FakeTableLocationProvider.reset();
+    }
+  }
+
+  @Test
+  void testABrokenProviderOnTheClasspathIsSkippedRatherThanFailingTheLookup() throws IOException {
+    // BrokenTableLocationProvider is registered in this module's test services file, so it is
+    // instantiated and asked for its name on every lookup here, including this one. That it fails
+    // with an Error rather than an exception is the point: name() is called by the factory and not
+    // by the loader, so nothing wraps it, and a catch that only took RuntimeException would let it
+    // through and stop every catalog from starting over one broken jar.
+    try (TableLocationProvider provider = create(DefaultTableLocationProvider.NAME)) {
+      Assertions.assertInstanceOf(DefaultTableLocationProvider.class, provider);
+    }
+
+    // The name it never managed to report is still not a name anyone can select.
+    Assertions.assertThrows(IllegalArgumentException.class, () -> create("broken"));
+  }
+
+  @Test
   void testUnknownProviderThrows() {
     IllegalArgumentException e =
         Assertions.assertThrows(IllegalArgumentException.class, () -> create("no-such-provider"));
     Assertions.assertTrue(
         e.getMessage().contains("No TableLocationProvider found for name 'no-such-provider'"),
         "Unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  void testACatalogPropertyWithANullValueReachesTheProvider() throws IOException {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("location", "/tmp/catalog");
+    properties.put("a-property-with-no-value", null);
+
+    // Nothing upstream rejects a catalog property whose value is null, so the factory must not be
+    // what turns one into a failure to build the provider.
+    try (TableLocationProvider provider =
+        TableLocationProviderFactory.create(FakeTableLocationProvider.NAME, properties)) {
+      FakeTableLocationProvider fake =
+          Assertions.assertInstanceOf(FakeTableLocationProvider.class, provider);
+      Assertions.assertTrue(fake.catalogProperties().containsKey("a-property-with-no-value"));
+      Assertions.assertNull(fake.catalogProperties().get("a-property-with-no-value"));
+    }
   }
 
   @Test

--- a/catalogs/catalog-lakehouse-generic/src/test/resources/META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.LakehouseTableDelegator
+++ b/catalogs/catalog-lakehouse-generic/src/test/resources/META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.LakehouseTableDelegator
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.catalog.lakehouse.generic.FakeTableDelegator

--- a/catalogs/catalog-lakehouse-generic/src/test/resources/META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider
+++ b/catalogs/catalog-lakehouse-generic/src/test/resources/META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider
@@ -17,3 +17,4 @@
 # under the License.
 #
 org.apache.gravitino.catalog.lakehouse.generic.FakeTableLocationProvider
+org.apache.gravitino.catalog.lakehouse.generic.BrokenTableLocationProvider

--- a/catalogs/catalog-lakehouse-generic/src/test/resources/META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider
+++ b/catalogs/catalog-lakehouse-generic/src/test/resources/META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.catalog.lakehouse.generic.FakeTableLocationProvider

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -221,15 +221,20 @@ complete record of the locations it handed out.
 
 Two constraints follow from `ServiceLoader` discovery:
 
-- The implementation needs a public no-argument constructor that is cheap and does not throw. Every
-  provider on the classpath is instantiated before the one named by the catalog property is selected,
-  so a heavy constructor slows catalog initialization for everyone, including catalogs using the
-  built-in provider, and one that throws costs that provider the ability to be selected at all. Put
-  clients, connection pools and other expensive setup in `initialize`.
+- The implementation needs a public no-argument constructor that is cheap and does not throw.
+  Selecting a provider means asking each candidate its name, and `name()` is an instance method, so
+  every provider on the classpath is constructed once before the named one is selected. That scan
+  happens once per class loader and its result is remembered, so a heavy constructor costs the first
+  catalog to start rather than every catalog, but it still costs that one -- including when the
+  provider it is slowing down is not the one being selected. A constructor that throws costs that
+  provider the ability to be selected at all. Put clients, connection pools and other expensive
+  setup in `initialize`, which runs only on the selected provider.
 - `name()` must be unique across the classpath and must not be `default`, which is reserved by the
   built-in provider. If two providers share a name, every catalog selecting that name fails to
-  initialize. A provider that cannot be instantiated at all is logged and skipped rather than
-  failing the lookup, so one broken jar does not stop every catalog from starting.
+  initialize. A candidate whose constructor or `name()` throws is logged and skipped, so one
+  misbehaving provider does not stop a catalog that named a different one. A services file naming a
+  class that cannot be loaded at all is not survivable in the same way: it fails the scan before any
+  candidate is reached.
 
 #### Key Property: `location`
 

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -71,20 +71,38 @@ Implementing `initialize` is optional: a provider that derives the location pure
 is given has nothing to prepare. Override it when the provider holds a remote client, a connection or
 any state that must outlive a single table creation, and release those resources in `close`.
 
-Both methods receive a `TableLocationContext`, which carries `tableIdentifier()`, `tableProperties()`
-and `schema()` -- the parent schema including its properties. Selection is per catalog, so a provider
+All three callbacks receive a `TableLocationContext`, which carries `tableIdentifier()`,
+`tableProperties()`, `schema()` -- the parent schema including its properties -- and
+`isExternal()`, the `external` property read as a boolean. Selection is per catalog, so a provider
 that needs different behaviour for different schemas has to read a schema property and dispatch on it
 itself. A provider doing that should reject an unrecognized value rather than falling back to another
 strategy, and should treat the property as immutable: a table provisioned under one strategy has to be
 unprovisioned under the same one.
 
-A user-supplied table `location` reaches the provider through the context, but the location the
-provider returns is what gets stored. Whether a user-supplied value is honoured is therefore up to the
-selected provider; the built-in provider honours it.
+A **request that supplies its own `location` never reaches the provider**
+-- the supplied value is stored, normalized only with a trailing slash. In this catalog a caller
+supplies a location mostly because the data is already there: an external Delta table, or a Lance
+registration, both of which point at a dataset that exists. Asking a provider for an address in
+those cases would repoint the table at a freshly allocated empty path and orphan the caller's data,
+while leaving behind an allocation that is never written to and never handed back.
+
+The catalog cannot tell those requests apart from a caller merely overriding placement, so it keeps
+the supplied location in both cases -- which is also exactly what it did before providers existed.
+A deployment that wants allocation to be mandatory has to reject a caller-supplied `location`
+before it reaches the catalog; a provider cannot enforce it, because it is not called. Everything
+else does reach the provider, including an external table that carries no `location`; the table
+format decides whether that combination is valid at all.
 
 `provisionTableLocation` runs on the server thread handling the table creation request. The catalog
 applies no timeout, so a provider that calls a remote service must bound every call itself and fail
 fast when the service is unavailable; a call that blocks holds that request thread until it returns.
+
+The catalog does not fence in-flight requests against `close()`, so a request that started before
+the catalog was closed can reach `provisionTableLocation`, `unprovisionTableLocation` or
+`releaseUnusedLocation` afterwards. A provider is not asked to keep working across a close, only to
+fail cleanly rather than corrupt anything -- which a closed client throwing already does. On the
+drop and release paths that failure is logged at WARN and nothing else happens; on the provisioning
+path it fails the table creation, which is the right answer for a catalog that is shutting down.
 
 `provisionTableLocation` must return a non-blank location; the catalog rejects the table creation
 otherwise. That is the only check: the shape of the path belongs to the provider, nothing downstream
@@ -95,7 +113,7 @@ When a table is dropped or purged, the catalog calls `unprovisionTableLocation` 
 can hand the location back. It reads the location to reclaim from `context.tableProperties()` under
 the `location` key, which the catalog fills in from the stored table properties read just before the
 table was removed. Dropping a schema with cascade unprovisions the location of every table it
-contains, one by one.
+contains, one by one, resolving the shared parent schema once for the whole cascade.
 
 The method has no default implementation, so every provider has to answer for it. A provider that
 composes the path from configuration and registers it nowhere -- like the built-in one -- writes an
@@ -108,20 +126,110 @@ and the drop still reports success, because reporting a drop that did happen as 
 only invite a retry that cannot undo anything. For the same reason a failed unprovisioning does not
 abort a cascading schema drop.
 
-`unprovisionTableLocation` is called at most once per dropped table, but a server crash between the
-removal and the call means it may not be called at all, so a provider reclaiming real storage needs
-its own reconciliation to catch those, and must tolerate being called for a location that is already
-released.
+`unprovisionTableLocation` is called once per dropped table, but it is not guaranteed to be called
+at all. A crash between the removal and the call skips it, and so does a failure raised inside the
+drop after the metadata is already gone, which takes no crash and leaves the server running
+normally. A provider reclaiming real storage needs its own reconciliation to catch both, and must
+tolerate being called for a location that is already released.
+
+**External tables are skipped.** The catalog does not own their data — the table formats leave the
+dataset in place on drop — so asking a provider to hand the location back would invite it to delete
+exactly the data the catalog just promised not to touch. A leak is recoverable and a deletion is
+not, so `unprovisionTableLocation` is not called for a table whose `external` property is true.
+`context.isExternal()` reports the same flag on the paths where the provider *is* called.
+
+The `external` flag is an approximation of the rule this callback wants, which is "hand back only
+what was handed out", and two cases stay asymmetric under it:
+
+- An external table created *without* a location does get one provisioned, because both table
+  formats check the location only after the catalog has filled it in. Skipping leaks that
+  allocation.
+- A table that is not external, but whose creation carried its own `location`, was never
+  provisioned, yet is still unprovisioned — so the provider is asked about a path it never issued.
+
+Telling those apart exactly would need the catalog to record, per table, whether it provisioned the
+location, which it does not do today. Both are why a provider reclaiming real storage needs its own
+reconciliation, and why it must tolerate a location it does not recognize.
+
+There is no separate purge flag in the context, because for the tables this catalog manages
+`purgeTable` delegates to `dropTable` and the two paths remove exactly the same things.
+
+##### Releasing a location the table format did not use
+
+A format may decline the location it was given and still report success. Lance's `EXIST_OK`
+creation mode returns the table that already exists, at the location it already had, and a client
+retrying a create is the ordinary way to reach that. Without a callback the location provisioned for
+that call would leak, once per retried create, with nothing in the logs to show it.
+
+That callback is **`releaseUnusedLocation`, not `unprovisionTableLocation`**, and the difference
+matters. The table here is alive: the creation succeeded and the caller is about to be handed the
+table. Only the location went unused. A provider that derives paths from configuration does the same
+nothing in both methods, but a provider that books allocations against `(schema, table)` would read
+the drop callback literally and delete the registration of a table that exists. Two methods make
+that difference hard to overlook in a way no runtime flag would. For the same reason the `external`
+property is *not* a signal to skip here, though it is on the drop path: the location being released
+was allocated by this provider moments ago, on request, so nobody else's data can be under it.
+
+`releaseUnusedLocation` has a default implementation that does nothing, which leaks the unused
+location. That is the deliberate default: not releasing is what this catalog did before the callback
+existed and costs one stray allocation, whereas releasing something the provider has misidentified
+costs live data. A provider that allocates real storage should implement it. A failure is logged at
+WARN and does not fail the creation, which already succeeded.
+
+This is deliberately the opposite call from `unprovisionTableLocation`, which has no default at all
+so that no provider can stay silent about drops by accident. The cost of silence is what differs:
+there it leaks a location on every drop, on the ordinary path, forever; here it leaks one location
+in the uncommon case that a format declined the one it was given. A provider that cannot release by
+path -- because the service behind it only deletes by table identity -- should leave the method
+alone and reclaim through its own reconciliation, rather than write a body that would be wrong.
+
+The catalog decides a location went unused by comparing the location it handed the format with the
+one the created table reports, ignoring a trailing slash, since that is the one rewrite the catalog
+performs itself. A format that rewrites the location further -- collapsing a duplicated separator,
+or normalizing a URI scheme -- looks from here like a format that declined it, so a provider whose
+paths may come back rewritten should verify before reclaiming.
+
+**Known limitations.** Four of them, and they all point the same way: a provider that manages real
+storage needs its own reconciliation against the catalog, and cannot treat these callbacks as a
+complete record of the locations it handed out.
+
+- `location` is a mutable table property, so `alterTable(setProperty("location", ...))` repoints a
+  table without the provider being told. The old location is never unprovisioned and the new one
+  never went through the provider.
+- `provisionTableLocation` runs before the table is actually created, so a creation that fails
+  afterwards -- a table that already exists, or a failure inside the table format itself -- leaves a
+  location provisioned for a table that does not exist. There is no compensating unprovision, and
+  that is deliberate: a table format that fails partway through creation may already have written to
+  the location, and unprovisioning would then tell the provider it may reclaim a path that has data
+  on it. Leaking an unused path is the safer of the two failures, and doing better would need the
+  format to report whether it touched storage before failing, which the interface cannot express.
+  The table format itself compensates where it can: Lance deletes the dataset it just created when
+  the metadata write then fails. Everything the catalog can check on its own -- the table format is
+  given, the format is supported -- is checked before the provider is consulted, so the cases that
+  remain are the ones only the table format can detect.
+- A table format that drops a table through its own internals rather than through the catalog does
+  not trigger the release callback. Lance's `OVERWRITE` creation mode does this: it drops the
+  existing table and creates a new one, so the old location is never handed back. This is the same
+  shape as the cascading schema drop, which the catalog does route through its own `dropTable`, but
+  a format-internal drop is not visible to the catalog at all.
+- `alterTable(rename(...))` changes a table's identity without telling the provider, and without
+  moving any data. A provider deriving the path from the table name is left with a path that no
+  longer matches the name, which is cosmetic. A provider that books allocations against
+  `(schema, table)` loses the table altogether: the drop that follows arrives under the new name,
+  and the allocation booked under the old one is never handed back. Such a provider has to reconcile
+  renames out of band, or the deployment has to forbid renaming tables in this catalog.
 
 Two constraints follow from `ServiceLoader` discovery:
 
 - The implementation needs a public no-argument constructor that is cheap and does not throw. Every
   provider on the classpath is instantiated before the one named by the catalog property is selected,
-  so a heavy or failing constructor breaks catalog initialization for everyone, including catalogs
-  using the built-in provider. Put clients, connection pools and other expensive setup in `initialize`.
+  so a heavy constructor slows catalog initialization for everyone, including catalogs using the
+  built-in provider, and one that throws costs that provider the ability to be selected at all. Put
+  clients, connection pools and other expensive setup in `initialize`.
 - `name()` must be unique across the classpath and must not be `default`, which is reserved by the
-  built-in provider. Two providers sharing a name make every catalog selecting that name fail to
-  initialize.
+  built-in provider. If two providers share a name, every catalog selecting that name fails to
+  initialize. A provider that cannot be instantiated at all is logged and skipped rather than
+  failing the lookup, so one broken jar does not stop every catalog from starting.
 
 #### Key Property: `location`
 

--- a/docs/lakehouse-generic-catalog.md
+++ b/docs/lakehouse-generic-catalog.md
@@ -48,13 +48,87 @@ For detailed information on available operations, see [Manage Relational Metadat
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------|
 | `provider`                  | Catalog provider type                                                                                                                                                                                          | `lakehouse-generic`     | Yes      |
 | `location`                  | Root storage path for all schemas and tables                                                                                                                                                                   | `s3://bucket/lakehouse` | No       |
+| `table-location-provider`   | Name of the [table location provider](#pluggable-table-location-provider) that provisions and unprovisions the locations of this catalog's tables. Defaults to `default`, which resolves the location from the table, schema and catalog `location` properties as described below. Immutable once the catalog is created.                               | `default`               | No       |
 | `lance.schema-refresh-mode` | Lance table schema refresh mode. `DECLARED_AND_EMPTY` (default) refreshes declared tables and tables with empty stored columns. `VERSION_CHECK` additionally refreshes when the Lance dataset version changes. | `DECLARED_AND_EMPTY`    | No       |
+
+#### Pluggable table location provider
+
+By default the catalog derives a new table's location from the `location` properties, following the
+hierarchy described in [Key Property: `location`](#key-property-location). Deployments that allocate
+storage through an external service can replace that logic with their own strategy.
+
+Implement `org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider`, register it in
+`META-INF/services/org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider`, drop the jar
+into `catalogs/lakehouse-generic/libs`, and select it with the `table-location-provider` catalog
+property (matched case-insensitively against `TableLocationProvider#name()`).
+
+One provider instance is created per catalog. `initialize` is called once with the catalog properties
+before the first provisioning, `provisionTableLocation` is called for every table creation and must
+be thread-safe, and `close` is called when the catalog is closed. The property is immutable, so a catalog
+keeps the provider it was created with.
+
+Implementing `initialize` is optional: a provider that derives the location purely from the context it
+is given has nothing to prepare. Override it when the provider holds a remote client, a connection or
+any state that must outlive a single table creation, and release those resources in `close`.
+
+Both methods receive a `TableLocationContext`, which carries `tableIdentifier()`, `tableProperties()`
+and `schema()` -- the parent schema including its properties. Selection is per catalog, so a provider
+that needs different behaviour for different schemas has to read a schema property and dispatch on it
+itself. A provider doing that should reject an unrecognized value rather than falling back to another
+strategy, and should treat the property as immutable: a table provisioned under one strategy has to be
+unprovisioned under the same one.
+
+A user-supplied table `location` reaches the provider through the context, but the location the
+provider returns is what gets stored. Whether a user-supplied value is honoured is therefore up to the
+selected provider; the built-in provider honours it.
+
+`provisionTableLocation` runs on the server thread handling the table creation request. The catalog
+applies no timeout, so a provider that calls a remote service must bound every call itself and fail
+fast when the service is unavailable; a call that blocks holds that request thread until it returns.
+
+`provisionTableLocation` must return a non-blank location; the catalog rejects the table creation
+otherwise. That is the only check: the shape of the path belongs to the provider, nothing downstream
+appends to it, and the value is stored verbatim so that a provider unprovisioning it later sees
+exactly the string it returned.
+
+When a table is dropped or purged, the catalog calls `unprovisionTableLocation` so that the provider
+can hand the location back. It reads the location to reclaim from `context.tableProperties()` under
+the `location` key, which the catalog fills in from the stored table properties read just before the
+table was removed. Dropping a schema with cascade unprovisions the location of every table it
+contains, one by one.
+
+The method has no default implementation, so every provider has to answer for it. A provider that
+composes the path from configuration and registers it nowhere -- like the built-in one -- writes an
+empty body.
+
+The unprovisioning happens *after* the table metadata, and the data of a managed table, have been
+removed, so a provider that fails does not roll the drop back: the table is gone either way. The
+failure is logged at WARN naming the table, the provider and the location that was not reclaimed,
+and the drop still reports success, because reporting a drop that did happen as unsuccessful would
+only invite a retry that cannot undo anything. For the same reason a failed unprovisioning does not
+abort a cascading schema drop.
+
+`unprovisionTableLocation` is called at most once per dropped table, but a server crash between the
+removal and the call means it may not be called at all, so a provider reclaiming real storage needs
+its own reconciliation to catch those, and must tolerate being called for a location that is already
+released.
+
+Two constraints follow from `ServiceLoader` discovery:
+
+- The implementation needs a public no-argument constructor that is cheap and does not throw. Every
+  provider on the classpath is instantiated before the one named by the catalog property is selected,
+  so a heavy or failing constructor breaks catalog initialization for everyone, including catalogs
+  using the built-in provider. Put clients, connection pools and other expensive setup in `initialize`.
+- `name()` must be unique across the classpath and must not be `default`, which is reserved by the
+  built-in provider. Two providers sharing a name make every catalog selecting that name fail to
+  initialize.
 
 #### Key Property: `location`
 
 The `location` property specifies the root directory for the lakehouse table. All schemas and tables are stored under this location unless explicitly overridden at the schema or table level.
 
-**Location Resolution Hierarchy:**
+**Location Resolution Hierarchy** (applies to the built-in provider; a custom
+`table-location-provider` defines its own):
 1. Table-level `location` (highest priority)
 2. Schema-level `location`, then the location of the table will be `{schema_location}/{table_name}`
 3. Catalog-level `location` (fallback), then the location of the table will be `{catalog_location}/{schema_name}/{table_name}`


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a `ServiceLoader`-based `TableLocationProvider` SPI to the generic lakehouse catalog, so a
deployment can replace the built-in path derivation with a strategy of its own. This implements the
design in #12971.

```java
public interface TableLocationProvider {
  String name();
  String provisionTableLocation(TableLocationContext context);
  void unprovisionTableLocation(TableLocationContext context);
}
```

Two operations: hand out a location for a table being created, hand one back for a table that is
gone.

**The catalog reports; the provider decides.** The catalog's part is to hand over an accurate
account of what happened -- what the creation request asked for, where the table ended up, whether
the data under a location is gone -- and the provider's part is to decide what that account means
for the storage it manages. The catalog does not model what an implementation keeps, and an
implementation is never asked to reconstruct what the catalog or the table formats did. There is one
exception, written as an exception rather than as the rule, and it is the external-drop skip below.

Earlier revisions exposed more -- a lifecycle pair, a third release callback, `isExternal()`,
`isPurge()`, and a call site for a location the format declined -- and each has since been removed
after review, because in every case the catalog was either deciding on the provider's behalf or
inferring what the provider had done internally.

**Responsibilities.** A provider owns the right to use a path; the table format owns the content at
the path. The dividing line is not physical against logical -- a provider may well create real
infrastructure -- but what a thing was created for: anything brought into being so that the path can
be used belongs to the provider, and anything written into the path belongs to the format. The
catalog owns neither; it stores the string verbatim and sequences the two calls.

**Scope.** Allocation hooks plus best-effort release notification, with recovery owned by the
provider and the deployment. Deliberately not a distributed transaction and not a recovery system.

- `TableLocationContext` -- an immutable, builder-built parameter object carrying the table
  identifier, the table properties, the parent schema and the catalog properties. One type for both
  callbacks, so a future input becomes an extra accessor rather than a signature change.
- `TableLocationProviderFactory` -- discovery and selection by name, case-insensitive. A missing
  name and a duplicated name both fail catalog initialization; a silent fallback to the built-in
  chain would be a policy bypass. A candidate whose constructor or `name()` throws is logged and
  skipped instead, so one misbehaving provider does not stop catalogs that named a different one. A
  services file naming a class that cannot be loaded at all still fails the scan, before any
  candidate is reached. Discovery is repeated per catalog rather than cached: catalog creation is
  rare, and `org.apache.gravitino.catalog.lakehouse.` is a *catalog* class under
  `IsolatedClassLoader`, so a cache keyed by class loader would have been per-catalog anyway.
- `DefaultTableLocationProvider` -- registered as `default`, reproducing the existing table → schema
  → catalog `location` hierarchy verbatim, including trailing-slash handling and the existing
  `IllegalArgumentException` message.
- `table-location-provider` -- a new, optional, immutable catalog property naming the provider,
  defaulting to `default`.

**No lifecycle.** A provider is created per catalog and is never initialized and never closed.
Configuration reaches it as `TableLocationContext#catalogProperties()` -- the same map on every
call, so reading it per call costs a lookup. A provider holding a remote client is expected to
create it lazily and to be safe to abandon, since a catalog is evicted from the server's catalog
cache when idle and the provider it held is simply discarded. Both callbacks are called
concurrently and must be thread-safe.

`catalogProperties()` is not only for third-party providers: the built-in one needs it for the
catalog-level step of its fallback chain, which it used to capture in `initialize`.

**A caller-supplied `location` reaches the provider too**, as the `location` entry of the context's
table properties. The decision is the provider's: return it unchanged to honour it, return
something else, or throw to refuse the creation. Deciding it in the catalog would leave a provider
that exists to enforce a placement policy with nothing to enforce, and a caller-supplied path is
exactly the case such a policy is for. The built-in provider returns it verbatim as its first
branch, so a catalog on the built-in provider is unaffected -- a test asserts a supplied location
resolves identically under both.

An implementation that allocates storage has to handle that case deliberately. In this catalog a
caller usually supplies a location because the data is already there -- an external Delta table, or
a Lance registration. Allocating a fresh path for one of those and returning it repoints the table
at an empty directory and orphans the caller's data while the creation still reports success.

**Dropping an external table skips unprovisioning; purging one does not.** On a drop the table
formats leave the external dataset in place, so asking a provider to hand the location back would
invite it to delete exactly the data the catalog just promised not to touch. A leak is recoverable
and a deletion is not.

A purge is the opposite request: `LanceTableOperations.purgeTable` deletes the external dataset that
its `dropTable` leaves alone, so by then the data is gone and the reason to skip has gone with it.

That leaves exactly three situations in which `unprovisionTableLocation` is reached: a dropped
managed table, a purged managed table, and a purged external one. There is deliberately no flag
distinguishing them, because the invariant they share is about the location rather than the table:
**nothing anyone needs is under the location named in the context**. In all three the table format
has already deleted the data under it. The catalog makes the drop-versus-purge and external
distinctions rather than passing them on, because the catalog is where the knowledge lives about
which formats leave data in place. It reads `external` with `Boolean#parseBoolean`, deliberately
the same reading the table formats and the property metadata use, since a catalog that disagreed
with the format about a value like `external=yes` would skip reclaiming a location the format had
just deleted the data under.

**What the callback releases, and what it must not touch.** A provider releases what it issued: the
reservation, the registry entry, whatever quota or grant it booked, and the name itself so that it
can be handed out again. It may remove a container it created itself -- a prefix or a bucket brought
into being so the path could be used -- but only after establishing that the container holds nothing
except what the provider itself put there. It must **not** delete content at the location: the table
format owns the data's lifecycle and has already removed it on every path that reaches the callback.
Nothing about the location string establishes ownership on its own -- the catalog supplies one fact,
and whether the provider holds anything there is a fact only the provider can establish from its own
records.

**A location that is provisioned and then not used is not handed back.** A format may decline the
location it was given and still report success -- Lance's `EXIST_OK` mode returns the existing table
at the location it already had. An earlier revision handed that location back, which meant comparing
two location strings and concluding from the comparison what a provider had done internally; and
when the request carried its own `location`, the location so named was the caller's own path while
the table was still alive. That call site is gone, and the case is a documented limitation instead:
an allocating provider reconciles it along with the failures it already has to reconcile.

**What provisioning promises.** Exactly one thing: that the location is usable. Not that a prefix
exists, not that a dataset exists, and not that the location is empty -- the last one deliberately,
because a caller usually supplies a location precisely when the data is already there.

`external` is only an approximation of the rule this wants -- "hand back only what was handed out"
-- and one case stays asymmetric, documented in the contract: an external table created *without* a
location does get one provisioned, because both formats check the location only after the catalog
has filled it in, so skipping its drop leaks that allocation. Being exact needs the catalog to
record, per table, whether it provisioned the location, which is a change of its own.

**Provisioning is the last thing `createTable` does** before handing over to the table format, so a
request this catalog can reject on its own -- no format given, a format it does not support --
never reaches the provider and never costs it an allocation.

**`dropSchema(cascade = true)` is routed through the catalog-level drop path.** It previously called
`tableOps(tableIdent).dropTable(tableIdent)` directly, which today only skips a cache invalidation.
Once a drop callback exists it also means the callback never fires on a cascade -- dropping a schema
with a hundred tables would leak all hundred allocations at once, silently. Routing the cascade
fixes that, and the missing `tableFormatCache.invalidate(ident)` falls out of the same change rather
than being a separate edit. Happy to split this into its own bug report if maintainers prefer.

**Ordering and failure semantics.** The table properties carrying the location to reclaim are read
*before* the removal and `unprovisionTableLocation` is called *after* it, so a provider is never
asked to reclaim the storage of a table that is still there. The two orderings fail differently and
only one is recoverable: releasing first and then failing to drop can destroy a live table's
storage, while dropping first and then failing to release leaves an inert orphan. A provider that
throws is logged at WARN -- naming the table, the provider and the unreclaimed location -- and the
drop still reports success, because the table really is gone; for the same reason a failed
unprovision does not abort a cascade. The cache invalidation sits in a `finally`, so a format that
removed the metadata and then threw does not leave a stale format cached under that name.

**Known limitations, documented rather than fixed.** All six are recorded in the interface contract
and in `docs/lakehouse-generic-catalog.md`, and they all point the same way: a provider managing
real storage needs its own reconciliation against the catalog and cannot treat these callbacks as a
complete record of what it handed out.

1. `location` is a mutable table property, so `alterTable(setProperty("location", ...))` repoints a
   table without the provider being told.
2. `provisionTableLocation` runs before the table exists, so a creation that fails afterwards leaves
   a location provisioned for a table that does not exist.
3. A location that is provisioned and then not used is not handed back. A creation mode such as
   Lance's `EXIST_OK` returns the table that already exists, at the location it already has, and the
   location provisioned for that call goes nowhere.
4. A table format that drops a table through its own internals does not trigger
   `unprovisionTableLocation`. Lance's `OVERWRITE` mode does exactly this.
5. A provider deriving a deterministic path from a table's identity hands out the same path again
   when a same-named table is created after the old one is gone, and the built-in provider is one
   such provider. If anything survived under that path, the next creation of that name fails inside
   the table format and keeps failing, because every retry derives the same path.
6. `alterTable(rename(...))` changes a table's identity without telling the provider and without
   moving data, so a provider booking allocations against `(schema, table)` loses the table: the
   later drop arrives under the new name.

These are not the same kind of problem. (2) is deliberate -- a format that fails partway through
creation may already have written to the location, so unprovisioning would tell the provider it may
reclaim a path with bytes on it; leaking an unused path is the safer failure. (3) is deliberate for
the same family of reason: detecting it means comparing two location strings and concluding from the
comparison what a provider did internally, which is the one inference this interface leaves to the
provider. (4) is not visible inside the catalog at all, and (5) follows from it and from (2): what
was left behind is outside what this interface can see or clear. (6) has to be reconciled by the
provider. Only (1) has a plausible fix, and it changes behaviour outside this SPI.

### Why are the changes needed?

`calculateTableLocation` walks a fixed chain -- table `location` property, then schema property plus
table name, then catalog property plus schema and table name, then failure -- and the chain is
private and not extensible. That priority order belongs to that particular logic, not to the catalog
as a whole: the built-in provider keeps it, and a different provider is free to use a different one.

Deployments that allocate storage through an internal path-allocation service cannot express this
today. There the path is the result of a remote call, not a configuration value: the service picks
the bucket, region and quota group and records ownership and lifecycle metadata, and a call that can
fail or time out cannot be expressed as string concatenation. The two available workarounds are both
poor -- make every client call the allocator and pass an explicit `location`, which does not stop a
client passing an arbitrary path that bypasses the policy, or fork the catalog.

The drop side is the sharper half. `ManagedTableOperations.purgeTable` delegates to `dropTable` and
neither touches storage, so a deployment whose paths are allocated elsewhere has no hook to hand them
back and leaks an allocation on every drop. The existing `DropTableEvent` cannot be used for this: it
carries only the user, the identifier and an existence flag -- not the location -- and it fires after
the metadata is already gone. The core javadoc already assigns that responsibility to the catalog
implementation and the fileset catalog already discharges it; the generic lakehouse catalog does not.

Gravitino already exposes `ServiceLoader` plugin points for table formats (`LakehouseTableDelegator`),
credentials (`CredentialProvider`) and file systems (`FileSystemProvider`). Location provisioning is
the one that remains fixed.

Fix: #12429

Design discussion: #12971.

### Does this PR introduce _any_ user-facing change?

Yes. Additive, except for one changed response.

- New catalog property `table-location-provider`. Optional, immutable once the catalog is created,
  defaults to `default`. A catalog that does not set it behaves exactly as before.
- New public SPI `org.apache.gravitino.catalog.lakehouse.generic.TableLocationProvider`, with
  `TableLocationContext` and `DefaultTableLocationProvider`.
- `docs/lakehouse-generic-catalog.md` gains a "Pluggable table location provider" section covering
  the contract, the responsibility boundary, the caller-supplied-location behaviour, the external
  drop/purge asymmetry, a worked allocate-and-release example, and the six limitations.

Location resolution is unchanged for a catalog on the built-in provider, and tests assert both that
a caller-supplied location resolves identically under the built-in and a custom provider, and that a
table falling all the way through to the catalog-level `location` still lands where it always did.

**One response changes: dropping a table that does not exist.** The drop path now reads the table
entity before removing it, because its properties carry the location to hand back. A missing entity
returns `false` instead of raising `NoSuchTableException`, so the REST layer answers `200` with
`{"dropped": false}` where it previously answered `404`. That is what `TableCatalog.dropTable`
documents ("False if the table does not exist") and what `TableOperations.dropTable` already had a
branch and a log line for; the previous `404` from this catalog was the odd one out.
`testDropNonExistentTableDoesNotUnprovision` pins the new response, and has since the first
revision. Callers treating a repeated `DELETE` as an error will now see it succeed with
`dropped: false`.

**A null property value is tolerated.** Nothing upstream rejects a table or catalog property whose
value is `null` -- neither `TableCreateRequest#validate()` nor `CatalogCreateRequest#validate()`
inspects properties -- so the maps reaching a provider are defensive copies that tolerate null values
rather than `ImmutableMap`, which would throw. This SPI must not be what turns a request the server
already accepted into a failure.

**Cost of the drop path.** The properties read there are passed on to resolve the table format, so a
drop reads the table entity once, as before. Building the context also needs the parent schema: a
cascading schema drop resolves it once for the whole cascade rather than once per table, a drop of an
empty schema does not resolve it at all, and a single drop reads it once. Resolving it lazily instead
was tried and reverted: the context is deliberately built in full *before* the table is removed, so
that a store read that fails does so while the table is still there, rather than from inside a
callback where it could only be reported as a provider failure it is not.

### How was this patch tested?

46 new unit tests; the module goes from 43 to 89, with 0 failures, 0 errors and 0 skipped.

- `TestDefaultTableLocationProvider` (9, all new) -- each level of the table → schema → catalog
  hierarchy, trailing-slash handling, null schema properties, the failure when no level supplies a
  location, the catalog-level property being read per call rather than captured, the provider name,
  and `unprovisionTableLocation` being a no-op.
- `TestTableLocationProviderFactory` (9, all new) -- default lookup, case-insensitive matching,
  discovery of a custom provider through a real `ServiceLoader` lookup, a fresh instance per call,
  unknown and blank names, the factory neither initializing nor closing what it returns, a broken
  provider on the classpath being skipped rather than failing the lookup, and every lookup scanning
  rather than answering from a cache.
- `TestGenericCatalogOperations` (29, 27 new) -- location validation (stored verbatim, blank
  rejected); provisioning on every creation path including a caller-supplied location and an
  external table; unprovisioning on drop, on purge and on a cascading schema drop; the external
  drop/purge asymmetry, including in a cascade; a non-canonical `external` value being read the way
  the formats read it; the catalog properties reaching the provider end to end; a failed unprovision
  still reporting the drop as successful and not aborting a cascade; a format failing after removing
  the metadata still invalidating the format cache; a drop reading the table entity only once; a
  cascade resolving the parent schema only once; an empty schema drop not resolving it at all; a
  provider refusing the creation leaving no table; and null-valued table and catalog properties.
- `TestPropertiesMetadata` (4, 1 new) -- the new catalog property.

`FakeTableLocationProvider`, `BrokenTableLocationProvider` and `FakeTableDelegator` are registered on
the test classpath only, so discovery is exercised through a real `ServiceLoader` lookup rather than
mocked. `BrokenTableLocationProvider` throws a `NoClassDefFoundError` from `name()` and is registered
permanently, so every lookup in the module has to survive a candidate that throws an `Error` rather
than an exception; reverting the fix makes the factory tests and the initialization of an unrelated
test class fail.

Each behavioural assertion was checked by reverting the code it covers and confirming the test fails,
rather than only that the suite is green.

```
./gradlew :catalogs:catalog-lakehouse-generic:test -PskipITs
./gradlew :catalogs:catalog-lakehouse-generic:javadoc spotlessCheck
```

Both pass, rebased on `769455366`. The 15 javadoc warnings are pre-existing and none falls on a line
this branch adds. No existing test changed behaviour.
