### PR TITLE
[#11805] improvement(catalog-jdbc): Validate external type strings before DDL interpolation

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/converter/JdbcTypeConverter.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/converter/JdbcTypeConverter.java
@@ -18,7 +18,9 @@
  */
 package org.apache.gravitino.catalog.jdbc.converter;
 
+import com.google.common.base.Preconditions;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import org.apache.gravitino.connector.DataTypeConverter;
 
 public abstract class JdbcTypeConverter
@@ -29,6 +31,152 @@ public abstract class JdbcTypeConverter
   public static final String TIMESTAMP = "timestamp";
   public static final String VARCHAR = "varchar";
   public static final String TEXT = "text";
+
+  /**
+   * Characters allowed outside single-quoted literals in an external type catalog string. Notably
+   * excludes {@code ;}, {@code /}, {@code *}, {@code #} and newlines, so the string can neither
+   * terminate the enclosing statement nor open a comment. The {@code --} line comment sequence is
+   * rejected separately, because a single {@code -} is legitimate in type names such as {@code
+   * user-defined}.
+   */
+  private static final Pattern EXTERNAL_TYPE_ALLOWED_CHARS =
+      Pattern.compile("[\\w .,:()<>\\[\\]=-]*");
+
+  /**
+   * Validates that an external type catalog string is safe to interpolate into the column type
+   * position of a generated DDL statement.
+   *
+   * <p>Catalog strings come from the caller and are written verbatim into the {@code CREATE TABLE}
+   * and {@code ALTER TABLE} statements that the JDBC catalogs build by string concatenation. This
+   * method deliberately does not check that the string names a type the backend understands, since
+   * the backend rejects unknown types by itself. It only ensures the string stays within the single
+   * type slot it is written into, so that it cannot append another comma separated {@code ALTER}
+   * action, terminate the statement, or open a comment that hides the rest of the generated SQL.
+   *
+   * @param catalogString The external type catalog string to validate.
+   * @return The unchanged {@code catalogString}, once it is known to be safe to interpolate.
+   * @throws IllegalArgumentException if {@code catalogString} is null or blank, or if it could
+   *     escape the column type position.
+   */
+  protected static String validateExternalTypeString(String catalogString) {
+    Preconditions.checkArgument(
+        catalogString != null && !catalogString.trim().isEmpty(),
+        "External type cannot be null or blank, but got: %s",
+        catalogString);
+
+    String unquoted = stripSingleQuotedLiterals(catalogString);
+
+    Preconditions.checkArgument(
+        EXTERNAL_TYPE_ALLOWED_CHARS.matcher(unquoted).matches(),
+        "External type contains characters that are not allowed outside a quoted literal: %s",
+        catalogString);
+    // Checked after the literals are stripped, so that a quoted literal is free to contain "--".
+    // Two hyphens that only became adjacent because a literal between them was removed are
+    // rejected as well, which errs on the safe side.
+    Preconditions.checkArgument(
+        !unquoted.contains("--"),
+        "External type cannot contain the SQL line comment sequence '--': %s",
+        catalogString);
+
+    checkBracketsAndCommas(unquoted, catalogString);
+    return catalogString;
+  }
+
+  /**
+   * Removes every single-quoted literal from the given catalog string, so that the remaining text
+   * can be checked without rejecting characters that are harmless inside a literal, such as the
+   * members of a MySQL {@code enum('a','b')} declaration.
+   *
+   * @param catalogString The external type catalog string to strip.
+   * @return The catalog string with the content of every quoted literal, and its quotes, removed.
+   * @throws IllegalArgumentException if a quoted literal is never closed.
+   */
+  private static String stripSingleQuotedLiterals(String catalogString) {
+    StringBuilder unquoted = new StringBuilder(catalogString.length());
+    int index = 0;
+    while (index < catalogString.length()) {
+      char current = catalogString.charAt(index);
+      if (current != '\'') {
+        unquoted.append(current);
+        index++;
+        continue;
+      }
+
+      index++;
+      boolean closed = false;
+      while (index < catalogString.length()) {
+        if (catalogString.charAt(index) != '\'') {
+          index++;
+        } else if (index + 1 < catalogString.length() && catalogString.charAt(index + 1) == '\'') {
+          // A doubled quote escapes a quote inside the literal, it does not end the literal.
+          index += 2;
+        } else {
+          index++;
+          closed = true;
+          break;
+        }
+      }
+      Preconditions.checkArgument(
+          closed, "External type has an unterminated quoted literal: %s", catalogString);
+    }
+    return unquoted.toString();
+  }
+
+  /**
+   * Checks that {@code ()}, {@code []} and {@code <>} are balanced in the given quote stripped
+   * text, and that every comma it contains is nested inside one of those pairs. A comma that is not
+   * nested would start another action in the comma separated {@code ALTER TABLE} statements that
+   * the JDBC catalogs generate.
+   *
+   * @param unquoted The catalog string with its quoted literals already stripped.
+   * @param catalogString The original catalog string, used for the error message.
+   * @throws IllegalArgumentException if a bracket pair is unbalanced or a comma is not nested.
+   */
+  private static void checkBracketsAndCommas(String unquoted, String catalogString) {
+    int parentheses = 0;
+    int squares = 0;
+    int angles = 0;
+    for (int index = 0; index < unquoted.length(); index++) {
+      switch (unquoted.charAt(index)) {
+        case '(':
+          parentheses++;
+          break;
+        case ')':
+          parentheses--;
+          break;
+        case '[':
+          squares++;
+          break;
+        case ']':
+          squares--;
+          break;
+        case '<':
+          angles++;
+          break;
+        case '>':
+          angles--;
+          break;
+        case ',':
+          Preconditions.checkArgument(
+              parentheses > 0 || squares > 0 || angles > 0,
+              "External type cannot contain a comma outside of brackets: %s",
+              catalogString);
+          break;
+        default:
+          break;
+      }
+
+      Preconditions.checkArgument(
+          parentheses >= 0 && squares >= 0 && angles >= 0,
+          "External type closes a bracket that was never opened: %s",
+          catalogString);
+    }
+
+    Preconditions.checkArgument(
+        parentheses == 0 && squares == 0 && angles == 0,
+        "External type has unbalanced brackets: %s",
+        catalogString);
+  }
 
   public static class JdbcTypeBean {
     /** Data type name. */

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/converter/TestJdbcTypeConverterExternalTypeValidation.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/converter/TestJdbcTypeConverterExternalTypeValidation.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.converter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests {@link JdbcTypeConverter#validateExternalTypeString(String)}. The accepted values are the
+ * external types the JDBC catalogs actually produce today, including the ClickHouse, OceanBase and
+ * Hologres shapes, so that those contrib catalogs can reuse this helper without widening it.
+ */
+public class TestJdbcTypeConverterExternalTypeValidation {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // MySQL, recovered from information_schema by MysqlTableOperations.
+        "enum('a','b','c')",
+        "set('x','y','z')",
+        "bit(8)",
+        "binary(16)",
+        "varbinary(100)",
+        "blob",
+        // Doris.
+        "json",
+        "variant",
+        "ipv4",
+        "ipv6",
+        "largeint",
+        "bitmap",
+        "hll",
+        "bigint unsigned",
+        // Doris falls back to the raw string when the type parameters cannot be parsed.
+        "varchar(abc)",
+        "char(xyz)",
+        "decimal(a,b)",
+        // PostgreSQL.
+        "numeric",
+        "bit",
+        // Used by the MySQL and PostgreSQL converter tests.
+        "user-defined",
+        // A quoted literal may contain anything, including an escaped quote.
+        "enum('it''s','ok')",
+        "enum('a;b')",
+        "enum('a--b')",
+        // ClickHouse, so the contrib follow-up can reuse this helper unchanged.
+        "Enum8('active'=1,'inactive'=2)",
+        "Enum16('x'=1,'y'=2)",
+        "Decimal(50,10)",
+        "Int128",
+        "Date32",
+        "IPv4",
+        "Map(String, Int32)",
+        "Tuple(Int32, String)",
+        // Nested generic types keep their commas inside angle brackets.
+        "struct<a:int,b:int>",
+        "array<int>"
+      })
+  public void testAcceptsLegitimateExternalTypes(String catalogString) {
+    Assertions.assertEquals(
+        catalogString, JdbcTypeConverter.validateExternalTypeString(catalogString));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // A top level comma appends another action to the generated ALTER TABLE statement.
+        "int, DROP COLUMN secret",
+        "decimal(10,2), DROP COLUMN secret",
+        // Statement separators and comment markers.
+        "json; DROP TABLE foo",
+        "int -- comment",
+        "int /* comment */",
+        "int#comment",
+        "int\nDROP COLUMN secret",
+        // Quoting that does not close.
+        "a'b",
+        "enum('a','b",
+        // Brackets that do not balance.
+        "foo(",
+        "foo)",
+        "a<b",
+        "struct<a:int",
+        // Blank input, which ExternalType.of accepts today.
+        "   "
+      })
+  public void testRejectsUnsafeExternalTypes(String catalogString) {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> JdbcTypeConverter.validateExternalTypeString(catalogString));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @EmptySource
+  public void testRejectsNullAndEmptyExternalTypes(String catalogString) {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> JdbcTypeConverter.validateExternalTypeString(catalogString));
+  }
+
+  @Test
+  public void testRejectsHyphensThatBecomeAdjacentAfterStrippingLiterals() {
+    // Conservative by design: the '--' check runs after quoted literals are removed, so hyphens
+    // that only become adjacent because a literal between them was stripped are rejected too.
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> JdbcTypeConverter.validateExternalTypeString("a-'x'-b"));
+  }
+
+  @Test
+  public void testErrorMessageNamesTheOffendingType() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> JdbcTypeConverter.validateExternalTypeString("int, DROP COLUMN secret"));
+    Assertions.assertTrue(
+        exception.getMessage().contains("int, DROP COLUMN secret"), exception.getMessage());
+  }
+}

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisTypeConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisTypeConverter.java
@@ -213,7 +213,7 @@ public class DorisTypeConverter extends JdbcTypeConverter {
     } else if (type instanceof Types.BinaryType) {
       return BINARY;
     } else if (type instanceof Types.ExternalType) {
-      return ((Types.ExternalType) type).catalogString();
+      return validateExternalTypeString(((Types.ExternalType) type).catalogString());
     }
     throw new IllegalArgumentException(
         String.format("Couldn't convert Gravitino type %s to Doris type", type.simpleString()));

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/converter/TestDorisTypeConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/converter/TestDorisTypeConverter.java
@@ -131,6 +131,20 @@ public class TestDorisTypeConverter {
   }
 
   @Test
