### PR TITLE
[#13068] fix(trino-connector): Enable Iceberg REST per-user sessions only under OAuth2

### DIFF
--- a/docs/trino-connector/authentication.md
+++ b/docs/trino-connector/authentication.md
@@ -197,7 +197,8 @@ For an Iceberg catalog reached through the Gravitino Iceberg REST server (IRC) â
 `lakehouse-iceberg` catalog for which the Gravitino server reports a running IRC; see [Iceberg
 catalog](./catalog-iceberg.md#how-trino-reaches-the-catalog) â€” the IRC's own authentication is
 configured once per Trino cluster with the `gravitino.iceberg.rest-catalog.` prefix, and
-`iceberg.rest-catalog.session=USER` is set automatically when `forwardUser=true`:
+`iceberg.rest-catalog.session=USER` is set automatically when `forwardUser=true` and the IRC is
+configured with `security=OAUTH2` (as below):
 
 ```properties
 gravitino.iceberg.rest-catalog.security=OAUTH2

--- a/docs/trino-connector/authentication.md
+++ b/docs/trino-connector/authentication.md
@@ -198,7 +198,7 @@ For an Iceberg catalog reached through the Gravitino Iceberg REST server (IRC) â
 catalog](./catalog-iceberg.md#how-trino-reaches-the-catalog) â€” the IRC's own authentication is
 configured once per Trino cluster with the `gravitino.iceberg.rest-catalog.` prefix, and
 `iceberg.rest-catalog.session=USER` is set automatically when `forwardUser=true` and the IRC is
-configured with `security=OAUTH2` (as below):
+configured with `gravitino.iceberg.rest-catalog.security=OAUTH2` (as below):
 
 ```properties
 gravitino.iceberg.rest-catalog.security=OAUTH2

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -114,9 +114,10 @@ when it ignores one.
 The connector sets `iceberg.rest-catalog.session=USER` automatically when both hold:
 
 - `gravitino.client.session.forwardUser=true`
-- the IRC authenticates with OAuth2 — either `gravitino.client.authType=oauth2`, or
-  `gravitino.iceberg.rest-catalog.security=OAUTH2` (or `trino.bypass.iceberg.rest-catalog.security`
-  on a catalog with its own REST backend)
+- the IRC authenticates with OAuth2, through any one of:
+  - `gravitino.client.authType=oauth2`
+  - `gravitino.iceberg.rest-catalog.security=OAUTH2`
+  - `trino.bypass.iceberg.rest-catalog.security=OAUTH2`, on a catalog with its own REST backend
 
 Each query then carries the end user's identity to the IRC, keeping per-user credential vending and
 per-user authorization intact. Otherwise the session mode is deliberately left off: the forwarded

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -111,11 +111,16 @@ Four keys are reserved: `iceberg.rest-catalog.uri`, `.warehouse`, `.prefix` and
 `gravitino.iceberg.rest-catalog.` or a catalog's `trino.bypass.` has no effect — the connector logs
 when it ignores one.
 
-When `gravitino.client.session.forwardUser=true` and the IRC is configured with
-`security=OAUTH2`, the connector also sets `iceberg.rest-catalog.session=USER` so that each query
-carries the end user's identity to the IRC, keeping per-user credential vending and per-user
-authorization intact. Under any other security mode the session mode is deliberately left off: the
-forwarded token cannot be exchanged, so it would carry no identity to the IRC. Set
+The connector sets `iceberg.rest-catalog.session=USER` automatically when both hold:
+
+- `gravitino.client.session.forwardUser=true`
+- the IRC authenticates with OAuth2 — either `gravitino.client.authType=oauth2`, or
+  `gravitino.iceberg.rest-catalog.security=OAUTH2` (or `trino.bypass.iceberg.rest-catalog.security`
+  on a catalog with its own REST backend)
+
+Each query then carries the end user's identity to the IRC, keeping per-user credential vending and
+per-user authorization intact. Otherwise the session mode is deliberately left off: the forwarded
+token cannot be exchanged, so it would carry no identity to the IRC. Set
 `gravitino.iceberg.rest-catalog.session` explicitly to override either way. See
 [Authentication](./authentication.md) for the full setup.
 

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -111,10 +111,12 @@ Four keys are reserved: `iceberg.rest-catalog.uri`, `.warehouse`, `.prefix` and
 `gravitino.iceberg.rest-catalog.` or a catalog's `trino.bypass.` has no effect — the connector logs
 when it ignores one.
 
-When `gravitino.client.session.forwardUser=true`, the connector also sets
-`iceberg.rest-catalog.session=USER` so that each query carries the end user's identity to the IRC,
-keeping per-user credential vending and per-user authorization intact. Set
-`gravitino.iceberg.rest-catalog.session` explicitly to override it. See
+When `gravitino.client.session.forwardUser=true` and the IRC is configured with
+`security=OAUTH2`, the connector also sets `iceberg.rest-catalog.session=USER` so that each query
+carries the end user's identity to the IRC, keeping per-user credential vending and per-user
+authorization intact. Under any other security mode the session mode is deliberately left off: the
+forwarded token cannot be exchanged, so it would carry no identity to the IRC. Set
+`gravitino.iceberg.rest-catalog.session` explicitly to override either way. See
 [Authentication](./authentication.md) for the full setup.
 
 ### Limitations

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
@@ -67,6 +67,7 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
   private static final String TRINO_ICEBERG_REST_SESSION = "iceberg.rest-catalog.session";
   private static final String TRINO_ICEBERG_REST_SECURITY = "iceberg.rest-catalog.security";
   private static final String TRINO_ICEBERG_REST_SECURITY_OAUTH2 = "OAUTH2";
+  private static final String TRINO_ICEBERG_REST_SESSION_USER = "USER";
   private static final String TRINO_FS_HADOOP_ENABLED = "fs.hadoop.enabled";
   private static final String TRINO_FS_NATIVE_S3_ENABLED = "fs.native-s3.enabled";
   private static final String TRINO_FS_NATIVE_GCS_ENABLED = "fs.native-gcs.enabled";
@@ -182,7 +183,8 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
     // The IRC's own authentication is a cluster-level operational setting, so it takes precedence
     // over anything set on a single catalog.
     config.putAll(gravitinoConfig.getIcebergRestCatalogConfig());
-    // Decided last, because it depends on the authentication the two putAll calls above settle.
+    // Runs after the two putAll calls above, because it depends on both the security mode and
+    // any explicit session value they settle.
     applyForwardUserSession(gravitinoConfig, config);
 
     warnOnReservedOverrides(catalog, config);
@@ -252,10 +254,9 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
   /**
    * Turns on Trino's per-user Iceberg REST sessions when user forwarding is enabled and the REST
    * catalog authenticates with OAuth2. In that session mode Trino signs a subject JWT for the
-   * session user and attaches it to every request, and the Iceberg client can only turn such a
-   * token into a usable credential through an OAuth2 token exchange. Under any other security mode
-   * there is no token endpoint to exchange it at, so the mode carries no user identity and merely
-   * makes Iceberg clients older than 1.9 fail every request; newer ones ignore the token instead.
+   * session user and attaches it to every request; the Iceberg client consumes such a token through
+   * an OAuth2 token exchange. Under any other security mode there is no token endpoint to exchange
+   * it at, so the token carries no user identity and the mode buys nothing.
    *
    * <p>An explicit {@code iceberg.rest-catalog.session} coming from the catalog or the connector
    * config is left untouched.
@@ -267,7 +268,7 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
     }
     if (TRINO_ICEBERG_REST_SECURITY_OAUTH2.equalsIgnoreCase(
         config.get(TRINO_ICEBERG_REST_SECURITY))) {
-      config.put(TRINO_ICEBERG_REST_SESSION, "USER");
+      config.put(TRINO_ICEBERG_REST_SESSION, TRINO_ICEBERG_REST_SESSION_USER);
     }
   }
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
@@ -65,6 +65,8 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
   private static final String TRINO_ICEBERG_REST_VENDED_CREDENTIALS =
       "iceberg.rest-catalog.vended-credentials-enabled";
   private static final String TRINO_ICEBERG_REST_SESSION = "iceberg.rest-catalog.session";
+  private static final String TRINO_ICEBERG_REST_SECURITY = "iceberg.rest-catalog.security";
+  private static final String TRINO_ICEBERG_REST_SECURITY_OAUTH2 = "OAUTH2";
   private static final String TRINO_FS_HADOOP_ENABLED = "fs.hadoop.enabled";
   private static final String TRINO_FS_NATIVE_S3_ENABLED = "fs.native-s3.enabled";
   private static final String TRINO_FS_NATIVE_GCS_ENABLED = "fs.native-gcs.enabled";
@@ -174,15 +176,14 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
     // precedence, unrelated to HashMap's (unspecified) iteration order.
     config.putAll(buildStorageProperties(catalog.getProperties()));
     config.put(TRINO_ICEBERG_REST_VENDED_CREDENTIALS, "true");
-    if (gravitinoConfig.isForwardUser()) {
-      config.put(TRINO_ICEBERG_REST_SESSION, "USER");
-    }
     // The catalog's own trino.bypass properties override the defaults above, so that a Trino
     // release renaming one of them can be worked around without a connector change.
     config.putAll(super.gravitinoToEngineProperties(catalog.getProperties()));
     // The IRC's own authentication is a cluster-level operational setting, so it takes precedence
     // over anything set on a single catalog.
     config.putAll(gravitinoConfig.getIcebergRestCatalogConfig());
+    // Decided last, because it depends on the authentication the two putAll calls above settle.
+    applyForwardUserSession(gravitinoConfig, config);
 
     warnOnReservedOverrides(catalog, config);
 
@@ -246,6 +247,28 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
     }
 
     return jdbcProperties;
+  }
+
+  /**
+   * Turns on Trino's per-user Iceberg REST sessions when user forwarding is enabled and the REST
+   * catalog authenticates with OAuth2. In that session mode Trino signs a subject JWT for the
+   * session user and attaches it to every request, and the Iceberg client can only turn such a
+   * token into a usable credential through an OAuth2 token exchange. Under any other security mode
+   * there is no token endpoint to exchange it at, so the mode carries no user identity and merely
+   * makes Iceberg clients older than 1.9 fail every request; newer ones ignore the token instead.
+   *
+   * <p>An explicit {@code iceberg.rest-catalog.session} coming from the catalog or the connector
+   * config is left untouched.
+   */
+  private void applyForwardUserSession(
+      GravitinoConfig gravitinoConfig, Map<String, String> config) {
+    if (!gravitinoConfig.isForwardUser() || config.containsKey(TRINO_ICEBERG_REST_SESSION)) {
+      return;
+    }
+    if (TRINO_ICEBERG_REST_SECURITY_OAUTH2.equalsIgnoreCase(
+        config.get(TRINO_ICEBERG_REST_SECURITY))) {
+      config.put(TRINO_ICEBERG_REST_SESSION, "USER");
+    }
   }
 
   // Called before the reserved keys (type/uri/warehouse/prefix) are put into `config` below, so

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
@@ -532,6 +532,14 @@ public class TestIcebergCatalogPropertyConverter {
                     "gravitino.iceberg.rest-catalog.session", "NONE")));
     Assertions.assertEquals("NONE", explicitConfig.get("iceberg.rest-catalog.session"));
 
