### PR TITLE
fix(common): handle overflowing parametric type sizes without throwing NumberFormatException

### DIFF
--- a/common/src/main/java/org/apache/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/org/apache/gravitino/json/JsonUtils.java
@@ -857,51 +857,58 @@ public class JsonUtils {
       return primitiveType;
     }
 
-    Matcher fixed = FIXED.matcher(lowerTypeString);
-    if (fixed.matches()) {
-      return Types.FixedType.of(Integer.parseInt(fixed.group(1)));
-    }
+    try {
+      Matcher fixed = FIXED.matcher(lowerTypeString);
+      if (fixed.matches()) {
+        return Types.FixedType.of(Integer.parseInt(fixed.group(1)));
+      }
 
-    Matcher fixedChar = FIXEDCHAR.matcher(lowerTypeString);
-    if (fixedChar.matches()) {
-      return Types.FixedCharType.of(Integer.parseInt(fixedChar.group(1)));
-    }
+      Matcher fixedChar = FIXEDCHAR.matcher(lowerTypeString);
+      if (fixedChar.matches()) {
+        return Types.FixedCharType.of(Integer.parseInt(fixedChar.group(1)));
+      }
 
-    Matcher varchar = VARCHAR.matcher(lowerTypeString);
-    if (varchar.matches()) {
-      return Types.VarCharType.of(Integer.parseInt(varchar.group(1)));
-    }
+      Matcher varchar = VARCHAR.matcher(lowerTypeString);
+      if (varchar.matches()) {
+        return Types.VarCharType.of(Integer.parseInt(varchar.group(1)));
+      }
 
-    Matcher decimal = DECIMAL.matcher(lowerTypeString);
-    if (decimal.matches()) {
-      return Types.DecimalType.of(
-          Integer.parseInt(decimal.group(1)), Integer.parseInt(decimal.group(2)));
-    }
+      Matcher decimal = DECIMAL.matcher(lowerTypeString);
+      if (decimal.matches()) {
+        return Types.DecimalType.of(
+            Integer.parseInt(decimal.group(1)), Integer.parseInt(decimal.group(2)));
+      }
 
-    // Match against the original string, not the lowercased one, so the CRS keeps its case.
-    Matcher geometry = GEOMETRY.matcher(orignalTypeString);
-    if (geometry.matches()) {
-      return Types.GeometryType.of(geometry.group(1));
-    }
+      // Match against the original string, not the lowercased one, so the CRS keeps its case.
+      Matcher geometry = GEOMETRY.matcher(orignalTypeString);
+      if (geometry.matches()) {
+        return Types.GeometryType.of(geometry.group(1));
+      }
 
-    Matcher geography = GEOGRAPHY.matcher(orignalTypeString);
-    if (geography.matches()) {
-      return Types.GeographyType.of(geography.group(1), geography.group(2));
-    }
+      Matcher geography = GEOGRAPHY.matcher(orignalTypeString);
+      if (geography.matches()) {
+        return Types.GeographyType.of(geography.group(1), geography.group(2));
+      }
 
-    Matcher time = TIME.matcher(lowerTypeString);
-    if (time.matches()) {
-      return Types.TimeType.of(Integer.parseInt(time.group(1)));
-    }
+      Matcher time = TIME.matcher(lowerTypeString);
+      if (time.matches()) {
+        return Types.TimeType.of(Integer.parseInt(time.group(1)));
+      }
 
-    Matcher timestampTz = TIMESTAMP_TZ.matcher(lowerTypeString);
-    if (timestampTz.matches()) {
-      return Types.TimestampType.withTimeZone(Integer.parseInt(timestampTz.group(1)));
-    }
+      Matcher timestampTz = TIMESTAMP_TZ.matcher(lowerTypeString);
+      if (timestampTz.matches()) {
+        return Types.TimestampType.withTimeZone(Integer.parseInt(timestampTz.group(1)));
+      }
 
-    Matcher timestamp = TIMESTAMP.matcher(lowerTypeString);
-    if (timestamp.matches()) {
-      return Types.TimestampType.withoutTimeZone(Integer.parseInt(timestamp.group(1)));
+      Matcher timestamp = TIMESTAMP.matcher(lowerTypeString);
+      if (timestamp.matches()) {
+        return Types.TimestampType.withoutTimeZone(Integer.parseInt(timestamp.group(1)));
+      }
+    } catch (NumberFormatException e) {
+      // A parametric size/precision whose digits overflow int is not a supported type;
+      // fall through to UnparsedType instead of throwing, matching how other
+      // unrecognized type strings are handled below.
+      return Types.UnparsedType.of(orignalTypeString);
     }
 
     return Types.UnparsedType.of(orignalTypeString);

--- a/common/src/test/java/org/apache/gravitino/json/TestJsonUtils.java
+++ b/common/src/test/java/org/apache/gravitino/json/TestJsonUtils.java
@@ -643,6 +643,28 @@ public class TestJsonUtils {
     Assertions.assertNull(e.getCause());
   }
 
+  @Test
+  public void testDeserializeParametricTypeWithOverflowingSize() throws JsonProcessingException {
+    // Regression: a parametric size/precision whose digits overflow int used to raise an
+    // uncaught NumberFormatException from Integer.parseInt in fromPrimitiveTypeString,
+    // aborting deserialization. It should fall back to UnparsedType like any other
+    // unrecognized type string.
+    String[] typeStrings = {
+      "fixed(2147483648)",
+      "char(9999999999)",
+      "varchar(9999999999)",
+      "decimal(9999999999,0)",
+      "time(9999999999)",
+      "timestamp(9999999999)",
+      "timestamp_tz(9999999999)",
+    };
+    for (String typeString : typeStrings) {
+      String json = objectMapper.writeValueAsString(typeString);
+      Type type = objectMapper.readValue(json, Type.class);
+      assertEquals(Types.UnparsedType.of(typeString), type);
+    }
+  }
+
   private static void assertRejected(String json, String expectedMessagePart) {
     IllegalArgumentException e =
         Assertions.assertThrows(


### PR DESCRIPTION
### What changes were proposed in this pull request?

`JsonUtils.fromPrimitiveTypeString` recognizes parametric primitive types (`fixed`, `char`, `varchar`, `decimal`, `time`, `timestamp`, `timestamp_tz`) with unbounded `\d+` capture groups and passes the captured digits straight to `Integer.parseInt`. A size/precision above `Integer.MAX_VALUE` still matches the pattern but overflows `parseInt`, so a type string such as `fixed(2147483648)` raises an uncaught `NumberFormatException`.

The method is designed to fall back to `Types.UnparsedType` for anything it does not recognize, but this overflow defeats that: the exception surfaces out of `TypeDeserializer` while Jackson deserializes a request (for example the column types of a create-table / create-view request), before request validation runs, so it becomes an internal error instead of the intended graceful handling.

This wraps the parametric-parse block so an overflowing size falls through to `UnparsedType` like any other unrecognized type string.

### Why are the changes needed?

A normal, authenticated request carrying an out-of-range parametric type size crashes deserialization with an uncaught `NumberFormatException` rather than being handled gracefully.

### Does this PR introduce any user-facing change?

No. Valid type strings behave exactly as before; only an over-long numeric size now yields `UnparsedType` instead of throwing.

### How was this patch tested?

Added `testDeserializeParametricTypeWithOverflowingSize` in `TestJsonUtils`, covering all seven parametric types.
