### PR TITLE
[#13111] fix(test): Pull the MinIO test image from quay.io

### DIFF
--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/MinIOContainer.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/MinIOContainer.java
@@ -41,7 +41,8 @@ import org.testcontainers.containers.Network;
 public class MinIOContainer extends BaseContainer {
   public static final Logger LOG = LoggerFactory.getLogger(MinIOContainer.class);
 
-  public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z";
+  // MinIO no longer publishes this image on Docker Hub; quay.io carries the same release.
+  public static final String DEFAULT_IMAGE = "quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z";
   public static final String HOST_NAME = "gravitino-ci-minio";
   public static final int PORT = 9000;
   public static final String ACCESS_KEY = "minioadmin";


### PR DESCRIPTION
### What changes were proposed in this pull request?

Point `MinIOContainer.DEFAULT_IMAGE` at `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z`. It's the same MinIO release, pulled from MinIO's quay.io organization instead of Docker Hub.

### Why are the changes needed?

Docker Hub removed the `minio/minio` repository, so every integration test that starts `MinIOContainer` fails with `pull access denied`. That includes `FilesetS3TokenConnectionIT` in Backend Integration Test and `IcebergRESTMinIOTokenAuthorizationIT`. This is a temporary fix, the same one apache/iceberg#18071 and apache/doris#67897 merged. Replacing MinIO is tracked in the discussion on #13111.

Fix: #13111

### Does this PR introduce _any_ user-facing change?

No. Test infrastructure only.

### How was this patch tested?

- `docker pull minio/minio:RELEASE.2025-09-07T16-13-09Z` fails with `pull access denied`; `docker pull quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` succeeds.
- `./gradlew :integration-test-common:spotlessCheck :integration-test-common:compileTestJava` passes.
- CI on this PR runs `FilesetS3TokenConnectionIT`.
