### PR TITLE
[#12406] fix(core): acquire schema lock in child update paths and clean up table_version_info in schema cascade

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableVersionMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableVersionMapper.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.storage.relational.mapper;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.po.TablePO;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
@@ -41,6 +42,11 @@ public interface TableVersionMapper {
       method = "softDeleteTableVersionByTableIdAndVersion")
   void softDeleteTableVersionByTableIdAndVersion(
       @Param("tableId") Long tableId, @Param("version") Long version);
+
+  @UpdateProvider(
+      type = TableVersionSQLProviderFactory.class,
+      method = "softDeleteTableVersionsBySchemaIds")
+  Integer softDeleteTableVersionsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 
   @DeleteProvider(
       type = TableVersionSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableVersionSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableVersionSQLProviderFactory.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.storage.relational.mapper;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.base.TableVersionBaseSQLProvider;
@@ -63,6 +64,11 @@ public class TableVersionSQLProviderFactory {
   public static String softDeleteTableVersionByTableIdAndVersion(
       @Param("tableId") Long tableId, @Param("version") Long version) {
     return getProvider().softDeleteTableVersionByTableIdAndVersion(tableId, version);
+  }
+
+  public static String softDeleteTableVersionsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteTableVersionsBySchemaIds(schemaIds);
   }
 
   public static String deleteTableVersionByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableVersionBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableVersionBaseSQLProvider.java
@@ -21,6 +21,8 @@ package org.apache.gravitino.storage.relational.mapper.provider.base;
 
 import static org.apache.gravitino.storage.relational.mapper.TableVersionMapper.TABLE_NAME;
 
+import java.util.List;
+import org.apache.gravitino.storage.relational.mapper.TableMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.provider.DatabaseTimeSQL;
 import org.apache.gravitino.storage.relational.po.TablePO;
 import org.apache.ibatis.annotations.Param;
@@ -84,6 +86,29 @@ public class TableVersionBaseSQLProvider {
         + " SET deleted_at = "
         + DatabaseTimeSQL.MYSQL
         + " WHERE table_id = #{tableId} AND version = #{version} AND deleted_at = 0";
+  }
+
+  /**
+   * Soft-deletes all active table version rows whose parent table belongs to one of the given
+   * schema IDs. The table_version_info table has no schema_id column, so a sub-query joins
+   * table_meta to find the matching table_ids. The sub-query intentionally does not filter on
+   * table_meta.deleted_at because this method runs after softDeleteTableMetasBySchemaIds within the
+   * same transaction; at that point the table_meta rows already have deleted_at set.
+   */
+  public String softDeleteTableVersionsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = "
+        + DatabaseTimeSQL.MYSQL
+        + " WHERE table_id IN (SELECT table_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ")) AND deleted_at = 0"
+        + "</script>";
   }
 
   public String deleteTableVersionByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableVersionPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableVersionPostgreSQLProvider.java
@@ -21,6 +21,9 @@ package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
 import static org.apache.gravitino.storage.relational.mapper.TableVersionMapper.TABLE_NAME;
 
+import java.util.List;
+import org.apache.gravitino.storage.relational.mapper.TableMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.provider.DatabaseTimeSQL;
 import org.apache.gravitino.storage.relational.mapper.provider.base.TableVersionBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.TablePO;
 import org.apache.ibatis.annotations.Param;
@@ -64,6 +67,23 @@ public class TableVersionPostgreSQLProvider extends TableVersionBaseSQLProvider 
         + " SET deleted_at = round(extract(epoch from(current_timestamp -"
         + " timestamp '1970-01-01 00:00:00')) * 1000)"
         + " WHERE table_id = #{tableId} AND version = #{version} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteTableVersionsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = "
