### PR TITLE
[#13100] fix(license): Add bundled Google auth and HTTP Client jars to LICENSE files

### DIFF
--- a/LICENSE.bin
+++ b/LICENSE.bin
@@ -303,6 +303,8 @@
    Apache Hadoop Yarn Client
    Apache Hive
    Apache HTrace
+   Google HTTP Client
+   Google HTTP Client GSON
    Apache HttpCore
    Apache HttpClient
    Apache Iceberg

--- a/LICENSE.iceberg
+++ b/LICENSE.iceberg
@@ -249,6 +249,8 @@
    Apache Hadoop
    Apache Hive
    Apache HTrace
+   Google HTTP Client
+   Google HTTP Client GSON
    Apache HttpComponents Client
    Apache HttpClient
    Apache HttpCore
@@ -313,6 +315,8 @@
    Apache Avro
    Apache Yetus - Audience Annotations
    ASM
+   Google auth Credentials
+   Google auth HTTP
    Javolution
    JLine
    JSch


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the bundled Google jars that the binary LICENSE files do not currently name:

| Jar | Licence | `LICENSE.bin` | `LICENSE.iceberg` |
| --- | --- | --- | --- |
| `google-auth-library-credentials-1.28.0` | BSD-3-Clause | already listed | **added** |
| `google-auth-library-oauth2-http-1.28.0` | BSD-3-Clause | already listed | **added** |
| `google-http-client-1.45.0` | Apache-2.0 | **added** | **added** |
| `google-http-client-gson-1.45.0` | Apache-2.0 | **added** | **added** |

Licences are taken from each artifact's parent POM — `google-auth-library-parent` declares "BSD New license" and `google-http-client-parent` declares "The Apache Software License, Version 2.0" — so each entry is placed in the matching section rather than inferred from the vendor.

### Why are the changes needed?

All four jars are present as standalone files in the assembled distributions, in both `package/` and `gravitino-iceberg-rest-server/libs/`. ASF policy requires every bundled third-party artifact to be named in the binary LICENSE.

`google-http-client` and `google-http-client-gson` reach the classpath solely as transitive dependencies of `google-auth-library-oauth2-http` (confirmed with `dependencyInsight`), which is why they were missed — only the direct dependency was reviewed.

All four are new to these distributions in this release. The released 1.3.0 tarballs contain none of them: at 1.3.0 this content existed only shaded inside the GCP bundles, which is why `LICENSE.bin` already names the two BSD-licensed auth jars. #12962 added `google-auth-library-oauth2-http` to `iceberg/iceberg-common` unshaded, so the jars now ship standalone.

`NOTICE.bin` and `NOTICE.iceberg` need no change: none of the four jars carries a `META-INF` `LICENSE` or `NOTICE` entry, so there is nothing to aggregate.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran `./gradlew assembleDistribution -x test`, enumerated the jars in each assembled distribution, and reconciled them against the corresponding LICENSE file.