+    // OAuth2 alone does not enable the mode; forwarding has to be asked for.
+    Map<String, String> noForwardingConfig =
+        buildConnectorConfig(
+            "catalog1",
+            properties,
+            icebergRestConfiguredConfig(ImmutableMap.of("gravitino.client.authType", "oauth2")));
+    Assertions.assertNull(noForwardingConfig.get("iceberg.rest-catalog.session"));
+
     Map<String, String> defaultConfig =
         buildConnectorConfig(
             "catalog1", properties, icebergRestConfiguredConfig(ImmutableMap.of()));
@@ -547,8 +555,9 @@ public class TestIcebergCatalogPropertyConverter {
             .put("jdbc-driver", "org.postgresql.Driver")
             .build();
 
-    // Under simple authentication the Iceberg REST catalog has no token endpoint to exchange
-    // Trino's subject JWT at, so the per-user session mode must stay off.
+    // With authType=simple no iceberg.rest-catalog.security is emitted, so the REST catalog has no
+    // token endpoint to exchange Trino's subject JWT at and the per-user session mode must stay
+    // off.
     Map<String, String> config =
         buildConnectorConfig(
             "catalog1",

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
@@ -499,13 +499,27 @@ public class TestIcebergCatalogPropertyConverter {
             .put("jdbc-driver", "org.postgresql.Driver")
             .build();
 
-    Map<String, String> config =
+    Map<String, String> oauth2Config =
         buildConnectorConfig(
             "catalog1",
             properties,
             icebergRestConfiguredConfig(
-                ImmutableMap.of("gravitino.client.session.forwardUser", "true")));
-    Assertions.assertEquals("USER", config.get("iceberg.rest-catalog.session"));
+                ImmutableMap.of(
+                    "gravitino.client.session.forwardUser", "true",
+                    "gravitino.client.authType", "oauth2")));
+    Assertions.assertEquals("USER", oauth2Config.get("iceberg.rest-catalog.session"));
+
+    // The session mode can also be reached without the Gravitino client itself using OAuth2, by
+    // pointing the REST catalog at its own OAuth2 provider.
+    Map<String, String> restOnlyOauth2Config =
+        buildConnectorConfig(
+            "catalog1",
+            properties,
+            icebergRestConfiguredConfig(
+                ImmutableMap.of(
+                    "gravitino.client.session.forwardUser", "true",
+                    "gravitino.iceberg.rest-catalog.security", "OAUTH2")));
+    Assertions.assertEquals("USER", restOnlyOauth2Config.get("iceberg.rest-catalog.session"));
 
     Map<String, String> explicitConfig =
         buildConnectorConfig(
@@ -514,6 +528,7 @@ public class TestIcebergCatalogPropertyConverter {
             icebergRestConfiguredConfig(
                 ImmutableMap.of(
                     "gravitino.client.session.forwardUser", "true",
+                    "gravitino.client.authType", "oauth2",
                     "gravitino.iceberg.rest-catalog.session", "NONE")));
     Assertions.assertEquals("NONE", explicitConfig.get("iceberg.rest-catalog.session"));
 
@@ -521,6 +536,28 @@ public class TestIcebergCatalogPropertyConverter {
         buildConnectorConfig(
             "catalog1", properties, icebergRestConfiguredConfig(ImmutableMap.of()));
     Assertions.assertNull(defaultConfig.get("iceberg.rest-catalog.session"));
+  }
+
+  @Test
+  public void testBuildConnectorPropertiesSkipsSessionUserWithoutOauth2() throws Exception {
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put("catalog-backend", "jdbc")
+            .put("uri", "jdbc:postgresql://localhost:5432/iceberg")
+            .put("jdbc-driver", "org.postgresql.Driver")
+            .build();
+
+    // Under simple authentication the Iceberg REST catalog has no token endpoint to exchange
+    // Trino's subject JWT at, so the per-user session mode must stay off.
+    Map<String, String> config =
+        buildConnectorConfig(
+            "catalog1",
+            properties,
+            icebergRestConfiguredConfig(
+                ImmutableMap.of(
+                    "gravitino.client.session.forwardUser", "true",
+                    "gravitino.client.authType", "simple")));
+    Assertions.assertNull(config.get("iceberg.rest-catalog.session"));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set `iceberg.rest-catalog.session=USER` only when the internal Iceberg REST
catalog authenticates with OAuth2, instead of whenever `forwardUser` is enabled.

### Why are the changes needed?

The per-user session mode makes the Iceberg client exchange a Trino-signed JWT
for an access token. Without OAuth2 there is no token endpoint, so the client
falls back to `{rest-uri}/v1/oauth/tokens` and every table load fails with
HTTP 404 on Trino 473. It carries no user identity in that case either.

Fix: #13068

### Does this PR introduce _any_ user-facing change?

No new property keys. With `forwardUser=true` and non-OAuth2 authentication,
`iceberg.rest-catalog.session` is no longer set; it can be restored with
`gravitino.iceberg.rest-catalog.session=USER`.

### How was this patch tested?

`TestIcebergCatalogPropertyConverter`, covering both OAuth2 routes, the explicit
override, and the simple-auth case.