+  public void testFromGravitinoExternalTypeValidation() {
+    // testExternalTypeRoundTrip already covers the legitimate values; these must be rejected.
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> DORIS_TYPE_CONVERTER.fromGravitino(Types.ExternalType.of("int, DROP COLUMN secret")));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> DORIS_TYPE_CONVERTER.fromGravitino(Types.ExternalType.of("json; DROP TABLE foo")));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> DORIS_TYPE_CONVERTER.fromGravitino(Types.ExternalType.of("int -- comment")));
+  }
+
+  @Test
   public void testMalformedTypeStringFallback() {
     // Malformed parameterized types (e.g. "varchar(abc)") should fallback to ExternalType
     // instead of throwing NumberFormatException. columnSize=null triggers fallback parsing

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlTypeConverter.java
@@ -161,7 +161,7 @@ public class MysqlTypeConverter extends JdbcTypeConverter {
     } else if (type instanceof Types.BooleanType) {
       return BIT;
     } else if (type instanceof Types.ExternalType) {
-      return ((Types.ExternalType) type).catalogString();
+      return validateExternalTypeString(((Types.ExternalType) type).catalogString());
     }
     throw new IllegalArgumentException(
         String.format("Couldn't convert Gravitino type %s to MySQL type", type.simpleString()));

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
@@ -104,6 +104,27 @@ public class TestMysqlTypeConverter {
         () -> MYSQL_TYPE_CONVERTER.fromGravitino(Types.UnparsedType.of(USER_DEFINED_TYPE)));
   }
 