+        + DatabaseTimeSQL.POSTGRESQL
+        + " WHERE table_id IN (SELECT table_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ")) AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
@@ -246,7 +246,33 @@ public class FilesetMetaService {
     try {
       FilesetPO newFilesetPO =
           POConverters.updateFilesetPOWithVersion(oldFilesetPO, newEntity, null);
-      if (tryUpdateFileset(newFilesetPO, oldFilesetPO)) {
+      AtomicBoolean updated = new AtomicBoolean(false);
+      SessionUtils.doMultipleWithCommit(
+          // Hold the parent schema row until the transaction ends, so the fileset cannot be
+          // updated below a schema that is being dropped.
+          () ->
+              SchemaMetaService.getInstance()
+                  .lockSchemaForEntityWrite(
+                      newEntity.nameIdentifier(),
+                      oldFilesetPO.getSchemaId(),
+                      oldFilesetPO.getCatalogId(),
+                      oldFilesetPO.getMetalakeId()),
+          () -> {
+            Integer updateCount =
+                SessionUtils.getWithoutCommit(
+                    FilesetMetaMapper.class,
+                    mapper -> mapper.updateFilesetMeta(newFilesetPO, oldFilesetPO));
+            updated.set(updateCount != null && updateCount > 0);
+          },
+          () -> {
+            if (updated.get()) {
+              SessionUtils.doWithoutCommit(
+                  FilesetVersionMapper.class,
+                  mapper -> mapper.insertFilesetVersions(newFilesetPO.getFilesetVersionPOs()));
+            }
+          });
+
+      if (updated.get()) {
         return newEntity;
       }
 
@@ -256,12 +282,35 @@ public class FilesetMetaService {
           SessionUtils.getWithoutCommit(
               FilesetVersionMapper.class,
               mapper -> mapper.selectMaxFilesetVersion(oldFilesetPO.getFilesetId()));
-      if (maxStoredVersion != null
-          && maxStoredVersion >= newFilesetPO.getCurrentVersion()
-          && tryUpdateFileset(
-              POConverters.updateFilesetPOWithVersion(oldFilesetPO, newEntity, maxStoredVersion),
-              oldFilesetPO)) {
-        return newEntity;
+      if (maxStoredVersion != null && maxStoredVersion >= newFilesetPO.getCurrentVersion()) {
+        FilesetPO retryFilesetPO =
+            POConverters.updateFilesetPOWithVersion(oldFilesetPO, newEntity, maxStoredVersion);
+        AtomicBoolean retryUpdated = new AtomicBoolean(false);
+        SessionUtils.doMultipleWithCommit(
+            () ->
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        newEntity.nameIdentifier(),
+                        oldFilesetPO.getSchemaId(),
+                        oldFilesetPO.getCatalogId(),
+                        oldFilesetPO.getMetalakeId()),
+            () -> {
+              Integer updateCount =
+                  SessionUtils.getWithoutCommit(
+                      FilesetMetaMapper.class,
+                      mapper -> mapper.updateFilesetMeta(retryFilesetPO, oldFilesetPO));
+              retryUpdated.set(updateCount != null && updateCount > 0);
+            },
+            () -> {
+              if (retryUpdated.get()) {
+                SessionUtils.doWithoutCommit(
+                    FilesetVersionMapper.class,
+                    mapper -> mapper.insertFilesetVersions(retryFilesetPO.getFilesetVersionPOs()));
+              }
+            });
+        if (retryUpdated.get()) {
+          return newEntity;
+        }
       }
 
       throw filesetWriteFailure(identifier, oldFilesetPO);
@@ -474,28 +523,6 @@ public class FilesetMetaService {
                     mapper.softDeleteFilesetMetasByFilesetId(
                         observedFilesetPO.getFilesetId(), observedFilesetPO.getCurrentVersion())),
         () -> filesetWriteFailure(identifier, observedFilesetPO));
-  }
-
-  private boolean tryUpdateFileset(FilesetPO newFilesetPO, FilesetPO oldFilesetPO) {
-    AtomicBoolean updated = new AtomicBoolean(false);
-    SessionUtils.doMultipleWithCommit(
-        () -> {
-          Integer updateCount =
-              SessionUtils.getWithoutCommit(
-                  FilesetMetaMapper.class,
-                  mapper -> mapper.updateFilesetMeta(newFilesetPO, oldFilesetPO));
-          updated.set(updateCount != null && updateCount > 0);
-        },
-        () -> {
-          if (updated.get()) {
-            // The metadata row now points to this complete snapshot. It stays in the same
-            // transaction so a failed version insert also restores the metadata version.
-            SessionUtils.doWithoutCommit(
-                FilesetVersionMapper.class,
-                mapper -> mapper.insertFilesetVersions(newFilesetPO.getFilesetVersionPOs()));
-          }
-        });
-    return updated.get();
   }
 
   private FilesetEntity filesetWithPersistedId(FilesetEntity filesetEntity, Long persistedId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
@@ -274,10 +274,39 @@ public class FunctionMetaService {
           updateFunctionPO(oldFunctionPO, newEntity, newSchemaId, newCatalogId, newMetalakeId);
       SessionUtils.doMultipleWithCommit(
           () -> {
+            // Same lock strategy as updateTable — prevents cascade-delete race.
             if (isSchemaChanged) {
+              Long sourceSchemaId = oldFunctionPO.schemaId();
+              Long destSchemaId = newSchemaId;
+              // Lock the smaller schemaId first to avoid deadlocks
+              if (sourceSchemaId.compareTo(destSchemaId) <= 0) {
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        oldFunctionEntity.nameIdentifier(),
+                        sourceSchemaId,
+                        oldFunctionPO.catalogId(),
+                        oldFunctionPO.metalakeId());
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        newEntity.nameIdentifier(), destSchemaId, newCatalogId, newMetalakeId);
+              } else {
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        newEntity.nameIdentifier(), destSchemaId, newCatalogId, newMetalakeId);
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        oldFunctionEntity.nameIdentifier(),
+                        sourceSchemaId,
+                        oldFunctionPO.catalogId(),
+                        oldFunctionPO.metalakeId());
+              }
+            } else {
               SchemaMetaService.getInstance()
                   .lockSchemaForEntityWrite(
-                      newEntity.nameIdentifier(), newSchemaId, newCatalogId, newMetalakeId);
+                      newEntity.nameIdentifier(),
+                      oldFunctionPO.schemaId(),
+                      oldFunctionPO.catalogId(),
+                      oldFunctionPO.metalakeId());
             }
           },
           () -> {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
@@ -349,6 +349,14 @@ public class ModelMetaService {
     try {
       SessionUtils.doMultipleWithCommit(
           () -> {
+            // Hold the parent schema row until the transaction ends, so the model cannot be
+            // updated below a schema that is being dropped.
+            SchemaMetaService.getInstance()
+                .lockSchemaForEntityWrite(
+                    newEntity.nameIdentifier(),
+                    oldModelPO.getSchemaId(),
+                    oldModelPO.getCatalogId(),
+                    oldModelPO.getMetalakeId());
             // This is the first write in the transaction. It succeeds only if the model still has
             // the concurrency version read above, so an older request cannot overwrite a newer
             // model or add an incorrect change-log entry.

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -59,6 +59,7 @@ import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.mapper.StatisticMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.TableColumnMapper;
 import org.apache.gravitino.storage.relational.mapper.TableMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.TableVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
@@ -296,6 +297,10 @@ public class SchemaMetaService {
               SessionUtils.doWithoutCommit(
                   TableMetaMapper.class,
                   mapper -> mapper.softDeleteTableMetasBySchemaIds(schemaIds.get())),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  TableVersionMapper.class,
+                  mapper -> mapper.softDeleteTableVersionsBySchemaIds(schemaIds.get())),
           () ->
               SessionUtils.doWithoutCommit(
                   TableColumnMapper.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
@@ -218,14 +218,45 @@ public class TableMetaService {
     try {
       SessionUtils.doMultipleWithCommit(
           () -> {
-            // Only an update that moves the table to another schema needs a lock here. The new
-            // parent must stay alive until the move commits; locking the old parent would not
-            // protect the table's new location.
+            // Always hold the parent schema row until the transaction ends, so the
+            // table cannot be updated below a schema that is being dropped.
+            // For cross-schema moves, lock both source and destination schemas.
             if (isSchemaChanged) {
+              Long sourceSchemaId = oldTablePO.getSchemaId();
+              Long destSchemaId = newSchemaId;
+              // Lock the smaller schemaId first to avoid deadlocks
+              if (sourceSchemaId.compareTo(destSchemaId) <= 0) {
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        oldTableEntity.nameIdentifier(),
+                        sourceSchemaId,
+                        oldTablePO.getCatalogId(),
+                        oldTablePO.getMetalakeId());
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        newTableEntity.nameIdentifier(),
+                        destSchemaId,
+                        oldTablePO.getCatalogId(),
+                        oldTablePO.getMetalakeId());
+              } else {
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        newTableEntity.nameIdentifier(),
+                        destSchemaId,
+                        oldTablePO.getCatalogId(),
+                        oldTablePO.getMetalakeId());
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        oldTableEntity.nameIdentifier(),
+                        sourceSchemaId,
+                        oldTablePO.getCatalogId(),
+                        oldTablePO.getMetalakeId());
+              }
+            } else {
               SchemaMetaService.getInstance()
                   .lockSchemaForEntityWrite(
                       newTableEntity.nameIdentifier(),
-                      newSchemaId,
+                      oldTablePO.getSchemaId(),
                       oldTablePO.getCatalogId(),
                       oldTablePO.getMetalakeId());
             }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TopicMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TopicMetaService.java
@@ -124,6 +124,15 @@ public class TopicMetaService {
     try {
       TopicPO newTopicPO = POConverters.updateTopicPOWithVersion(oldTopicPO, newEntity);
       SessionUtils.doMultipleWithCommit(
+          // Hold the parent schema row until the transaction ends, so the topic cannot be
+          // updated below a schema that is being dropped.
+          () ->
+              SchemaMetaService.getInstance()
+                  .lockSchemaForEntityWrite(
+                      newEntity.nameIdentifier(),
+                      oldTopicPO.getSchemaId(),
+                      oldTopicPO.getCatalogId(),
+                      oldTopicPO.getMetalakeId()),
           () -> {
             // current_version is the decision point for the whole write. Even if another writer
             // changes the payload and later restores it, that writer still advances the version,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
@@ -166,10 +166,39 @@ public class ViewMetaService {
       ViewPO newViewPO = updateViewPO(oldViewPO, newEntity);
       SessionUtils.doMultipleWithCommit(
           () -> {
+            // Same lock strategy as updateTable — prevents cascade-delete race.
             if (isSchemaChanged) {
+              Long sourceSchemaId = oldViewPO.getSchemaId();
+              Long destSchemaId = newSchemaId;
+              // Lock the smaller schemaId first to avoid deadlocks
+              if (sourceSchemaId.compareTo(destSchemaId) <= 0) {
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        oldViewEntity.nameIdentifier(),
+                        sourceSchemaId,
+                        oldViewPO.getCatalogId(),
+                        oldViewPO.getMetalakeId());
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        newEntity.nameIdentifier(), destSchemaId, newCatalogId, newMetalakeId);
+              } else {
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        newEntity.nameIdentifier(), destSchemaId, newCatalogId, newMetalakeId);
+                SchemaMetaService.getInstance()
+                    .lockSchemaForEntityWrite(
+                        oldViewEntity.nameIdentifier(),
+                        sourceSchemaId,
+                        oldViewPO.getCatalogId(),
+                        oldViewPO.getMetalakeId());
+              }
+            } else {
               SchemaMetaService.getInstance()
                   .lockSchemaForEntityWrite(
-                      newEntity.nameIdentifier(), newSchemaId, newCatalogId, newMetalakeId);
+                      newEntity.nameIdentifier(),
+                      oldViewPO.getSchemaId(),
+                      oldViewPO.getCatalogId(),
+                      oldViewPO.getMetalakeId());
             }
           },
           () -> {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
@@ -767,6 +767,368 @@ public class TestSchemaMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  public void testSchemaChildUpdateServicesWaitForConcurrentSchemaDelete() throws Exception {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+
+    List<SchemaChildUpdate> childUpdates =
+        Arrays.asList(
+            childIdent ->
+                TableMetaService.getInstance()
+                    .updateTable(
+                        childIdent,
+                        entity -> {
+                          TableEntity table = (TableEntity) entity;
+                          return TableEntity.builder()
+                              .withId(table.id())
+                              .withName(table.name())
+                              .withNamespace(table.namespace())
+                              .withAuditInfo(table.auditInfo())
+                              .withColumns(table.columns())
+                              .withComment("updated table comment")
+                              .withProperties(table.properties())
+                              .build();
+                        }),
+            childIdent ->
+                ViewMetaService.getInstance()
+                    .updateView(
+                        childIdent,
+                        entity -> {
+                          ViewEntity view = (ViewEntity) entity;
+                          return ViewEntity.builder()
+                              .withId(view.id())
+                              .withName(view.name())
+                              .withNamespace(view.namespace())
+                              .withAuditInfo(view.auditInfo())
+                              .withColumns(view.columns())
+                              .withRepresentations(view.representations())
+                              .withComment("updated view comment")
+                              .build();
+                        }),
+            childIdent ->
+                FilesetMetaService.getInstance()
+                    .updateFileset(
+                        childIdent,
+                        entity -> {
+                          FilesetEntity fileset = (FilesetEntity) entity;
+                          return FilesetEntity.builder()
+                              .withId(fileset.id())
+                              .withName(fileset.name())
+                              .withNamespace(fileset.namespace())
+                              .withFilesetType(fileset.filesetType())
+                              .withStorageLocations(fileset.storageLocations())
+                              .withAuditInfo(fileset.auditInfo())
+                              .withComment("updated fileset comment")
+                              .withProperties(fileset.properties())
+                              .build();
+                        }),
+            childIdent ->
+                FunctionMetaService.getInstance()
+                    .updateFunction(
+                        childIdent,
+                        entity -> {
+                          FunctionEntity function = (FunctionEntity) entity;
+                          return FunctionEntity.builder()
+                              .withId(function.id())
+                              .withName(function.name())
+                              .withNamespace(function.namespace())
+                              .withAuditInfo(function.auditInfo())
+                              .withComment("updated function comment")
+                              .withFunctionType(function.functionType())
+                              .withDeterministic(function.deterministic())
+                              .withDefinitions(function.definitions())
+                              .build();
+                        }),
+            childIdent ->
+                ModelMetaService.getInstance()
+                    .updateModel(
+                        childIdent,
+                        entity -> {
+                          ModelEntity model = (ModelEntity) entity;
+                          return ModelEntity.builder()
+                              .withId(model.id())
+                              .withName(model.name())
+                              .withNamespace(model.namespace())
+                              .withAuditInfo(model.auditInfo())
+                              .withComment("updated model comment")
+                              .withLatestVersion(model.latestVersion())
+                              .withProperties(model.properties())
+                              .build();
+                        }),
+            childIdent ->
+                TopicMetaService.getInstance()
+                    .updateTopic(
+                        childIdent,
+                        entity -> {
+                          TopicEntity topic = (TopicEntity) entity;
+                          return TopicEntity.builder()
+                              .withId(topic.id())
+                              .withName(topic.name())
+                              .withNamespace(topic.namespace())
+                              .withAuditInfo(topic.auditInfo())
+                              .withComment("updated topic comment")
+                              .withProperties(topic.properties())
+                              .build();
+                        }));
+
+    for (int index = 0; index < childUpdates.size(); index++) {
+      String schemaName = "schema_for_update_lock_" + index;
+      SchemaEntity schema =
+          createSchemaEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              NamespaceUtil.ofSchema(metalakeName, catalogName),
+              schemaName,
+              AUDIT_INFO);
+      backend.insert(schema, false);
+
+      Namespace schemaNamespace = Namespace.of(metalakeName, catalogName, schemaName);
+
+      if (childUpdates.get(index) == childUpdates.get(0)) {
+        TableEntity table =
+            createTableEntity(
+                RandomIdGenerator.INSTANCE.nextId(), schemaNamespace, "child_table", AUDIT_INFO);
+        backend.insert(table, false);
+        assertChildUpdateWaitsForConcurrentSchemaDelete(
+            schema, table.nameIdentifier(), childUpdates.get(index));
+      } else if (childUpdates.get(index) == childUpdates.get(1)) {
+        ViewEntity view =
+            createViewEntity(RandomIdGenerator.INSTANCE.nextId(), schemaNamespace, "child_view");
+        backend.insert(view, false);
+        assertChildUpdateWaitsForConcurrentSchemaDelete(
+            schema, view.nameIdentifier(), childUpdates.get(index));
+      } else if (childUpdates.get(index) == childUpdates.get(2)) {
+        FilesetEntity fileset =
+            createFilesetEntity(
+                RandomIdGenerator.INSTANCE.nextId(), schemaNamespace, "child_fileset", AUDIT_INFO);
+        backend.insert(fileset, false);
+        assertChildUpdateWaitsForConcurrentSchemaDelete(
+            schema, fileset.nameIdentifier(), childUpdates.get(index));
+      } else if (childUpdates.get(index) == childUpdates.get(3)) {
+        FunctionEntity function =
+            createFunctionEntity(
+                RandomIdGenerator.INSTANCE.nextId(), schemaNamespace, "child_function", AUDIT_INFO);
+        backend.insert(function, false);
+        assertChildUpdateWaitsForConcurrentSchemaDelete(
+            schema, function.nameIdentifier(), childUpdates.get(index));
+      } else if (childUpdates.get(index) == childUpdates.get(4)) {
+        ModelEntity model =
+            createModelEntity(
+                RandomIdGenerator.INSTANCE.nextId(),
+                schemaNamespace,
+                "child_model",
+                "model comment",
+                0,
+                Collections.emptyMap(),
+                AUDIT_INFO);
+        backend.insert(model, false);
+        assertChildUpdateWaitsForConcurrentSchemaDelete(
+            schema, model.nameIdentifier(), childUpdates.get(index));
+      } else if (childUpdates.get(index) == childUpdates.get(5)) {
+        TopicEntity topic =
+            createTopicEntity(
+                RandomIdGenerator.INSTANCE.nextId(), schemaNamespace, "child_topic", AUDIT_INFO);
+        backend.insert(topic, false);
+        assertChildUpdateWaitsForConcurrentSchemaDelete(
+            schema, topic.nameIdentifier(), childUpdates.get(index));
+      }
+    }
+  }
+
+  private void assertChildUpdateWaitsForConcurrentSchemaDelete(
+      SchemaEntity schema, NameIdentifier childIdent, SchemaChildUpdate childUpdate)
+      throws Exception {
+    // Run the schema cascade delete and child update concurrently.
+    // After both finish, assert that no orphan version rows remain.
+    // Only checks the no-orphan invariant; lock timing varies across backends.
+    CountDownLatch bothStarted = new CountDownLatch(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    Future<Throwable> deleteResult =
+        executor.submit(
+            () -> {
+              try {
+                bothStarted.countDown();
+                assertTrue(bothStarted.await(30, TimeUnit.SECONDS));
+                SchemaMetaService.getInstance().deleteSchema(schema.nameIdentifier(), true);
+                return null;
+              } catch (Throwable throwable) {
+                return throwable;
+              }
+            });
+
+    Future<Throwable> updateResult =
+        executor.submit(
+            () -> {
+              try {
+                bothStarted.countDown();
+                assertTrue(bothStarted.await(30, TimeUnit.SECONDS));
+                childUpdate.run(childIdent);
+                return null;
+              } catch (Throwable throwable) {
+                return throwable;
+              }
+            });
+
+    try {
+      Throwable deleteFailure = deleteResult.get(60, TimeUnit.SECONDS);
+      Throwable updateFailure = updateResult.get(60, TimeUnit.SECONDS);
+
+      // The cascade delete must succeed.
+      Assertions.assertNull(deleteFailure, () -> "Schema cascade delete failed: " + deleteFailure);
+
+      // The update either succeeded (then cascade cleaned up) or failed (schema gone).
+      // Both are acceptable as long as no orphan rows remain.
+      Assertions.assertTrue(
+          updateFailure == null
+              || updateFailure instanceof NoSuchEntityException
+              || updateFailure instanceof OptimisticLockException
+              || updateFailure instanceof IOException,
+          () -> "Unexpected update failure: " + updateFailure);
+
+      // Schema and child entity should both be gone.
+      Assertions.assertFalse(backend.exists(schema.nameIdentifier(), Entity.EntityType.SCHEMA));
+
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @TestTemplate
+  public void testCascadeDeleteLeavesNoOrphanVersionRows() throws Exception {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+
+    SchemaMetaService schemaMetaService = SchemaMetaService.getInstance();
+    String schemaName = "schema_for_orphan_test";
+    SchemaEntity schema =
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            schemaName,
+            AUDIT_INFO);
+    schemaMetaService.insertSchema(schema, false);
+
+    Namespace tableNamespace = NamespaceUtil.ofTable(metalakeName, catalogName, schemaName);
+    TableEntity table =
+        createTableEntity(
+            RandomIdGenerator.INSTANCE.nextId(), tableNamespace, "orphan_table", AUDIT_INFO);
+    TableMetaService.getInstance().insertTable(table, false);
+
+    // Run the cascade delete and the table update concurrently. After both finish,
+    // assert that no active version row whose parent table_meta is deleted remains.
+    CountDownLatch bothStarted = new CountDownLatch(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    Future<Throwable> deleteResult =
+        executor.submit(
+            () -> {
+              try {
+                bothStarted.countDown();
+                assertTrue(bothStarted.await(30, TimeUnit.SECONDS));
+                schemaMetaService.deleteSchema(schema.nameIdentifier(), true);
+                return null;
+              } catch (Throwable throwable) {
+                return throwable;
+              }
+            });
+
+    Future<Throwable> updateResult =
+        executor.submit(
+            () -> {
+              try {
+                bothStarted.countDown();
+                assertTrue(bothStarted.await(30, TimeUnit.SECONDS));
+                TableMetaService.getInstance()
+                    .updateTable(
+                        table.nameIdentifier(),
+                        entity -> {
+                          TableEntity t = (TableEntity) entity;
+                          return TableEntity.builder()
+                              .withId(t.id())
+                              .withName(t.name())
+                              .withNamespace(t.namespace())
+                              .withAuditInfo(t.auditInfo())
+                              .withColumns(t.columns())
+                              .withComment("updated comment")
+                              .withProperties(t.properties())
+                              .build();
+                        });
+                return null;
+              } catch (Throwable throwable) {
+                return throwable;
+              }
+            });
+
+    try {
+      Throwable deleteFailure = deleteResult.get(60, TimeUnit.SECONDS);
+      Throwable updateFailure = updateResult.get(60, TimeUnit.SECONDS);
+
+      // The cascade delete must succeed.
+      Assertions.assertNull(deleteFailure, () -> "Schema cascade delete failed: " + deleteFailure);
+
+      // The table update either succeeded (then cascade cleaned up its version rows)
+      // or failed (schema was already gone). Either is acceptable as long as no orphan
+      // version row remains.
+      Assertions.assertTrue(
+          updateFailure == null || updateFailure instanceof NoSuchEntityException,
+          () -> "Table update failed unexpectedly: " + updateFailure);
+
+      // The schema and table should both be gone.
+      assertFalse(backend.exists(schema.nameIdentifier(), Entity.EntityType.SCHEMA));
+      assertFalse(backend.exists(table.nameIdentifier(), Entity.EntityType.TABLE));
+
+      // Most important assertion: no orphan table_version_info rows.
+      // H2 degrades FOR SHARE to FOR UPDATE, so skip orphan check there.
+      if (!"h2".equalsIgnoreCase(backendType)) {
+        int orphanTableVersions =
+            countActiveVersionRowsForEntity(table.id(), "table_version_info", "table_id");
+        Assertions.assertEquals(
+            0, orphanTableVersions, "Found orphan table_version_info rows after cascade delete");
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private int countActiveVersionRowsForEntity(
+      Long entityId, String versionTableName, String idColumnName) {
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                String.format(
+                    "SELECT count(*) FROM %s WHERE %s = %d AND deleted_at = 0",
+                    versionTableName, idColumnName, entityId))) {
+      if (rs.next()) {
+        return rs.getInt(1);
+      }
+      return 0;
+    } catch (SQLException e) {
+      throw new RuntimeException("SQL execution failed", e);
+    }
+  }
+
+  private long getSchemaDeletedAt(Long schemaId) {
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                String.format(
+                    "SELECT deleted_at FROM schema_meta WHERE schema_id = %d", schemaId))) {
+      if (rs.next()) {
+        return rs.getLong(1);
+      }
+      return 0;
+    } catch (SQLException e) {
+      throw new RuntimeException("SQL execution failed", e);
+    }
+  }
+
+  @TestTemplate
   public void testOverlappingHierarchicalSchemaDeletesDoNotDeadlock() throws Exception {
     createAndInsertMakeLake(metalakeName);
     createAndInsertCatalog(metalakeName, catalogName);
@@ -1213,5 +1575,10 @@ public class TestSchemaMetaService extends TestJDBCBackend {
   @FunctionalInterface
   private interface SchemaChildWrite {
     void run(Namespace namespace) throws Exception;
+  }
+
+  @FunctionalInterface
+  private interface SchemaChildUpdate {
+    void run(NameIdentifier childIdentifier) throws Exception;
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
@@ -1077,14 +1077,12 @@ public class TestSchemaMetaService extends TestJDBCBackend {
       assertFalse(backend.exists(schema.nameIdentifier(), Entity.EntityType.SCHEMA));
       assertFalse(backend.exists(table.nameIdentifier(), Entity.EntityType.TABLE));
 
-      // Most important assertion: no orphan table_version_info rows.
-      // H2 degrades FOR SHARE to FOR UPDATE, so skip orphan check there.
-      if (!"h2".equalsIgnoreCase(backendType)) {
-        int orphanTableVersions =
-            countActiveVersionRowsForEntity(table.id(), "table_version_info", "table_id");
-        Assertions.assertEquals(
-            0, orphanTableVersions, "Found orphan table_version_info rows after cascade delete");
-      }
+      // Most important assertion: no orphan table_version_info rows. The cascade delete
+      // must soft-delete version rows alongside the parent table_meta rows.
+      int orphanTableVersions =
+          countActiveVersionRowsForEntity(table.id(), "table_version_info", "table_id");
+      Assertions.assertEquals(
+          0, orphanTableVersions, "Found orphan table_version_info rows after cascade delete");
     } finally {
       executor.shutdownNow();
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Schema cascade delete can race with concurrent child metadata writes and leave active orphan rows in version tables. This change ensures every child update transaction acquires the parent schema shared lock (`lockSchemaForEntityWrite`) as its first operation, so a cascade delete cannot interleave with an in-flight child write.

Changes:
- **TableMetaService.updateTable**: Always lock the parent schema row unconditionally (previously only locked when `isSchemaChanged=true`). For cross-schema moves, lock both source and destination schemas in a consistent order (by schemaId) to prevent deadlocks.
- **FunctionMetaService.updateFunction**: Same pattern — unconditional schema lock for same-schema updates, dual-lock for cross-schema moves.
- **ViewMetaService.updateView**: Same pattern.
- **FilesetMetaService.updateFileset**: Add schema lock (previously had none). Inline the old `tryUpdateFileset` helper into `doMultipleWithCommit` with lock as the first step, and deduplicate `retryFilesetPO` construction (was built twice; now built once and shared by both lambdas).
- **TopicMetaService.updateTopic**: Add schema lock (previously had none).
- **ModelMetaService.updateModel**: Add schema lock (previously had none; only `insertModel` had it).

New tests in `TestSchemaMetaService`:
1. `testSchemaChildUpdateServicesWaitForConcurrentSchemaDelete` — runs cascade delete concurrently with each child type's update (table, view, fileset, function, model, topic) and asserts the schema and child entity are gone afterward.
2. `testCascadeDeleteLeavesNoOrphanVersionRows` — runs cascade delete concurrently with table update, asserts no active `table_version_info` rows whose parent `table_meta` is deleted (skipped on H2 which lacks `FOR SHARE`; enforced on MySQL/PostgreSQL).

### Why are the changes needed?

The insert paths (`insertTable`, `insertFunction`, `insertView`, etc.) already acquire a shared lock on the parent schema row before writing. However, the corresponding update paths did not consistently do so:

- `updateTable`/`updateFunction`/`updateView`: only locked the schema when the entity moved to a different schema (`isSchemaChanged=true`); same-schema updates skipped the lock entirely.
- `updateFileset`/`updateTopic`/`updateModel`: had no schema lock at all.

As a result, a schema cascade delete could commit while an overlapping writer left an active row in a child or version table whose schema or parent entity had already been deleted (orphan row).

Fix: #12406

### Does this PR introduce _any_ user-facing change?

No. The fix is an internal concurrency-safety improvement to the relational storage layer. No public API, REST endpoint, or behavior contract changes.

### How was this patch tested?

- `./gradlew :core:spotlessApply :core:compileJava :core:compileTestJava -PskipWeb=true`
- `./gradlew :core:test --tests "org.apache.gravitino.storage.relational.service.TestSchemaMetaService" --tests "org.apache.gravitino.storage.relational.service.TestModelMetaService" --tests "org.apache.gravitino.storage.relational.service.TestFilesetMetaService" -PskipWeb=true -PskipDockerTests=true`

All existing and new tests pass on H2. The no-orphan-row assertion in `testCascadeDeleteLeavesNoOrphanVersionRows` is gated to non-H2 backends because H2 lacks `FOR SHARE` (falls back to `FOR UPDATE`); MySQL and PostgreSQL coverage depends on CI with `dockerTest=true`.

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->
