### PR TITLE
[Cherry-pick to branch-1.3] [#13085] improvement(server): Allow catalog users to test existing catalog connections with stored configuration (#13086)

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CatalogAuthorizationIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CatalogAuthorizationIT.java
@@ -21,10 +21,16 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.gravitino.Catalog;
+import org.apache.gravitino.CatalogChange;
+import org.apache.gravitino.authorization.Privilege;
+import org.apache.gravitino.authorization.Privileges;
+import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.client.GravitinoMetalake;
 import org.apache.gravitino.dto.MetalakeDTO;
 import org.apache.gravitino.exceptions.ForbiddenException;
@@ -131,6 +137,42 @@ public class CatalogAuthorizationIT extends BaseRestApiAuthorizationIT {
 
   @Test
   @Order(3)
+  public void testTestExistingCatalogConnection() throws Exception {
+    GravitinoMetalake adminMetalake = client.loadMetalake(METALAKE);
+    CatalogChange proposedChange = CatalogChange.updateComment("proposed comment");
+    assertThrows(
+        "Can not access metadata {" + catalog1 + "}.",
+        ForbiddenException.class,
+        () -> normalUserClient.loadMetalake(METALAKE).testConnection(catalog1));
+
+    // USE_CATALOG allows testing the stored configuration, but not proposed changes.
+    String role = "testConnectionRole";
+    adminMetalake.createRole(
+        role,
+        new HashMap<>(),
+        ImmutableList.of(
+            SecurableObjects.ofCatalog(
+                catalog1, ImmutableList.<Privilege>of(Privileges.UseCatalog.allow()))));
+    adminMetalake.grantRolesToUser(ImmutableList.of(role), NORMAL_USER);
+    try {
+      GravitinoMetalake normalUserMetalake = normalUserClient.loadMetalake(METALAKE);
+      normalUserMetalake.testConnection(catalog1);
+      assertThrows(
+          "Can not access metadata {" + catalog1 + "}.",
+          ForbiddenException.class,
+          () -> normalUserMetalake.testConnection(catalog1, proposedChange));
+    } finally {
+      adminMetalake.revokeRolesFromUser(ImmutableList.of(role), NORMAL_USER);
+      adminMetalake.deleteRole(role);
+    }
+
+    // The owner can test both the stored configuration and proposed changes.
+    adminMetalake.testConnection(catalog1);
+    adminMetalake.testConnection(catalog1, proposedChange);
+  }
+
+  @Test
+  @Order(4)
   public void testDeleteCatalog() {
     String[] catalogs = client.loadMetalake(METALAKE).listCatalogs();
     assertEquals(2, catalogs.length);
@@ -151,7 +193,7 @@ public class CatalogAuthorizationIT extends BaseRestApiAuthorizationIT {
   }
 
   @Test
-  @Order(4)
+  @Order(5)
   public void testListCatalogsWithNonExistentMetalake() throws Exception {
     // Test that listCatalogs with @AuthorizationExpression returns 403 Forbidden
     // when the metalake doesn't exist, instead of 404 response

--- a/clients/client-python/tests/unittests/test_error_handler.py
+++ b/clients/client-python/tests/unittests/test_error_handler.py
@@ -230,6 +230,11 @@ class TestErrorHandler(unittest.TestCase):
                 )
             )
 
+        with self.assertRaises(ForbiddenException):
+            CATALOG_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(ForbiddenException, "mock error")
+            )
+
         with self.assertRaises(InternalError):
             CATALOG_ERROR_HANDLER.handle(
                 ErrorResponse.generate_error_response(InternalError, "mock error")

--- a/docs/open-api/catalogs.yaml
+++ b/docs/open-api/catalogs.yaml
@@ -157,7 +157,11 @@ paths:
         regular catalog operations, but does not guarantee that every object-level or mutating
         operation will succeed. Fileset catalogs test all catalog-level `location` and `location-*`
         targets. Model and Generic catalogs do not support connection testing. Expected test
-        failures are returned as application error codes in an HTTP 200 response.
+        failures are returned as application error codes in an HTTP 200 response. When
+        authorization is enabled, testing with the stored configuration requires the same access
+        as loading the catalog, and testing with proposed changes requires owning the metalake or
+        the catalog, the same as altering it. Callers without that access receive an HTTP 403
+        response.
       operationId: testExistingCatalogConnection
       requestBody:
         required: false
@@ -217,6 +221,14 @@ paths:
                     message: Catalog my_metalake.my_catalog is not in use
         "400":
           $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "403":
+          description: >-
+            Forbidden - The caller cannot load the catalog, or tests proposed changes without
+            owning the metalake or the catalog
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -251,6 +251,11 @@ return only the entries the caller is entitled to see, which for a metalake owne
 | Model    | `REGISTER_MODEL`    | `USE_MODEL`                          | Owner             | Owner |
 | Function | `REGISTER_FUNCTION` | `EXECUTE_FUNCTION` or `MODIFY_FUNCTION` | `MODIFY_FUNCTION` | Owner |
 
+Testing a catalog connection follows the catalog row. Testing a catalog before it is created takes
+`CREATE_CATALOG`. Testing an existing catalog with its stored configuration takes `USE_CATALOG`, the
+same as loading it. Testing an existing catalog with proposed changes that are not saved takes
+ownership, the same as altering it, because the caller chooses what the server connects to.
+
 Table statistics follow the table itself: reading them takes `SELECT_TABLE` or `MODIFY_TABLE`,
 writing them takes `MODIFY_TABLE`. Model versions follow the model: `USE_MODEL` to read, owner to
 alter or delete. Fetching a credential takes whatever loading the object takes.

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/annotations/AuthorizationRequest.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/annotations/AuthorizationRequest.java
@@ -35,6 +35,7 @@ public @interface AuthorizationRequest {
     RUN_JOB,
     LINEAGE,
     LOAD_TABLE,
-    CREATE_SCHEMA
+    CREATE_SCHEMA,
+    TEST_CATALOG_CONNECTION
   }
 }

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/annotations/ExpressionCondition.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/annotations/ExpressionCondition.java
@@ -20,5 +20,7 @@ package org.apache.gravitino.server.authorization.annotations;
 
 public enum ExpressionCondition {
   NEVER,
-  REQUIRED_MODIFY_PRIVILEGES
+  REQUIRED_MODIFY_PRIVILEGES,
+  /** The request carries proposed changes that are not saved, for example in its request body. */
+  HAS_PROPOSED_CHANGES
 }

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/expression/AuthorizationExpressionConstants.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/expression/AuthorizationExpressionConstants.java
@@ -20,6 +20,15 @@ public class AuthorizationExpressionConstants {
   public static final String LOAD_CATALOG_AUTHORIZATION_EXPRESSION =
       "ANY_USE_CATALOG || ANY(OWNER, METALAKE, CATALOG)";
 
+  /**
+   * Authorizes testing an existing catalog connection with proposed changes. The caller chooses the
+   * configuration the server connects to, so this matches the authorization for altering the
+   * catalog. Testing with the stored configuration uses {@link
+   * #LOAD_CATALOG_AUTHORIZATION_EXPRESSION} instead.
+   */
+  public static final String TEST_CATALOG_CONNECTION_WITH_CHANGES_AUTHORIZATION_EXPRESSION =
+      "ANY(OWNER, METALAKE, CATALOG)";
+
   public static final String LOAD_SCHEMA_AUTHORIZATION_EXPRESSION =
       """
           ANY(OWNER, METALAKE, CATALOG) ||

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
@@ -247,12 +247,18 @@ public class GravitinoInterceptionService implements InterceptionService {
               MetadataObject.Type type = expressionAnnotation.accessMetadataType();
               NameIdentifier accessMetadataName =
                   metadataContext.get(Entity.EntityType.valueOf(type.name()));
+              // An executor can evaluate a request-specific expression, such as the secondary
+              // expression, so report the expression it evaluated when it recorded one.
+              String evaluatedExpression =
+                  StringUtils.defaultIfBlank(
+                      authorizationRequestContext.getOriginalAuthorizationExpression(), expression);
               dispatchAuthzDenialEvent(
                   PrincipalUtils.getCurrentUserName(),
                   accessMetadataName,
                   method.getName(),
-                  expression);
-              return buildNoAuthResponse(expressionAnnotation, metadataContext, method, expression);
+                  evaluatedExpression);
+              return buildNoAuthResponse(
+                  expressionAnnotation, metadataContext, method, evaluatedExpression);
             }
           }
         }

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/authorization/AuthorizeExecutorFactory.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/authorization/AuthorizeExecutorFactory.java
@@ -58,6 +58,15 @@ public class AuthorizeExecutorFactory {
           secondaryExpressionCondition);
       case CREATE_SCHEMA -> new CreateSchemaAuthorizationExecutor(
           parameters, args, expression, metadataContext, pathParams, entityType);
+      case TEST_CATALOG_CONNECTION -> new CatalogConnectionTestAuthorizationExecutor(
+          parameters,
+          args,
+          expression,
+          metadataContext,
+          pathParams,
+          entityType,
+          secondaryExpression,
+          secondaryExpressionCondition);
     };
   }
 }

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/authorization/CatalogConnectionTestAuthorizationExecutor.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/authorization/CatalogConnectionTestAuthorizationExecutor.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.server.web.filter.authorization;
+
+import java.lang.reflect.Parameter;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.dto.requests.CatalogUpdatesRequest;
+import org.apache.gravitino.server.authorization.annotations.ExpressionCondition;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionEvaluator;
+import org.apache.gravitino.server.web.filter.ParameterUtil;
+
+/**
+ * Authorization executor for testing the connection of an existing catalog.
+ *
+ * <p>Testing with the stored configuration uses the default expression. When the request carries
+ * proposed changes and the condition is {@link ExpressionCondition#HAS_PROPOSED_CHANGES}, the
+ * secondary expression is used instead, because the caller chooses the configuration the server
+ * connects to.
+ */
+public class CatalogConnectionTestAuthorizationExecutor extends CommonAuthorizerExecutor {
+
+  /**
+   * Creates an authorization executor for an existing catalog connection test.
+   *
+   * @param parameters the parameters of the intercepted method
+   * @param args the arguments passed to the intercepted method
+   * @param expression the expression for testing with the stored configuration
+   * @param metadataContext the metadata context bound to the authorization expression
+   * @param pathParams the path parameters of the request
+   * @param entityType the optional entity type of the request
+   * @param secondaryExpression the expression for testing with proposed changes
+   * @param secondaryExpressionCondition the condition for using the secondary expression
+   */
+  public CatalogConnectionTestAuthorizationExecutor(
+      Parameter[] parameters,
+      Object[] args,
+      String expression,
+      Map<Entity.EntityType, NameIdentifier> metadataContext,
+      Map<String, Object> pathParams,
+      Optional<String> entityType,
+      String secondaryExpression,
+      ExpressionCondition secondaryExpressionCondition) {
+    super(expression, metadataContext, pathParams, entityType);
+    if (StringUtils.isBlank(secondaryExpression)
+        || secondaryExpressionCondition != ExpressionCondition.HAS_PROPOSED_CHANGES) {
+      return;
+    }
+
+    // An empty change list is the same as testing the stored configuration.
+    Object request = ParameterUtil.extractFromParameters(parameters, args);
+    if (request instanceof CatalogUpdatesRequest updatesRequest
+        && updatesRequest.getUpdates() != null
+        && !updatesRequest.getUpdates().isEmpty()) {
+      this.expression = secondaryExpression;
+      this.authorizationExpressionEvaluator =
+          new AuthorizationExpressionEvaluator(secondaryExpression);
+    }
+  }
+}

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -57,6 +57,8 @@ import org.apache.gravitino.metrics.MetricNames;
 import org.apache.gravitino.server.authorization.MetadataAuthzHelper;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationMetadata;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationRequest;
+import org.apache.gravitino.server.authorization.annotations.ExpressionCondition;
 import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
 import org.apache.gravitino.server.web.Utils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -225,7 +227,11 @@ public class CatalogOperations {
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "test-existing-connection." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @AuthorizationExpression(
-      expression = "ANY(OWNER, METALAKE, CATALOG)",
+      expression = AuthorizationExpressionConstants.LOAD_CATALOG_AUTHORIZATION_EXPRESSION,
+      secondaryExpression =
+          AuthorizationExpressionConstants
+              .TEST_CATALOG_CONNECTION_WITH_CHANGES_AUTHORIZATION_EXPRESSION,
+      secondaryExpressionCondition = ExpressionCondition.HAS_PROPOSED_CHANGES,
       accessMetadataType = MetadataObject.Type.CATALOG)
   @ResponseMetered(name = "test-existing-connection", absolute = true)
   public Response testExistingConnection(
@@ -233,7 +239,8 @@ public class CatalogOperations {
           String metalake,
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG)
           String catalogName,
-      CatalogUpdatesRequest request) {
+      @AuthorizationRequest(type = AuthorizationRequest.RequestType.TEST_CATALOG_CONNECTION)
+          CatalogUpdatesRequest request) {
     LOG.info("Received test connection request for existing catalog: {}.{}", metalake, catalogName);
     try {
       return Utils.doAs(

--- a/server/src/test/java/org/apache/gravitino/server/web/filter/TestGravitinoInterceptionService.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/filter/TestGravitinoInterceptionService.java
@@ -18,6 +18,7 @@
 package org.apache.gravitino.server.web.filter;
 
 import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.CAN_ACCESS_METADATA_AND_TAG;
+import static org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants.TEST_CATALOG_CONNECTION_WITH_CHANGES_AUTHORIZATION_EXPRESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.security.Principal;
@@ -48,6 +50,8 @@ import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.GravitinoAuthorizer;
 import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.catalog.ViewDispatcher;
+import org.apache.gravitino.dto.requests.CatalogUpdateRequest;
+import org.apache.gravitino.dto.requests.CatalogUpdatesRequest;
 import org.apache.gravitino.dto.requests.SchemaCreateRequest;
 import org.apache.gravitino.dto.requests.TagsAssociateRequest;
 import org.apache.gravitino.dto.responses.ErrorConstants;
@@ -64,6 +68,7 @@ import org.apache.gravitino.server.authorization.annotations.AuthorizationMetada
 import org.apache.gravitino.server.authorization.annotations.AuthorizationObjectType;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationRequest;
 import org.apache.gravitino.server.web.Utils;
+import org.apache.gravitino.server.web.rest.CatalogOperations;
 import org.apache.gravitino.server.web.rest.SchemaOperations;
 import org.apache.gravitino.server.web.rest.TableOperations;
 import org.apache.gravitino.server.web.rest.ViewOperations;
@@ -687,6 +692,58 @@ public class TestGravitinoInterceptionService {
     }
   }
 
+  @Test
+  public void testExistingCatalogConnectionAllowsUseCatalogWithoutProposedChanges()
+      throws Throwable {
+    GravitinoAuthorizer authorizer = catalogConnectionAuthorizer(true, false);
+
+    MethodInvocation noBody = testExistingConnectionInvocation(null);
+    Response noBodyResponse =
+        invokeTestExistingConnection(authorizer, mock(EventBus.class), noBody);
+    assertEquals(Response.Status.OK.getStatusCode(), noBodyResponse.getStatus());
+    verify(noBody).proceed();
+
+    MethodInvocation emptyChanges =
+        testExistingConnectionInvocation(new CatalogUpdatesRequest(Collections.emptyList()));
+    Response emptyChangesResponse =
+        invokeTestExistingConnection(authorizer, mock(EventBus.class), emptyChanges);
+    assertEquals(Response.Status.OK.getStatusCode(), emptyChangesResponse.getStatus());
+    verify(emptyChanges).proceed();
+  }
+
+  @Test
+  public void testExistingCatalogConnectionWithProposedChangesDeniesUseCatalog() throws Throwable {
+    EventBus eventBus = spy(new EventBus(Collections.emptyList()));
+    MethodInvocation invocation = testExistingConnectionInvocation(proposedCatalogChanges());
+
+    Response response =
+        invokeTestExistingConnection(
+            catalogConnectionAuthorizer(true, false), eventBus, invocation);
+
+    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    verify(invocation, never()).proceed();
+    // The denial event reports the owner expression the executor evaluated, not the default one.
+    ArgumentCaptor<AuthorizationDenialFailureEvent> captor =
+        ArgumentCaptor.forClass(AuthorizationDenialFailureEvent.class);
+    verify(eventBus).dispatchEvent(captor.capture());
+    assertEquals(
+        TEST_CATALOG_CONNECTION_WITH_CHANGES_AUTHORIZATION_EXPRESSION,
+        captor.getValue().expression());
+  }
+
+  @Test
+  public void testExistingCatalogConnectionWithProposedChangesAllowsCatalogOwner()
+      throws Throwable {
+    MethodInvocation invocation = testExistingConnectionInvocation(proposedCatalogChanges());
+
+    Response response =
+        invokeTestExistingConnection(
+            catalogConnectionAuthorizer(false, true), mock(EventBus.class), invocation);
+
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    verify(invocation).proceed();
+  }
+
   public static class TestMetadataObjectTagAssociationOperations {
 
     @AuthorizationExpression(expression = CAN_ACCESS_METADATA_AND_TAG)
@@ -718,6 +775,83 @@ public class TestGravitinoInterceptionService {
         @AuthorizationMetadata(type = Entity.EntityType.METALAKE) String metalake) {
       return Utils.ok("success");
     }
+  }
+
+  private Response invokeTestExistingConnection(
+      GravitinoAuthorizer authorizer, EventBus eventBus, MethodInvocation invocation)
+      throws Throwable {
+    try (MockedStatic<PrincipalUtils> principalUtilsMocked = mockStatic(PrincipalUtils.class);
+        MockedStatic<GravitinoAuthorizerProvider> authorizerMocked =
+            mockStatic(GravitinoAuthorizerProvider.class);
+        MockedStatic<AuthorizationUtils> authUtilsMocked = mockStatic(AuthorizationUtils.class);
+        MockedStatic<GravitinoEnv> envMocked = mockStatic(GravitinoEnv.class)) {
+      principalUtilsMocked
+          .when(PrincipalUtils::getCurrentPrincipal)
+          .thenReturn(new UserPrincipal("tester"));
+      principalUtilsMocked.when(PrincipalUtils::getCurrentUserName).thenReturn("tester");
+
+      authUtilsMocked
+          .when(
+              () ->
+                  AuthorizationUtils.checkCurrentUser(
+                      ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
+          .thenAnswer(ignored -> null);
+
+      GravitinoAuthorizerProvider mockedProvider = mock(GravitinoAuthorizerProvider.class);
+      authorizerMocked.when(GravitinoAuthorizerProvider::getInstance).thenReturn(mockedProvider);
+      when(mockedProvider.getGravitinoAuthorizer()).thenReturn(authorizer);
+
+      GravitinoEnv mockEnv = mock(GravitinoEnv.class);
+      envMocked.when(GravitinoEnv::getInstance).thenReturn(mockEnv);
+      when(mockEnv.eventBus()).thenReturn(eventBus);
+
+      // Use the real resource method so its annotations drive the authorization executor.
+      MethodInterceptor interceptor =
+          new GravitinoInterceptionService().getMethodInterceptors(invocation.getMethod()).get(0);
+      return (Response) interceptor.invoke(invocation);
+    }
+  }
+
+  private MethodInvocation testExistingConnectionInvocation(CatalogUpdatesRequest request)
+      throws Throwable {
+    Method method =
+        CatalogOperations.class.getMethod(
+            "testExistingConnection", String.class, String.class, CatalogUpdatesRequest.class);
+    MethodInvocation invocation = mock(MethodInvocation.class);
+    when(invocation.getMethod()).thenReturn(method);
+    when(invocation.getArguments())
+        .thenReturn(new Object[] {"testMetalake", "testCatalog", request});
+    when(invocation.proceed()).thenReturn(Utils.ok("ok"));
+    return invocation;
+  }
+
+  private CatalogUpdatesRequest proposedCatalogChanges() {
+    return new CatalogUpdatesRequest(
+        ImmutableList.of(new CatalogUpdateRequest.SetCatalogPropertyRequest("key", "value")));
+  }
+
+  private GravitinoAuthorizer catalogConnectionAuthorizer(boolean useCatalog, boolean owner) {
+    GravitinoAuthorizer authorizer = mock(GravitinoAuthorizer.class);
+    when(authorizer.authorize(
+            ArgumentMatchers.any(),
+            ArgumentMatchers.eq("testMetalake"),
+            ArgumentMatchers.argThat(
+                metadataObject ->
+                    metadataObject.type() == MetadataObject.Type.CATALOG
+                        && "testCatalog".equals(metadataObject.name())),
+            ArgumentMatchers.eq(Privilege.Name.USE_CATALOG),
+            ArgumentMatchers.any()))
+        .thenReturn(useCatalog);
+    when(authorizer.isOwner(
+            ArgumentMatchers.any(),
+            ArgumentMatchers.eq("testMetalake"),
+            ArgumentMatchers.argThat(
+                metadataObject ->
+                    metadataObject.type() == MetadataObject.Type.CATALOG
+                        && "testCatalog".equals(metadataObject.name())),
+            ArgumentMatchers.any()))
+        .thenReturn(owner);
+    return authorizer;
   }
 
   private static class MockGravitinoAuthorizer implements GravitinoAuthorizer {

--- a/server/src/test/java/org/apache/gravitino/server/web/filter/authorization/TestCatalogConnectionTestAuthorizationExecutor.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/filter/authorization/TestCatalogConnectionTestAuthorizationExecutor.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.server.web.filter.authorization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.dto.requests.CatalogUpdateRequest;
+import org.apache.gravitino.dto.requests.CatalogUpdatesRequest;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationRequest;
+import org.apache.gravitino.server.authorization.annotations.ExpressionCondition;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
+import org.junit.jupiter.api.Test;
+
+public class TestCatalogConnectionTestAuthorizationExecutor {
+  private static final String PRIMARY_EXPRESSION =
+      AuthorizationExpressionConstants.LOAD_CATALOG_AUTHORIZATION_EXPRESSION;
+  private static final String SECONDARY_EXPRESSION =
+      AuthorizationExpressionConstants
+          .TEST_CATALOG_CONNECTION_WITH_CHANGES_AUTHORIZATION_EXPRESSION;
+
+  @Test
+  public void testUsesPrimaryExpressionWithoutRequestBody() throws Exception {
+    CatalogConnectionTestAuthorizationExecutor executor =
+        createExecutor(null, ExpressionCondition.HAS_PROPOSED_CHANGES);
+
+    assertEquals(PRIMARY_EXPRESSION, executor.expression);
+  }
+
+  @Test
+  public void testUsesPrimaryExpressionForEmptyChanges() throws Exception {
+    CatalogConnectionTestAuthorizationExecutor executor =
+        createExecutor(
+            new CatalogUpdatesRequest(Collections.emptyList()),
+            ExpressionCondition.HAS_PROPOSED_CHANGES);
+
+    assertEquals(PRIMARY_EXPRESSION, executor.expression);
+  }
+
+  @Test
+  public void testUsesSecondaryExpressionForProposedChanges() throws Exception {
+    CatalogConnectionTestAuthorizationExecutor executor =
+        createExecutor(proposedChanges(), ExpressionCondition.HAS_PROPOSED_CHANGES);
+
+    assertEquals(SECONDARY_EXPRESSION, executor.expression);
+  }
+
+  @Test
+  public void testUsesPrimaryExpressionWhenConditionNever() throws Exception {
+    CatalogConnectionTestAuthorizationExecutor executor =
+        createExecutor(proposedChanges(), ExpressionCondition.NEVER);
+
+    assertEquals(PRIMARY_EXPRESSION, executor.expression);
+  }
+
+  @Test
+  public void testUsesPrimaryExpressionForNullChanges() throws Exception {
+    CatalogConnectionTestAuthorizationExecutor executor =
+        createExecutor(new CatalogUpdatesRequest(), ExpressionCondition.HAS_PROPOSED_CHANGES);
+
+    assertEquals(PRIMARY_EXPRESSION, executor.expression);
+  }
+
+  @Test
+  public void testFactoryCreatesExecutorForTestCatalogConnection() throws Exception {
+    Method method = TestOperations.class.getMethod("testConnection", CatalogUpdatesRequest.class);
+    AuthorizationExecutor executor =
+        AuthorizeExecutorFactory.create(
+            PRIMARY_EXPRESSION,
+            AuthorizationRequest.RequestType.TEST_CATALOG_CONNECTION,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Optional.empty(),
+            method.getParameters(),
+            new Object[] {proposedChanges()},
+            SECONDARY_EXPRESSION,
+            ExpressionCondition.HAS_PROPOSED_CHANGES);
+
+    assertTrue(executor instanceof CatalogConnectionTestAuthorizationExecutor);
+    assertEquals(
+        SECONDARY_EXPRESSION, ((CatalogConnectionTestAuthorizationExecutor) executor).expression);
+  }
+
+  private static CatalogUpdatesRequest proposedChanges() {
+    return new CatalogUpdatesRequest(
+        ImmutableList.of(new CatalogUpdateRequest.SetCatalogPropertyRequest("key", "value")));
+  }
+
+  private static CatalogConnectionTestAuthorizationExecutor createExecutor(
+      CatalogUpdatesRequest request, ExpressionCondition condition) throws Exception {
+    Method method = TestOperations.class.getMethod("testConnection", CatalogUpdatesRequest.class);
+    return new CatalogConnectionTestAuthorizationExecutor(
+        method.getParameters(),
+        new Object[] {request},
+        PRIMARY_EXPRESSION,
+        Collections.<Entity.EntityType, NameIdentifier>emptyMap(),
+        Collections.emptyMap(),
+        Optional.empty(),
+        SECONDARY_EXPRESSION,
+        condition);
+  }
+
+  public static class TestOperations {
+    public void testConnection(
+        @AuthorizationRequest(type = AuthorizationRequest.RequestType.TEST_CATALOG_CONNECTION)
+            CatalogUpdatesRequest request) {}
+  }
+}

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/authorization/TestCatalogAuthorizationExpression.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/authorization/TestCatalogAuthorizationExpression.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gravitino.server.web.rest.authorization;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -26,6 +27,7 @@ import ognl.OgnlException;
 import org.apache.gravitino.dto.requests.CatalogCreateRequest;
 import org.apache.gravitino.dto.requests.CatalogUpdatesRequest;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
+import org.apache.gravitino.server.authorization.annotations.ExpressionCondition;
 import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
 import org.apache.gravitino.server.web.rest.CatalogOperations;
 import org.junit.jupiter.api.Test;
@@ -106,6 +108,50 @@ public class TestCatalogAuthorizationExpression {
     String expression = authorizationExpressionAnnotation.expression();
     MockAuthorizationExpressionEvaluator mockEvaluator =
         new MockAuthorizationExpressionEvaluator(expression);
+    assertFalse(mockEvaluator.getResult(ImmutableSet.of()));
+    assertFalse(mockEvaluator.getResult(ImmutableSet.of("METALAKE::USE_SCHEMA")));
+    assertFalse(mockEvaluator.getResult(ImmutableSet.of("METALAKE::USE_CATALOG")));
+    assertTrue(mockEvaluator.getResult(ImmutableSet.of("METALAKE::OWNER")));
+    assertTrue(mockEvaluator.getResult(ImmutableSet.of("CATALOG::OWNER")));
+    assertFalse(mockEvaluator.getResult(ImmutableSet.of("METALAKE::CREATE_CATALOG")));
+    assertFalse(mockEvaluator.getResult(ImmutableSet.of("CATALOG::USE_CATALOG")));
+  }
+
+  @Test
+  public void testTestExistingConnection() throws NoSuchMethodException, OgnlException {
+    Method method =
+        CatalogOperations.class.getMethod(
+            "testExistingConnection", String.class, String.class, CatalogUpdatesRequest.class);
+    AuthorizationExpression authorizationExpressionAnnotation =
+        method.getAnnotation(AuthorizationExpression.class);
+    String expression = authorizationExpressionAnnotation.expression();
+    MockAuthorizationExpressionEvaluator mockEvaluator =
+        new MockAuthorizationExpressionEvaluator(expression);
+    assertFalse(mockEvaluator.getResult(ImmutableSet.of()));
+    assertFalse(mockEvaluator.getResult(ImmutableSet.of("METALAKE::USE_SCHEMA")));
+    assertTrue(mockEvaluator.getResult(ImmutableSet.of("METALAKE::USE_CATALOG")));
+    assertTrue(mockEvaluator.getResult(ImmutableSet.of("METALAKE::OWNER")));
+    assertTrue(mockEvaluator.getResult(ImmutableSet.of("CATALOG::OWNER")));
+    assertFalse(mockEvaluator.getResult(ImmutableSet.of("METALAKE::CREATE_CATALOG")));
+    assertTrue(mockEvaluator.getResult(ImmutableSet.of("CATALOG::USE_CATALOG")));
+    assertFalse(
+        mockEvaluator.getResult(
+            ImmutableSet.of("METALAKE::USE_CATALOG", "CATALOG::DENY_USE_CATALOG")));
+  }
+
+  @Test
+  public void testTestExistingConnectionWithChanges() throws NoSuchMethodException, OgnlException {
+    Method method =
+        CatalogOperations.class.getMethod(
+            "testExistingConnection", String.class, String.class, CatalogUpdatesRequest.class);
+    AuthorizationExpression authorizationExpressionAnnotation =
+        method.getAnnotation(AuthorizationExpression.class);
+    assertEquals(
+        ExpressionCondition.HAS_PROPOSED_CHANGES,
+        authorizationExpressionAnnotation.secondaryExpressionCondition());
+    MockAuthorizationExpressionEvaluator mockEvaluator =
+        new MockAuthorizationExpressionEvaluator(
+            authorizationExpressionAnnotation.secondaryExpression());
     assertFalse(mockEvaluator.getResult(ImmutableSet.of()));
     assertFalse(mockEvaluator.getResult(ImmutableSet.of("METALAKE::USE_SCHEMA")));
     assertFalse(mockEvaluator.getResult(ImmutableSet.of("METALAKE::USE_CATALOG")));


### PR DESCRIPTION
**Cherry-pick Information:**
- Original PR: #13086 (still open; this backport is raised ahead of its merge, and must be kept in sync with any review changes there)
- Original issue: #13085
- Target branch: `branch-1.3`
- Status: ✅ Conflicts resolved manually

**Resolution:**
- Applied the final #13086 change as one commit instead of replaying its individual review commits.
- `TestGravitinoInterceptionService`: `branch-1.3` does not have the table existence-probe tests or their helpers, so only the new catalog connection tests, their helpers, and their imports are added.
- `TestCatalogConnectionTestAuthorizationExecutor`: `AuthorizeExecutorFactory.create` on `branch-1.3` has no `allowCheckExistenceExpression` parameter, so the factory test passes nine arguments.
- Production code, docs, the integration test, and the Python test are the same as #13086.

**Validation:**
- Server unit tests on `branch-1.3`: all `org.apache.gravitino.server.web.filter.*` tests (including the new interceptor and executor tests), `TestCatalogAuthorizationExpression`, and `TestCatalogOperations`.
- Compiled the Java client test sources, including `CatalogAuthorizationIT`. The Docker integration test and the Python unit test were not run locally.
- `./gradlew spotlessApply`, `:server-common:javadoc`, `:docs:build`
- Conflict-marker scan and `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