+  @Test
+  public void testFromGravitinoExternalTypeValidation() {
+    // Full type declarations recovered by MysqlTableOperations must survive the validation.
+    checkGravitinoTypeToJdbcType("enum('a','b','c')", Types.ExternalType.of("enum('a','b','c')"));
+    checkGravitinoTypeToJdbcType("set('x','y','z')", Types.ExternalType.of("set('x','y','z')"));
+    checkGravitinoTypeToJdbcType("bit(8)", Types.ExternalType.of("bit(8)"));
+    checkGravitinoTypeToJdbcType("binary(16)", Types.ExternalType.of("binary(16)"));
+    checkGravitinoTypeToJdbcType("varbinary(100)", Types.ExternalType.of("varbinary(100)"));
+
+    // An external type cannot escape the column type position of the generated DDL.
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> MYSQL_TYPE_CONVERTER.fromGravitino(Types.ExternalType.of("int, DROP COLUMN secret")));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> MYSQL_TYPE_CONVERTER.fromGravitino(Types.ExternalType.of("json; DROP TABLE foo")));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> MYSQL_TYPE_CONVERTER.fromGravitino(Types.ExternalType.of("int -- comment")));
+  }
+
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {
     Assertions.assertEquals(jdbcTypeName, MYSQL_TYPE_CONVERTER.fromGravitino(gravitinoType));
   }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
