### PR TITLE
[MINOR] test(lance): Fix missing-schema assertion for Lance Spark 0.5.1

### DIFF
--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceSparkRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceSparkRESTServiceIT.java
@@ -299,8 +299,7 @@ public class LanceSparkRESTServiceIT extends BaseIT {
     RuntimeException exception =
         Assertions.assertThrows(
             RuntimeException.class, () -> createLanceTable(nonExistentSchemaName, tableName));
-    assertFailureContainsAll(
-        exception, "NoSuchSchemaException", nonExistentSchemaName, "does not exist");
+    assertFailureContainsAll(exception, nonExistentSchemaName, "does not exist");
     Assertions.assertFalse(catalog.asSchemas().schemaExists(nonExistentSchemaName));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make the missing-schema assertion in `LanceSparkRESTServiceIT` compatible with Lance Spark 0.5.1 by removing the requirement that its error message contain `NoSuchSchemaException`. Keep checks that table creation throws, the message identifies the missing schema and says it does not exist, and the schema remains absent.

### Why are the changes needed?

Lance Spark 0.5.1 reports `Namespace not found: Schema ... does not exist` without the Gravitino exception class name. The existing assertion fails despite the expected missing-schema behavior, breaking the [compatibility matrix](https://github.com/apache/gravitino/actions/runs/34051320348/job/101535350951).

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Reproduced the original failure locally on the CI commit: 0.2.0 and 0.4.0 passed all 12 tests each; 0.5.1 failed only this assertion. With the change, all 36 tests passed across the three versions. Revalidated on the latest main with formatting:

```bash
SKIP_DOCKER_TESTS=true ./gradlew spotlessApply \
  :lance:lance-rest-server:lanceSparkMatrixTest \
  -PlanceSparkBundleVersions=0.2.0,0.4.0,0.5.1 \
  -PskipDockerTests=true -PskipWeb=true
```