@@ -148,7 +148,7 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
     } else if (type instanceof Types.ListType) {
       return fromGravitinoArrayType((ListType) type);
     } else if (type instanceof Types.ExternalType) {
-      return ((Types.ExternalType) type).catalogString();
+      return validateExternalTypeString(((Types.ExternalType) type).catalogString());
     }
     throw new IllegalArgumentException(
         String.format(

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -127,6 +127,26 @@ public class TestPostgreSqlTypeConverter {
         () -> POSTGRE_SQL_TYPE_CONVERTER.fromGravitino(Types.UnparsedType.of(USER_DEFINED_TYPE)));
   }
 
+  @Test
+  public void testFromGravitinoExternalTypeValidation() {
+    checkGravitinoTypeToJdbcType(NUMERIC, Types.ExternalType.of(NUMERIC));
+
+    // An external type cannot append another action to the generated ALTER TABLE statement.
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            POSTGRE_SQL_TYPE_CONVERTER.fromGravitino(
+                Types.ExternalType.of("int, ALTER COLUMN other SET DATA TYPE text")));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            POSTGRE_SQL_TYPE_CONVERTER.fromGravitino(
+                Types.ExternalType.of("json; DROP TABLE foo")));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> POSTGRE_SQL_TYPE_CONVERTER.fromGravitino(Types.ExternalType.of("int -- comment")));
+  }
+
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {
     Assertions.assertEquals(jdbcTypeName, POSTGRE_SQL_TYPE_CONVERTER.fromGravitino(gravitinoType));
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a shared `validateExternalTypeString` helper to `JdbcTypeConverter` and call it from
`fromGravitino` in the MySQL, PostgreSQL and Doris converters.

The helper keeps an external type string inside the single column type slot it is written into,
rather than trying to prove it names a valid type:

1. Reject null, empty and blank values.
2. Strip single-quoted literals, so quoted content such as the members of `enum('a','b')` may
   contain anything.
3. Restrict the remaining characters to `[\w .,:()<>\[\]=-]`.
4. Reject the `--` line comment sequence.
5. Require `()`, `[]` and `<>` to be balanced and never negative, with every comma nested inside
   a bracket pair.

A rejected value throws `IllegalArgumentException` naming the offending string.

### Why are the changes needed?

External type catalog strings come from the caller and were interpolated verbatim into the DDL
that the JDBC catalogs build by string concatenation, with nothing validating them on the way.
`JsonUtils.readExternalType` only checks that the `catalogString` field is present, and
`Types.ExternalType.of` stores whatever it is given, including `null` and `" "`.

The case that matters is a top level comma rather than a semicolon.
`MysqlTableOperations.generateAlterTableSql:410` and `DorisTableOperations:810` join their
actions with `",\n"` inside a single `ALTER TABLE` statement, and
`PostgreSqlTableOperations:604-614` appends `,\nALTER COLUMN ... SET NOT NULL` right after the
type, so a value such as `int, DROP COLUMN secret` contributes an action of its own.

Fix: #11805

### Does this PR introduce _any_ user-facing change?

No API or property changes. An external type that could escape the column type position is now
rejected with `IllegalArgumentException` instead of reaching the database.

### How was this patch tested?

New `TestJdbcTypeConverterExternalTypeValidation` in `catalog-jdbc-common` covers the algorithm
with 51 cases. Accepted: the MySQL full declarations (`enum('a','b','c')`, `set('x','y','z')`,
`bit(8)`, `binary(16)`, `varbinary(100)`), the Doris external types and malformed parse fallbacks
(`bigint unsigned`, `decimal(a,b)`), PostgreSQL `numeric`/`bit`, `user-defined`, escaped quotes
(`enum('it''s','ok')`), and the ClickHouse shapes. Rejected: top level commas, `;`, `--`,
`/* */`, `#`, newlines, unterminated quotes, unbalanced brackets, blank and null.

Each of the three converter test classes also gets a wiring test that goes through
`fromGravitino`.

```
./gradlew :catalogs:catalog-jdbc-common:test :catalogs:catalog-jdbc-mysql:test \
          :catalogs:catalog-jdbc-postgresql:test :catalogs:catalog-jdbc-doris:test -PskipITs
```

catalog-jdbc-common 95 tests, catalog-jdbc-mysql 13, catalog-jdbc-postgresql 47,
catalog-jdbc-doris 36, no failures. `spotlessCheck` is clean.

### Notes for reviewers

@FANNG1 one open question, and two places where I followed your prose over your example regex.

**Open question: `=`.** You listed `=` among the characters to rule out, but ClickHouse stores
`Enum8('active'=1,'inactive'=2)` as an external type today
(`TestClickHouseTypeConverter:108`, `CatalogClickHouseIT:2934`). ClickHouse is not wired up in
this PR, but since the helper lives in the shared base class, excluding `=` now means widening it
again in the follow-up. My reading is that `=` is safe here: with `;` outside the set, top level
commas rejected and brackets required balanced, a bare `=` in the column type position cannot
start a new action or terminate the statement, so at worst it is a syntax error the database
rejects anyway. Say the word and I will drop it and remove the ClickHouse rows from the test.

**`-` allowed, `--` rejected as a sequence.** You named `--`, not `-`, so I read the missing
hyphen in `[\w .,:()<>\[\]]` as a side effect rather than the intent — a lone hyphen cannot open
a comment. It also matters concretely: `TestMysqlTypeConverter:101` and
`TestPostgreSqlTypeConverter:124` already assert that
`fromGravitino(ExternalType.of("user-defined"))` returns the value unchanged, so excluding `-`
would fail two currently passing tests. `/* */` and `#` need no special case, since `/`, `*` and
`#` are outside the character set.

**Commas nest inside `<>` too.** You track `<>` as a bracket pair and say commas outside brackets
are rejected, so I allowed them inside all three pairs, which keeps generic types such as
`struct<a:int,b:int>` working.

Scope is the three converters named in the issue. ClickHouse, OceanBase and Hologres do the same
passthrough and can reuse this helper; I will open a follow-up for them. Hologres looks more
exposed than the rest: `HologresTableOperations:501` joins with `"\n"` and each clause carries
its own `;`, so a semicolon there could append an entire statement rather than an extra action.
Glue builds AWS SDK objects rather than SQL, and StarRocks already throws for external types, so
neither needs this.

One gap worth flagging: `TestMysqlTableOperations`, which is what produces the
`enum('a','b','c')` values, is tagged `gravitino-docker-test` and I could not get it to run
locally, so those literals are covered by unit tests rather than end to end.
